### PR TITLE
Remove no-op regex in interpretation service

### DIFF
--- a/apps/web/src/lib/server/domains/feedback/pipeline/interpretation.service.ts
+++ b/apps/web/src/lib/server/domains/feedback/pipeline/interpretation.service.ts
@@ -80,9 +80,7 @@ export async function interpretSignal(signalId: FeedbackSignalId): Promise<void>
           // Drizzle returns pgvector columns as strings — parse to number[]
           const raw = sourcePost.embedding as unknown
           searchEmbedding =
-            typeof raw === 'string'
-              ? JSON.parse(raw.replace(/^\[/, '[').replace(/\]$/, ']'))
-              : (raw as number[])
+            typeof raw === 'string' ? JSON.parse(raw) : (raw as number[])
         }
       }
     }


### PR DESCRIPTION
## Summary
- Removed identity `.replace()` calls in pgvector string parsing that replaced `[` with `[` and `]` with `]`
- Simplified to direct `JSON.parse(raw)` which is functionally identical
- Existing test already covers the pgvector parse path

## Test plan
- [x] Typecheck passes
- [x] Lint passes
- [x] All 634 tests pass