### PR TITLE
feat: add docs links to integration and settings pages

### DIFF
--- a/apps/web/src/components/admin/settings/integrations/integration-header.tsx
+++ b/apps/web/src/components/admin/settings/integrations/integration-header.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 import { BackLink } from '@/components/ui/back-link'
 import { Badge } from '@/components/ui/badge'
+import { DocsLink } from '@/components/ui/docs-link'
 import type { IntegrationCatalogEntry } from '@/lib/server/integrations/types'
 
 interface IntegrationHeaderProps {
@@ -57,6 +58,11 @@ export function IntegrationHeader({
               )}
             </div>
             <p className="text-sm text-muted-foreground">{catalog.description}</p>
+            {catalog.docsUrl && (
+              <DocsLink href={catalog.docsUrl} className="mt-1 text-xs">
+                Learn how to set up {catalog.name}
+              </DocsLink>
+            )}
             {workspaceName && (
               <p className="mt-1 text-xs text-muted-foreground">
                 Connected to <span className="font-medium">{workspaceName}</span>

--- a/apps/web/src/components/ui/docs-link.tsx
+++ b/apps/web/src/components/ui/docs-link.tsx
@@ -1,0 +1,22 @@
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/16/solid'
+import { cn } from '@/lib/shared/utils'
+
+interface DocsLinkProps {
+  href: string
+  className?: string
+  children: React.ReactNode
+}
+
+export function DocsLink({ href, className, children }: DocsLinkProps) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cn('inline-flex items-center gap-1 text-primary hover:underline', className)}
+    >
+      {children}
+      <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5" />
+    </a>
+  )
+}

--- a/apps/web/src/lib/server/integrations/asana/catalog.ts
+++ b/apps/web/src/lib/server/integrations/asana/catalog.ts
@@ -23,4 +23,5 @@ export const asanaCatalog: IntegrationCatalogEntry = {
   settingsPath: '/admin/settings/integrations/asana',
   available: true,
   configurable: true,
+  docsUrl: 'https://www.quackback.io/docs/integrations/asana',
 }

--- a/apps/web/src/lib/server/integrations/azure-devops/catalog.ts
+++ b/apps/web/src/lib/server/integrations/azure-devops/catalog.ts
@@ -19,4 +19,5 @@ export const azureDevOpsCatalog: IntegrationCatalogEntry = {
   settingsPath: '/admin/settings/integrations/azure-devops',
   available: true,
   configurable: false,
+  docsUrl: 'https://www.quackback.io/docs/integrations/azure-devops',
 }

--- a/apps/web/src/lib/server/integrations/clickup/catalog.ts
+++ b/apps/web/src/lib/server/integrations/clickup/catalog.ts
@@ -23,4 +23,5 @@ export const clickupCatalog: IntegrationCatalogEntry = {
   settingsPath: '/admin/settings/integrations/clickup',
   available: true,
   configurable: true,
+  docsUrl: 'https://www.quackback.io/docs/integrations/clickup',
 }

--- a/apps/web/src/lib/server/integrations/discord/catalog.ts
+++ b/apps/web/src/lib/server/integrations/discord/catalog.ts
@@ -21,4 +21,5 @@ export const discordCatalog: IntegrationCatalogEntry = {
   settingsPath: '/admin/settings/integrations/discord',
   available: true,
   configurable: true,
+  docsUrl: 'https://www.quackback.io/docs/integrations/discord',
 }

--- a/apps/web/src/lib/server/integrations/freshdesk/catalog.ts
+++ b/apps/web/src/lib/server/integrations/freshdesk/catalog.ts
@@ -21,4 +21,5 @@ export const freshdeskCatalog: IntegrationCatalogEntry = {
   settingsPath: '/admin/settings/integrations/freshdesk',
   available: true,
   configurable: true,
+  docsUrl: 'https://www.quackback.io/docs/integrations/freshdesk',
 }

--- a/apps/web/src/lib/server/integrations/github/catalog.ts
+++ b/apps/web/src/lib/server/integrations/github/catalog.ts
@@ -23,4 +23,5 @@ export const githubCatalog: IntegrationCatalogEntry = {
   settingsPath: '/admin/settings/integrations/github',
   available: true,
   configurable: true,
+  docsUrl: 'https://www.quackback.io/docs/integrations/github',
 }

--- a/apps/web/src/lib/server/integrations/gitlab/catalog.ts
+++ b/apps/web/src/lib/server/integrations/gitlab/catalog.ts
@@ -24,4 +24,5 @@ export const gitlabCatalog: IntegrationCatalogEntry = {
   settingsPath: '/admin/settings/integrations/gitlab',
   available: true,
   configurable: true,
+  docsUrl: 'https://www.quackback.io/docs/integrations/gitlab',
 }

--- a/apps/web/src/lib/server/integrations/hubspot/catalog.ts
+++ b/apps/web/src/lib/server/integrations/hubspot/catalog.ts
@@ -21,4 +21,5 @@ export const hubspotCatalog: IntegrationCatalogEntry = {
   settingsPath: '/admin/settings/integrations/hubspot',
   available: true,
   configurable: true,
+  docsUrl: 'https://www.quackback.io/docs/integrations/hubspot',
 }

--- a/apps/web/src/lib/server/integrations/intercom/catalog.ts
+++ b/apps/web/src/lib/server/integrations/intercom/catalog.ts
@@ -20,4 +20,5 @@ export const intercomCatalog: IntegrationCatalogEntry = {
   settingsPath: '/admin/settings/integrations/intercom',
   available: true,
   configurable: true,
+  docsUrl: 'https://www.quackback.io/docs/integrations/intercom',
 }

--- a/apps/web/src/lib/server/integrations/jira/catalog.ts
+++ b/apps/web/src/lib/server/integrations/jira/catalog.ts
@@ -24,4 +24,5 @@ export const jiraCatalog: IntegrationCatalogEntry = {
   settingsPath: '/admin/settings/integrations/jira',
   available: true,
   configurable: true,
+  docsUrl: 'https://www.quackback.io/docs/integrations/jira',
 }

--- a/apps/web/src/lib/server/integrations/linear/catalog.ts
+++ b/apps/web/src/lib/server/integrations/linear/catalog.ts
@@ -23,4 +23,5 @@ export const linearCatalog: IntegrationCatalogEntry = {
   settingsPath: '/admin/settings/integrations/linear',
   available: true,
   configurable: true,
+  docsUrl: 'https://www.quackback.io/docs/integrations/linear',
 }

--- a/apps/web/src/lib/server/integrations/make/catalog.ts
+++ b/apps/web/src/lib/server/integrations/make/catalog.ts
@@ -20,4 +20,5 @@ export const makeCatalog: IntegrationCatalogEntry = {
   settingsPath: '/admin/settings/integrations/make',
   available: true,
   configurable: false,
+  docsUrl: 'https://www.quackback.io/docs/integrations/make',
 }

--- a/apps/web/src/lib/server/integrations/monday/catalog.ts
+++ b/apps/web/src/lib/server/integrations/monday/catalog.ts
@@ -24,4 +24,5 @@ export const mondayCatalog: IntegrationCatalogEntry = {
   settingsPath: '/admin/settings/integrations/monday',
   available: true,
   configurable: true,
+  docsUrl: 'https://www.quackback.io/docs/integrations/monday',
 }

--- a/apps/web/src/lib/server/integrations/n8n/catalog.ts
+++ b/apps/web/src/lib/server/integrations/n8n/catalog.ts
@@ -20,4 +20,5 @@ export const n8nCatalog: IntegrationCatalogEntry = {
   settingsPath: '/admin/settings/integrations/n8n',
   available: true,
   configurable: false,
+  docsUrl: 'https://www.quackback.io/docs/integrations/n8n',
 }

--- a/apps/web/src/lib/server/integrations/notion/catalog.ts
+++ b/apps/web/src/lib/server/integrations/notion/catalog.ts
@@ -25,4 +25,5 @@ export const notionCatalog: IntegrationCatalogEntry = {
   settingsPath: '/admin/settings/integrations/notion',
   available: true,
   configurable: true,
+  docsUrl: 'https://www.quackback.io/docs/integrations/notion',
 }

--- a/apps/web/src/lib/server/integrations/salesforce/catalog.ts
+++ b/apps/web/src/lib/server/integrations/salesforce/catalog.ts
@@ -23,4 +23,5 @@ export const salesforceCatalog: IntegrationCatalogEntry = {
   settingsPath: '/admin/settings/integrations/salesforce',
   available: true,
   configurable: true,
+  docsUrl: 'https://www.quackback.io/docs/integrations/salesforce',
 }

--- a/apps/web/src/lib/server/integrations/shortcut/catalog.ts
+++ b/apps/web/src/lib/server/integrations/shortcut/catalog.ts
@@ -23,4 +23,5 @@ export const shortcutCatalog: IntegrationCatalogEntry = {
   settingsPath: '/admin/settings/integrations/shortcut',
   available: true,
   configurable: false,
+  docsUrl: 'https://www.quackback.io/docs/integrations/shortcut',
 }

--- a/apps/web/src/lib/server/integrations/slack/catalog.ts
+++ b/apps/web/src/lib/server/integrations/slack/catalog.ts
@@ -22,4 +22,5 @@ export const slackCatalog: IntegrationCatalogEntry = {
   settingsPath: '/admin/settings/integrations/slack',
   available: true,
   configurable: true,
+  docsUrl: 'https://www.quackback.io/docs/integrations/slack',
 }

--- a/apps/web/src/lib/server/integrations/stripe/catalog.ts
+++ b/apps/web/src/lib/server/integrations/stripe/catalog.ts
@@ -25,4 +25,5 @@ export const stripeCatalog: IntegrationCatalogEntry = {
   settingsPath: '/admin/settings/integrations/stripe',
   available: true,
   configurable: true,
+  docsUrl: 'https://www.quackback.io/docs/integrations/stripe',
 }

--- a/apps/web/src/lib/server/integrations/teams/catalog.ts
+++ b/apps/web/src/lib/server/integrations/teams/catalog.ts
@@ -20,4 +20,5 @@ export const teamsCatalog: IntegrationCatalogEntry = {
   settingsPath: '/admin/settings/integrations/teams',
   available: true,
   configurable: true,
+  docsUrl: 'https://www.quackback.io/docs/integrations/teams',
 }

--- a/apps/web/src/lib/server/integrations/trello/catalog.ts
+++ b/apps/web/src/lib/server/integrations/trello/catalog.ts
@@ -24,4 +24,5 @@ export const trelloCatalog: IntegrationCatalogEntry = {
   settingsPath: '/admin/settings/integrations/trello',
   available: true,
   configurable: true,
+  docsUrl: 'https://www.quackback.io/docs/integrations/trello',
 }

--- a/apps/web/src/lib/server/integrations/types.ts
+++ b/apps/web/src/lib/server/integrations/types.ts
@@ -116,6 +116,8 @@ export interface IntegrationCatalogEntry {
   configurable: boolean
   /** Field definitions for platform credentials. Present in catalog API response, empty array if none needed. */
   platformCredentialFields?: PlatformCredentialField[]
+  /** Link to the setup guide on the docs site */
+  docsUrl?: string
 }
 
 export interface IntegrationDefinition {

--- a/apps/web/src/lib/server/integrations/zapier/catalog.ts
+++ b/apps/web/src/lib/server/integrations/zapier/catalog.ts
@@ -21,4 +21,5 @@ export const zapierCatalog: IntegrationCatalogEntry = {
   settingsPath: '/admin/settings/integrations/zapier',
   available: true,
   configurable: false,
+  docsUrl: 'https://www.quackback.io/docs/integrations/zapier',
 }

--- a/apps/web/src/lib/server/integrations/zendesk/catalog.ts
+++ b/apps/web/src/lib/server/integrations/zendesk/catalog.ts
@@ -20,4 +20,5 @@ export const zendeskCatalog: IntegrationCatalogEntry = {
   settingsPath: '/admin/settings/integrations/zendesk',
   available: true,
   configurable: true,
+  docsUrl: 'https://www.quackback.io/docs/integrations/zendesk',
 }

--- a/apps/web/src/routes/admin/settings.api-keys.tsx
+++ b/apps/web/src/routes/admin/settings.api-keys.tsx
@@ -3,6 +3,7 @@ import { useSuspenseQuery } from '@tanstack/react-query'
 import { adminQueries } from '@/lib/client/queries/admin'
 import { KeyIcon } from '@heroicons/react/24/solid'
 import { BackLink } from '@/components/ui/back-link'
+import { DocsLink } from '@/components/ui/docs-link'
 import { PageHeader } from '@/components/shared/page-header'
 import { ApiKeysSettings } from '@/components/admin/settings/api-keys/api-keys-settings'
 import { SettingsCard } from '@/components/admin/settings/settings-card'
@@ -42,36 +43,17 @@ function ApiKeysPage() {
       </SettingsCard>
 
       <SettingsCard title="API Documentation" description="Learn how to use the Quackback API">
-        <div className="text-sm text-muted-foreground">
-          <p className="mb-3">
+        <div className="text-sm text-muted-foreground space-y-3">
+          <p>
             The Quackback API allows you to programmatically manage posts, boards, comments, and
             more.
           </p>
-          <a
-            href="/api/v1/docs"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 text-primary hover:underline"
-          >
-            View API Documentation
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-              className="h-4 w-4"
-            >
-              <path
-                fillRule="evenodd"
-                d="M4.25 5.5a.75.75 0 00-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 00.75-.75v-4a.75.75 0 011.5 0v4A2.25 2.25 0 0112.75 17h-8.5A2.25 2.25 0 012 14.75v-8.5A2.25 2.25 0 014.25 4h5a.75.75 0 010 1.5h-5z"
-                clipRule="evenodd"
-              />
-              <path
-                fillRule="evenodd"
-                d="M6.194 12.753a.75.75 0 001.06.053L16.5 4.44v2.81a.75.75 0 001.5 0v-4.5a.75.75 0 00-.75-.75h-4.5a.75.75 0 000 1.5h2.553l-9.056 8.194a.75.75 0 00-.053 1.06z"
-                clipRule="evenodd"
-              />
-            </svg>
-          </a>
+          <div className="flex flex-col gap-2">
+            <DocsLink href="https://www.quackback.io/docs/api/overview">
+              Learn how to set up API keys
+            </DocsLink>
+            <DocsLink href="/api/v1/docs">View API Reference</DocsLink>
+          </div>
         </div>
       </SettingsCard>
     </div>

--- a/apps/web/src/routes/admin/settings.mcp.tsx
+++ b/apps/web/src/routes/admin/settings.mcp.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { CommandLineIcon } from '@heroicons/react/24/solid'
 import { BackLink } from '@/components/ui/back-link'
+import { DocsLink } from '@/components/ui/docs-link'
 import { PageHeader } from '@/components/shared/page-header'
 import { SettingsCard } from '@/components/admin/settings/settings-card'
 import { McpServerSettings } from '@/components/admin/settings/mcp/mcp-server-settings'
@@ -49,6 +50,11 @@ function McpSettingsPage() {
         title="Setup Guide"
         description="Connect AI tools to your Quackback instance via MCP"
       >
+        <div className="mb-4">
+          <DocsLink href="https://www.quackback.io/docs/mcp" className="text-sm">
+            Learn how to set up the MCP server
+          </DocsLink>
+        </div>
         <McpSetupGuide endpointUrl={endpointUrl} />
       </SettingsCard>
     </div>

--- a/apps/web/src/routes/admin/settings.webhooks.tsx
+++ b/apps/web/src/routes/admin/settings.webhooks.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { BoltIcon } from '@heroicons/react/24/solid'
 import { BackLink } from '@/components/ui/back-link'
+import { DocsLink } from '@/components/ui/docs-link'
 import { PageHeader } from '@/components/shared/page-header'
 import { adminQueries } from '@/lib/client/queries/admin'
 import { SettingsCard } from '@/components/admin/settings/settings-card'
@@ -45,36 +46,17 @@ function WebhooksPage() {
         title="Webhook Documentation"
         description="Learn how to receive and verify webhooks"
       >
-        <div className="text-sm text-muted-foreground">
-          <p className="mb-3">
+        <div className="text-sm text-muted-foreground space-y-3">
+          <p>
             Webhooks allow you to receive real-time notifications when posts are created, statuses
             change, vote milestones are reached, or comments are added.
           </p>
-          <a
-            href="/api/v1/docs"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 text-primary hover:underline"
-          >
-            View API Documentation
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-              className="h-4 w-4"
-            >
-              <path
-                fillRule="evenodd"
-                d="M4.25 5.5a.75.75 0 00-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 00.75-.75v-4a.75.75 0 011.5 0v4A2.25 2.25 0 0112.75 17h-8.5A2.25 2.25 0 012 14.75v-8.5A2.25 2.25 0 014.25 4h5a.75.75 0 010 1.5h-5z"
-                clipRule="evenodd"
-              />
-              <path
-                fillRule="evenodd"
-                d="M6.194 12.753a.75.75 0 001.06.053L16.5 4.44v2.81a.75.75 0 001.5 0v-4.5a.75.75 0 00-.75-.75h-4.5a.75.75 0 000 1.5h2.553l-9.056 8.194a.75.75 0 00-.053 1.06z"
-                clipRule="evenodd"
-              />
-            </svg>
-          </a>
+          <div className="flex flex-col gap-2">
+            <DocsLink href="https://www.quackback.io/docs/integrations/webhooks">
+              Learn how to set up webhooks
+            </DocsLink>
+            <DocsLink href="/api/v1/docs">View API Reference</DocsLink>
+          </div>
         </div>
       </SettingsCard>
     </div>


### PR DESCRIPTION
## Summary
- **Add docsUrl to all 24 integration catalogs** - Each integration now links to its setup guide on quackback.io/docs, displayed as a "Learn how to set up X" link in the integration header
- **Add docs links to settings pages** - API keys, webhooks, and MCP settings pages now link to their respective documentation
- **Extract shared DocsLink component** - Deduplicated 7 inline SVG icons into a single `DocsLink` component using `@heroicons/react`

## Test plan
- [x] Verify docs links appear on integration settings pages and open correct URLs
- [x] Verify docs links on API keys, webhooks, and MCP settings pages
- [x] Run `bun run typecheck` to verify no type errors