### PR TITLE
refactor: replace toggleReaction with explicit add/remove

### DIFF
--- a/apps/web/src/components/public/comment-thread.tsx
+++ b/apps/web/src/components/public/comment-thread.tsx
@@ -21,7 +21,7 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { TimeAgo } from '@/components/ui/time-ago'
 import { REACTION_EMOJIS } from '@/lib/shared/db-types'
-import { toggleReactionFn } from '@/lib/server/functions/comments'
+import { addReactionFn, removeReactionFn } from '@/lib/server/functions/comments'
 import type { CommentReactionCount } from '@/lib/shared'
 import type { PublicCommentView } from '@/lib/client/queries/portal-detail'
 import { cn, getInitials } from '@/lib/shared/utils'
@@ -206,12 +206,14 @@ function CommentItem({
     setShowEmojiPicker(false)
     setIsPending(true)
     try {
-      const result = await toggleReactionFn({
+      const hasReacted = reactions.some((r) => r.emoji === emoji && r.hasReacted)
+      const fn = hasReacted ? removeReactionFn : addReactionFn
+      const result = await fn({
         data: { commentId: comment.id, emoji },
       })
       setReactions(result.reactions)
     } catch (error) {
-      console.error('Failed to toggle reaction:', error)
+      console.error('Failed to update reaction:', error)
     } finally {
       setIsPending(false)
     }

--- a/apps/web/src/lib/client/mutations/portal-comments.ts
+++ b/apps/web/src/lib/client/mutations/portal-comments.ts
@@ -10,7 +10,8 @@ import {
   createCommentFn,
   userEditCommentFn,
   userDeleteCommentFn,
-  toggleReactionFn,
+  addReactionFn,
+  removeReactionFn,
   pinCommentFn,
   unpinCommentFn,
 } from '@/lib/server/functions/comments'
@@ -271,7 +272,10 @@ export function useToggleReaction({
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: (emoji: string) => toggleReactionFn({ data: { commentId, emoji } }),
+    mutationFn: ({ emoji, hasReacted }: { emoji: string; hasReacted: boolean }) => {
+      const fn = hasReacted ? removeReactionFn : addReactionFn
+      return fn({ data: { commentId, emoji } })
+    },
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: portalDetailQueries.postDetail(postId).queryKey })
       onSuccess?.(data)


### PR DESCRIPTION
## Summary
- Removes the `toggleReaction` function from `comment.service.ts` (~80 lines of atomic CTE SQL)
- Updates all callers (server functions, mutations, UI component) to use the existing `addReaction`/`removeReaction` with an explicit `hasReacted` flag
- Both operations are idempotent (double-add = no-op, double-remove = no-op), making behavior predictable and avoiding accidental state flips

## Test plan
- [x] All 448 vitest tests pass
- [x] Typecheck clean
- [x] Reactions tested via MCP `react_to_comment` tool (add/remove)