### PR TITLE
chore: security hardening and cleanup

### DIFF
--- a/apps/web/src/lib/server/domains/posts/post.service.ts
+++ b/apps/web/src/lib/server/domains/posts/post.service.ts
@@ -189,10 +189,9 @@ export async function updatePost(
       updateData.officialResponsePrincipalId = null
       updateData.officialResponseAt = null
     } else {
-      // Set or update official response with member-scoped identity
-      const responsePrincipalId = input.officialResponsePrincipalId || responder?.principalId
+      // Set or update official response — always use the authenticated responder
       updateData.officialResponse = input.officialResponse
-      updateData.officialResponsePrincipalId = responsePrincipalId
+      updateData.officialResponsePrincipalId = responder?.principalId ?? null
       updateData.officialResponseAt = new Date()
     }
   }

--- a/apps/web/src/lib/server/domains/posts/post.types.ts
+++ b/apps/web/src/lib/server/domains/posts/post.types.ts
@@ -29,7 +29,6 @@ export interface UpdatePostInput {
   tagIds?: TagId[]
   ownerPrincipalId?: PrincipalId | null
   officialResponse?: string | null
-  officialResponsePrincipalId?: PrincipalId | null
 }
 
 /**


### PR DESCRIPTION
## Summary
- **API keys**: timing-safe hash comparison to prevent timing oracle attacks, extract `toApiKey` helper
- **Rate limiter**: cap store size (50K) to prevent memory exhaustion from spoofed IPs
- **API responses**: add security headers (`X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Cache-Control: no-store, private`)
- **Posts**: always attribute official response to the authenticated responder (removes unused `officialResponsePrincipalId` input field)
- **Admin**: remove debug logging from invitation magic link flow, use `URL` constructor

## Test plan
- [x] Existing test suite passes (373 tests)
- [x] API responses include security headers
- [x] API key verification still works
- [x] Official response attribution works correctly