### PR TITLE
fix(api): add role-based auth and consolidate auth middleware

### DIFF
--- a/apps/web/src/lib/server/mcp/handler.ts
+++ b/apps/web/src/lib/server/mcp/handler.ts
@@ -6,14 +6,14 @@
  */
 
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
-import { withApiKeyAuthTeam } from '@/lib/server/domains/api/auth'
+import { withApiKeyAuth } from '@/lib/server/domains/api/auth'
 import { db, member, eq } from '@/lib/server/db'
 import { createMcpServer } from './server'
 import type { McpAuthContext } from './types'
 
 /** Resolve auth context from API key → member → user */
 export async function resolveAuthContext(request: Request): Promise<McpAuthContext | Response> {
-  const authResult = await withApiKeyAuthTeam(request)
+  const authResult = await withApiKeyAuth(request, { role: 'team' })
   if (authResult instanceof Response) return authResult
 
   const memberRecord = await db.query.member.findFirst({

--- a/apps/web/src/routes/api/v1/boards/$boardId.ts
+++ b/apps/web/src/routes/api/v1/boards/$boardId.ts
@@ -27,7 +27,7 @@ export const Route = createFileRoute('/api/v1/boards/$boardId')({
        */
       GET: async ({ request, params }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {
@@ -63,7 +63,7 @@ export const Route = createFileRoute('/api/v1/boards/$boardId')({
        */
       PATCH: async ({ request, params }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {
@@ -114,7 +114,7 @@ export const Route = createFileRoute('/api/v1/boards/$boardId')({
        */
       DELETE: async ({ request, params }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {

--- a/apps/web/src/routes/api/v1/boards/index.ts
+++ b/apps/web/src/routes/api/v1/boards/index.ts
@@ -30,7 +30,7 @@ export const Route = createFileRoute('/api/v1/boards/')({
        */
       GET: async ({ request }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {
@@ -63,7 +63,7 @@ export const Route = createFileRoute('/api/v1/boards/')({
        */
       POST: async ({ request }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {

--- a/apps/web/src/routes/api/v1/changelog/$entryId.ts
+++ b/apps/web/src/routes/api/v1/changelog/$entryId.ts
@@ -26,7 +26,7 @@ export const Route = createFileRoute('/api/v1/changelog/$entryId')({
        */
       GET: async ({ request, params }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {
@@ -69,8 +69,8 @@ export const Route = createFileRoute('/api/v1/changelog/$entryId')({
        * Update a changelog entry
        */
       PATCH: async ({ request, params }) => {
-        // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        // Authenticate (admin only)
+        const authResult = await withApiKeyAuth(request, { role: 'admin' })
         if (authResult instanceof Response) return authResult
 
         try {
@@ -138,8 +138,8 @@ export const Route = createFileRoute('/api/v1/changelog/$entryId')({
        * Delete a changelog entry
        */
       DELETE: async ({ request, params }) => {
-        // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        // Authenticate (admin only)
+        const authResult = await withApiKeyAuth(request, { role: 'admin' })
         if (authResult instanceof Response) return authResult
 
         try {

--- a/apps/web/src/routes/api/v1/changelog/index.ts
+++ b/apps/web/src/routes/api/v1/changelog/index.ts
@@ -26,7 +26,7 @@ export const Route = createFileRoute('/api/v1/changelog/')({
        */
       GET: async ({ request }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {
@@ -93,8 +93,8 @@ export const Route = createFileRoute('/api/v1/changelog/')({
        * Create a new changelog entry
        */
       POST: async ({ request }) => {
-        // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        // Authenticate (admin only)
+        const authResult = await withApiKeyAuth(request, { role: 'admin' })
         if (authResult instanceof Response) return authResult
 
         try {

--- a/apps/web/src/routes/api/v1/comments/$commentId.ts
+++ b/apps/web/src/routes/api/v1/comments/$commentId.ts
@@ -24,7 +24,7 @@ export const Route = createFileRoute('/api/v1/comments/$commentId')({
        */
       GET: async ({ request, params }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {
@@ -62,7 +62,7 @@ export const Route = createFileRoute('/api/v1/comments/$commentId')({
        */
       PATCH: async ({ request, params }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
         const { memberId } = authResult
 
@@ -126,7 +126,7 @@ export const Route = createFileRoute('/api/v1/comments/$commentId')({
        */
       DELETE: async ({ request, params }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
         const { memberId } = authResult
 

--- a/apps/web/src/routes/api/v1/members/$memberId.ts
+++ b/apps/web/src/routes/api/v1/members/$memberId.ts
@@ -25,7 +25,7 @@ export const Route = createFileRoute('/api/v1/members/$memberId')({
        */
       GET: async ({ request, params }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {
@@ -78,8 +78,8 @@ export const Route = createFileRoute('/api/v1/members/$memberId')({
        * Update a team member's role
        */
       PATCH: async ({ request, params }) => {
-        // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        // Authenticate (admin only)
+        const authResult = await withApiKeyAuth(request, { role: 'admin' })
         if (authResult instanceof Response) return authResult
         const { memberId: actingMemberId } = authResult
 
@@ -142,8 +142,8 @@ export const Route = createFileRoute('/api/v1/members/$memberId')({
        * Remove a team member (converts them to a portal user)
        */
       DELETE: async ({ request, params }) => {
-        // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        // Authenticate (admin only)
+        const authResult = await withApiKeyAuth(request, { role: 'admin' })
         if (authResult instanceof Response) return authResult
         const { memberId: actingMemberId } = authResult
 

--- a/apps/web/src/routes/api/v1/members/index.ts
+++ b/apps/web/src/routes/api/v1/members/index.ts
@@ -11,7 +11,7 @@ export const Route = createFileRoute('/api/v1/members/')({
        */
       GET: async ({ request }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {

--- a/apps/web/src/routes/api/v1/posts/$postId.comments.ts
+++ b/apps/web/src/routes/api/v1/posts/$postId.comments.ts
@@ -25,7 +25,7 @@ export const Route = createFileRoute('/api/v1/posts/$postId/comments')({
        */
       GET: async ({ request, params }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {
@@ -66,7 +66,7 @@ export const Route = createFileRoute('/api/v1/posts/$postId/comments')({
        */
       POST: async ({ request, params }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
         const { memberId } = authResult
 

--- a/apps/web/src/routes/api/v1/posts/$postId.ts
+++ b/apps/web/src/routes/api/v1/posts/$postId.ts
@@ -33,7 +33,7 @@ export const Route = createFileRoute('/api/v1/posts/$postId')({
        */
       GET: async ({ request, params }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {
@@ -90,7 +90,7 @@ export const Route = createFileRoute('/api/v1/posts/$postId')({
        */
       PATCH: async ({ request, params }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
         const { memberId } = authResult
 
@@ -169,7 +169,7 @@ export const Route = createFileRoute('/api/v1/posts/$postId')({
        */
       DELETE: async ({ request, params }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
         const { memberId } = authResult
 

--- a/apps/web/src/routes/api/v1/posts/$postId.vote.ts
+++ b/apps/web/src/routes/api/v1/posts/$postId.vote.ts
@@ -13,7 +13,7 @@ export const Route = createFileRoute('/api/v1/posts/$postId/vote')({
        */
       POST: async ({ request, params }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
         const { memberId } = authResult
 

--- a/apps/web/src/routes/api/v1/posts/index.ts
+++ b/apps/web/src/routes/api/v1/posts/index.ts
@@ -34,7 +34,7 @@ export const Route = createFileRoute('/api/v1/posts/')({
        */
       GET: async ({ request }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {
@@ -122,7 +122,7 @@ export const Route = createFileRoute('/api/v1/posts/')({
        */
       POST: async ({ request }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
         const { memberId } = authResult
 

--- a/apps/web/src/routes/api/v1/roadmaps/$roadmapId.posts.$postId.ts
+++ b/apps/web/src/routes/api/v1/roadmaps/$roadmapId.posts.$postId.ts
@@ -13,7 +13,7 @@ export const Route = createFileRoute('/api/v1/roadmaps/$roadmapId/posts/$postId'
        */
       DELETE: async ({ request, params }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {

--- a/apps/web/src/routes/api/v1/roadmaps/$roadmapId.posts.ts
+++ b/apps/web/src/routes/api/v1/roadmaps/$roadmapId.posts.ts
@@ -24,7 +24,7 @@ export const Route = createFileRoute('/api/v1/roadmaps/$roadmapId/posts')({
        */
       GET: async ({ request, params }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {
@@ -76,7 +76,7 @@ export const Route = createFileRoute('/api/v1/roadmaps/$roadmapId/posts')({
        */
       POST: async ({ request, params }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {

--- a/apps/web/src/routes/api/v1/roadmaps/$roadmapId.ts
+++ b/apps/web/src/routes/api/v1/roadmaps/$roadmapId.ts
@@ -26,7 +26,7 @@ export const Route = createFileRoute('/api/v1/roadmaps/$roadmapId')({
        */
       GET: async ({ request, params }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {
@@ -61,7 +61,7 @@ export const Route = createFileRoute('/api/v1/roadmaps/$roadmapId')({
        */
       PATCH: async ({ request, params }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {
@@ -110,7 +110,7 @@ export const Route = createFileRoute('/api/v1/roadmaps/$roadmapId')({
        */
       DELETE: async ({ request, params }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {

--- a/apps/web/src/routes/api/v1/roadmaps/index.ts
+++ b/apps/web/src/routes/api/v1/roadmaps/index.ts
@@ -29,7 +29,7 @@ export const Route = createFileRoute('/api/v1/roadmaps/')({
        */
       GET: async ({ request }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {
@@ -60,7 +60,7 @@ export const Route = createFileRoute('/api/v1/roadmaps/')({
        */
       POST: async ({ request }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {

--- a/apps/web/src/routes/api/v1/statuses/$statusId.ts
+++ b/apps/web/src/routes/api/v1/statuses/$statusId.ts
@@ -30,7 +30,7 @@ export const Route = createFileRoute('/api/v1/statuses/$statusId')({
        */
       GET: async ({ request, params }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {
@@ -67,7 +67,7 @@ export const Route = createFileRoute('/api/v1/statuses/$statusId')({
        */
       PATCH: async ({ request, params }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {
@@ -119,7 +119,7 @@ export const Route = createFileRoute('/api/v1/statuses/$statusId')({
        */
       DELETE: async ({ request, params }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {

--- a/apps/web/src/routes/api/v1/statuses/index.ts
+++ b/apps/web/src/routes/api/v1/statuses/index.ts
@@ -32,7 +32,7 @@ export const Route = createFileRoute('/api/v1/statuses/')({
        */
       GET: async ({ request }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {
@@ -65,7 +65,7 @@ export const Route = createFileRoute('/api/v1/statuses/')({
        */
       POST: async ({ request }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {

--- a/apps/web/src/routes/api/v1/tags/$tagId.ts
+++ b/apps/web/src/routes/api/v1/tags/$tagId.ts
@@ -28,7 +28,7 @@ export const Route = createFileRoute('/api/v1/tags/$tagId')({
        */
       GET: async ({ request, params }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {
@@ -60,7 +60,7 @@ export const Route = createFileRoute('/api/v1/tags/$tagId')({
        */
       PATCH: async ({ request, params }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {
@@ -105,7 +105,7 @@ export const Route = createFileRoute('/api/v1/tags/$tagId')({
        */
       DELETE: async ({ request, params }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {

--- a/apps/web/src/routes/api/v1/tags/index.ts
+++ b/apps/web/src/routes/api/v1/tags/index.ts
@@ -27,7 +27,7 @@ export const Route = createFileRoute('/api/v1/tags/')({
        */
       GET: async ({ request }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {
@@ -55,7 +55,7 @@ export const Route = createFileRoute('/api/v1/tags/')({
        */
       POST: async ({ request }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {

--- a/apps/web/src/routes/api/v1/users/$memberId.ts
+++ b/apps/web/src/routes/api/v1/users/$memberId.ts
@@ -18,7 +18,7 @@ export const Route = createFileRoute('/api/v1/users/$memberId')({
        */
       GET: async ({ request, params }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {
@@ -76,8 +76,8 @@ export const Route = createFileRoute('/api/v1/users/$memberId')({
        * Remove a portal user
        */
       DELETE: async ({ request, params }) => {
-        // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        // Authenticate (admin only)
+        const authResult = await withApiKeyAuth(request, { role: 'admin' })
         if (authResult instanceof Response) return authResult
 
         try {

--- a/apps/web/src/routes/api/v1/users/index.ts
+++ b/apps/web/src/routes/api/v1/users/index.ts
@@ -16,7 +16,7 @@ export const Route = createFileRoute('/api/v1/users/')({
        */
       GET: async ({ request }) => {
         // Authenticate
-        const authResult = await withApiKeyAuth(request)
+        const authResult = await withApiKeyAuth(request, { role: 'team' })
         if (authResult instanceof Response) return authResult
 
         try {

--- a/apps/web/src/routes/api/v1/webhooks/$webhookId.rotate.ts
+++ b/apps/web/src/routes/api/v1/webhooks/$webhookId.rotate.ts
@@ -1,5 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { withApiKeyAuthAdmin } from '@/lib/server/domains/api/auth'
+import { withApiKeyAuth } from '@/lib/server/domains/api/auth'
 import { successResponse, handleDomainError } from '@/lib/server/domains/api/responses'
 import { validateTypeId } from '@/lib/server/domains/api/validation'
 import type { WebhookId } from '@quackback/ids'
@@ -13,7 +13,7 @@ export const Route = createFileRoute('/api/v1/webhooks/$webhookId/rotate')({
        */
       POST: async ({ request, params }) => {
         // Authenticate (admin only)
-        const authResult = await withApiKeyAuthAdmin(request)
+        const authResult = await withApiKeyAuth(request, { role: 'admin' })
         if (authResult instanceof Response) return authResult
 
         try {

--- a/apps/web/src/routes/api/v1/webhooks/$webhookId.ts
+++ b/apps/web/src/routes/api/v1/webhooks/$webhookId.ts
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { z } from 'zod'
-import { withApiKeyAuthAdmin } from '@/lib/server/domains/api/auth'
+import { withApiKeyAuth } from '@/lib/server/domains/api/auth'
 import {
   successResponse,
   noContentResponse,
@@ -29,7 +29,7 @@ export const Route = createFileRoute('/api/v1/webhooks/$webhookId')({
        */
       GET: async ({ request, params }) => {
         // Authenticate
-        const authResult = await withApiKeyAuthAdmin(request)
+        const authResult = await withApiKeyAuth(request, { role: 'admin' })
         if (authResult instanceof Response) return authResult
 
         try {
@@ -54,7 +54,7 @@ export const Route = createFileRoute('/api/v1/webhooks/$webhookId')({
        */
       PATCH: async ({ request, params }) => {
         // Authenticate
-        const authResult = await withApiKeyAuthAdmin(request)
+        const authResult = await withApiKeyAuth(request, { role: 'admin' })
         if (authResult instanceof Response) return authResult
 
         try {
@@ -104,7 +104,7 @@ export const Route = createFileRoute('/api/v1/webhooks/$webhookId')({
        */
       DELETE: async ({ request, params }) => {
         // Authenticate
-        const authResult = await withApiKeyAuthAdmin(request)
+        const authResult = await withApiKeyAuth(request, { role: 'admin' })
         if (authResult instanceof Response) return authResult
 
         try {

--- a/apps/web/src/routes/api/v1/webhooks/index.ts
+++ b/apps/web/src/routes/api/v1/webhooks/index.ts
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { z } from 'zod'
-import { withApiKeyAuthAdmin } from '@/lib/server/domains/api/auth'
+import { withApiKeyAuth } from '@/lib/server/domains/api/auth'
 import {
   successResponse,
   createdResponse,
@@ -27,7 +27,7 @@ export const Route = createFileRoute('/api/v1/webhooks/')({
        */
       GET: async ({ request }) => {
         // Authenticate
-        const authResult = await withApiKeyAuthAdmin(request)
+        const authResult = await withApiKeyAuth(request, { role: 'admin' })
         if (authResult instanceof Response) return authResult
 
         try {
@@ -46,7 +46,7 @@ export const Route = createFileRoute('/api/v1/webhooks/')({
        */
       POST: async ({ request }) => {
         // Authenticate
-        const authResult = await withApiKeyAuthAdmin(request)
+        const authResult = await withApiKeyAuth(request, { role: 'admin' })
         if (authResult instanceof Response) return authResult
         const { memberId } = authResult
 


### PR DESCRIPTION
## Summary
- Consolidate `withApiKeyAuth`, `withApiKeyAuthTeam`, `withApiKeyAuthAdmin` into a single `withApiKeyAuth(request, { role: 'team' | 'admin' })` function
- All 21 REST API endpoints + MCP handler now enforce proper role-based access (team for reads, admin for sensitive mutations)
- Add 3 new auth tests covering 403 responses for insufficient roles

## Test plan
- [x] `bun run typecheck` passes
- [x] All 329 tests pass
- [x] Lint clean
- [x] No stale references to old function names