### PR TITLE
feat: improve OAuth consent page, MCP setup guide, and avatar uploads

### DIFF
--- a/apps/web/src/components/admin/settings/portal-auth/portal-auth-settings.tsx
+++ b/apps/web/src/components/admin/settings/portal-auth/portal-auth-settings.tsx
@@ -171,9 +171,21 @@ export function PortalAuthSettings({ initialConfig, credentialStatus }: PortalAu
                         </TooltipTrigger>
                         <TooltipContent>
                           <p>
-                            {!emailConfigured
-                              ? 'Requires email to be configured (SMTP or Resend)'
-                              : 'At least one authentication method must be enabled'}
+                            {!emailConfigured ? (
+                              <>
+                                Requires email to be configured (SMTP or Resend).{' '}
+                                <a
+                                  href="https://www.quackback.io/docs/auth/email-otp"
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="underline"
+                                >
+                                  Learn more
+                                </a>
+                              </>
+                            ) : (
+                              'At least one authentication method must be enabled'
+                            )}
                           </p>
                         </TooltipContent>
                       </Tooltip>

--- a/apps/web/src/lib/client/mutations/avatar.ts
+++ b/apps/web/src/lib/client/mutations/avatar.ts
@@ -1,0 +1,63 @@
+/**
+ * Avatar mutation hooks
+ *
+ * Upload and delete user avatar using presigned S3 URLs.
+ * Follows the same pattern as workspace logo mutations.
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { UserId } from '@quackback/ids'
+import { getAvatarUploadUrlFn } from '@/lib/server/functions/uploads'
+import { saveAvatarKeyFn, removeAvatarFn } from '@/lib/server/functions/user'
+import { settingsQueries } from '@/lib/client/queries/settings'
+
+export function useUploadAvatar(userId: UserId) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (file: Blob) => {
+      // 1. Get presigned URL from server
+      const { uploadUrl, key } = await getAvatarUploadUrlFn({
+        data: {
+          filename: (file as File).name || 'avatar.png',
+          contentType: file.type || 'image/png',
+          fileSize: file.size,
+        },
+      })
+
+      // 2. Upload directly to S3
+      const uploadResponse = await fetch(uploadUrl, {
+        method: 'PUT',
+        body: file,
+        headers: {
+          'Content-Type': file.type || 'image/png',
+        },
+      })
+
+      if (!uploadResponse.ok) {
+        throw new Error('Failed to upload avatar to storage')
+      }
+
+      // 3. Save the S3 key to the database
+      await saveAvatarKeyFn({ data: { key } })
+    },
+    onSuccess: () => {
+      queryClient.refetchQueries({
+        queryKey: settingsQueries.userProfile(userId).queryKey,
+      })
+    },
+  })
+}
+
+export function useDeleteAvatar(userId: UserId) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: () => removeAvatarFn(),
+    onSuccess: () => {
+      queryClient.refetchQueries({
+        queryKey: settingsQueries.userProfile(userId).queryKey,
+      })
+    },
+  })
+}

--- a/apps/web/src/lib/client/mutations/index.ts
+++ b/apps/web/src/lib/client/mutations/index.ts
@@ -78,3 +78,6 @@ export {
 
 // User mutations
 export { useRemovePortalUser } from './users'
+
+// Avatar mutations
+export { useUploadAvatar, useDeleteAvatar } from './avatar'

--- a/apps/web/src/lib/server/auth/index.ts
+++ b/apps/web/src/lib/server/auth/index.ts
@@ -255,13 +255,22 @@ async function createAuth() {
         ],
 
         // Default scopes for dynamically registered clients
-        clientRegistrationDefaultScopes: ['openid', 'profile', 'read:feedback'],
-
-        // Additional scopes allowed for dynamically registered clients
-        clientRegistrationAllowedScopes: ['offline_access', 'write:feedback', 'write:changelog'],
+        clientRegistrationDefaultScopes: [
+          'openid',
+          'profile',
+          'read:feedback',
+          'offline_access',
+          'write:feedback',
+          'write:changelog',
+        ],
 
         // MCP endpoint is a valid token audience
         validAudiences: [`${baseURL}/api/mcp`],
+
+        // Better Auth warns that /.well-known/oauth-authorization-server/api/auth
+        // doesn't exist, but we intentionally serve metadata at the root well-known
+        // path (matching the official Better Auth demo pattern — see #7453)
+        silenceWarnings: { oauthAuthServerConfig: true },
 
         // Embed principal info in the JWT so MCP handler can avoid extra DB lookups
         customAccessTokenClaims: async ({ user }) => {

--- a/apps/web/src/routes/[.]well-known.oauth-authorization-server.ts
+++ b/apps/web/src/routes/[.]well-known.oauth-authorization-server.ts
@@ -3,14 +3,21 @@
  *
  * GET /.well-known/oauth-authorization-server
  *
- * Returns authorization server metadata (endpoints, scopes, etc.)
- * for OAuth 2.1 discovery. The oauth-provider plugin marks these
- * as SERVER_ONLY, so we serve them manually via the exported helper.
+ * Returns metadata about the OAuth 2.1 authorization server,
+ * including supported grant types, endpoints, and scopes.
+ * This is fetched by MCP clients (e.g., Claude Code) during
+ * the OAuth discovery flow.
+ *
+ * Note: Better Auth's oauthProvider plugin uses /api/auth as its
+ * basePath, making the issuer `<origin>/api/auth`. RFC 8414 says
+ * the metadata should live at `/.well-known/oauth-authorization-server/api/auth`,
+ * but the official Better Auth demo serves it at the root well-known
+ * path instead (see github.com/better-auth/better-auth #7453).
+ * We follow the same pattern and silence the framework warning.
  */
 
 import { createFileRoute } from '@tanstack/react-router'
 
-/** Structural type matching what oauthProviderAuthServerMetadata expects from the auth instance */
 interface AuthWithOAuthServerConfig {
   api: { getOAuthServerConfig: (...args: never[]) => unknown }
 }

--- a/apps/web/src/routes/_portal/settings.profile.tsx
+++ b/apps/web/src/routes/_portal/settings.profile.tsx
@@ -1,5 +1,4 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { useSuspenseQuery } from '@tanstack/react-query'
 import { settingsQueries } from '@/lib/client/queries/settings'
 import { UserIcon } from '@heroicons/react/24/solid'
 import { PageHeader } from '@/components/shared/page-header'
@@ -27,10 +26,6 @@ export const Route = createFileRoute('/_portal/settings/profile')({
 function ProfilePage() {
   const { user } = Route.useLoaderData()
 
-  // Read pre-fetched data from React Query cache
-  const profileQuery = useSuspenseQuery(settingsQueries.userProfile(user.id))
-  const { avatarUrl, oauthAvatarUrl, hasCustomAvatar } = profileQuery.data
-
   return (
     <div className="space-y-6">
       <PageHeader
@@ -50,9 +45,6 @@ function ProfilePage() {
             name: user.name,
             email: user.email,
           }}
-          initialAvatarUrl={avatarUrl}
-          oauthAvatarUrl={oauthAvatarUrl}
-          hasCustomAvatar={hasCustomAvatar}
         />
       </div>
     </div>

--- a/apps/web/src/routes/oauth/consent.tsx
+++ b/apps/web/src/routes/oauth/consent.tsx
@@ -1,9 +1,9 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
 import { z } from 'zod'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { Check, ShieldCheck } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Check, ExternalLink, Globe, ShieldCheck } from 'lucide-react'
 
 const searchSchema = z.object({
   client_id: z.string(),
@@ -24,27 +24,74 @@ export const Route = createFileRoute('/oauth/consent')({
   component: ConsentPage,
 })
 
-const SCOPE_LABELS: Record<string, string> = {
-  openid: 'Access your user ID',
-  profile: 'View your name and avatar',
-  email: 'View your email address',
-  'read:feedback': 'Read feedback posts, comments, and boards',
-  'write:feedback': 'Create and triage feedback posts, add comments',
-  'write:changelog': 'Create changelog entries',
-  offline_access: "Stay connected when you're not using it",
+interface OAuthClientInfo {
+  client_name?: string
+  client_uri?: string
+  logo_uri?: string
+  policy_uri?: string
+  tos_uri?: string
+}
+
+const SCOPE_LABELS: Record<string, { label: string; description: string }> = {
+  openid: { label: 'User ID', description: 'Access your user identifier' },
+  profile: { label: 'Profile', description: 'View your name and avatar' },
+  email: { label: 'Email', description: 'View your email address' },
+  'read:feedback': {
+    label: 'Read feedback',
+    description: 'Read posts, comments, boards, and roadmaps',
+  },
+  'write:feedback': {
+    label: 'Write feedback',
+    description: 'Create posts, add comments, and vote',
+  },
+  'write:changelog': {
+    label: 'Write changelogs',
+    description: 'Create and publish changelog entries',
+  },
+  offline_access: {
+    label: 'Offline access',
+    description: "Stay connected when you're not actively using it",
+  },
+}
+
+/** Scopes that are standard OIDC plumbing — not worth showing to users */
+const HIDDEN_SCOPES = new Set(['openid', 'profile', 'email', 'offline_access'])
+
+function useClientInfo(clientId: string) {
+  const [client, setClient] = useState<OAuthClientInfo | null>(null)
+
+  useEffect(() => {
+    fetch(`/api/auth/oauth2/public-client?client_id=${encodeURIComponent(clientId)}`, {
+      credentials: 'include',
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => setClient(data ?? {}))
+      .catch(() => setClient({}))
+  }, [clientId])
+
+  return client
 }
 
 function ConsentPage() {
   const search = Route.useSearch()
-  const scopes = search.scope?.split(' ').filter(Boolean) ?? []
+  const client = useClientInfo(search.client_id)
+  const allScopes: string[] = search.scope?.split(' ').filter(Boolean) ?? []
+  const visibleScopes = allScopes.filter((s) => !HIDDEN_SCOPES.has(s))
   const [submitting, setSubmitting] = useState<'accept' | 'deny' | null>(null)
+
+  const clientName = client?.client_name || 'An application'
+  const clientDomain = (() => {
+    if (!client?.client_uri) return null
+    try {
+      return new URL(client.client_uri).hostname
+    } catch {
+      return null
+    }
+  })()
 
   async function handleConsent(accept: boolean) {
     setSubmitting(accept ? 'accept' : 'deny')
     try {
-      // Pass oauth_query with the full signed query string from the URL.
-      // The oauth-provider plugin's before hook uses this to restore OAuth state
-      // (the state is request-scoped and doesn't persist across the redirect).
       const oauthQuery = window.location.search.replace(/^\?/, '')
 
       const response = await fetch('/api/auth/oauth2/consent', {
@@ -64,46 +111,103 @@ function ConsentPage() {
       }
 
       const data = await response.json()
-      if (data.redirect && data.uri) {
-        window.location.href = data.uri
-      } else if (data.redirectUrl) {
-        window.location.href = data.redirectUrl
+      const redirectTo = data.uri ?? data.redirectUrl
+      if (redirectTo) {
+        window.location.href = redirectTo
       }
     } catch {
       setSubmitting(null)
     }
   }
 
+  // Show nothing while loading client info to avoid flash
+  if (client === null) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <Card className="w-full max-w-md">
+          <CardHeader className="text-center">
+            <div className="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-muted animate-pulse" />
+            <div className="mx-auto h-5 w-48 rounded bg-muted animate-pulse" />
+            <div className="mx-auto mt-2 h-4 w-64 rounded bg-muted animate-pulse" />
+          </CardHeader>
+        </Card>
+      </div>
+    )
+  }
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-background">
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
-          <div className="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
-            <ShieldCheck className="h-6 w-6 text-primary" />
+          {/* Client identity */}
+          <div className="mx-auto mb-3 flex h-14 w-14 items-center justify-center rounded-full bg-muted">
+            {client.logo_uri ? (
+              <img
+                src={client.logo_uri}
+                alt={clientName}
+                className="h-14 w-14 rounded-full object-cover"
+              />
+            ) : (
+              <Globe className="h-7 w-7 text-muted-foreground" />
+            )}
           </div>
-          <CardTitle className="text-xl">Authorize Access</CardTitle>
-          <CardDescription>An application wants to access your account</CardDescription>
-          {search.redirect_uri && (
-            <p className="mt-1 text-xs text-muted-foreground break-all">
-              Redirecting to: <code className="font-mono">{search.redirect_uri}</code>
+
+          <CardTitle className="text-xl">{clientName}</CardTitle>
+
+          <p className="mt-1 text-sm text-muted-foreground">wants to access your account</p>
+
+          {clientDomain && (
+            <p className="mt-1 text-xs text-muted-foreground">
+              {client.client_uri ? (
+                <a
+                  href={client.client_uri}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 hover:underline"
+                >
+                  {clientDomain}
+                  <ExternalLink className="h-3 w-3" />
+                </a>
+              ) : (
+                clientDomain
+              )}
             </p>
           )}
         </CardHeader>
+
         <CardContent className="space-y-6">
-          {scopes.length > 0 && (
+          {/* Permissions */}
+          {visibleScopes.length > 0 && (
             <div className="rounded-lg border p-4 space-y-3">
-              <p className="text-sm font-medium">This will allow the application to:</p>
-              <ul className="space-y-2">
-                {scopes.map((s: string) => (
-                  <li key={s} className="flex items-start gap-2 text-sm">
-                    <Check className="mt-0.5 h-4 w-4 shrink-0 text-green-500" />
-                    <span>{SCOPE_LABELS[s] ?? s}</span>
-                  </li>
-                ))}
+              <p className="text-sm font-medium text-muted-foreground">
+                This will allow {client.client_name || 'the application'} to:
+              </p>
+              <ul className="space-y-2.5">
+                {visibleScopes.map((s) => {
+                  const scope = SCOPE_LABELS[s]
+                  return (
+                    <li key={s} className="flex items-start gap-2.5">
+                      <Check className="mt-0.5 h-4 w-4 shrink-0 text-green-500" />
+                      <div>
+                        <p className="text-sm font-medium">{scope?.label ?? s}</p>
+                        {scope?.description && (
+                          <p className="text-xs text-muted-foreground">{scope.description}</p>
+                        )}
+                      </div>
+                    </li>
+                  )
+                })}
               </ul>
             </div>
           )}
 
+          {/* Authorization notice */}
+          <div className="flex items-start gap-2 text-xs text-muted-foreground">
+            <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0" />
+            <p>You can revoke this access at any time from your account settings.</p>
+          </div>
+
+          {/* Actions */}
           <div className="flex gap-3">
             <Button
               variant="outline"
@@ -121,6 +225,35 @@ function ConsentPage() {
               {submitting === 'accept' ? 'Authorizing...' : 'Authorize'}
             </Button>
           </div>
+
+          {/* Legal links */}
+          {(client.tos_uri || client.policy_uri) && (
+            <p className="text-center text-xs text-muted-foreground">
+              {'By authorizing, you agree to '}
+              {client.tos_uri && (
+                <a
+                  href={client.tos_uri}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-foreground"
+                >
+                  Terms of Service
+                </a>
+              )}
+              {client.tos_uri && client.policy_uri && ' and '}
+              {client.policy_uri && (
+                <a
+                  href={client.policy_uri}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-foreground"
+                >
+                  Privacy Policy
+                </a>
+              )}
+              .
+            </p>
+          )}
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- Redesign OAuth consent page: shows client identity (name, logo, domain), structured scope labels with descriptions, hides OIDC plumbing scopes, loading skeleton, legal links (ToS/privacy)
- Add OAuth setup instructions to MCP setup guide alongside existing API key docs
- Grant all scopes by default for dynamically registered OAuth clients (removes the allowed/default split)
- Refactor avatar uploads to use presigned S3 URLs with dedicated React Query mutation hooks
- Add docs link to portal auth email OTP tooltip
- Silence Better Auth well-known path warning with inline documentation

## Test plan
- [x] OAuth consent flow shows client name and scopes correctly
- [x] MCP setup guide displays both API key and OAuth tabs
- [x] Avatar upload/delete works via presigned S3 URLs
- [x] Portal auth tooltip links to docs