### PR TITLE
feat(deploy): add Railway one-click deploy template

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Feedback tools should be simple. Quackback focuses on the essentials: voting, ro
 
 Quackback can be deployed anywhere that supports Docker or Node.js.
 
+### One-Click Deploy
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/bcnu9a)
+
 ### Production (Docker)
 
 ```bash

--- a/apps/web/src/routes/api/health.ts
+++ b/apps/web/src/routes/api/health.ts
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/api/health')({
+  server: {
+    handlers: {
+      GET: async () => {
+        return Response.json({ status: 'ok' })
+      },
+    },
+  },
+})

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -22,7 +22,7 @@ docker run -d \
   --name quackback \
   -p 3000:3000 \
   -e DATABASE_URL="postgresql://user:pass@host:5432/quackback" \
-  -e BETTER_AUTH_SECRET="your-secret-32-chars-minimum" \
+  -e SECRET_KEY="your-secret-32-chars-minimum" \
   -e BASE_URL="https://your-domain.com" \
   ghcr.io/quackbackhq/quackback:latest
 ```

--- a/deploy/railway-template.yml
+++ b/deploy/railway-template.yml
@@ -1,0 +1,56 @@
+# Railway Template Specification
+# This file documents the Railway template configuration.
+# It is NOT consumed by Railway — the template lives in Railway's platform.
+# Keep this in sync with the Railway web UI template.
+#
+# Template ID: bcnu9a
+# Template URL: https://railway.com/deploy/bcnu9a
+# Last updated: 2026-02-05
+
+services:
+  postgres:
+    image: pgvector/pgvector:pg17
+    volumes:
+      - mount: /var/lib/postgresql/data
+    env:
+      POSTGRES_DB: quackback
+      POSTGRES_USER: quackback
+      POSTGRES_PASSWORD: ${{secret(32)}}
+    networking: private
+
+  bucket:
+    type: bucket
+    # Railway-provided S3-compatible object storage
+    # Region is selected by the user during deployment
+
+  quackback:
+    image: ghcr.io/quackbackio/quackback:latest
+    healthcheck:
+      path: /api/health
+      timeout: 300
+    restart:
+      policy: ON_FAILURE
+      maxRetries: 3
+    networking: public
+    env:
+      DATABASE_URL: postgresql://quackback:${{postgres.POSTGRES_PASSWORD}}@${{postgres.RAILWAY_PRIVATE_DOMAIN}}:5432/quackback
+      SECRET_KEY: ${{secret(64)}}
+      BASE_URL: https://${{RAILWAY_PUBLIC_DOMAIN}}
+      PORT: '3000'
+      NODE_ENV: production
+      S3_ENDPOINT: ${{Bucket.ENDPOINT}}
+      S3_BUCKET: ${{Bucket.BUCKET}}
+      S3_REGION: ${{Bucket.REGION}}
+      S3_ACCESS_KEY_ID: ${{Bucket.ACCESS_KEY_ID}}
+      S3_SECRET_ACCESS_KEY: ${{Bucket.SECRET_ACCESS_KEY}}
+    optional_env:
+      - EMAIL_SMTP_HOST
+      - EMAIL_SMTP_PORT
+      - EMAIL_SMTP_USER
+      - EMAIL_SMTP_PASS
+      - EMAIL_RESEND_API_KEY
+      - EMAIL_FROM
+      - GITHUB_CLIENT_ID
+      - GITHUB_CLIENT_SECRET
+      - GOOGLE_CLIENT_ID
+      - GOOGLE_CLIENT_SECRET

--- a/deploy/self-hosted/README.md
+++ b/deploy/self-hosted/README.md
@@ -45,7 +45,7 @@ docker run -d \
   --name quackback \
   -p 3000:3000 \
   -e DATABASE_URL="postgresql://user:pass@host:5432/quackback" \
-  -e BETTER_AUTH_SECRET="your-secret-key-at-least-32-chars" \
+  -e SECRET_KEY="your-secret-key-at-least-32-chars" \
   -e BASE_URL="https://your-domain.com" \
   ghcr.io/quackbackhq/quackback:latest
 ```
@@ -82,11 +82,11 @@ docker pull ghcr.io/quackbackhq/quackback:latest-enterprise
 
 ### Required
 
-| Variable             | Description                     | Example                                           |
-| -------------------- | ------------------------------- | ------------------------------------------------- |
-| `DATABASE_URL`       | PostgreSQL connection string    | `postgresql://user:pass@localhost:5432/quackback` |
-| `BETTER_AUTH_SECRET` | Auth encryption key (32+ chars) | `your-very-long-random-secret-key`                |
-| `BASE_URL`           | Public URL of your instance     | `https://feedback.yourcompany.com`                |
+| Variable       | Description                     | Example                                           |
+| -------------- | ------------------------------- | ------------------------------------------------- |
+| `DATABASE_URL` | PostgreSQL connection string    | `postgresql://user:pass@localhost:5432/quackback` |
+| `SECRET_KEY`   | Auth encryption key (32+ chars) | `your-very-long-random-secret-key`                |
+| `BASE_URL`     | Public URL of your instance     | `https://feedback.yourcompany.com`                |
 
 ### Optional
 
@@ -272,7 +272,7 @@ docker run -d \
   --name quackback \
   -p 3000:3000 \
   -e DATABASE_URL="postgresql://..." \
-  -e BETTER_AUTH_SECRET="..." \
+  -e SECRET_KEY="..." \
   -e QUACKBACK_LICENSE_KEY="your-license-key" \
   ghcr.io/quackbackhq/quackback:latest-enterprise
 ```
@@ -393,9 +393,22 @@ curl -X POST 'https://api.resend.com/emails' \
 
 ## One-Click Deployments
 
+### Railway
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/bcnu9a)
+
+Deploys Quackback + PostgreSQL (with pgvector) + S3-compatible storage bucket to Railway. After deploying:
+
+1. **Find your OTP code**: If email is not configured, login codes appear in Railway's deployment logs
+2. **Configure email** (recommended): Add SMTP or Resend API key in the service's environment variables
+3. **Custom domain**: Add a custom domain in Railway, then update the `BASE_URL` environment variable to match
+
+File uploads (logos, avatars, changelog images) work out of the box via the included Railway storage bucket.
+
+> Railway offers a free trial with $5 credit. See [Railway pricing](https://railway.com/pricing) for details.
+
 Coming soon:
 
-- Railway
 - Render
 - DigitalOcean App Platform
 - Fly.io


### PR DESCRIPTION
## Summary

- Add a **Deploy on Railway** button for one-click deployment of Quackback + PostgreSQL (pgvector) + S3 storage bucket
- Add `/api/health` endpoint for Railway health checks (minimal, no DB queries)
- Add `deploy/railway-template.yml` as version-controlled documentation of the Railway template config
- Rename `BETTER_AUTH_SECRET` → `SECRET_KEY` in deploy docs to match the actual codebase

## Details

The Railway template (ID: `bcnu9a`) provisions:
- **Quackback app** from `ghcr.io/quackbackio/quackback:latest` with health check and restart policy
- **PostgreSQL 17** with pgvector extension on private networking
- **S3-compatible storage bucket** for file uploads (logos, avatars, changelog images)
- Auto-generated `SECRET_KEY` (64 chars) and `DATABASE_URL` via Railway template variables

## Test plan

- [x] Verify `/api/health` returns `{"status":"ok"}` locally
- [x] Click "Deploy on Railway" button from README — template page loads
- [x] Complete a fresh Railway deployment and verify onboarding works
- [x] Verify file uploads work via the included storage bucket