### PR TITLE
fix: show full URLs on MCP settings page

### DIFF
--- a/apps/web/src/components/admin/settings/mcp/mcp-setup-guide.tsx
+++ b/apps/web/src/components/admin/settings/mcp/mcp-setup-guide.tsx
@@ -150,36 +150,23 @@ export function McpSetupGuide({ endpointUrl }: McpSetupGuideProps) {
   return (
     <div className="space-y-6 text-sm text-muted-foreground">
       {/* Endpoint & Auth */}
-      <div className="space-y-4">
+      <div className="space-y-3">
         <div>
-          <h4 className="font-medium text-foreground mb-1.5">Endpoint URL</h4>
+          <h4 className="font-medium text-foreground mb-1.5">Endpoint</h4>
           <code className="block rounded-md bg-muted px-3 py-2.5 text-xs font-mono break-all select-all">
             {endpointUrl}
           </code>
         </div>
 
-        <div>
-          <h4 className="font-medium text-foreground mb-1.5">Authentication</h4>
-          <div className="space-y-2">
-            <p>Two authentication methods are supported:</p>
-            <ul className="list-disc list-inside space-y-1 text-xs">
-              <li>
-                <span className="font-medium text-foreground">API Key</span> - for CI/automation.
-                Requires a <InlineCode>qb_</InlineCode> token in the{' '}
-                <InlineCode>Authorization</InlineCode> header.{' '}
-                <Link to="/admin/settings/api-keys" className="text-primary hover:underline">
-                  Create an API key
-                </Link>{' '}
-                if you haven't already.
-              </li>
-              <li>
-                <span className="font-medium text-foreground">OAuth</span> - for interactive use.
-                The client opens a browser-based login flow, no API key needed. Supported by Claude
-                Code and Claude Desktop.
-              </li>
-            </ul>
-          </div>
-        </div>
+        <p className="text-xs">
+          Authenticate with an{' '}
+          <Link to="/admin/settings/api-keys" className="text-primary hover:underline">
+            API key
+          </Link>{' '}
+          (<InlineCode>Authorization: Bearer qb_...</InlineCode>) or via{' '}
+          <span className="font-medium text-foreground">OAuth</span> (browser login flow, supported
+          by Claude Code and Claude Desktop).
+        </p>
       </div>
 
       {/* Client Setup Tabs */}
@@ -196,140 +183,90 @@ export function McpSetupGuide({ endpointUrl }: McpSetupGuideProps) {
 
           <TabsContent value="claude-code">
             <div className="space-y-4">
-              <div className="space-y-3">
+              <div className="space-y-2">
                 <p className="font-medium text-foreground text-xs">With OAuth (recommended)</p>
-                <p>
-                  Add to <InlineCode>.mcp.json</InlineCode> in your project root. Claude Code will
-                  open a browser login flow on first use.
+                <p className="text-xs">
+                  Add to <InlineCode>.mcp.json</InlineCode> in your project root:
                 </p>
                 <CodeBlock>{claudeCodeOAuthConfig(endpointUrl)}</CodeBlock>
               </div>
-              <div className="space-y-3">
+              <div className="space-y-2">
                 <p className="font-medium text-foreground text-xs">With API Key</p>
-                <p>
-                  Set the <InlineCode>QUACKBACK_API_KEY</InlineCode> environment variable to your
-                  API key.
+                <p className="text-xs">
+                  Set <InlineCode>QUACKBACK_API_KEY</InlineCode> in your environment:
                 </p>
                 <CodeBlock>{claudeCodeConfig(endpointUrl)}</CodeBlock>
-                <p className="text-xs">
-                  Or use the CLI:{' '}
-                  <InlineCode>
-                    claude mcp add --transport http quackback {endpointUrl} --header
-                    &quot;Authorization: Bearer $QUACKBACK_API_KEY&quot;
-                  </InlineCode>
-                </p>
               </div>
             </div>
           </TabsContent>
 
           <TabsContent value="cursor">
-            <div className="space-y-3">
-              <p>
-                Add to <InlineCode>.cursor/mcp.json</InlineCode> in your project root. Set the{' '}
-                <InlineCode>QUACKBACK_API_KEY</InlineCode> environment variable to your API key.
+            <div className="space-y-2">
+              <p className="text-xs">
+                Add to <InlineCode>.cursor/mcp.json</InlineCode>. Set{' '}
+                <InlineCode>QUACKBACK_API_KEY</InlineCode> in your environment. OAuth is not
+                supported.
               </p>
               <CodeBlock>{cursorConfig(endpointUrl)}</CodeBlock>
-              <p className="text-xs">
-                Cursor uses <InlineCode>{'${env:VAR}'}</InlineCode> syntax for environment
-                variables. Requires Cursor v0.48.0+. OAuth is not supported by Cursor - use an API
-                key.
-              </p>
             </div>
           </TabsContent>
 
           <TabsContent value="vscode">
-            <div className="space-y-3">
-              <p>
-                Add to <InlineCode>.vscode/mcp.json</InlineCode> in your project root. VS Code will
-                prompt you for the API key on first use and store it securely.
+            <div className="space-y-2">
+              <p className="text-xs">
+                Add to <InlineCode>.vscode/mcp.json</InlineCode>. VS Code will prompt for the API
+                key on first use. Note: uses <InlineCode>servers</InlineCode> not{' '}
+                <InlineCode>mcpServers</InlineCode>. OAuth is not supported.
               </p>
               <CodeBlock>{vscodeConfig(endpointUrl)}</CodeBlock>
-              <p className="text-xs">
-                Note: VS Code uses <InlineCode>servers</InlineCode> (not{' '}
-                <InlineCode>mcpServers</InlineCode>) as the top-level key. OAuth is not supported by
-                VS Code - use an API key.
-              </p>
             </div>
           </TabsContent>
 
           <TabsContent value="windsurf">
-            <div className="space-y-3">
-              <p>
-                Add to <InlineCode>~/.codeium/windsurf/mcp_config.json</InlineCode>. Set the{' '}
-                <InlineCode>QUACKBACK_API_KEY</InlineCode> environment variable to your API key.
+            <div className="space-y-2">
+              <p className="text-xs">
+                Add to <InlineCode>~/.codeium/windsurf/mcp_config.json</InlineCode>. Set{' '}
+                <InlineCode>QUACKBACK_API_KEY</InlineCode> in your environment. Note: uses{' '}
+                <InlineCode>serverUrl</InlineCode> not <InlineCode>url</InlineCode>. OAuth is not
+                supported.
               </p>
               <CodeBlock>{windsurfConfig(endpointUrl)}</CodeBlock>
-              <p className="text-xs">
-                Note: Windsurf uses <InlineCode>serverUrl</InlineCode> instead of{' '}
-                <InlineCode>url</InlineCode>. OAuth is not supported by Windsurf - use an API key.
-              </p>
             </div>
           </TabsContent>
 
           <TabsContent value="claude-desktop">
             <div className="space-y-4">
-              <p>
-                Claude Desktop requires <InlineCode>mcp-remote</InlineCode> as a bridge. Add to{' '}
-                <InlineCode>claude_desktop_config.json</InlineCode>:
+              <p className="text-xs">
+                Requires <InlineCode>mcp-remote</InlineCode> as a bridge (Node.js must be
+                installed). Add to <InlineCode>claude_desktop_config.json</InlineCode>:
               </p>
-              <div className="space-y-3">
+              <div className="space-y-2">
                 <p className="font-medium text-foreground text-xs">With OAuth (recommended)</p>
                 <CodeBlock>{claudeDesktopOAuthConfig(endpointUrl)}</CodeBlock>
-                <p className="text-xs">
-                  A browser login flow will open on first use. Requires Node.js installed.
-                </p>
               </div>
-              <div className="space-y-3">
+              <div className="space-y-2">
                 <p className="font-medium text-foreground text-xs">With API Key</p>
                 <CodeBlock>{claudeDesktopApiKeyConfig(endpointUrl)}</CodeBlock>
-                <p className="text-xs">
-                  Replace <InlineCode>qb_YOUR_API_KEY</InlineCode> with your actual API key.
-                </p>
               </div>
             </div>
           </TabsContent>
         </Tabs>
       </div>
 
-      {/* Tools & Resources */}
-      <div className="grid gap-6 sm:grid-cols-2">
-        <div>
-          <h4 className="font-medium text-foreground mb-2">Tools</h4>
-          <div className="space-y-2">
-            <DefinitionItem label="search" description="Search across posts and changelogs" />
-            <DefinitionItem
-              label="get_details"
-              description="Get full details for any entity by ID"
-            />
-            <DefinitionItem label="triage_post" description="Update status, tags, or owner" />
-            <DefinitionItem label="add_comment" description="Post a comment on a feedback post" />
-            <DefinitionItem label="create_post" description="Submit new feedback" />
-            <DefinitionItem label="create_changelog" description="Create a changelog entry" />
-          </div>
-        </div>
-
-        <div>
-          <h4 className="font-medium text-foreground mb-2">Resources</h4>
-          <div className="space-y-2">
-            <DefinitionItem label="quackback://boards" description="List all boards" />
-            <DefinitionItem label="quackback://statuses" description="List all statuses" />
-            <DefinitionItem label="quackback://tags" description="List all tags" />
-            <DefinitionItem label="quackback://roadmaps" description="List all roadmaps" />
-            <DefinitionItem label="quackback://members" description="List all team members" />
-          </div>
-        </div>
+      {/* Available Tools */}
+      <div>
+        <h4 className="font-medium text-foreground mb-2">Available Tools</h4>
+        <p className="text-xs mb-2">
+          <InlineCode>search</InlineCode> <InlineCode>get_details</InlineCode>{' '}
+          <InlineCode>triage_post</InlineCode> <InlineCode>vote_post</InlineCode>{' '}
+          <InlineCode>add_comment</InlineCode> <InlineCode>update_comment</InlineCode>{' '}
+          <InlineCode>delete_comment</InlineCode> <InlineCode>react_to_comment</InlineCode>{' '}
+          <InlineCode>create_post</InlineCode> <InlineCode>merge_post</InlineCode>{' '}
+          <InlineCode>unmerge_post</InlineCode> <InlineCode>manage_roadmap_post</InlineCode>{' '}
+          <InlineCode>create_changelog</InlineCode> <InlineCode>update_changelog</InlineCode>{' '}
+          <InlineCode>delete_changelog</InlineCode>
+        </p>
       </div>
-    </div>
-  )
-}
-
-function DefinitionItem({ label, description }: { label: string; description: string }) {
-  return (
-    <div className="flex items-start gap-2">
-      <code className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-xs font-mono mt-0.5">
-        {label}
-      </code>
-      <span className="text-xs text-muted-foreground">{description}</span>
     </div>
   )
 }

--- a/apps/web/src/routes/admin/settings.mcp.tsx
+++ b/apps/web/src/routes/admin/settings.mcp.tsx
@@ -23,10 +23,16 @@ export const Route = createFileRoute('/admin/settings/mcp')({
   component: McpSettingsPage,
 })
 
-function McpSettingsPage() {
+function useEndpointUrl() {
   const { baseUrl } = Route.useLoaderData()
+  if (baseUrl) return `${baseUrl}/api/mcp`
+  if (typeof window !== 'undefined') return `${window.location.origin}/api/mcp`
+  return '/api/mcp'
+}
+
+function McpSettingsPage() {
   const developerConfigQuery = useSuspenseQuery(settingsQueries.developerConfig())
-  const endpointUrl = `${baseUrl}/api/mcp`
+  const endpointUrl = useEndpointUrl()
 
   return (
     <div className="space-y-6 max-w-5xl">


### PR DESCRIPTION
## Summary
- Fix endpoint URL showing as just `/api/mcp` by falling back to `window.location.origin` when `BASE_URL` is empty during SSR
- Condense the setup guide copy - collapsed verbose auth section, tightened per-tab help text
- List all 15 MCP tools instead of the previous subset of 6

## Test plan
- [x] Typecheck passes