### PR TITLE
fix: add email to OAuth protected resource scopes

### DIFF
--- a/apps/web/src/routes/[.]well-known.oauth-protected-resource.ts
+++ b/apps/web/src/routes/[.]well-known.oauth-protected-resource.ts
@@ -26,6 +26,7 @@ export const Route = createFileRoute('/.well-known/oauth-protected-resource')({
             scopes_supported: [
               'openid',
               'profile',
+              'email',
               'offline_access',
               'read:feedback',
               'write:feedback',


### PR DESCRIPTION
## Summary
- ChatGPT requests the standard OIDC `email` scope during OAuth discovery, but our `/.well-known/oauth-protected-resource` metadata didn't list it in `scopes_supported`
- This caused an `invalid_scope` error redirect back to ChatGPT
- The `email` scope was already registered in Better Auth config and the consent page - this just adds it to the discovery metadata to match

## Test plan
- [x] Verify `/.well-known/oauth-protected-resource` response includes `email` in `scopes_supported`
- [x] Retry ChatGPT MCP connection and confirm no `invalid_scope` error