### PR TITLE
fix: revalidate OAuth role from DB, allow author comment edits via MCP

### DIFF
--- a/apps/web/src/lib/server/mcp/__tests__/handler.test.ts
+++ b/apps/web/src/lib/server/mcp/__tests__/handler.test.ts
@@ -308,15 +308,18 @@ function oauthRequest(body: unknown, token = 'oauth_test_token_abc123'): Request
 
 /** Set up mocks for a valid OAuth JWT verification. */
 async function setupValidOAuth(overrides?: { role?: string; scopes?: string[] }) {
+  const role = overrides?.role ?? 'admin'
   const { verifyAccessToken } = await import('better-auth/oauth2')
   vi.mocked(verifyAccessToken).mockResolvedValue({
     sub: MOCK_USER_ID,
     principalId: MOCK_MEMBER_ID,
-    role: overrides?.role ?? 'admin',
+    role,
     scope: (overrides?.scopes ?? ['read:feedback', 'write:feedback', 'write:changelog']).join(' '),
     name: 'Jane Admin',
     email: 'jane@example.com',
   })
+  // resolveOAuthContext re-reads the principal's current role from DB
+  mockFindFirst.mockResolvedValue({ role })
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────────

--- a/apps/web/src/lib/server/mcp/tools.ts
+++ b/apps/web/src/lib/server/mcp/tools.ts
@@ -692,7 +692,7 @@ Examples:
   // update_comment
   server.tool(
     'update_comment',
-    `Edit a comment's content. Team members can edit any comment.
+    `Edit a comment's content. Team members can edit any comment; authors can edit their own.
 
 Examples:
 - Edit: update_comment({ commentId: "comment_01abc...", content: "Updated feedback response." })`,
@@ -701,8 +701,7 @@ Examples:
     async (args: UpdateCommentArgs): Promise<CallToolResult> => {
       const scopeDenied = requireScope(auth, 'write:feedback')
       if (scopeDenied) return scopeDenied
-      const roleDenied = requireTeamRole(auth)
-      if (roleDenied) return roleDenied
+      // No team role gate — the service layer allows comment authors OR team members
       try {
         const result = await updateComment(
           args.commentId as CommentId,
@@ -725,6 +724,7 @@ Examples:
   server.tool(
     'delete_comment',
     `Hard-delete a comment and all its replies (cascade). This cannot be undone.
+Authors can delete their own comments; team members can delete any comment.
 
 Examples:
 - Delete: delete_comment({ commentId: "comment_01abc..." })`,
@@ -733,8 +733,7 @@ Examples:
     async (args: DeleteCommentArgs): Promise<CallToolResult> => {
       const scopeDenied = requireScope(auth, 'write:feedback')
       if (scopeDenied) return scopeDenied
-      const roleDenied = requireTeamRole(auth)
-      if (roleDenied) return roleDenied
+      // No team role gate — the service layer allows comment authors OR team members
       try {
         await deleteComment(args.commentId as CommentId, {
           principalId: auth.principalId,


### PR DESCRIPTION
## Summary

Addresses two Codex review comments from #33:

- **P1 - Revalidate OAuth principal role** (`handler.ts`): `resolveOAuthContext` now re-reads the principal's current role from the database instead of trusting the JWT `role` claim. This ensures role changes (demotions, revocations) take effect immediately rather than at token expiry. Verified this is the only auth path with this issue - all other paths (API keys, session cookies, widget tokens) already do fresh DB lookups.

- **P2 - Allow comment authors to use update/delete MCP tools** (`tools.ts`): Removed `requireTeamRole` gate from `update_comment` and `delete_comment`. The underlying service layer already implements author-or-team-member permission checks, so the MCP gate was redundantly blocking portal users from editing/deleting their own comments.

## Test plan
- [x] All 448 vitest tests pass
- [x] Typecheck clean
- [x] Test mocks updated for OAuth DB role lookup