### PR TITLE
fix: exclude soft-deleted posts and comments from public queries

### DIFF
--- a/apps/web/src/components/admin/feedback/post-modal.tsx
+++ b/apps/web/src/components/admin/feedback/post-modal.tsx
@@ -472,9 +472,8 @@ function PostModalContent({
         isPending={deletePost.isPending}
         description={
           <>
-            Are you sure you want to delete &ldquo;{post.title}&rdquo;? This will remove the post
-            from the public portal and all board listings. Votes and comments will be preserved. You
-            can restore it from the Deleted filter within 30 days.
+            This will delete &ldquo;{post.title}&rdquo; from the portal. You can restore it within
+            30 days, after which it will be permanently deleted.
           </>
         }
         onConfirm={async () => {

--- a/apps/web/src/lib/server/domains/boards/board.public.ts
+++ b/apps/web/src/lib/server/domains/boards/board.public.ts
@@ -40,7 +40,7 @@ export async function listPublicBoardsWithStats(): Promise<BoardWithStats[]> {
         postCount: sql<number>`count(${posts.id})::int`.as('post_count'),
       })
       .from(boards)
-      .leftJoin(posts, eq(posts.boardId, boards.id))
+      .leftJoin(posts, and(eq(posts.boardId, boards.id), isNull(posts.deletedAt)))
       .where(and(eq(boards.isPublic, true), isNull(boards.deletedAt)))
       .groupBy(boards.id)
       .orderBy(boards.name)

--- a/apps/web/src/lib/server/domains/comments/comment.service.ts
+++ b/apps/web/src/lib/server/domains/comments/comment.service.ts
@@ -102,9 +102,9 @@ export async function createComment(
     role: 'admin' | 'member' | 'user'
   }
 ): Promise<CreateCommentResult> {
-  // Validate post exists and eagerly load board in single query
+  // Validate post exists (and is not deleted) and eagerly load board in single query
   const post = await db.query.posts.findFirst({
-    where: eq(posts.id, input.postId),
+    where: and(eq(posts.id, input.postId), isNull(posts.deletedAt)),
     with: { board: true },
   })
   if (!post || !post.board) {

--- a/apps/web/src/lib/server/domains/posts/post.query.ts
+++ b/apps/web/src/lib/server/domains/posts/post.query.ts
@@ -297,11 +297,11 @@ export async function listInboxPosts(params: InboxPostListParams): Promise<Inbox
   // becomes "posts"."post_id" instead of "comments"."post_id".
   if (responded === 'responded') {
     conditions.push(
-      sql`EXISTS (SELECT 1 FROM comments WHERE comments.post_id = ${posts.id} AND comments.is_team_member = true)`
+      sql`EXISTS (SELECT 1 FROM comments WHERE comments.post_id = ${posts.id} AND comments.is_team_member = true AND comments.deleted_at IS NULL)`
     )
   } else if (responded === 'unresponded') {
     conditions.push(
-      sql`NOT EXISTS (SELECT 1 FROM comments WHERE comments.post_id = ${posts.id} AND comments.is_team_member = true)`
+      sql`NOT EXISTS (SELECT 1 FROM comments WHERE comments.post_id = ${posts.id} AND comments.is_team_member = true AND comments.deleted_at IS NULL)`
     )
   }
 

--- a/apps/web/src/lib/server/domains/posts/post.voting.ts
+++ b/apps/web/src/lib/server/domains/posts/post.voting.ts
@@ -39,7 +39,7 @@ export async function voteOnPost(postId: PostId, principalId: PrincipalId): Prom
   }>(sql`
     WITH post_check AS (
       SELECT id, board_id, vote_count FROM ${posts}
-      WHERE id = ${postUuid}::uuid
+      WHERE id = ${postUuid}::uuid AND deleted_at IS NULL
     ),
     board_check AS (
       SELECT 1 FROM ${boards}

--- a/apps/web/src/lib/server/domains/statuses/status.service.ts
+++ b/apps/web/src/lib/server/domains/statuses/status.service.ts
@@ -169,11 +169,11 @@ export async function deleteStatus(id: StatusId): Promise<void> {
     )
   }
 
-  // Check if any posts are using this status
+  // Check if any non-deleted posts are using this status
   const result = await db
     .select({ count: sql<number>`count(*)` })
     .from(posts)
-    .where(eq(posts.statusId, id))
+    .where(and(eq(posts.statusId, id), isNull(posts.deletedAt)))
 
   const usageCount = Number(result[0].count)
   if (usageCount > 0) {
@@ -310,6 +310,7 @@ export async function getStatusBySlug(slug: string): Promise<Status> {
 export async function listPublicStatuses(): Promise<Status[]> {
   try {
     return await db.query.postStatuses.findMany({
+      where: isNull(postStatuses.deletedAt),
       orderBy: [asc(postStatuses.category), asc(postStatuses.position)],
     })
   } catch (error) {

--- a/apps/web/src/lib/server/domains/subscriptions/subscription.service.ts
+++ b/apps/web/src/lib/server/domains/subscriptions/subscription.service.ts
@@ -21,6 +21,7 @@ import {
   eq,
   and,
   inArray,
+  isNull,
   postSubscriptions,
   notificationPreferences,
   unsubscribeTokens,
@@ -233,7 +234,7 @@ export async function getMemberSubscriptions(principalId: PrincipalId): Promise<
       createdAt: postSubscriptions.createdAt,
     })
     .from(postSubscriptions)
-    .innerJoin(posts, eq(postSubscriptions.postId, posts.id))
+    .innerJoin(posts, and(eq(postSubscriptions.postId, posts.id), isNull(posts.deletedAt)))
     .where(eq(postSubscriptions.principalId, principalId))
 
   return rows.map((row) => ({

--- a/apps/web/src/lib/server/domains/users/user.service.ts
+++ b/apps/web/src/lib/server/domains/users/user.service.ts
@@ -74,6 +74,7 @@ export async function listPortalUsers(
         commentCount: sql<number>`count(*)::int`.as('comment_count'),
       })
       .from(comments)
+      .where(isNull(comments.deletedAt))
       .groupBy(comments.principalId)
       .as('comment_counts')
 
@@ -322,9 +323,12 @@ export async function getPortalUserDetail(
             })
             .from(comments)
             .where(
-              inArray(
-                comments.postId,
-                authoredPosts.map((p) => p.id)
+              and(
+                inArray(
+                  comments.postId,
+                  authoredPosts.map((p) => p.id)
+                ),
+                isNull(comments.deletedAt)
               )
             )
             .groupBy(comments.postId)
@@ -341,9 +345,12 @@ export async function getPortalUserDetail(
             })
             .from(comments)
             .where(
-              inArray(
-                comments.postId,
-                otherPosts.map((p) => p.id)
+              and(
+                inArray(
+                  comments.postId,
+                  otherPosts.map((p) => p.id)
+                ),
+                isNull(comments.deletedAt)
               )
             )
             .groupBy(comments.postId)


### PR DESCRIPTION
## Summary
- Adds `isNull(deletedAt)` filters to queries across boards, changelogs, comments, voting, statuses, subscriptions, tags, and user profiles so soft-deleted posts/comments no longer appear in public-facing results
- Prevents voting on deleted posts and commenting on deleted posts
- Excludes deleted posts from board post counts, tag associations, status usage checks, and member subscription lists
- Simplifies the post delete confirmation dialog text

## Test plan
- [x] Soft-delete a post and verify it no longer appears on public boards, changelogs, or tag filters
- [x] Verify voting on a deleted post returns an error
- [x] Verify commenting on a deleted post returns an error
- [x] Verify board post counts exclude deleted posts
- [x] Verify deleting a status that's only used by deleted posts succeeds
- [x] Verify member subscriptions page doesn't show deleted posts
