### PR TITLE
fix: add email to OAuth client registration default scopes

### DIFF
--- a/apps/web/src/lib/server/auth/index.ts
+++ b/apps/web/src/lib/server/auth/index.ts
@@ -258,6 +258,7 @@ async function createAuth() {
         clientRegistrationDefaultScopes: [
           'openid',
           'profile',
+          'email',
           'read:feedback',
           'offline_access',
           'write:feedback',


### PR DESCRIPTION
## Summary
- Follow-up to #63 / v0.3.8 - that fix added `email` to the protected resource metadata but ChatGPT still gets `invalid_scope`
- Root cause: `clientRegistrationDefaultScopes` didn't include `email`, so dynamically registered clients (like ChatGPT) aren't allowed to request it
- After deploying, ChatGPT's existing client registration in prod will also need its `scopes` column updated (or deleted so it re-registers)

## Test plan
- [x] Deploy and retry ChatGPT MCP connection
- [x] If still failing, delete ChatGPT's row from `oauth_client` so it re-registers with the new defaults