### PR TITLE
fix: use server-resolved BASE_URL for settings pages

### DIFF
--- a/apps/web/src/lib/server/functions/bootstrap.ts
+++ b/apps/web/src/lib/server/functions/bootstrap.ts
@@ -3,11 +3,13 @@ import { getRequestHeaders } from '@tanstack/react-start/server'
 import { getTenantSettings } from '@/lib/server/domains/settings/settings.service'
 import { auth } from '@/lib/server/auth/index'
 import { db, principal, eq } from '@/lib/server/db'
+import { config } from '@/lib/server/config'
 import type { Session } from './auth'
 import type { TenantSettings } from '@/lib/server/domains/settings'
 import type { SessionId, UserId } from '@quackback/ids'
 
 export interface BootstrapData {
+  baseUrl: string
   session: Session | null
   settings: TenantSettings | null
   userRole: 'admin' | 'member' | 'user' | null
@@ -80,6 +82,6 @@ export const getBootstrapData = createServerFn({ method: 'GET' }).handler(
       }, 10_000)
     }
 
-    return { session, settings, userRole }
+    return { baseUrl: config.baseUrl, session, settings, userRole }
   }
 )

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -54,6 +54,7 @@ const systemThemeScript = `
 
 export interface RouterContext {
   queryClient: QueryClient
+  baseUrl?: string
   session?: BootstrapData['session']
   settings?: TenantSettings | null
   userRole?: 'admin' | 'member' | 'user' | null
@@ -78,7 +79,7 @@ function isOnboardingExempt(pathname: string): boolean {
 
 export const Route = createRootRouteWithContext<RouterContext>()({
   beforeLoad: async ({ location }) => {
-    const { session, settings, userRole } = await getBootstrapData()
+    const { baseUrl, session, settings, userRole } = await getBootstrapData()
 
     if (!isOnboardingExempt(location.pathname)) {
       const setupState = getSetupState(settings?.settings?.setupState ?? null)
@@ -87,7 +88,7 @@ export const Route = createRootRouteWithContext<RouterContext>()({
       }
     }
 
-    return { session, settings, userRole }
+    return { baseUrl, session, settings, userRole }
   },
   head: () => ({
     meta: [

--- a/apps/web/src/routes/admin/settings.mcp.tsx
+++ b/apps/web/src/routes/admin/settings.mcp.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, useRouteContext } from '@tanstack/react-router'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { CommandLineIcon } from '@heroicons/react/24/solid'
 import { BackLink } from '@/components/ui/back-link'
@@ -8,7 +8,6 @@ import { SettingsCard } from '@/components/admin/settings/settings-card'
 import { McpServerSettings } from '@/components/admin/settings/mcp/mcp-server-settings'
 import { McpSetupGuide } from '@/components/admin/settings/mcp/mcp-setup-guide'
 import { settingsQueries } from '@/lib/client/queries/settings'
-import { getBaseUrl } from '@/lib/shared/routing'
 
 export const Route = createFileRoute('/admin/settings/mcp')({
   loader: async ({ context }) => {
@@ -24,7 +23,7 @@ export const Route = createFileRoute('/admin/settings/mcp')({
 })
 
 function useEndpointUrl() {
-  const baseUrl = getBaseUrl()
+  const { baseUrl } = useRouteContext({ from: '__root__' })
   return baseUrl ? `${baseUrl}/api/mcp` : '/api/mcp'
 }
 

--- a/apps/web/src/routes/admin/settings.widget.tsx
+++ b/apps/web/src/routes/admin/settings.widget.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, useRouter } from '@tanstack/react-router'
+import { createFileRoute, useRouter, useRouteContext } from '@tanstack/react-router'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { useState, useTransition, useMemo } from 'react'
 import {
@@ -19,7 +19,6 @@ import { Button } from '@/components/ui/button'
 import { settingsQueries } from '@/lib/client/queries/settings'
 import { adminQueries } from '@/lib/client/queries/admin'
 import { updateWidgetConfigFn, regenerateWidgetSecretFn } from '@/lib/server/functions/settings'
-import { getBaseUrl } from '@/lib/shared/routing'
 
 export const Route = createFileRoute('/admin/settings/widget')({
   loader: async ({ context }) => {
@@ -55,7 +54,7 @@ function WidgetSettingsPage() {
   const widgetConfigQuery = useSuspenseQuery(settingsQueries.widgetConfig())
   const widgetSecretQuery = useSuspenseQuery(settingsQueries.widgetSecret())
   const boardsQuery = useSuspenseQuery(adminQueries.boards())
-  const baseUrl = getBaseUrl()
+  const { baseUrl } = useRouteContext({ from: '__root__' })
 
   return (
     <div className="space-y-6 max-w-5xl">
@@ -71,7 +70,7 @@ function WidgetSettingsPage() {
       <WidgetToggle initialEnabled={widgetConfigQuery.data.enabled} />
       <WidgetGeneralSettings config={widgetConfigQuery.data} boards={boardsQuery.data} />
       <WidgetIdentifySettings config={widgetConfigQuery.data} secret={widgetSecretQuery.data} />
-      <WidgetEmbedCode baseUrl={baseUrl} />
+      <WidgetEmbedCode baseUrl={baseUrl ?? ''} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Addresses review feedback from #43 where switching to `window.location.origin` broke reverse proxy deployments
- Threads `BASE_URL` through the bootstrap server function (`createServerFn`) into the router context
- Settings pages now always display the server-configured `BASE_URL`, whether loaded via SSR or client-side navigation

## Changes
- `bootstrap.ts` - Add `baseUrl: config.baseUrl` to bootstrap data
- `__root.tsx` - Add `baseUrl` to `RouterContext` and thread it through
- `settings.mcp.tsx` - Use `useRouteContext({ from: '__root__' })` instead of shared `getBaseUrl()`
- `settings.widget.tsx` - Same fix for widget embed code

## Why this works
`getBootstrapData` is a `createServerFn` - it always resolves server-side (via RPC during client-side nav), so `config.baseUrl` always reads from `process.env.BASE_URL`.

## Test plan
- [x] TypeScript typecheck passes
- [x] All 467 tests pass
- [x] Navigate to MCP settings via client-side nav - verify full BASE_URL shown
- [x] Navigate to Widget settings via client-side nav - verify embed snippet has BASE_URL
- [x] Full page reload on both pages still shows correct URLs
- [x] With BASE_URL different from browser origin (reverse proxy), verify correct URL displayed
