### PR TITLE
feat: log build and version info on startup

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quackback/web",
-  "version": "0.1.0",
+  "version": "0.3.3",
   "private": true,
   "license": "AGPL-3.0",
   "type": "module",

--- a/apps/web/src/lib/server/startup.ts
+++ b/apps/web/src/lib/server/startup.ts
@@ -1,0 +1,32 @@
+/**
+ * Startup banner -- logs build and runtime info once on first request.
+ * Build-time constants are injected via Vite `define`; runtime info is read at call time.
+ */
+
+let _logged = false
+
+export function logStartupBanner(): void {
+  if (_logged) return
+  _logged = true
+
+  const runtime =
+    typeof globalThis.Bun !== 'undefined' ? `bun ${Bun.version}` : `node ${process.version}`
+  const env = process.env.NODE_ENV ?? 'development'
+  const port = process.env.PORT ?? '3000'
+  const baseUrl = process.env.BASE_URL ?? `http://localhost:${port}`
+
+  const lines = [
+    '',
+    '========================================',
+    `  Quackback v${__APP_VERSION__} (${__GIT_COMMIT__})`,
+    '========================================',
+    `  Environment: ${env}`,
+    `  Runtime:     ${runtime}`,
+    `  Base URL:    ${baseUrl}`,
+    `  Built:       ${__BUILD_TIME__}`,
+    '========================================',
+    '',
+  ]
+
+  console.log(lines.join('\n'))
+}

--- a/apps/web/src/lib/server/telemetry/payload.ts
+++ b/apps/web/src/lib/server/telemetry/payload.ts
@@ -1,5 +1,4 @@
-import { existsSync, readFileSync } from 'fs'
-import { resolve } from 'path'
+import { existsSync } from 'fs'
 import { getOrCreateInstanceId } from './instance-id'
 
 export interface TelemetryPayload {
@@ -25,25 +24,12 @@ export interface TelemetryPayload {
   }
 }
 
-let _version: string | undefined
-
-function getVersion(): string {
-  if (_version) return _version
-  try {
-    const pkg = JSON.parse(readFileSync(resolve(process.cwd(), 'package.json'), 'utf-8'))
-    _version = pkg.version ?? '0.0.0'
-  } catch {
-    _version = '0.0.0'
-  }
-  return _version!
-}
-
 function getRuntime(): 'bun' | 'node' {
   return typeof globalThis.Bun !== 'undefined' ? 'bun' : 'node'
 }
 
 function getRuntimeVersion(): string {
-  const raw = getRuntime() === 'bun' ? (Bun?.version ?? process.version) : process.version
+  const raw = getRuntime() === 'bun' ? Bun.version : process.version
   const [major, minor] = raw.replace(/^v/, '').split('.')
   return major && minor ? `${major}.${minor}` : raw
 }
@@ -119,7 +105,7 @@ export async function buildPayload(): Promise<TelemetryPayload> {
   ])
 
   return {
-    version: getVersion(),
+    version: __APP_VERSION__,
     runtime: getRuntime(),
     runtimeVersion: getRuntimeVersion(),
     os: process.platform,

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,5 +1,10 @@
 /// <reference types="vite/client" />
 
+// Build-time constants injected by Vite define
+declare const __APP_VERSION__: string
+declare const __GIT_COMMIT__: string
+declare const __BUILD_TIME__: string
+
 // Support for importing SQL files as raw strings
 declare module '*.sql?raw' {
   const content: string


### PR DESCRIPTION
## Summary
- Injects version, git commit SHA, and build timestamp at compile time via Vite `define`
- Logs a startup banner on first request showing version, commit, environment, runtime, base URL, and build time
- Bumps version to `0.3.3` to match latest release tag
- Switches telemetry payload to use build-time version constant instead of reading `package.json` at runtime (which was unreliable in Docker)

Example output:
```
========================================
  Quackback v0.3.3 (8efa4be9)
========================================
  Environment: production
  Runtime:     bun 1.3.7
  Base URL:    https://feedback.example.com
  Built:       2026-02-18T01:37:09.048Z
========================================
```

## Test plan
- [x] Run `bun run dev`, hit localhost - verify banner appears in console on first request
- [x] Run `bun run build` - verify `__APP_VERSION__`, `__GIT_COMMIT__`, `__BUILD_TIME__` are inlined in built output
- [x] Verify `bun run typecheck` passes