### PR TITLE
fix(security): prevent stored XSS via TipTap JSON content

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,6 +25,7 @@
     "@floating-ui/dom": "^1.7.5",
     "@heroicons/react": "^2.2.0",
     "@hookform/resolvers": "^5.2.2",
+    "@modelcontextprotocol/sdk": "^1.12.0",
     "@quackback/db": "workspace:*",
     "@quackback/email": "workspace:*",
     "@quackback/ids": "workspace:*",
@@ -78,6 +79,7 @@
     "date-fns": "^4.1.0",
     "drizzle-orm": "^0.45.1",
     "framer-motion": "^12.29.2",
+    "isomorphic-dompurify": "^2.35.0",
     "jose": "^6.1.3",
     "lowlight": "^3.3.0",
     "lucide-react": "^0.563.0",
@@ -97,14 +99,14 @@
     "typeid-js": "^1.2.0",
     "zod": "^4.3.6",
     "zod-openapi": "^5.4.6",
-    "zustand": "^5.0.10",
-    "@modelcontextprotocol/sdk": "^1.12.0"
+    "zustand": "^5.0.10"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.0",
     "@tailwindcss/vite": "^4.1.18",
     "@types/bcryptjs": "^3.0.0",
     "@types/bun": "^1.3.6",
+    "@types/dompurify": "^3.2.0",
     "@types/node": "^25.0.10",
     "@types/papaparse": "^5.5.2",
     "@types/react": "^19.2.10",

--- a/apps/web/src/components/admin/changelog/changelog-modal.tsx
+++ b/apps/web/src/components/admin/changelog/changelog-modal.tsx
@@ -12,6 +12,7 @@ import { Cog6ToothIcon } from '@heroicons/react/24/solid'
 import { ModalHeader } from '@/components/shared/modal-header'
 import { UrlModalShell } from '@/components/shared/url-modal-shell'
 import { updateChangelogSchema } from '@/lib/shared/schemas/changelog'
+import type { TiptapContent } from '@/lib/shared/schemas/posts'
 import { useUpdateChangelog } from '@/lib/client/mutations/changelog'
 import { changelogQueries } from '@/lib/client/queries/changelog'
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet'
@@ -104,7 +105,7 @@ function ChangelogModalContent({ entryId, onClose }: ChangelogModalContentProps)
         id: entryId,
         title: data.title,
         content: data.content,
-        contentJson,
+        contentJson: contentJson as TiptapContent | null,
         linkedPostIds,
         publishState,
       },

--- a/apps/web/src/components/admin/changelog/create-changelog-dialog.tsx
+++ b/apps/web/src/components/admin/changelog/create-changelog-dialog.tsx
@@ -6,6 +6,7 @@ import { ModalFooter } from '@/components/shared/modal-footer'
 import { useForm } from 'react-hook-form'
 import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
 import { createChangelogSchema } from '@/lib/shared/schemas/changelog'
+import type { TiptapContent } from '@/lib/shared/schemas/posts'
 import { useCreateChangelog } from '@/lib/client/mutations/changelog'
 import { Dialog, DialogContent, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet'
@@ -58,7 +59,7 @@ export function CreateChangelogDialog({ onChangelogCreated }: CreateChangelogDia
       {
         title: data.title,
         content: data.content,
-        contentJson,
+        contentJson: contentJson as TiptapContent | null,
         linkedPostIds,
         publishState,
       },

--- a/apps/web/src/components/admin/changelog/edit-changelog-dialog.tsx
+++ b/apps/web/src/components/admin/changelog/edit-changelog-dialog.tsx
@@ -7,6 +7,7 @@ import { useForm } from 'react-hook-form'
 import { useQuery } from '@tanstack/react-query'
 import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
 import { updateChangelogSchema } from '@/lib/shared/schemas/changelog'
+import type { TiptapContent } from '@/lib/shared/schemas/posts'
 import { useUpdateChangelog } from '@/lib/client/mutations/changelog'
 import { changelogQueries } from '@/lib/client/queries/changelog'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
@@ -105,7 +106,7 @@ export function EditChangelogDialog({ id, open, onOpenChange }: EditChangelogDia
         id,
         title: data.title,
         content: data.content,
-        contentJson,
+        contentJson: contentJson as TiptapContent | null,
         linkedPostIds,
         publishState,
       },

--- a/apps/web/src/lib/server/__tests__/sanitize-tiptap.test.ts
+++ b/apps/web/src/lib/server/__tests__/sanitize-tiptap.test.ts
@@ -1,0 +1,509 @@
+import { describe, it, expect } from 'vitest'
+import { sanitizeTiptapContent } from '../sanitize-tiptap'
+
+// Alias that accepts unknown — used to test garbage input the sanitizer should handle gracefully
+const sanitize = sanitizeTiptapContent as (
+  input: unknown
+) => ReturnType<typeof sanitizeTiptapContent>
+
+describe('sanitizeTiptapContent', () => {
+  // ============================================
+  // Basic structure
+  // ============================================
+
+  it('returns empty doc for invalid input', () => {
+    expect(sanitize({ type: 'invalid' })).toEqual({ type: 'doc' })
+    expect(sanitize({})).toEqual({ type: 'doc' })
+    expect(sanitize(null)).toEqual({ type: 'doc' })
+  })
+
+  it('passes through valid simple content unchanged', () => {
+    const input = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Hello world' }],
+        },
+      ],
+    }
+    const result = sanitizeTiptapContent(input)
+    expect(result.type).toBe('doc')
+    expect(result.content).toHaveLength(1)
+    expect(result.content![0].type).toBe('paragraph')
+    expect(result.content![0].content![0].text).toBe('Hello world')
+  })
+
+  it('handles empty doc', () => {
+    expect(sanitizeTiptapContent({ type: 'doc' })).toEqual({ type: 'doc' })
+  })
+
+  it('handles doc with empty content array', () => {
+    expect(sanitizeTiptapContent({ type: 'doc', content: [] })).toEqual({
+      type: 'doc',
+    })
+  })
+
+  // ============================================
+  // Node type filtering
+  // ============================================
+
+  it('strips unknown node types', () => {
+    const input = {
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'Keep' }] },
+        { type: 'script', content: [{ type: 'text', text: 'Remove me' }] },
+        { type: 'div', content: [{ type: 'text', text: 'Also remove' }] },
+      ],
+    }
+    const result = sanitizeTiptapContent(input)
+    expect(result.content).toHaveLength(1)
+    expect(result.content![0].type).toBe('paragraph')
+  })
+
+  it('allows all valid node types', () => {
+    const validTypes = [
+      'paragraph',
+      'heading',
+      'text',
+      'bulletList',
+      'orderedList',
+      'listItem',
+      'taskList',
+      'taskItem',
+      'blockquote',
+      'codeBlock',
+      'image',
+      'resizableImage',
+      'youtube',
+      'horizontalRule',
+      'hardBreak',
+      'table',
+      'tableRow',
+      'tableHeader',
+      'tableCell',
+    ]
+    for (const type of validTypes) {
+      const input = {
+        type: 'doc',
+        content: [{ type }],
+      }
+      const result = sanitizeTiptapContent(input)
+      // text nodes require a text field to pass, others pass without content
+      if (type === 'text') continue
+      expect(result.content?.some((n: Record<string, unknown>) => n.type === type)).toBe(true)
+    }
+  })
+
+  // ============================================
+  // Heading level sanitization
+  // ============================================
+
+  it('preserves valid heading levels (1-6)', () => {
+    for (const level of [1, 2, 3, 4, 5, 6]) {
+      const input = {
+        type: 'doc',
+        content: [{ type: 'heading', attrs: { level } }],
+      }
+      const result = sanitizeTiptapContent(input)
+      expect(result.content![0].attrs!.level).toBe(level)
+    }
+  })
+
+  it('defaults invalid heading level to 2', () => {
+    const input = {
+      type: 'doc',
+      content: [{ type: 'heading', attrs: { level: 99 } }],
+    }
+    const result = sanitizeTiptapContent(input)
+    expect(result.content![0].attrs!.level).toBe(2)
+  })
+
+  it('sanitizes XSS in heading level', () => {
+    const input = {
+      type: 'doc',
+      content: [
+        {
+          type: 'heading',
+          attrs: { level: '1><script>alert(1)</script><h1' },
+        },
+      ],
+    }
+    const result = sanitizeTiptapContent(input)
+    // NaN from Number() → defaults to 2
+    expect(result.content![0].attrs!.level).toBe(2)
+  })
+
+  // ============================================
+  // Code block language sanitization
+  // ============================================
+
+  it('preserves valid code block languages', () => {
+    for (const language of ['javascript', 'python', 'c++', 'c-sharp', 'rust']) {
+      const input = {
+        type: 'doc',
+        content: [{ type: 'codeBlock', attrs: { language } }],
+      }
+      const result = sanitizeTiptapContent(input)
+      expect(result.content![0].attrs!.language).toBe(language)
+    }
+  })
+
+  it('strips XSS in code block language', () => {
+    const input = {
+      type: 'doc',
+      content: [
+        {
+          type: 'codeBlock',
+          attrs: { language: 'js"><script>alert(1)</script>' },
+        },
+      ],
+    }
+    const result = sanitizeTiptapContent(input)
+    expect(result.content![0].attrs!.language).toBe('')
+  })
+
+  // ============================================
+  // Image sanitization
+  // ============================================
+
+  it('preserves valid image URLs', () => {
+    const input = {
+      type: 'doc',
+      content: [
+        {
+          type: 'image',
+          attrs: { src: 'https://example.com/photo.jpg', alt: 'A photo' },
+        },
+      ],
+    }
+    const result = sanitizeTiptapContent(input)
+    expect(result.content![0].attrs!.src).toBe('https://example.com/photo.jpg')
+    expect(result.content![0].attrs!.alt).toBe('A photo')
+  })
+
+  it('blocks javascript: URLs in images', () => {
+    const input = {
+      type: 'doc',
+      content: [
+        {
+          type: 'image',
+          attrs: { src: 'javascript:alert(1)' },
+        },
+      ],
+    }
+    const result = sanitizeTiptapContent(input)
+    expect(result.content![0].attrs!.src).toBe('')
+  })
+
+  it('blocks data:image/svg+xml in images', () => {
+    const input = {
+      type: 'doc',
+      content: [
+        {
+          type: 'image',
+          attrs: {
+            src: 'data:image/svg+xml,<svg onload="alert(1)"/>',
+          },
+        },
+      ],
+    }
+    const result = sanitizeTiptapContent(input)
+    expect(result.content![0].attrs!.src).toBe('')
+  })
+
+  it('allows safe data:image URLs', () => {
+    const src = 'data:image/png;base64,iVBORw0KGgo='
+    const input = {
+      type: 'doc',
+      content: [{ type: 'image', attrs: { src } }],
+    }
+    const result = sanitizeTiptapContent(input)
+    expect(result.content![0].attrs!.src).toBe(src)
+  })
+
+  it('sanitizes image width/height to safe integers', () => {
+    const input = {
+      type: 'doc',
+      content: [
+        {
+          type: 'resizableImage',
+          attrs: {
+            src: 'https://example.com/img.png',
+            width: '500"><script>alert(1)</script>',
+            height: -100,
+          },
+        },
+      ],
+    }
+    const result = sanitizeTiptapContent(input)
+    // Invalid width/height removed (default 0 → deleted)
+    expect(result.content![0].attrs!.width).toBeUndefined()
+    expect(result.content![0].attrs!.height).toBeUndefined()
+  })
+
+  // ============================================
+  // YouTube sanitization
+  // ============================================
+
+  it('preserves valid YouTube attrs', () => {
+    const input = {
+      type: 'doc',
+      content: [
+        {
+          type: 'youtube',
+          attrs: {
+            src: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+            width: 640,
+            height: 360,
+          },
+        },
+      ],
+    }
+    const result = sanitizeTiptapContent(input)
+    expect(result.content![0].attrs!.src).toBe('https://www.youtube.com/watch?v=dQw4w9WgXcQ')
+    expect(result.content![0].attrs!.width).toBe(640)
+    expect(result.content![0].attrs!.height).toBe(360)
+  })
+
+  it('sanitizes XSS in YouTube width/height', () => {
+    const input = {
+      type: 'doc',
+      content: [
+        {
+          type: 'youtube',
+          attrs: {
+            src: 'https://www.youtube.com/watch?v=test',
+            width: '640" onload="alert(1)',
+            height: '360" onerror="alert(2)',
+          },
+        },
+      ],
+    }
+    const result = sanitizeTiptapContent(input)
+    // NaN → defaults
+    expect(result.content![0].attrs!.width).toBe(640)
+    expect(result.content![0].attrs!.height).toBe(360)
+  })
+
+  // ============================================
+  // Mark sanitization
+  // ============================================
+
+  it('preserves valid marks', () => {
+    const input = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'Bold text',
+              marks: [{ type: 'bold' }],
+            },
+          ],
+        },
+      ],
+    }
+    const result = sanitizeTiptapContent(input)
+    expect(result.content![0].content![0].marks).toEqual([{ type: 'bold' }])
+  })
+
+  it('strips unknown mark types', () => {
+    const input = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'Test',
+              marks: [{ type: 'bold' }, { type: 'onclick' }, { type: 'italic' }],
+            },
+          ],
+        },
+      ],
+    }
+    const result = sanitizeTiptapContent(input)
+    expect(result.content![0].content![0].marks).toEqual([{ type: 'bold' }, { type: 'italic' }])
+  })
+
+  it('sanitizes link mark href', () => {
+    const input = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'Click me',
+              marks: [
+                {
+                  type: 'link',
+                  attrs: { href: 'javascript:alert(1)' },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+    const result = sanitizeTiptapContent(input)
+    // javascript: URL → link mark removed entirely
+    expect(result.content![0].content![0].marks).toBeUndefined()
+  })
+
+  it('preserves valid link marks with safe attrs', () => {
+    const input = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'Visit',
+              marks: [
+                {
+                  type: 'link',
+                  attrs: { href: 'https://example.com' },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+    const result = sanitizeTiptapContent(input)
+    const mark = result.content![0].content![0].marks![0]
+    expect(mark.type).toBe('link')
+    expect(mark.attrs!.href).toBe('https://example.com/')
+    expect(mark.attrs!.target).toBe('_blank')
+    expect(mark.attrs!.rel).toBe('noopener noreferrer')
+  })
+
+  // ============================================
+  // Attribute stripping
+  // ============================================
+
+  it('strips unknown attributes from nodes', () => {
+    const input = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          attrs: { onclick: 'alert(1)', style: 'color:red', class: 'evil' },
+        },
+      ],
+    }
+    const result = sanitizeTiptapContent(input)
+    // Paragraph gets no attrs
+    expect(result.content![0].attrs).toBeUndefined()
+  })
+
+  // ============================================
+  // Depth protection
+  // ============================================
+
+  it('stops at max depth (20)', () => {
+    // Build a deeply nested structure
+    let node: Record<string, unknown> = { type: 'text', text: 'deep' }
+    for (let i = 0; i < 25; i++) {
+      node = { type: 'paragraph', content: [node] }
+    }
+    const input = { type: 'doc', content: [node] }
+    const result = sanitizeTiptapContent(input)
+    // Should have content but truncated at depth 20
+    expect(result.type).toBe('doc')
+
+    // Verify the deepest text is cut off
+    let current: Record<string, unknown> = result
+    let depth = 0
+    while ((current?.content as Record<string, unknown>[])?.[0]) {
+      current = (current.content as Record<string, unknown>[])[0]
+      depth++
+    }
+    // Should not reach the full 26 levels
+    expect(depth).toBeLessThanOrEqual(21)
+  })
+
+  // ============================================
+  // Complex content
+  // ============================================
+
+  it('handles complex nested content correctly', () => {
+    const input = {
+      type: 'doc',
+      content: [
+        {
+          type: 'heading',
+          attrs: { level: 2 },
+          content: [{ type: 'text', text: 'Features' }],
+        },
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    {
+                      type: 'text',
+                      text: 'Bold feature',
+                      marks: [{ type: 'bold' }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'codeBlock',
+          attrs: { language: 'typescript' },
+          content: [{ type: 'text', text: 'const x = 1' }],
+        },
+        { type: 'horizontalRule' },
+        {
+          type: 'blockquote',
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                {
+                  type: 'text',
+                  text: 'A quote with a ',
+                },
+                {
+                  type: 'text',
+                  text: 'link',
+                  marks: [
+                    {
+                      type: 'link',
+                      attrs: { href: 'https://example.com' },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+    const result = sanitizeTiptapContent(input)
+    expect(result.content).toHaveLength(5)
+    expect(result.content![0].type).toBe('heading')
+    expect(result.content![0].attrs!.level).toBe(2)
+    expect(result.content![1].type).toBe('bulletList')
+    expect(result.content![2].type).toBe('codeBlock')
+    expect(result.content![2].attrs!.language).toBe('typescript')
+    expect(result.content![3].type).toBe('horizontalRule')
+    expect(result.content![4].type).toBe('blockquote')
+  })
+})

--- a/apps/web/src/lib/server/functions/changelog.ts
+++ b/apps/web/src/lib/server/functions/changelog.ts
@@ -7,6 +7,7 @@
 import { createServerFn } from '@tanstack/react-start'
 import type { BoardId, ChangelogId, PostId } from '@quackback/ids'
 // Note: BoardId is only used for searchShippedPosts filtering
+import { sanitizeTiptapContent } from '@/lib/server/sanitize-tiptap'
 import { requireAuth } from './auth-helpers'
 import {
   createChangelog,
@@ -72,7 +73,7 @@ export const createChangelogFn = createServerFn({ method: 'POST' })
       {
         title: data.title,
         content: data.content,
-        contentJson: data.contentJson ?? null,
+        contentJson: data.contentJson ? sanitizeTiptapContent(data.contentJson) : null,
         linkedPostIds: (data.linkedPostIds ?? []) as PostId[],
         publishState: data.publishState as PublishState,
       },
@@ -101,7 +102,7 @@ export const updateChangelogFn = createServerFn({ method: 'POST' })
     const entry = await updateChangelog(data.id as ChangelogId, {
       title: data.title,
       content: data.content,
-      contentJson: data.contentJson ?? undefined,
+      contentJson: data.contentJson ? sanitizeTiptapContent(data.contentJson) : undefined,
       linkedPostIds: data.linkedPostIds as PostId[] | undefined,
       publishState: data.publishState as PublishState | undefined,
     })

--- a/apps/web/src/lib/server/functions/posts.ts
+++ b/apps/web/src/lib/server/functions/posts.ts
@@ -12,7 +12,8 @@ import {
   type MemberId,
   type UserId,
 } from '@quackback/ids'
-import type { TiptapContent } from '@/lib/shared/schemas/posts'
+import { tiptapContentSchema, type TiptapContent } from '@/lib/shared/schemas/posts'
+import { sanitizeTiptapContent } from '@/lib/server/sanitize-tiptap'
 import { requireAuth } from './auth-helpers'
 import { createPost, updatePost } from '@/lib/server/domains/posts/post.service'
 import {
@@ -80,10 +81,7 @@ function serializePostDates<
 // Schemas
 // ============================================
 
-const tiptapContentSchema = z.object({
-  type: z.literal('doc'),
-  content: z.array(z.any()).optional(),
-})
+// tiptapContentSchema imported from @/lib/shared/schemas/posts
 
 const listInboxPostsSchema = z.object({
   boardIds: z.array(z.string()).optional(),
@@ -271,7 +269,7 @@ export const createPostFn = createServerFn({ method: 'POST' })
         {
           title: data.title,
           content: data.content,
-          contentJson: data.contentJson,
+          contentJson: data.contentJson ? sanitizeTiptapContent(data.contentJson) : undefined,
           boardId: data.boardId as BoardId,
           statusId: data.statusId as StatusId | undefined,
           tagIds: data.tagIds as TagId[] | undefined,
@@ -309,7 +307,7 @@ export const updatePostFn = createServerFn({ method: 'POST' })
         {
           title: data.title,
           content: data.content,
-          contentJson: data.contentJson,
+          contentJson: data.contentJson ? sanitizeTiptapContent(data.contentJson) : undefined,
           ownerMemberId: data.ownerId as MemberId | null | undefined,
           officialResponse: data.officialResponse,
         },

--- a/apps/web/src/lib/server/sanitize-tiptap.ts
+++ b/apps/web/src/lib/server/sanitize-tiptap.ts
@@ -1,0 +1,228 @@
+/**
+ * TipTap JSON Content Sanitizer
+ *
+ * Sanitizes TipTap JSON content at the server function layer (mutation time)
+ * to prevent stored XSS. Validates node types against an allowlist and
+ * coerces/sanitizes attributes per node type.
+ *
+ * This is Layer 1 of a two-layer defense:
+ * - Layer 1 (here): JSON sanitization on write
+ * - Layer 2: DOMPurify on HTML output at render time
+ */
+
+import { sanitizeUrl, sanitizeImageUrl, safePositiveInt } from '@/lib/shared/utils/sanitize'
+import type { TiptapContent } from '@/lib/shared/schemas/posts'
+
+// Node types that match the TipTap editor extensions
+const ALLOWED_NODE_TYPES = new Set([
+  'doc',
+  'paragraph',
+  'heading',
+  'text',
+  'bulletList',
+  'orderedList',
+  'listItem',
+  'taskList',
+  'taskItem',
+  'blockquote',
+  'codeBlock',
+  'image',
+  'resizableImage',
+  'youtube',
+  'horizontalRule',
+  'hardBreak',
+  'table',
+  'tableRow',
+  'tableHeader',
+  'tableCell',
+])
+
+// Mark types that match the TipTap editor extensions
+const ALLOWED_MARK_TYPES = new Set(['bold', 'italic', 'underline', 'strike', 'code', 'link'])
+
+const VALID_HEADING_LEVELS = new Set([1, 2, 3, 4, 5, 6])
+
+// Max 50 chars, only alphanumeric, hyphens, underscores, dots, plus
+const LANGUAGE_PATTERN = /^[\w.+-]{0,50}$/
+
+interface TiptapNode {
+  type: string
+  content?: TiptapNode[]
+  text?: string
+  marks?: TiptapMark[]
+  attrs?: Record<string, unknown>
+}
+
+interface TiptapMark {
+  type: string
+  attrs?: Record<string, unknown>
+}
+
+/**
+ * Sanitize a TipTap mark (bold, italic, link, etc.)
+ */
+function sanitizeMark(mark: TiptapMark): TiptapMark | null {
+  if (!mark || typeof mark.type !== 'string') return null
+  if (!ALLOWED_MARK_TYPES.has(mark.type)) return null
+
+  if (mark.type === 'link') {
+    const href = sanitizeUrl(String(mark.attrs?.href ?? ''))
+    if (!href) return null
+    return {
+      type: 'link',
+      attrs: {
+        href,
+        target: '_blank',
+        rel: 'noopener noreferrer',
+      },
+    }
+  }
+
+  // Simple marks (bold, italic, etc.) need no attrs
+  return { type: mark.type }
+}
+
+/**
+ * Sanitize attributes for a specific node type.
+ * Returns a clean attrs object with only safe, validated values.
+ */
+function sanitizeAttrs(
+  type: string,
+  attrs: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined {
+  if (!attrs) return undefined
+
+  switch (type) {
+    case 'heading': {
+      const rawLevel = Number(attrs.level)
+      const level = VALID_HEADING_LEVELS.has(rawLevel) ? rawLevel : 2
+      return { level }
+    }
+
+    case 'codeBlock': {
+      const rawLang = String(attrs.language ?? '')
+      const language = LANGUAGE_PATTERN.test(rawLang) ? rawLang : ''
+      return { language }
+    }
+
+    case 'youtube': {
+      const src = sanitizeUrl(String(attrs.src ?? ''))
+      return {
+        src,
+        width: safePositiveInt(attrs.width, 640),
+        height: safePositiveInt(attrs.height, 360),
+      }
+    }
+
+    case 'image':
+    case 'resizableImage': {
+      const src = sanitizeImageUrl(String(attrs.src ?? ''))
+      if (!src) return { src: '', alt: '' }
+      const result: Record<string, unknown> = { src, alt: String(attrs.alt ?? '').slice(0, 500) }
+      if (attrs.width !== undefined) result.width = safePositiveInt(attrs.width, 0)
+      if (attrs.height !== undefined) result.height = safePositiveInt(attrs.height, 0)
+      // Remove zero-value dimensions
+      if (result.width === 0) delete result.width
+      if (result.height === 0) delete result.height
+      return result
+    }
+
+    case 'taskItem':
+      return { checked: Boolean(attrs.checked) }
+
+    case 'orderedList':
+      return attrs.start !== undefined
+        ? { start: safePositiveInt(attrs.start, 1, 999999) }
+        : undefined
+
+    // Nodes with no meaningful attrs to sanitize
+    case 'doc':
+    case 'paragraph':
+    case 'text':
+    case 'bulletList':
+    case 'listItem':
+    case 'taskList':
+    case 'blockquote':
+    case 'horizontalRule':
+    case 'hardBreak':
+    case 'table':
+    case 'tableRow':
+    case 'tableHeader':
+    case 'tableCell':
+      return undefined
+
+    default:
+      return undefined
+  }
+}
+
+/**
+ * Recursively sanitize a TipTap JSON node tree.
+ * - Strips unknown node types
+ * - Validates and coerces attributes per node type
+ * - Sanitizes marks (bold, italic, link, etc.)
+ * - Sanitizes URLs in links and images
+ */
+function sanitizeNode(node: TiptapNode, depth = 0): TiptapNode | null {
+  // Prevent deeply nested content (potential DoS or stack overflow)
+  if (depth > 20) return null
+
+  if (!node || typeof node.type !== 'string') return null
+
+  // Strip unknown node types
+  if (!ALLOWED_NODE_TYPES.has(node.type)) return null
+
+  const sanitized: TiptapNode = { type: node.type }
+
+  // Sanitize text content
+  if (node.type === 'text') {
+    if (typeof node.text !== 'string') return null
+    sanitized.text = node.text
+  }
+
+  // Sanitize attributes
+  const attrs = sanitizeAttrs(node.type, node.attrs)
+  if (attrs !== undefined) {
+    sanitized.attrs = attrs
+  }
+
+  // Sanitize marks (only on text nodes)
+  if (node.marks && Array.isArray(node.marks)) {
+    const sanitizedMarks = node.marks.map(sanitizeMark).filter((m): m is TiptapMark => m !== null)
+    if (sanitizedMarks.length > 0) {
+      sanitized.marks = sanitizedMarks
+    }
+  }
+
+  // Recursively sanitize child content
+  if (node.content && Array.isArray(node.content)) {
+    const sanitizedContent = node.content
+      .map((child) => sanitizeNode(child, depth + 1))
+      .filter((child): child is TiptapNode => child !== null)
+    if (sanitizedContent.length > 0) {
+      sanitized.content = sanitizedContent
+    }
+  }
+
+  return sanitized
+}
+
+/**
+ * Sanitize TipTap JSON content for safe storage.
+ *
+ * Call this in server functions before passing contentJson to services.
+ * Strips unknown node types and validates/coerces all attributes.
+ *
+ * @param content - Raw TipTap JSON from client
+ * @returns Sanitized TipTap JSON safe for storage and rendering
+ */
+export function sanitizeTiptapContent(content: {
+  type: string
+  content?: unknown[]
+}): TiptapContent {
+  const sanitized = sanitizeNode(content as TiptapNode)
+  if (!sanitized || sanitized.type !== 'doc') {
+    return { type: 'doc' } as TiptapContent
+  }
+  return sanitized as TiptapContent
+}

--- a/apps/web/src/lib/shared/schemas/changelog.ts
+++ b/apps/web/src/lib/shared/schemas/changelog.ts
@@ -5,6 +5,7 @@
  */
 
 import { z } from 'zod'
+import { tiptapContentSchema } from './posts'
 
 /**
  * Publish state schema
@@ -21,7 +22,7 @@ export const publishStateSchema = z.discriminatedUnion('type', [
 export const createChangelogSchema = z.object({
   title: z.string().min(1).max(200),
   content: z.string().min(1),
-  contentJson: z.any().optional(),
+  contentJson: tiptapContentSchema.nullable().optional(),
   linkedPostIds: z.array(z.string()).optional(),
   publishState: publishStateSchema,
 })
@@ -33,7 +34,7 @@ export const updateChangelogSchema = z.object({
   id: z.string().min(1),
   title: z.string().min(1).max(200).optional(),
   content: z.string().min(1).optional(),
-  contentJson: z.any().optional(),
+  contentJson: tiptapContentSchema.nullable().optional(),
   linkedPostIds: z.array(z.string()).optional(),
   publishState: publishStateSchema.optional(),
 })

--- a/apps/web/src/lib/shared/utils/index.ts
+++ b/apps/web/src/lib/shared/utils/index.ts
@@ -4,3 +4,11 @@
 
 export { cn } from './cn'
 export { getInitials, stripHtml } from './string'
+export {
+  escapeHtmlAttr,
+  sanitizeUrl,
+  sanitizeImageUrl,
+  sanitizeImageUrl as sanitizeImageSrc,
+  safePositiveInt,
+  extractYoutubeId,
+} from './sanitize'

--- a/apps/web/src/lib/shared/utils/sanitize.ts
+++ b/apps/web/src/lib/shared/utils/sanitize.ts
@@ -1,0 +1,106 @@
+/**
+ * HTML/URL sanitization utilities
+ *
+ * Used by both server-side TipTap JSON sanitizer and client-side rich text renderer.
+ */
+
+/**
+ * Escape HTML special characters in attribute values to prevent XSS
+ */
+export function escapeHtmlAttr(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+/**
+ * Sanitize URLs for use in href attributes - only allow safe protocols
+ */
+export function sanitizeUrl(url: string): string {
+  if (!url || typeof url !== 'string') return ''
+
+  try {
+    // Handle relative URLs by using a base
+    const parsed = new URL(url, 'https://example.com')
+
+    // Only allow safe protocols
+    const safeProtocols = ['http:', 'https:', 'mailto:']
+    if (!safeProtocols.includes(parsed.protocol)) {
+      return ''
+    }
+
+    // Return the original URL if it was relative, otherwise the full href
+    return url.startsWith('/') ? url : parsed.href
+  } catch {
+    // Invalid URL - reject it
+    return ''
+  }
+}
+
+/**
+ * Sanitize image URLs - allow http(s) and safe raster data URIs.
+ * Blocks SVG data URIs which can contain executable script.
+ */
+export function sanitizeImageUrl(url: string): string {
+  if (!url || typeof url !== 'string') return ''
+
+  // Allow data URIs only for safe raster image formats
+  if (url.startsWith('data:image/')) {
+    // Block SVG data URIs (can contain <script> tags)
+    if (url.startsWith('data:image/svg')) {
+      return ''
+    }
+    // Only allow known-safe raster formats
+    if (/^data:image\/(png|jpeg|jpg|gif|webp|avif|bmp);/.test(url)) {
+      return url
+    }
+    return ''
+  }
+
+  try {
+    const parsed = new URL(url, 'https://example.com')
+
+    // Only allow http(s) for image sources
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      return ''
+    }
+
+    return url.startsWith('/') ? url : parsed.href
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * Coerce a value to a positive integer within a range, or return a default.
+ */
+export function safePositiveInt(value: unknown, defaultVal: number, max = 4096): number {
+  const num = Number(value)
+  if (Number.isFinite(num) && num > 0 && num <= max) {
+    return Math.round(num)
+  }
+  return defaultVal
+}
+
+/**
+ * Extract YouTube video ID from various URL formats.
+ * Returns null if no valid ID found. Only allows safe characters.
+ */
+export function extractYoutubeId(url: string): string | null {
+  if (!url || typeof url !== 'string') return null
+
+  const patterns = [
+    /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&\n?#]+)/,
+    /youtube\.com\/v\/([^&\n?#]+)/,
+    /youtube\.com\/shorts\/([^&\n?#]+)/,
+  ]
+  for (const pattern of patterns) {
+    const match = url.match(pattern)
+    // Only allow alphanumeric, hyphens, and underscores (actual YouTube ID charset)
+    if (match && /^[\w-]+$/.test(match[1])) return match[1]
+  }
+  return null
+}

--- a/bun.lock
+++ b/bun.lock
@@ -104,6 +104,7 @@
         "date-fns": "^4.1.0",
         "drizzle-orm": "^0.45.1",
         "framer-motion": "^12.29.2",
+        "isomorphic-dompurify": "^2.35.0",
         "jose": "^6.1.3",
         "lowlight": "^3.3.0",
         "lucide-react": "^0.563.0",
@@ -130,6 +131,7 @@
         "@tailwindcss/vite": "^4.1.18",
         "@types/bcryptjs": "^3.0.0",
         "@types/bun": "^1.3.6",
+        "@types/dompurify": "^3.2.0",
         "@types/node": "^25.0.10",
         "@types/papaparse": "^5.5.2",
         "@types/react": "^19.2.10",
@@ -210,6 +212,14 @@
     "@noble/ciphers": "2.0.0",
   },
   "packages": {
+    "@acemir/cssom": ["@acemir/cssom@0.9.31", "", {}, "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA=="],
+
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@4.1.2", "", { "dependencies": { "@csstools/css-calc": "^3.0.0", "@csstools/css-color-parser": "^4.0.1", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0", "lru-cache": "^11.2.5" } }, "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg=="],
+
+    "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@6.7.8", "", { "dependencies": { "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.1.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.2.5" } }, "sha512-stisC1nULNc9oH5lakAj8MH88ZxeGxzyWNDfbdCxvJSJIvDsHNZqYvscGTgy/ysgXWLJPt6K/4t0/GjvtKcFJQ=="],
+
+    "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
+
     "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],
 
     "@aws-crypto/crc32c": ["@aws-crypto/crc32c@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag=="],
@@ -388,6 +398,18 @@
 
     "@codemirror/view": ["@codemirror/view@6.39.12", "", { "dependencies": { "@codemirror/state": "^6.5.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-f+/VsHVn/kOA9lltk/GFzuYwVVAKmOnNjxbrhkk3tPHntFqjWeI2TbIXx006YkBkqC10wZ4NsnWXCQiFPeAISQ=="],
 
+    "@csstools/color-helpers": ["@csstools/color-helpers@6.0.1", "", {}, "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ=="],
+
+    "@csstools/css-calc": ["@csstools/css-calc@3.0.0", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-q4d82GTl8BIlh/dTnVsWmxnbWJeb3kiU8eUH71UxlxnS+WIaALmtzTL8gR15PkYOexMQYVk0CO4qIG93C1IvPA=="],
+
+    "@csstools/css-color-parser": ["@csstools/css-color-parser@4.0.1", "", { "dependencies": { "@csstools/color-helpers": "^6.0.1", "@csstools/css-calc": "^3.0.0" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw=="],
+
+    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@4.0.0", "", { "peerDependencies": { "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w=="],
+
+    "@csstools/css-syntax-patches-for-csstree": ["@csstools/css-syntax-patches-for-csstree@1.0.26", "", {}, "sha512-6boXK0KkzT5u5xOgF6TKB+CLq9SOpEGmkZw0g5n9/7yg85wab3UzSxB8TxhLJ31L4SGJ6BCFRw/iftTha1CJXA=="],
+
+    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
+
     "@date-fns/tz": ["@date-fns/tz@1.4.1", "", {}, "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA=="],
 
     "@deno/shim-deno": ["@deno/shim-deno@0.19.2", "", { "dependencies": { "@deno/shim-deno-test": "^0.5.0", "which": "^4.0.0" } }, "sha512-q3VTHl44ad8T2Tw2SpeAvghdGOjlnLPDNO2cpOxwMrBE/PVas6geWpbpIgrM+czOCH0yejp0yi8OaTuB+NU40Q=="],
@@ -483,6 +505,8 @@
     "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+
+    "@exodus/bytes": ["@exodus/bytes@1.11.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-wO3vd8nsEHdumsXrjGO/v4p6irbg7hy9kvIeR6i2AwylZSk4HJdWgL0FNaVquW1+AweJcdvU1IEpuIWk/WaPnA=="],
 
     "@faker-js/faker": ["@faker-js/faker@10.2.0", "", {}, "sha512-rTXwAsIxpCqzUnZvrxVh3L0QA0NzToqWBLAhV+zDV3MIIwiQhAZHMdPCIaj5n/yADu/tyk12wIPgL6YHGXJP+g=="],
 
@@ -1304,6 +1328,8 @@
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
+    "@types/dompurify": ["@types/dompurify@3.2.0", "", { "dependencies": { "dompurify": "*" } }, "sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
@@ -1333,6 +1359,8 @@
     "@types/resolve": ["@types/resolve@1.20.2", "", {}, "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q=="],
 
     "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
+
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -1470,6 +1498,8 @@
 
     "better-call": ["better-call@1.1.8", "", { "dependencies": { "@better-auth/utils": "^0.3.0", "@better-fetch/fetch": "^1.1.4", "rou3": "^0.7.10", "set-cookie-parser": "^2.7.1" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-XMQ2rs6FNXasGNfMjzbyroSwKwYbZ/T3IxruSS6U2MJRsSYh3wYtG3o6H00ZlKZ/C/UPOAD97tqgQJNsxyeTXw=="],
 
+    "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
+
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
     "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
@@ -1600,11 +1630,17 @@
 
     "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
 
+    "css-tree": ["css-tree@3.1.0", "", { "dependencies": { "mdn-data": "2.12.2", "source-map-js": "^1.0.1" } }, "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w=="],
+
     "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
 
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
+    "cssstyle": ["cssstyle@5.3.7", "", { "dependencies": { "@asamuzakjp/css-color": "^4.1.1", "@csstools/css-syntax-patches-for-csstree": "^1.0.21", "css-tree": "^3.1.0", "lru-cache": "^11.2.4" } }, "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ=="],
+
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "data-urls": ["data-urls@6.0.1", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^15.1.0" } }, "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ=="],
 
     "data-view-buffer": ["data-view-buffer@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ=="],
 
@@ -1621,6 +1657,8 @@
     "db0": ["db0@0.3.4", "", { "peerDependencies": { "@electric-sql/pglite": "*", "@libsql/client": "*", "better-sqlite3": "*", "drizzle-orm": "*", "mysql2": "*", "sqlite3": "*" }, "optionalPeers": ["@electric-sql/pglite", "@libsql/client", "better-sqlite3", "drizzle-orm", "mysql2", "sqlite3"] }, "sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
@@ -1662,6 +1700,8 @@
 
     "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
 
+    "dompurify": ["dompurify@3.3.1", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q=="],
+
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
     "dot-prop": ["dot-prop@10.1.0", "", { "dependencies": { "type-fest": "^5.0.0" } }, "sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q=="],
@@ -1694,7 +1734,7 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.18.4", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q=="],
 
-    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 
@@ -1908,6 +1948,8 @@
 
     "hsl-matcher": ["hsl-matcher@1.2.4", "", {}, "sha512-tS7XnJS33Egirm+6cI+Z/kH/aVZt94uxGlJxOZlGql2/yqbAzPg3zHHnTnVN4cVpoJnEYEGq+LE3iXbuUIe8BA=="],
 
+    "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
+
     "html-to-text": ["html-to-text@9.0.5", "", { "dependencies": { "@selderee/plugin-htmlparser2": "^0.11.0", "deepmerge": "^4.3.1", "dom-serializer": "^2.0.0", "htmlparser2": "^8.0.2", "selderee": "^0.11.0" } }, "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg=="],
 
     "htmlparser2": ["htmlparser2@8.0.2", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1", "entities": "^4.4.0" } }, "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA=="],
@@ -1915,6 +1957,8 @@
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "http-proxy": ["http-proxy@1.18.1", "", { "dependencies": { "eventemitter3": "^4.0.0", "follow-redirects": "^1.0.0", "requires-port": "^1.0.0" } }, "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
     "http-shutdown": ["http-shutdown@1.2.2", "", {}, "sha512-S9wWkJ/VSY9/k4qcjG318bqJNruzE4HySUhFYknwmu6LBP97KLLfwNf+n4V1BHurvFNkSKLFnK/RsuUnRTf9Vw=="],
 
@@ -1996,6 +2040,8 @@
 
     "is-path-inside": ["is-path-inside@4.0.0", "", {}, "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA=="],
 
+    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "is-reference": ["is-reference@1.2.1", "", { "dependencies": { "@types/estree": "*" } }, "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ=="],
@@ -2030,6 +2076,8 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "isomorphic-dompurify": ["isomorphic-dompurify@2.35.0", "", { "dependencies": { "dompurify": "^3.3.1", "jsdom": "^27.4.0" } }, "sha512-a9+LQqylQCU8f1zmsYmg2tfrbdY2YS/Hc+xntcq/mDI2MY3Q108nq8K23BWDIg6YGC5JsUMC15fj2ZMqCzt/+A=="],
+
     "iterator.prototype": ["iterator.prototype@1.1.5", "", { "dependencies": { "define-data-property": "^1.1.4", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "get-proto": "^1.0.0", "has-symbols": "^1.1.0", "set-function-name": "^2.0.2" } }, "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g=="],
 
     "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
@@ -2041,6 +2089,8 @@
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "jsdom": ["jsdom@27.4.0", "", { "dependencies": { "@acemir/cssom": "^0.9.28", "@asamuzakjp/dom-selector": "^6.7.6", "@exodus/bytes": "^1.6.0", "cssstyle": "^5.3.4", "data-urls": "^6.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.6", "is-potential-custom-element-name": "^1.0.1", "parse5": "^8.0.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.0", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^15.1.0", "ws": "^8.18.3", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
@@ -2137,6 +2187,8 @@
     "marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mdn-data": ["mdn-data@2.12.2", "", {}, "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA=="],
 
     "mdurl": ["mdurl@2.0.0", "", {}, "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="],
 
@@ -2280,7 +2332,7 @@
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
-    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+    "parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
 
     "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@7.1.0", "", { "dependencies": { "domhandler": "^5.0.3", "parse5": "^7.0.0" } }, "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g=="],
 
@@ -2500,6 +2552,8 @@
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
+    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
+
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "scule": ["scule@1.3.0", "", {}, "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g=="],
@@ -2614,6 +2668,8 @@
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
+    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
+
     "system-architecture": ["system-architecture@0.1.0", "", {}, "sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA=="],
 
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
@@ -2646,11 +2702,17 @@
 
     "tiptap-extension-resizable-image": ["tiptap-extension-resizable-image@2.1.0", "", { "peerDependencies": { "@tiptap/core": ">=2", "@tiptap/pm": ">=2", "@tiptap/react": ">=2", "react": ">=18" } }, "sha512-uvdY/mTHMZ3EF3Z+b61y1htOUg8oF4TiepNFF1pYRg/KITYoYSteF5/L2/qtlZF9SMrzzwnrtRFQFzn/qBj7qQ=="],
 
+    "tldts": ["tldts@7.0.22", "", { "dependencies": { "tldts-core": "^7.0.22" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-nqpKFC53CgopKPjT6Wfb6tpIcZXHcI6G37hesvikhx0EmUGPkZrujRyAjgnmp1SHNgpQfKVanZ+KfpANFt2Hxw=="],
+
+    "tldts-core": ["tldts-core@7.0.22", "", {}, "sha512-KgbTDC5wzlL6j/x6np6wCnDSMUq4kucHNm00KXPbfNzmllCmtmvtykJHfmgdHntwIeupW04y8s1N/43S1PkQDw=="],
+
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
-    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+    "tough-cookie": ["tough-cookie@6.0.0", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w=="],
+
+    "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
     "ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
 
@@ -2748,7 +2810,9 @@
 
     "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
 
-    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
+    "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
 
     "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
 
@@ -2756,7 +2820,7 @@
 
     "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
 
-    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
+    "whatwg-url": ["whatwg-url@15.1.0", "", { "dependencies": { "tr46": "^6.0.0", "webidl-conversions": "^8.0.0" } }, "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -2782,7 +2846,11 @@
 
     "ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
+    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
     "xmlbuilder2": ["xmlbuilder2@4.0.3", "", { "dependencies": { "@oozcitak/dom": "^2.0.2", "@oozcitak/infra": "^2.0.2", "@oozcitak/util": "^10.0.0", "js-yaml": "^4.1.1" } }, "sha512-bx8Q1STctnNaaDymWnkfQLKofs0mGNN7rLLapJlGuV3VlvegD7Ls4ggMjE3aUSWItCCzU0PEv45lI87iSigiCA=="],
+
+    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
@@ -2813,6 +2881,10 @@
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
 
     "zustand": ["zustand@5.0.10", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-U1AiltS1O9hSy3rul+Ub82ut2fqIAefiSuwECWt6jlMVUGejvf+5omLcRBSzqbRagSM3hQZbtzdeRc6QVScXTg=="],
+
+    "@asamuzakjp/css-color/lru-cache": ["lru-cache@11.2.5", "", {}, "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw=="],
+
+    "@asamuzakjp/dom-selector/lru-cache": ["lru-cache@11.2.5", "", {}, "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw=="],
 
     "@aws-crypto/sha1-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
@@ -2954,6 +3026,8 @@
 
     "cheerio/htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
 
+    "cheerio/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
@@ -2962,7 +3036,13 @@
 
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
+    "cssstyle/lru-cache": ["lru-cache@11.2.5", "", {}, "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw=="],
+
+    "data-urls/whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
+
     "dax-sh/undici-types": ["undici-types@5.28.4", "", {}, "sha512-3OeMF5Lyowe8VW0skf5qaIE7Or3yS9LS7fvMUI0gg4YxpIBVg0L8BxCmROw2CcYhSkpR68Epz7CGc8MPj94Uww=="],
+
+    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "dot-prop/type-fest": ["type-fest@5.4.2", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-FLEenlVYf7Zcd34ISMLo3ZzRE1gRjY1nMDTp+bQRBiPsaKyIW8K3Zr99ioHDUgA9OGuGGJPyYpNcffGmBhJfGg=="],
 
@@ -2984,9 +3064,13 @@
 
     "globby/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
+    "htmlparser2/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
     "http-proxy/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
     "is-inside-container/is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+
+    "jsdom/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
     "lazystream/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
@@ -2997,6 +3081,8 @@
     "listhen/h3": ["h3@1.15.5", "", { "dependencies": { "cookie-es": "^1.2.2", "crossws": "^0.3.5", "defu": "^6.1.4", "destr": "^2.0.5", "iron-webcrypto": "^1.2.1", "node-mock-http": "^1.0.4", "radix3": "^1.1.2", "ufo": "^1.6.3", "uncrypto": "^0.1.3" } }, "sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg=="],
 
     "listhen/pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
+
+    "markdown-it/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
@@ -3020,6 +3106,8 @@
 
     "nitropack/unstorage": ["unstorage@1.17.4", "", { "dependencies": { "anymatch": "^3.1.3", "chokidar": "^5.0.0", "destr": "^2.0.5", "h3": "^1.15.5", "lru-cache": "^11.2.0", "node-fetch-native": "^1.6.7", "ofetch": "^1.5.1", "ufo": "^1.6.3" }, "peerDependencies": { "@azure/app-configuration": "^1.8.0", "@azure/cosmos": "^4.2.0", "@azure/data-tables": "^13.3.0", "@azure/identity": "^4.6.0", "@azure/keyvault-secrets": "^4.9.0", "@azure/storage-blob": "^12.26.0", "@capacitor/preferences": "^6 || ^7 || ^8", "@deno/kv": ">=0.9.0", "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0", "@planetscale/database": "^1.19.0", "@upstash/redis": "^1.34.3", "@vercel/blob": ">=0.27.1", "@vercel/functions": "^2.2.12 || ^3.0.0", "@vercel/kv": "^1 || ^2 || ^3", "aws4fetch": "^1.0.20", "db0": ">=0.2.1", "idb-keyval": "^6.2.1", "ioredis": "^5.4.2", "uploadthing": "^7.4.4" }, "optionalPeers": ["@azure/app-configuration", "@azure/cosmos", "@azure/data-tables", "@azure/identity", "@azure/keyvault-secrets", "@azure/storage-blob", "@capacitor/preferences", "@deno/kv", "@netlify/blobs", "@planetscale/database", "@upstash/redis", "@vercel/blob", "@vercel/functions", "@vercel/kv", "aws4fetch", "db0", "idb-keyval", "ioredis", "uploadthing"] }, "sha512-fHK0yNg38tBiJKp/Vgsq4j0JEsCmgqH58HAn707S7zGkArbZsVr/CwINoi+nh3h98BRCwKvx1K3Xg9u3VV83sw=="],
 
+    "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
+
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
     "nypm/citty": ["citty@0.2.0", "", {}, "sha512-8csy5IBFI2ex2hTVpaHN2j+LNE199AgiI7y4dMintrr8i0lQiFn+0AWMZrWdHKIgMOer65f8IThysYhoReqjWA=="],
@@ -3028,7 +3116,9 @@
 
     "p-queue/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
-    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+    "parse5-htmlparser2-tree-adapter/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "parse5-parser-stream/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "path-scurry/lru-cache": ["lru-cache@11.2.5", "", {}, "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw=="],
 
@@ -3303,6 +3393,10 @@
     "nitropack/h3/cookie-es": ["cookie-es@1.2.2", "", {}, "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg=="],
 
     "nitropack/unstorage/lru-cache": ["lru-cache@11.2.5", "", {}, "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw=="],
+
+    "node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
+    "node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
     "readdir-glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 


### PR DESCRIPTION
## Summary

- Add two-layer defense against stored XSS through TipTap rich text content
- **Layer 1**: JSON sanitizer (`sanitize-tiptap.ts`) runs at mutation time on all 6 server function entry points — validates node/mark types against allowlists, coerces attributes (heading levels, code block languages, image/YouTube URLs and dimensions), strips unknowns, max depth 20
- **Layer 2**: DOMPurify wraps `generateContentHTML()` at render time as defense-in-depth for legacy DB content
- Tighten Zod schemas with recursive TipTap node validation, extract shared sanitize utils

## Test plan

- [x] `bun run typecheck` — 0 errors
- [x] `bun run test` — 326 tests pass (25 new sanitizer tests)
- [x] `bun run lint` — 0 errors, 0 warnings
- [x] Manual: create post with rich content (headings, code blocks, images, YouTube, links, tables) — verify renders correctly
- [x] Manual: craft malicious `contentJson` via devtools — verify XSS payloads are sanitized