### PR TITLE
fix: use config.baseUrl to prevent mixed content errors

### DIFF
--- a/apps/web/src/routes/api/v1/docs.ts
+++ b/apps/web/src/routes/api/v1/docs.ts
@@ -1,4 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { config } from '@/lib/server/config'
 
 export const Route = createFileRoute('/api/v1/docs')({
   server: {
@@ -9,9 +10,8 @@ export const Route = createFileRoute('/api/v1/docs')({
        *
        * This endpoint is public and does not require authentication.
        */
-      GET: async ({ request }) => {
-        const url = new URL(request.url)
-        const baseUrl = `${url.protocol}//${url.host}`
+      GET: async () => {
+        const baseUrl = config.baseUrl
 
         const html = `<!DOCTYPE html>
 <html lang="en">

--- a/apps/web/src/routes/api/widget/sdk[.]js.ts
+++ b/apps/web/src/routes/api/widget/sdk[.]js.ts
@@ -1,4 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { config } from '@/lib/server/config'
 import { buildWidgetSDK, type WidgetTheme } from '@/lib/shared/widget/sdk-template'
 
 function jsResponse(body: string, maxAge: number): Response {
@@ -45,7 +46,7 @@ function extractThemeFromCss(css: string): WidgetTheme {
 export const Route = createFileRoute('/api/widget/sdk.js')({
   server: {
     handlers: {
-      GET: async ({ request }) => {
+      GET: async () => {
         const { getWidgetConfig, getBrandingConfig } =
           await import('@/lib/server/domains/settings/settings.service')
         const widgetConfig = await getWidgetConfig()
@@ -57,8 +58,7 @@ export const Route = createFileRoute('/api/widget/sdk.js')({
           )
         }
 
-        const url = new URL(request.url)
-        const baseUrl = `${url.protocol}//${url.host}`
+        const baseUrl = config.baseUrl
 
         // Resolve theme from branding for trigger button styling
         const theme: WidgetTheme = {}

--- a/apps/web/src/routes/changelog/feed.ts
+++ b/apps/web/src/routes/changelog/feed.ts
@@ -1,4 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { config } from '@/lib/server/config'
 import { db, changelogEntries, desc, isNotNull, lte } from '@/lib/server/db'
 import { getSettingsBrandingData } from '@/lib/server/settings-utils'
 import { stripHtml } from '@/lib/shared/utils'
@@ -10,9 +11,8 @@ export const Route = createFileRoute('/changelog/feed')({
        * GET /changelog/feed
        * Returns RSS 2.0 feed of published changelog entries
        */
-      GET: async ({ request }) => {
-        const url = new URL(request.url)
-        const baseUrl = `${url.protocol}//${url.host}`
+      GET: async () => {
+        const baseUrl = config.baseUrl
 
         // Get workspace branding for feed title
         const branding = await getSettingsBrandingData()


### PR DESCRIPTION
## Summary
- Widget SDK, RSS feed, and API docs were deriving `baseUrl` from `request.url`, which arrives as `http://` behind Cloudflare TLS termination
- This caused the widget iframe to load over `http://`, triggering mixed content errors on HTTPS sites
- Switched all three routes to use `config.baseUrl` (from `BASE_URL` env var), consistent with the rest of the codebase

## Test plan
- [x] Deploy and verify the widget iframe loads over HTTPS on quackback.io
- [x] Verify `/changelog/feed` RSS links use HTTPS
- [x] Verify `/api/v1/docs` Swagger UI uses HTTPS base URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)
