### PR TITLE
fix: portal auth toggle incorrectly locked when password key missing

### DIFF
--- a/apps/web/src/lib/server/domains/settings/__tests__/parse-json-config.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/parse-json-config.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { parseJsonConfig } from '../settings.service'
+import { DEFAULT_PORTAL_CONFIG, DEFAULT_WIDGET_CONFIG } from '../settings.types'
+
+describe('parseJsonConfig', () => {
+  it('returns default when json is null', () => {
+    const result = parseJsonConfig(null, DEFAULT_PORTAL_CONFIG)
+    expect(result).toEqual(DEFAULT_PORTAL_CONFIG)
+  })
+
+  it('returns default when json is invalid', () => {
+    const result = parseJsonConfig('not valid json', DEFAULT_PORTAL_CONFIG)
+    expect(result).toEqual(DEFAULT_PORTAL_CONFIG)
+  })
+
+  it('deep merges nested objects instead of replacing them', () => {
+    // Stored config only has email enabled — password key is missing
+    const stored = JSON.stringify({
+      oauth: { email: true },
+    })
+
+    const result = parseJsonConfig(stored, DEFAULT_PORTAL_CONFIG)
+
+    // password should be preserved from the default (true)
+    expect(result.oauth.password).toBe(true)
+    // email should come from stored config
+    expect(result.oauth.email).toBe(true)
+    // features should be preserved from the default
+    expect(result.features).toEqual(DEFAULT_PORTAL_CONFIG.features)
+  })
+
+  it('stored values override defaults for nested keys', () => {
+    const stored = JSON.stringify({
+      oauth: { password: false, email: true },
+      features: { publicView: false },
+    })
+
+    const result = parseJsonConfig(stored, DEFAULT_PORTAL_CONFIG)
+
+    expect(result.oauth.password).toBe(false)
+    expect(result.oauth.email).toBe(true)
+    // google/github preserved from defaults
+    expect(result.oauth.google).toBe(true)
+    expect(result.oauth.github).toBe(true)
+    // Explicit override
+    expect(result.features.publicView).toBe(false)
+    // Rest of features preserved from defaults
+    expect(result.features.submissions).toBe(true)
+  })
+
+  it('handles flat configs (no nested objects)', () => {
+    const stored = JSON.stringify({ enabled: true })
+
+    const result = parseJsonConfig(stored, DEFAULT_WIDGET_CONFIG)
+
+    expect(result.enabled).toBe(true)
+    expect(result.identifyVerification).toBe(false)
+  })
+
+  it('preserves default oauth.password when stored oauth omits it (bug fix)', () => {
+    // This is the exact scenario that caused the bug:
+    // DB stored oauth without password key, shallow merge lost the default
+    const stored = JSON.stringify({
+      oauth: { email: true, google: false, github: false },
+      features: DEFAULT_PORTAL_CONFIG.features,
+    })
+
+    const result = parseJsonConfig(stored, DEFAULT_PORTAL_CONFIG)
+
+    // password must be true from defaults — this is what the toggle displays
+    expect(result.oauth.password).toBe(true)
+    // Count of enabled methods must be >= 2 so email isn't the "last" one
+    const enabledCount = Object.values(result.oauth).filter(Boolean).length
+    expect(enabledCount).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/apps/web/src/lib/server/domains/settings/settings.service.ts
+++ b/apps/web/src/lib/server/domains/settings/settings.service.ts
@@ -25,10 +25,11 @@ import { randomBytes } from 'crypto'
 
 type SettingsRecord = NonNullable<Awaited<ReturnType<typeof db.query.settings.findFirst>>>
 
-function parseJsonConfig<T>(json: string | null, defaultValue: T): T {
+/** @internal Exported for testing */
+export function parseJsonConfig<T extends object>(json: string | null, defaultValue: T): T {
   if (!json) return defaultValue
   try {
-    return { ...defaultValue, ...JSON.parse(json) } as T
+    return deepMerge(defaultValue, JSON.parse(json))
   } catch {
     return defaultValue
   }


### PR DESCRIPTION
## Summary
- **Bug**: Email OTP toggle was locked (showing "At least one authentication method must be enabled") even when Password was also enabled
- **Root cause**: `parseJsonConfig` used shallow merge (`{ ...default, ...stored }`), so the stored `oauth` object entirely replaced the default. If the DB's `oauth` lacked an explicit `password` key, the UI showed password as ON (via `?? true` fallback) but the enabled method count didn't include it - making email OTP appear as the last enabled method
- **Fix**: Switch `parseJsonConfig` to use the existing `deepMerge` function so nested default keys like `password: true` are preserved when the stored config omits them

## Test plan
- [x] Added `parse-json-config.test.ts` covering the exact bug scenario and deep merge behavior
- [x] All 19 settings domain tests pass
- [x] TypeScript typecheck passes