### PR TITLE
fix: rewrite invitation acceptance flow and fix invite modal UX

### DIFF
--- a/apps/web/src/routes/accept-invitation.$id.tsx
+++ b/apps/web/src/routes/accept-invitation.$id.tsx
@@ -1,31 +1,34 @@
-import { createFileRoute, redirect } from '@tanstack/react-router'
+import { createFileRoute, isRedirect } from '@tanstack/react-router'
 import { useState } from 'react'
+import { ArrowPathIcon } from '@heroicons/react/24/solid'
 import { Spinner } from '@/components/shared/spinner'
-import { acceptInvitationFn } from '@/lib/server/functions/invitations'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  acceptInvitationFn,
+  getInvitationDetailsFn,
+  setPasswordFn,
+} from '@/lib/server/functions/invitations'
 
 export const Route = createFileRoute('/accept-invitation/$id')({
   loader: async ({ params, context }) => {
     const { id } = params
     const { session } = context
 
-    // With magic links, users are authenticated before reaching this page.
-    // The magic link verification creates a session and redirects here.
     if (!session?.user) {
-      return { error: 'Please use the invitation link from your email to join the team.' }
+      return {
+        state: 'error' as const,
+        error: 'Please use the invitation link from your email to join the team.',
+      }
     }
 
-    // User is authenticated - accept the invitation immediately
     try {
-      await acceptInvitationFn({ data: id })
-      // Success - redirect directly to admin dashboard
-      throw redirect({ to: '/admin' })
-    } catch (error) {
-      // Don't treat redirect as an error
-      if (error instanceof Response || (error as { status?: number })?.status === 302) {
-        throw error
-      }
-      const message = error instanceof Error ? error.message : 'Failed to accept invitation'
-      return { error: message }
+      const data = await getInvitationDetailsFn({ data: id })
+      return { state: 'welcome' as const, ...data }
+    } catch (err) {
+      if (isRedirect(err)) throw err
+      const message = err instanceof Error ? err.message : 'Failed to load invitation'
+      return { state: 'error' as const, error: message }
     }
   },
   component: AcceptInvitationPage,
@@ -33,15 +36,186 @@ export const Route = createFileRoute('/accept-invitation/$id')({
 
 function AcceptInvitationPage() {
   const data = Route.useLoaderData()
-  const [retrying, setRetrying] = useState(false)
 
-  // If we reach this component, there was an error (success redirects in loader)
-  const error = data?.error || 'An unexpected error occurred'
-
-  const handleRetry = () => {
-    setRetrying(true)
-    window.location.reload()
+  if (data.state === 'error') {
+    return <ErrorView error={data.error} />
   }
+
+  return (
+    <WelcomeView
+      invite={data.invite}
+      passwordEnabled={data.passwordEnabled}
+      requiresPasswordSetup={data.requiresPasswordSetup}
+    />
+  )
+}
+
+function WelcomeView({
+  invite,
+  passwordEnabled,
+  requiresPasswordSetup,
+}: {
+  invite: {
+    name: string | null
+    email: string
+    workspaceName: string
+    inviterName: string | null
+  }
+  passwordEnabled: boolean
+  requiresPasswordSetup: boolean
+}) {
+  const { id } = Route.useParams()
+  const [name, setName] = useState(invite.name ?? '')
+  const [password, setPassword] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    await accept(false)
+  }
+
+  async function accept(skipPassword: boolean) {
+    const trimmedName = name.trim()
+
+    if (trimmedName.length < 2) {
+      setError('Please enter your name (at least 2 characters)')
+      return
+    }
+    if (requiresPasswordSetup && password.length < 8) {
+      setError('Please set a password (at least 8 characters)')
+      return
+    }
+    if (!requiresPasswordSetup && !skipPassword && password && password.length < 8) {
+      setError('Password must be at least 8 characters')
+      return
+    }
+
+    setError('')
+    setIsLoading(true)
+
+    try {
+      // For users without an existing credential password, password setup is required.
+      if (requiresPasswordSetup) {
+        await setPasswordFn({ data: { newPassword: password } })
+      }
+
+      await acceptInvitationFn({ data: { invitationId: id, name: trimmedName } })
+
+      // Optional password setup for users who already had a credential account.
+      if (!requiresPasswordSetup && !skipPassword && password.length >= 8) {
+        await setPasswordFn({ data: { newPassword: password } }).catch((err) => {
+          console.warn('[accept-invitation] optional setPassword failed:', err)
+        })
+      }
+
+      window.location.href = '/admin'
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to accept invitation'
+      // Treat "already accepted" as success (idempotency on retry)
+      if (message.includes('already been accepted')) {
+        window.location.href = '/admin'
+        return
+      }
+      setError(message)
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background">
+      <div className="w-full max-w-md px-4">
+        <div className="overflow-hidden rounded-2xl border border-border/50 bg-gradient-to-b from-card/90 to-card/70 backdrop-blur-sm">
+          <div className="p-8">
+            <div className="mb-6 text-center">
+              <h1 className="text-2xl font-bold">Welcome to {invite.workspaceName}</h1>
+              <p className="mt-2 text-muted-foreground">
+                {invite.inviterName
+                  ? `You were invited by ${invite.inviterName}`
+                  : 'You have been invited to join the team'}
+              </p>
+            </div>
+
+            {error && (
+              <div className="mb-4 rounded-lg bg-destructive/10 border border-destructive/20 px-4 py-3 text-sm text-destructive">
+                {error}
+              </div>
+            )}
+
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="space-y-2">
+                <label htmlFor="name" className="text-sm font-medium">
+                  Your name
+                </label>
+                <Input
+                  id="name"
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  required
+                  placeholder="Jane Doe"
+                  autoComplete="name"
+                  autoFocus
+                  disabled={isLoading}
+                  className="h-11"
+                />
+              </div>
+
+              {passwordEnabled && (
+                <div className="space-y-2">
+                  <label htmlFor="password" className="text-sm font-medium">
+                    Set a password{' '}
+                    {!requiresPasswordSetup && (
+                      <span className="text-muted-foreground font-normal">(optional)</span>
+                    )}
+                  </label>
+                  <Input
+                    id="password"
+                    type="password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    placeholder="At least 8 characters"
+                    autoComplete="new-password"
+                    disabled={isLoading}
+                    required={requiresPasswordSetup}
+                    className="h-11"
+                  />
+                </div>
+              )}
+
+              <Button
+                type="submit"
+                disabled={
+                  isLoading ||
+                  name.trim().length < 2 ||
+                  (requiresPasswordSetup && password.length < 8)
+                }
+                className="w-full h-11"
+              >
+                {isLoading ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : 'Get started'}
+              </Button>
+
+              {passwordEnabled && !requiresPasswordSetup && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => accept(true)}
+                  disabled={isLoading}
+                  className="w-full text-muted-foreground"
+                >
+                  Skip password setup
+                </Button>
+              )}
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ErrorView({ error }: { error: string }) {
+  const [retrying, setRetrying] = useState(false)
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background">
@@ -56,12 +230,14 @@ function AcceptInvitationPage() {
             <div className="text-destructive text-xl font-medium">Unable to accept invitation</div>
             <p className="mt-2 text-muted-foreground">{error}</p>
             <div className="mt-6 flex flex-col gap-3">
-              <button
-                onClick={handleRetry}
-                className="inline-flex items-center justify-center rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+              <Button
+                onClick={() => {
+                  setRetrying(true)
+                  window.location.reload()
+                }}
               >
                 Try Again
-              </button>
+              </Button>
               <a
                 href="/"
                 className="text-sm text-muted-foreground hover:text-foreground transition-colors"


### PR DESCRIPTION
## Summary

- **Rewrite accept-invitation page** - Replace broken auto-accept-in-loader pattern with a welcome page that collects the user's name and optionally sets a password
- **Fix "Failed to set password"** - Better Auth's `setPassword` endpoint has no HTTP path (server-side only API). Created `setPasswordFn` server function that calls `auth.api.setPassword()` instead of fetching a non-existent endpoint
- **Fix invite modal URL overflow** - Redesigned the no-email success state with `break-all` wrapping, a prominent "Copy invitation link" button, and a "Done" dismiss action
- **Fix TOCTOU race condition** - Replaced read-then-update with atomic conditional `UPDATE ... WHERE status = 'pending'` to prevent double-accept on concurrent requests
- **Add email ownership check** - `getInvitationDetailsFn` now verifies the authenticated user's email matches the invitation

## Test plan
- [x] Send an invitation from admin settings when email is not configured
- [x] Verify the invite modal shows the full URL with a copy button that works
- [x] Click the magic link and verify the welcome page loads with name + password fields
- [x] Accept the invitation with name and password, verify redirect to /admin
- [x] Test edge cases: expired invitation, already-accepted invitation, wrong email
- [x] Test double-click on "Get started" button (should not create duplicate principals)