### PR TITLE
fix: show post description for plain-text posts

### DIFF
--- a/apps/web/src/components/admin/feedback/post-modal.tsx
+++ b/apps/web/src/components/admin/feedback/post-modal.tsx
@@ -86,6 +86,26 @@ function toPortalComments(post: PostDetails): PublicCommentView[] {
   return post.comments.map(mapComment)
 }
 
+/** Convert plain text to TipTap JSON format for posts without contentJson */
+function getInitialContentJson(post: {
+  contentJson?: unknown
+  content: string
+}): JSONContent | null {
+  if (post.contentJson) {
+    return post.contentJson as JSONContent
+  }
+  if (post.content) {
+    return {
+      type: 'doc',
+      content: post.content.split('\n').map((line) => ({
+        type: 'paragraph',
+        content: line ? [{ type: 'text', text: line }] : [],
+      })),
+    }
+  }
+  return null
+}
+
 function PostModalContent({
   postId,
   currentUser,
@@ -104,9 +124,7 @@ function PostModalContent({
 
   // Form state - always in edit mode
   const [title, setTitle] = useState(post.title)
-  const [contentJson, setContentJson] = useState<JSONContent | null>(
-    (post.contentJson as JSONContent) ?? null
-  )
+  const [contentJson, setContentJson] = useState<JSONContent | null>(getInitialContentJson(post))
   const [hasInitialized, setHasInitialized] = useState(false)
 
   // UI state
@@ -132,7 +150,7 @@ function PostModalContent({
   useEffect(() => {
     if (post && !hasInitialized) {
       setTitle(post.title)
-      setContentJson((post.contentJson as JSONContent) ?? null)
+      setContentJson(getInitialContentJson(post))
       setHasInitialized(true)
     }
   }, [post, hasInitialized])
@@ -140,7 +158,7 @@ function PostModalContent({
   // Reset when navigating to different post
   useEffect(() => {
     setTitle(post.title)
-    setContentJson((post.contentJson as JSONContent) ?? null)
+    setContentJson(getInitialContentJson(post))
     setShowMergeDialog(false)
   }, [post.id, post.title, post.contentJson])
 

--- a/apps/web/src/components/public/post-detail/post-content-section.tsx
+++ b/apps/web/src/components/public/post-detail/post-content-section.tsx
@@ -36,6 +36,26 @@ export function PostContentSectionSkeleton(): React.ReactElement {
   )
 }
 
+/** Convert plain text to TipTap JSON format for posts without contentJson */
+function getInitialContentJson(post: {
+  contentJson: unknown
+  content: string
+}): JSONContent | null {
+  if (post.contentJson) {
+    return post.contentJson as JSONContent
+  }
+  if (post.content) {
+    return {
+      type: 'doc',
+      content: post.content.split('\n').map((line) => ({
+        type: 'paragraph',
+        content: line ? [{ type: 'text', text: line }] : [],
+      })),
+    }
+  }
+  return null
+}
+
 interface PostContentSectionProps {
   post: PublicPostDetailView
   currentStatus?: { name: string; color: string | null }
@@ -88,13 +108,13 @@ export function PostContentSection({
 }: PostContentSectionProps): React.ReactElement {
   const [editTitle, setEditTitle] = useState(post.title)
   const [editContentJson, setEditContentJson] = useState<JSONContent | null>(
-    (post.contentJson as JSONContent) ?? null
+    getInitialContentJson(post)
   )
 
   useEffect(() => {
     if (isEditing) {
       setEditTitle(post.title)
-      setEditContentJson((post.contentJson as JSONContent) ?? null)
+      setEditContentJson(getInitialContentJson(post))
     }
   }, [isEditing, post.title, post.contentJson])
 


### PR DESCRIPTION
## Summary
- Posts created via API or plain text submission only populate `content`, not `contentJson`. The admin post modal and public edit mode only read `contentJson`, showing an empty editor with "Add more details..." placeholder instead of the actual description.
- Added `getInitialContentJson()` helper that converts plain text to TipTap JSON as a fallback, matching the existing pattern in `edit-post-dialog.tsx`.
- Fixed in both admin post modal and public post edit mode.

## Test plan
- [x] Open a post in the admin modal that was created via API (plain text only) - description should now display
- [x] Edit that post and save - content should persist correctly
- [x] Open a post with rich text contentJson - should still display as before
- [x] Edit a post in the public portal view that only has plain text content - editor should show the content