### PR TITLE
fix: validate avatar S3 keys and sanitize OAuth consent URLs

### DIFF
--- a/apps/web/src/lib/server/functions/user.ts
+++ b/apps/web/src/lib/server/functions/user.ts
@@ -25,7 +25,7 @@ const updateProfileNameSchema = z.object({
 })
 
 const saveAvatarKeySchema = z.object({
-  key: z.string().min(1),
+  key: z.string().min(1).startsWith('avatars/', 'Avatar key must start with "avatars/"'),
 })
 
 const updateNotificationPreferencesSchema = z.object({


### PR DESCRIPTION
- Restrict saveAvatarKeySchema to only accept keys starting with
  "avatars/" prefix, preventing users from referencing or deleting
  arbitrary S3 objects via the avatar save endpoint
- Add URL scheme validation for tos_uri, policy_uri, and client_uri
  on the OAuth consent page, blocking dangerous schemes like
  javascript: or data: from being rendered as clickable links

Resolves PR #35 review comments.

https://claude.ai/code/session_01JHkatzYSyJte3nCZmyFv7m