### PR TITLE
Fix missing soft-delete filter on board queries

### DIFF
--- a/apps/web/src/lib/server/functions/admin.ts
+++ b/apps/web/src/lib/server/functions/admin.ts
@@ -16,7 +16,7 @@ import {
 import type { TiptapContent } from '@/lib/shared/schemas/posts'
 import { requireAuth } from './auth-helpers'
 import { getSettings } from './workspace'
-import { db, invitation, principal, user, boards, eq, and, isNull } from '@/lib/server/db'
+import { db, invitation, principal, user, eq, and } from '@/lib/server/db'
 import { listInboxPosts } from '@/lib/server/domains/posts/post.query'
 import { listBoards } from '@/lib/server/domains/boards/board.service'
 import { listTags } from '@/lib/server/domains/tags/tag.service'
@@ -320,9 +320,7 @@ export const fetchBoardsForSettings = createServerFn({ method: 'GET' }).handler(
   try {
     await requireAuth({ roles: ['admin', 'member'] })
 
-    const orgBoards = await db.query.boards.findMany({
-      where: isNull(boards.deletedAt),
-    })
+    const orgBoards = await listBoards()
     console.log(`[fn:admin] fetchBoardsForSettings: count=${orgBoards.length}`)
     return orgBoards.map((b) => ({
       ...b,

--- a/apps/web/src/lib/server/functions/onboarding.ts
+++ b/apps/web/src/lib/server/functions/onboarding.ts
@@ -6,18 +6,8 @@ import { USE_CASE_TYPES, type SetupState, type UseCaseType } from '@/lib/server/
 import { getSession } from './auth'
 import { getSettings } from './workspace'
 import { syncPrincipalProfile } from '@/lib/server/domains/principals/principal.service'
-import {
-  db,
-  settings,
-  principal,
-  user,
-  postStatuses,
-  boards,
-  eq,
-  asc,
-  isNull,
-  DEFAULT_STATUSES,
-} from '@/lib/server/db'
+import { listBoards } from '@/lib/server/domains/boards/board.service'
+import { db, settings, principal, user, postStatuses, eq, DEFAULT_STATUSES } from '@/lib/server/db'
 
 /**
  * Server functions for onboarding workflow.
@@ -437,10 +427,7 @@ export const saveUseCaseFn = createServerFn({ method: 'POST' })
 export const listBoardsForOnboarding = createServerFn({ method: 'GET' }).handler(async () => {
   console.log(`[fn:onboarding] listBoardsForOnboarding`)
   try {
-    const boardList = await db.query.boards.findMany({
-      where: isNull(boards.deletedAt),
-      orderBy: [asc(boards.name)],
-    })
+    const boardList = await listBoards()
     return boardList.map((b) => ({
       id: b.id,
       name: b.name,


### PR DESCRIPTION
## Summary
- Adds soft-delete filtering to `fetchBoardsForSettings` and `listBoardsForOnboarding` which were returning deleted boards
- Replaces inline queries with existing `listBoards()` service call (caught during simplify review)

## Test plan
- [x] Typecheck passes
- [x] Lint passes
- [x] All 634 tests pass