### PR TITLE
fix: use shared getBaseUrl for settings page URLs

### DIFF
--- a/apps/web/src/routes/admin/settings.mcp.tsx
+++ b/apps/web/src/routes/admin/settings.mcp.tsx
@@ -8,6 +8,7 @@ import { SettingsCard } from '@/components/admin/settings/settings-card'
 import { McpServerSettings } from '@/components/admin/settings/mcp/mcp-server-settings'
 import { McpSetupGuide } from '@/components/admin/settings/mcp/mcp-setup-guide'
 import { settingsQueries } from '@/lib/client/queries/settings'
+import { getBaseUrl } from '@/lib/shared/routing'
 
 export const Route = createFileRoute('/admin/settings/mcp')({
   loader: async ({ context }) => {
@@ -17,17 +18,14 @@ export const Route = createFileRoute('/admin/settings/mcp')({
     const { queryClient } = context
     await queryClient.ensureQueryData(settingsQueries.developerConfig())
 
-    const { getBaseUrl } = await import('@/lib/server/config')
-    return { baseUrl: getBaseUrl() }
+    return {}
   },
   component: McpSettingsPage,
 })
 
 function useEndpointUrl() {
-  const { baseUrl } = Route.useLoaderData()
-  if (baseUrl) return `${baseUrl}/api/mcp`
-  if (typeof window !== 'undefined') return `${window.location.origin}/api/mcp`
-  return '/api/mcp'
+  const baseUrl = getBaseUrl()
+  return baseUrl ? `${baseUrl}/api/mcp` : '/api/mcp'
 }
 
 function McpSettingsPage() {

--- a/apps/web/src/routes/admin/settings.widget.tsx
+++ b/apps/web/src/routes/admin/settings.widget.tsx
@@ -19,6 +19,7 @@ import { Button } from '@/components/ui/button'
 import { settingsQueries } from '@/lib/client/queries/settings'
 import { adminQueries } from '@/lib/client/queries/admin'
 import { updateWidgetConfigFn, regenerateWidgetSecretFn } from '@/lib/server/functions/settings'
+import { getBaseUrl } from '@/lib/shared/routing'
 
 export const Route = createFileRoute('/admin/settings/widget')({
   loader: async ({ context }) => {
@@ -32,8 +33,7 @@ export const Route = createFileRoute('/admin/settings/widget')({
       queryClient.ensureQueryData(adminQueries.boards()),
     ])
 
-    const { getBaseUrl } = await import('@/lib/server/config')
-    return { baseUrl: getBaseUrl() }
+    return {}
   },
   component: WidgetSettingsPage,
 })
@@ -52,10 +52,10 @@ function SavingIndicator({ visible }: { visible: boolean }) {
 }
 
 function WidgetSettingsPage() {
-  const { baseUrl } = Route.useLoaderData()
   const widgetConfigQuery = useSuspenseQuery(settingsQueries.widgetConfig())
   const widgetSecretQuery = useSuspenseQuery(settingsQueries.widgetSecret())
   const boardsQuery = useSuspenseQuery(adminQueries.boards())
+  const baseUrl = getBaseUrl()
 
   return (
     <div className="space-y-6 max-w-5xl">


### PR DESCRIPTION
## Summary
- **Bug**: MCP and widget settings pages showed relative URLs (e.g. `/api/mcp`) instead of full URLs when navigating via client-side navigation. Full page reload showed the correct URL.
- **Root cause**: Both pages imported `getBaseUrl` from `@/lib/server/config` in their route loader. During client-side navigation, the loader runs on the client where server config (`process.env.BASE_URL`) is unavailable, so `getBaseUrl()` returned an empty string.
- **Fix**: Switch to the shared `getBaseUrl()` from `@/lib/shared/routing` which correctly uses `window.location.origin` on the client and `process.env.BASE_URL` on the server.

## Changes
- `settings.mcp.tsx` - use shared `getBaseUrl()` in component instead of loader
- `settings.widget.tsx` - same fix for widget embed code snippet URL

## Test plan
- [x] TypeScript typecheck passes
- [x] Navigate to MCP settings via client-side nav - verify full URL shown
- [x] Navigate to Widget settings via client-side nav - verify embed snippet has full URL
- [x] Full page reload on both pages still shows correct URLs