### PR TITLE
feat: add delete_post and restore_post MCP tools

### DIFF
--- a/apps/web/src/routes/api/v1/posts/index.ts
+++ b/apps/web/src/routes/api/v1/posts/index.ts
@@ -51,7 +51,7 @@ export const Route = createFileRoute('/api/v1/posts/')({
           const tagIdsParam = url.searchParams.get('tagIds') ?? undefined
           const search = url.searchParams.get('search') ?? undefined
           const sort = (url.searchParams.get('sort') as 'newest' | 'oldest' | 'votes') ?? 'newest'
-          const showDeleted = url.searchParams.get('deleted') === 'true'
+          const showDeleted = url.searchParams.get('showDeleted') === 'true'
 
           // Validate boardId filter if provided
           const { isValidTypeId } = await import('@quackback/ids')
@@ -96,6 +96,7 @@ export const Route = createFileRoute('/api/v1/posts/')({
               tags: post.tags?.map((t) => ({ id: t.id, name: t.name, color: t.color })) ?? [],
               createdAt: post.createdAt.toISOString(),
               updatedAt: post.updatedAt.toISOString(),
+              deletedAt: post.deletedAt?.toISOString() ?? null,
             })),
             {
               pagination: {


### PR DESCRIPTION
## Summary

- Add `delete_post` and `restore_post` MCP tools for programmatic post management
- Add `showDeleted` parameter to `search` MCP tool
- Add `?showDeleted=true` query parameter to `GET /api/v1/posts` endpoint

## MCP tools

| Tool | Annotation | Scope | Description |
|------|-----------|-------|-------------|
| `delete_post` | DESTRUCTIVE | `write:feedback` | Soft-delete a post |
| `restore_post` | WRITE | `write:feedback` | Restore a deleted post (30-day window) |
| `search` (updated) | READ | `read:feedback` | New `showDeleted` boolean parameter |

## API

- `GET /api/v1/posts?showDeleted=true` - show only soft-deleted posts (team only, last 30 days)

## Tests

- 9 new MCP handler tests: tool success/error cases, scope enforcement, search showDeleted, role enforcement

## Test plan

- [x] Use `delete_post` MCP tool - verify post hidden from search
- [x] Use `restore_post` MCP tool - verify post visible again
- [x] Use `search` with `showDeleted: true` - verify deleted posts returned
- [x] Call `GET /api/v1/posts?showDeleted=true` - verify deleted posts included
- [x] Run `bun run test` - all tests pass