### PR TITLE
fix: log startup banner at server init instead of first request

### DIFF
--- a/apps/web/src/lib/server/functions/bootstrap.ts
+++ b/apps/web/src/lib/server/functions/bootstrap.ts
@@ -73,9 +73,6 @@ export const getBootstrapData = createServerFn({ method: 'GET' }).handler(
     if (!_initialized) {
       _initialized = true
 
-      const { logStartupBanner } = await import('@/lib/server/startup')
-      logStartupBanner()
-
       // Delay telemetry to let the DB connection initialize
       setTimeout(async () => {
         try {

--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -1,0 +1,10 @@
+import handler, { createServerEntry } from '@tanstack/react-start/server-entry'
+import { logStartupBanner } from '@/lib/server/startup'
+
+logStartupBanner()
+
+export default createServerEntry({
+  fetch(request) {
+    return handler.fetch(request)
+  },
+})


### PR DESCRIPTION
## Summary
- Add `server.ts` entry point so the startup banner logs when the server module initializes, not on first request
- Remove the deferred `logStartupBanner()` call from `bootstrap.ts`

## Test plan
- [x] Run `bun run dev` and verify the banner prints without visiting the page
