### PR TITLE
fix: treat date-only dateTo as end-of-day

### DIFF
--- a/apps/web/src/lib/server/mcp/tools.ts
+++ b/apps/web/src/lib/server/mcp/tools.ts
@@ -972,7 +972,13 @@ async function searchPosts(args: SearchArgs): Promise<CallToolResult> {
     statusSlugs: args.status ? [args.status] : undefined,
     tagIds: args.tagIds as TagId[] | undefined,
     dateFrom: args.dateFrom ? new Date(args.dateFrom) : undefined,
-    dateTo: args.dateTo ? new Date(args.dateTo) : undefined,
+    dateTo: (() => {
+      if (!args.dateTo) return undefined
+      const d = new Date(args.dateTo)
+      // Treat date-only dateTo (e.g. "2024-06-30") as end-of-day so the full day is included
+      if (/^\d{4}-\d{2}-\d{2}$/.test(args.dateTo)) d.setUTCHours(23, 59, 59, 999)
+      return d
+    })(),
     showDeleted: args.showDeleted || undefined,
     sort: args.sort,
     cursor: cursorValue,

--- a/apps/web/src/routes/api/v1/posts/index.ts
+++ b/apps/web/src/routes/api/v1/posts/index.ts
@@ -74,6 +74,10 @@ export const Route = createFileRoute('/api/v1/posts/')({
           // Parse date filters (ISO 8601 strings)
           const dateFrom = dateFromParam ? new Date(dateFromParam) : undefined
           const dateTo = dateToParam ? new Date(dateToParam) : undefined
+          // Treat date-only dateTo (e.g. "2024-06-30") as end-of-day so the full day is included
+          if (dateTo && dateToParam && /^\d{4}-\d{2}-\d{2}$/.test(dateToParam)) {
+            dateTo.setUTCHours(23, 59, 59, 999)
+          }
 
           const result = await listInboxPosts({
             boardIds: boardId ? [boardId] : undefined,


### PR DESCRIPTION
## Summary
- **Fix dateTo off-by-one** - `new Date("2024-06-30")` resolves to midnight at the start of that day, so `created_at <= dateTo` excluded records from later on June 30. Date-only `dateTo` strings are now set to `23:59:59.999 UTC` so the full final day is included.
- Applied in both the public API route and MCP search tool.

Fixes #61

## Test plan
- [x] `bun run build` passes
- [x] Date-only `dateTo` (e.g. `2024-06-30`) now includes the full day
- [x] Full ISO timestamps (e.g. `2024-06-30T12:00:00Z`) are unaffected