### PR TITLE
Add password reset flow, profile password management, and voter subscription controls

### DIFF
--- a/apps/web/src/components/admin/feedback/voters-modal.tsx
+++ b/apps/web/src/components/admin/feedback/voters-modal.tsx
@@ -1,12 +1,23 @@
+import { useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline'
+import { BellIcon, BellSlashIcon } from '@heroicons/react/24/solid'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Avatar } from '@/components/ui/avatar'
 import { TimeAgo } from '@/components/ui/time-ago'
 import { Skeleton } from '@/components/ui/skeleton'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+} from '@/components/ui/dropdown-menu'
 import { SOURCE_TYPE_LABELS, SourceTypeIcon } from '@/components/admin/feedback/source-type-icon'
 import { adminQueries } from '@/lib/client/queries/admin'
-import type { PostId } from '@quackback/ids'
+import { useUpdateVoterSubscription } from '@/lib/client/mutations/admin-subscriptions'
+import type { PostId, PrincipalId } from '@quackback/ids'
+import type { SubscriptionLevel } from '@/lib/server/domains/subscriptions/subscription.types'
 
 interface VotersModalProps {
   postId: PostId
@@ -15,11 +26,29 @@ interface VotersModalProps {
   onOpenChange: (open: boolean) => void
 }
 
+const SUBSCRIPTION_LABELS: Record<SubscriptionLevel, string> = {
+  all: 'All activity',
+  status_only: 'Status only',
+  none: 'Not subscribed',
+}
+
 export function VotersModal({ postId, voteCount, open, onOpenChange }: VotersModalProps) {
   const { data: voters, isLoading } = useQuery({
     ...adminQueries.postVoters(postId),
     enabled: open,
   })
+
+  const updateSubscription = useUpdateVoterSubscription(postId)
+
+  const summary = useMemo(() => {
+    if (!voters) return null
+    const total = voters.length
+    const statusCount = voters.filter(
+      (v) => v.subscriptionLevel === 'all' || v.subscriptionLevel === 'status_only'
+    ).length
+    const commentCount = voters.filter((v) => v.subscriptionLevel === 'all').length
+    return { total, statusCount, commentCount }
+  }, [voters])
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -42,28 +71,103 @@ export function VotersModal({ postId, voteCount, open, onOpenChange }: VotersMod
             </div>
           ) : voters && voters.length > 0 ? (
             <div className="space-y-3">
-              {voters.map((voter) => (
-                <div key={voter.principalId} className="flex items-center gap-3">
-                  <Avatar
-                    src={voter.avatarUrl}
-                    name={voter.displayName}
-                    className="h-8 w-8 text-xs"
-                  />
-                  <div className="min-w-0 flex-1">
-                    <p className="text-sm font-medium text-foreground truncate">
-                      {voter.displayName || voter.email || 'Anonymous'}
-                    </p>
-                    <VoterSourceLine voter={voter} />
+              {voters.map((voter) => {
+                const isAnonymous = !voter.email && !voter.displayName
+                return (
+                  <div key={voter.principalId} className="flex items-center gap-3">
+                    <Avatar
+                      src={voter.avatarUrl}
+                      name={voter.displayName}
+                      className="h-8 w-8 text-xs"
+                    />
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-medium text-foreground truncate">
+                        {voter.displayName || voter.email || 'Anonymous'}
+                      </p>
+                      <VoterSourceLine voter={voter} />
+                    </div>
+                    {isAnonymous ? (
+                      <span className="text-xs text-muted-foreground">—</span>
+                    ) : (
+                      <SubscriptionBadge
+                        level={voter.subscriptionLevel}
+                        onChangeLevel={(level) =>
+                          updateSubscription.mutate({
+                            principalId: voter.principalId as PrincipalId,
+                            level,
+                          })
+                        }
+                      />
+                    )}
                   </div>
-                </div>
-              ))}
+                )
+              })}
             </div>
           ) : (
             <p className="text-sm text-muted-foreground text-center py-4">No voters yet</p>
           )}
         </div>
+        {summary && summary.total > 0 && (
+          <div className="border-t pt-3 -mx-6 px-6 text-xs text-muted-foreground">
+            {summary.statusCount} of {summary.total} voters notified on status change
+            {' · '}
+            {summary.commentCount} on comments
+          </div>
+        )}
       </DialogContent>
     </Dialog>
+  )
+}
+
+function SubscriptionBadge({
+  level,
+  onChangeLevel,
+}: {
+  level: SubscriptionLevel
+  onChangeLevel: (level: SubscriptionLevel) => void
+}) {
+  const config = {
+    all: {
+      icon: BellIcon,
+      className: 'text-emerald-600 bg-emerald-50 dark:text-emerald-400 dark:bg-emerald-950',
+    },
+    status_only: {
+      icon: BellIcon,
+      className: 'text-blue-600 bg-blue-50 dark:text-blue-400 dark:bg-blue-950',
+    },
+    none: {
+      icon: BellSlashIcon,
+      className: 'text-muted-foreground bg-muted',
+    },
+  }[level]
+
+  const Icon = config.icon
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium shrink-0 cursor-pointer transition-opacity hover:opacity-80 ${config.className}`}
+        >
+          <Icon className="h-3 w-3" />
+          <span>{SUBSCRIPTION_LABELS[level]}</span>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuRadioGroup
+          value={level}
+          onValueChange={(v) => onChangeLevel(v as SubscriptionLevel)}
+        >
+          {(Object.entries(SUBSCRIPTION_LABELS) as Array<[SubscriptionLevel, string]>).map(
+            ([value, label]) => (
+              <DropdownMenuRadioItem key={value} value={value}>
+                {label}
+              </DropdownMenuRadioItem>
+            )
+          )}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }
 

--- a/apps/web/src/components/auth/portal-auth-form-inline.tsx
+++ b/apps/web/src/components/auth/portal-auth-form-inline.tsx
@@ -99,7 +99,6 @@ export function PortalAuthFormInline({
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [code, setCode] = useState('')
-  const [newPassword, setNewPassword] = useState('')
   const [error, setError] = useState('')
   const [loadingAction, setLoadingAction] = useState<string | null>(null)
   const [resendCooldown, setResendCooldown] = useState(0)
@@ -259,7 +258,7 @@ export function PortalAuthFormInline({
     }
   }
 
-  // --- Forgot/reset password handlers ---
+  // --- Forgot password handler ---
   const handleForgotSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setError('')
@@ -271,49 +270,17 @@ export function PortalAuthFormInline({
 
     setLoadingAction('forgot')
     try {
-      const result = await authClient.emailOtp.sendVerificationOtp({
+      const result = await authClient.requestPasswordReset({
         email,
-        type: 'forget-password',
+        redirectTo: '/auth/reset-password',
       })
       if (result.error) {
-        throw new Error(result.error.message || 'Failed to send reset code')
+        throw new Error(result.error.message || 'Failed to send reset link')
       }
       setStep('reset')
-      setResendCooldown(60)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to send reset code')
+      setError(err instanceof Error ? err.message : 'Failed to send reset link')
     } finally {
-      setLoadingAction(null)
-    }
-  }
-
-  const handleResetSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    setError('')
-
-    if (!code.trim() || code.length !== 6) {
-      setError('Please enter the 6-digit code')
-      return
-    }
-    if (!newPassword || newPassword.length < 8) {
-      setError('New password must be at least 8 characters')
-      return
-    }
-
-    setLoadingAction('reset')
-    try {
-      const result = await authClient.emailOtp.resetPassword({
-        email,
-        otp: code,
-        password: newPassword,
-      })
-      if (result.error) {
-        throw new Error(result.error.message || 'Failed to reset password')
-      }
-      const { postAuthSuccess } = await import('@/lib/client/hooks/use-auth-broadcast')
-      postAuthSuccess()
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to reset password')
       setLoadingAction(null)
     }
   }
@@ -343,25 +310,9 @@ export function PortalAuthFormInline({
     sendCode()
   }
 
-  const handleResendForgot = () => {
-    if (resendCooldown > 0) return
-    setCode('')
-    setNewPassword('')
-    setLoadingAction('forgot')
-    authClient.emailOtp
-      .sendVerificationOtp({ email, type: 'forget-password' })
-      .then((result) => {
-        if (result.error) setError(result.error.message || 'Failed to resend code')
-        else setResendCooldown(60)
-      })
-      .catch(() => setError('Failed to resend code'))
-      .finally(() => setLoadingAction(null))
-  }
-
   const handleBack = () => {
     setError('')
     setCode('')
-    setNewPassword('')
     setStep(defaultStep)
   }
 
@@ -803,7 +754,7 @@ export function PortalAuthFormInline({
           <div className="text-center">
             <h2 className="text-lg font-semibold">Reset your password</h2>
             <p className="mt-1 text-sm text-muted-foreground">
-              Enter your email and we&apos;ll send you a code to reset your password.
+              Enter your email and we&apos;ll send you a link to reset your password.
             </p>
           </div>
 
@@ -832,103 +783,37 @@ export function PortalAuthFormInline({
             {loadingAction === 'forgot' ? (
               <>
                 <ArrowPathIcon className="mr-2 h-4 w-4 animate-spin" />
-                Sending code...
+                Sending link...
               </>
             ) : (
-              'Send reset code'
+              'Send reset link'
             )}
           </Button>
         </form>
       )}
 
-      {/* Reset password: enter code + new password */}
+      {/* Reset password: check email confirmation */}
       {step === 'reset' && (
-        <form onSubmit={handleResetSubmit} className="space-y-4">
+        <div className="space-y-4">
           <button
             type="button"
-            onClick={() => {
-              setError('')
-              setCode('')
-              setNewPassword('')
-              setStep('forgot')
-            }}
+            onClick={handleBack}
             className="flex items-center text-sm text-muted-foreground hover:text-foreground"
           >
             <ArrowLeftIcon className="mr-1 h-4 w-4" />
             Back
           </button>
 
-          <div className="rounded-lg bg-muted/50 p-4">
-            <p className="text-sm text-center">
-              We sent a reset code to <span className="font-medium text-foreground">{email}</span>
+          <div className="text-center space-y-3">
+            <EnvelopeIcon className="h-10 w-10 text-primary mx-auto" />
+            <h2 className="text-lg font-semibold">Check your email</h2>
+            <p className="text-sm text-muted-foreground">
+              We sent a password reset link to{' '}
+              <span className="font-medium text-foreground">{email}</span>. The link expires in 24
+              hours.
             </p>
           </div>
-
-          {error && <FormError message={error} />}
-
-          <div className="space-y-2">
-            <label htmlFor="inline-reset-code" className="text-sm font-medium">
-              Reset code
-            </label>
-            <Input
-              ref={codeInputRef}
-              id="inline-reset-code"
-              type="text"
-              inputMode="numeric"
-              pattern="[0-9]*"
-              maxLength={6}
-              placeholder="000000"
-              value={code}
-              onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
-              disabled={loadingAction !== null}
-              className="text-center text-2xl tracking-widest"
-              autoComplete="one-time-code"
-            />
-          </div>
-
-          <div className="space-y-2">
-            <label htmlFor="inline-new-password" className="text-sm font-medium">
-              New password
-            </label>
-            <Input
-              id="inline-new-password"
-              type="password"
-              placeholder="At least 8 characters"
-              value={newPassword}
-              onChange={(e) => setNewPassword(e.target.value)}
-              disabled={loadingAction !== null}
-              autoComplete="new-password"
-            />
-          </div>
-
-          <Button
-            type="submit"
-            disabled={loadingAction !== null || code.length !== 6 || newPassword.length < 8}
-            className="w-full"
-          >
-            {loadingAction === 'reset' ? (
-              <>
-                <ArrowPathIcon className="mr-2 h-4 w-4 animate-spin" />
-                Resetting password...
-              </>
-            ) : (
-              'Reset password'
-            )}
-          </Button>
-
-          <div className="text-center">
-            <button
-              type="button"
-              onClick={handleResendForgot}
-              disabled={resendCooldown > 0 || loadingAction !== null}
-              className="text-sm text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {resendCooldown > 0
-                ? `Resend code in ${resendCooldown}s`
-                : "Didn't receive a code? Resend"}
-            </button>
-          </div>
-        </form>
+        </div>
       )}
     </div>
   )

--- a/apps/web/src/components/auth/portal-auth-form.tsx
+++ b/apps/web/src/components/auth/portal-auth-form.tsx
@@ -41,7 +41,7 @@ type Step = 'credentials' | 'email' | 'code' | 'forgot' | 'reset'
  * - Password (sign in / sign up)
  * - Email OTP (magic codes)
  * - OAuth (GitHub, Google, etc.)
- * - Forgot/reset password via OTP
+ * - Forgot/reset password via email link
  *
  * Flow: credentials → redirect (or email → code → redirect for OTP)
  * - Better-auth automatically creates users if they don't exist
@@ -67,7 +67,6 @@ export function PortalAuthForm({
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [code, setCode] = useState('')
-  const [newPassword, setNewPassword] = useState('')
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
   const [resendCooldown, setResendCooldown] = useState(0)
@@ -211,7 +210,7 @@ export function PortalAuthForm({
     }
   }
 
-  // --- Forgot/reset password handlers ---
+  // --- Forgot password handler ---
   const handleForgotSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setError('')
@@ -223,49 +222,16 @@ export function PortalAuthForm({
 
     setLoading(true)
     try {
-      const result = await authClient.emailOtp.sendVerificationOtp({
+      const result = await authClient.requestPasswordReset({
         email,
-        type: 'forget-password',
+        redirectTo: '/auth/reset-password',
       })
       if (result.error) {
-        throw new Error(result.error.message || 'Failed to send reset code')
+        throw new Error(result.error.message || 'Failed to send reset link')
       }
       setStep('reset')
-      setResendCooldown(60)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to send reset code')
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  const handleResetSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    setError('')
-
-    if (!code.trim() || code.length !== 6) {
-      setError('Please enter the 6-digit code')
-      return
-    }
-    if (!newPassword || newPassword.length < 8) {
-      setError('New password must be at least 8 characters')
-      return
-    }
-
-    setLoading(true)
-    try {
-      const result = await authClient.emailOtp.resetPassword({
-        email,
-        otp: code,
-        password: newPassword,
-      })
-      if (result.error) {
-        throw new Error(result.error.message || 'Failed to reset password')
-      }
-      // Auto sign-in after reset
-      window.location.href = callbackUrl
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to reset password')
+      setError(err instanceof Error ? err.message : 'Failed to send reset link')
     } finally {
       setLoading(false)
     }
@@ -296,25 +262,9 @@ export function PortalAuthForm({
     sendCode()
   }
 
-  const handleResendForgot = () => {
-    if (resendCooldown > 0) return
-    setCode('')
-    setNewPassword('')
-    setLoading(true)
-    authClient.emailOtp
-      .sendVerificationOtp({ email, type: 'forget-password' })
-      .then((result) => {
-        if (result.error) setError(result.error.message || 'Failed to resend code')
-        else setResendCooldown(60)
-      })
-      .catch(() => setError('Failed to resend code'))
-      .finally(() => setLoading(false))
-  }
-
   const handleBack = () => {
     setError('')
     setCode('')
-    setNewPassword('')
     setStep(defaultStep)
   }
 
@@ -616,7 +566,7 @@ export function PortalAuthForm({
           <div className="text-center">
             <h2 className="text-lg font-semibold">Reset your password</h2>
             <p className="mt-1 text-sm text-muted-foreground">
-              Enter your email and we&apos;ll send you a code to reset your password.
+              Enter your email and we&apos;ll send you a link to reset your password.
             </p>
           </div>
 
@@ -641,103 +591,37 @@ export function PortalAuthForm({
             {loading ? (
               <>
                 <ArrowPathIcon className="mr-2 h-4 w-4 animate-spin" />
-                Sending code...
+                Sending link...
               </>
             ) : (
-              'Send reset code'
+              'Send reset link'
             )}
           </Button>
         </form>
       )}
 
-      {/* Reset password: enter code + new password */}
+      {/* Reset password: check email confirmation */}
       {step === 'reset' && (
-        <form onSubmit={handleResetSubmit} className="space-y-4">
+        <div className="space-y-4">
           <button
             type="button"
-            onClick={() => {
-              setError('')
-              setCode('')
-              setNewPassword('')
-              setStep('forgot')
-            }}
+            onClick={handleBack}
             className="flex items-center text-sm text-muted-foreground hover:text-foreground"
           >
             <ArrowLeftIcon className="mr-1 h-4 w-4" />
             Back
           </button>
 
-          <div className="rounded-lg bg-muted/50 p-4">
-            <p className="text-sm text-center">
-              We sent a reset code to <span className="font-medium text-foreground">{email}</span>
+          <div className="text-center space-y-3">
+            <EnvelopeIcon className="h-10 w-10 text-primary mx-auto" />
+            <h2 className="text-lg font-semibold">Check your email</h2>
+            <p className="text-sm text-muted-foreground">
+              We sent a password reset link to{' '}
+              <span className="font-medium text-foreground">{email}</span>. The link expires in 24
+              hours.
             </p>
           </div>
-
-          {error && <FormError message={error} />}
-
-          <div className="space-y-2">
-            <label htmlFor="reset-code" className="text-sm font-medium">
-              Reset code
-            </label>
-            <Input
-              ref={codeInputRef}
-              id="reset-code"
-              type="text"
-              inputMode="numeric"
-              pattern="[0-9]*"
-              maxLength={6}
-              placeholder="000000"
-              value={code}
-              onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
-              disabled={loading}
-              className="text-center text-2xl tracking-widest"
-              autoComplete="one-time-code"
-            />
-          </div>
-
-          <div className="space-y-2">
-            <label htmlFor="new-password" className="text-sm font-medium">
-              New password
-            </label>
-            <Input
-              id="new-password"
-              type="password"
-              placeholder="At least 8 characters"
-              value={newPassword}
-              onChange={(e) => setNewPassword(e.target.value)}
-              disabled={loading}
-              autoComplete="new-password"
-            />
-          </div>
-
-          <Button
-            type="submit"
-            disabled={loading || code.length !== 6 || newPassword.length < 8}
-            className="w-full"
-          >
-            {loading ? (
-              <>
-                <ArrowPathIcon className="mr-2 h-4 w-4 animate-spin" />
-                Resetting password...
-              </>
-            ) : (
-              'Reset password'
-            )}
-          </Button>
-
-          <div className="text-center">
-            <button
-              type="button"
-              onClick={handleResendForgot}
-              disabled={resendCooldown > 0 || loading}
-              className="text-sm text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {resendCooldown > 0
-                ? `Resend code in ${resendCooldown}s`
-                : "Didn't receive a code? Resend"}
-            </button>
-          </div>
-        </form>
+        </div>
       )}
     </div>
   )

--- a/apps/web/src/components/settings/password-form.tsx
+++ b/apps/web/src/components/settings/password-form.tsx
@@ -1,0 +1,175 @@
+import { useState, useEffect } from 'react'
+import { toast } from 'sonner'
+import { ArrowPathIcon } from '@heroicons/react/24/solid'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { FormError } from '@/components/shared/form-error'
+import { authClient } from '@/lib/server/auth/client'
+
+export function PasswordForm() {
+  const [hasPassword, setHasPassword] = useState<boolean | null>(null)
+  const [currentPassword, setCurrentPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    authClient.listAccounts().then((result) => {
+      if (result.data) {
+        const hasCredential = result.data.some(
+          (acc: { providerId: string }) => acc.providerId === 'credential'
+        )
+        setHasPassword(hasCredential)
+      }
+    })
+  }, [])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+
+    if (newPassword.length < 8) {
+      setError('Password must be at least 8 characters')
+      return
+    }
+    if (newPassword !== confirmPassword) {
+      setError('Passwords do not match')
+      return
+    }
+
+    setLoading(true)
+    try {
+      if (hasPassword) {
+        if (!currentPassword) {
+          setError('Current password is required')
+          setLoading(false)
+          return
+        }
+        const result = await authClient.changePassword({
+          currentPassword,
+          newPassword,
+          revokeOtherSessions: false,
+        })
+        if (result.error) {
+          throw new Error(result.error.message || 'Failed to change password')
+        }
+        toast.success('Password changed')
+      } else {
+        const { error: fetchError } = await authClient.$fetch('/set-password', {
+          method: 'POST',
+          body: { newPassword },
+        })
+        if (fetchError) {
+          throw new Error(fetchError.message || 'Failed to set password')
+        }
+        setHasPassword(true)
+        toast.success('Password set')
+      }
+      setCurrentPassword('')
+      setNewPassword('')
+      setConfirmPassword('')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update password')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // Loading accounts
+  if (hasPassword === null) {
+    return (
+      <div className="rounded-xl border border-border/50 bg-card p-6 shadow-sm">
+        <h2 className="font-medium mb-1">Password</h2>
+        <p className="text-sm text-muted-foreground mb-4">Loading...</p>
+      </div>
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div className="rounded-xl border border-border/50 bg-card p-6 shadow-sm">
+        <h2 className="font-medium mb-1">{hasPassword ? 'Change password' : 'Set password'}</h2>
+        <p className="text-sm text-muted-foreground mb-4">
+          {hasPassword
+            ? 'Update your current password'
+            : 'Add a password to sign in with email and password'}
+        </p>
+
+        <div className="space-y-4">
+          {error && <FormError message={error} />}
+
+          {hasPassword && (
+            <div className="space-y-2">
+              <label htmlFor="current-password" className="text-sm font-medium">
+                Current password
+              </label>
+              <Input
+                id="current-password"
+                type="password"
+                value={currentPassword}
+                onChange={(e) => setCurrentPassword(e.target.value)}
+                disabled={loading}
+                autoComplete="current-password"
+              />
+            </div>
+          )}
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <label htmlFor="new-password" className="text-sm font-medium">
+                New password
+              </label>
+              <Input
+                id="new-password"
+                type="password"
+                placeholder="At least 8 characters"
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                disabled={loading}
+                autoComplete="new-password"
+              />
+            </div>
+            <div className="space-y-2">
+              <label htmlFor="confirm-password" className="text-sm font-medium">
+                Confirm password
+              </label>
+              <Input
+                id="confirm-password"
+                type="password"
+                placeholder="Re-enter your password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                disabled={loading}
+                autoComplete="new-password"
+              />
+            </div>
+          </div>
+
+          <div className="flex justify-end">
+            <Button
+              type="submit"
+              disabled={
+                loading ||
+                newPassword.length < 8 ||
+                newPassword !== confirmPassword ||
+                (hasPassword && !currentPassword)
+              }
+            >
+              {loading ? (
+                <>
+                  <ArrowPathIcon className="h-4 w-4 animate-spin mr-2" />
+                  {hasPassword ? 'Changing...' : 'Setting...'}
+                </>
+              ) : hasPassword ? (
+                'Change password'
+              ) : (
+                'Set password'
+              )}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </form>
+  )
+}

--- a/apps/web/src/components/settings/profile-form.tsx
+++ b/apps/web/src/components/settings/profile-form.tsx
@@ -12,6 +12,7 @@ import { useRouter } from '@tanstack/react-router'
 import { updateProfileNameFn } from '@/lib/server/functions/user'
 import { useUploadAvatar, useDeleteAvatar } from '@/lib/client/mutations/avatar'
 import { settingsQueries } from '@/lib/client/queries/settings'
+import { PasswordForm } from '@/components/settings/password-form'
 
 interface ProfileFormProps {
   user: {
@@ -260,6 +261,9 @@ export function ProfileForm({ user }: ProfileFormProps) {
           </div>
         </div>
       </form>
+
+      {/* Password */}
+      <PasswordForm />
 
       {/* Image Cropper Modal */}
       {cropImageSrc && (

--- a/apps/web/src/lib/client/mutations/admin-subscriptions.ts
+++ b/apps/web/src/lib/client/mutations/admin-subscriptions.ts
@@ -1,0 +1,46 @@
+/**
+ * Admin subscription mutations
+ *
+ * Mutation hooks for admin-level subscription management (e.g. changing a voter's notification level).
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { PostId, PrincipalId } from '@quackback/ids'
+import type { SubscriptionLevel } from '@/lib/server/domains/subscriptions/subscription.types'
+import { adminUpdateVoterSubscriptionFn } from '@/lib/server/functions/subscriptions'
+
+export function useUpdateVoterSubscription(postId: PostId) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (input: { principalId: PrincipalId; level: SubscriptionLevel }) =>
+      adminUpdateVoterSubscriptionFn({
+        data: { postId, principalId: input.principalId, level: input.level },
+      }),
+    onMutate: async ({ principalId, level }) => {
+      const queryKey = ['inbox', 'voters', postId]
+      await queryClient.cancelQueries({ queryKey })
+
+      const previous =
+        queryClient.getQueryData<
+          Array<{ principalId: string; subscriptionLevel: SubscriptionLevel }>
+        >(queryKey)
+
+      queryClient.setQueryData(
+        queryKey,
+        (old: Array<{ principalId: string; subscriptionLevel: SubscriptionLevel }> | undefined) =>
+          old?.map((v) => (v.principalId === principalId ? { ...v, subscriptionLevel: level } : v))
+      )
+
+      return { previous }
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(['inbox', 'voters', postId], context.previous)
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['inbox', 'voters', postId] })
+    },
+  })
+}

--- a/apps/web/src/lib/client/mutations/index.ts
+++ b/apps/web/src/lib/client/mutations/index.ts
@@ -107,3 +107,6 @@ export {
   useUpdateUserAttribute,
   useDeleteUserAttribute,
 } from './user-attributes'
+
+// Admin subscription mutations
+export { useUpdateVoterSubscription } from './admin-subscriptions'

--- a/apps/web/src/lib/server/auth/index.ts
+++ b/apps/web/src/lib/server/auth/index.ts
@@ -54,7 +54,8 @@ async function createAuth() {
     oauthConsent: oauthConsentTable,
     eq,
   } = await import('@/lib/server/db')
-  const { sendSigninCodeEmail, isEmailConfigured } = await import('@quackback/email')
+  const { sendSigninCodeEmail, sendPasswordResetEmail, isEmailConfigured } =
+    await import('@quackback/email')
   const { getPlatformCredentials } =
     await import('@/lib/server/domains/platform-credentials/platform-credential.service')
   const { getAllAuthProviders } = await import('./auth-providers')
@@ -151,6 +152,16 @@ async function createAuth() {
       minPasswordLength: 8,
       maxPasswordLength: 128,
       autoSignIn: true,
+      async sendResetPassword({ user, url }) {
+        if (!isEmailConfigured()) {
+          console.warn(
+            `[auth] Password reset requested for ${user.email} but email is not configured. Link will not be delivered.`
+          )
+          return
+        }
+        await sendPasswordResetEmail({ to: user.email, resetLink: url })
+      },
+      resetPasswordTokenExpiresIn: 60 * 60 * 24, // 24 hours
     },
 
     // Account linking - allow users to link multiple OAuth providers to their account

--- a/apps/web/src/lib/server/domains/posts/post.voting.ts
+++ b/apps/web/src/lib/server/domains/posts/post.voting.ts
@@ -14,12 +14,17 @@ import {
   user,
   sql,
   eq,
+  and,
   desc,
 } from '@/lib/server/db'
 import { createId, toUuid, type PostId, type PrincipalId } from '@quackback/ids'
 import { getExecuteRows } from '@/lib/server/utils'
 import { NotFoundError } from '@/lib/shared/errors'
 import type { VoteResult } from './post.types'
+import {
+  levelFromFlags,
+  type SubscriptionLevel,
+} from '@/lib/server/domains/subscriptions/subscription.types'
 
 export interface VoterInfo {
   principalId: string
@@ -29,6 +34,7 @@ export interface VoterInfo {
   sourceType: string | null
   sourceExternalUrl: string | null
   createdAt: Date | string
+  subscriptionLevel: SubscriptionLevel
 }
 
 /**
@@ -238,12 +244,33 @@ export async function getPostVoters(postId: PostId): Promise<VoterInfo[]> {
       sourceType: votes.sourceType,
       sourceExternalUrl: votes.sourceExternalUrl,
       createdAt: votes.createdAt,
+      notifyComments: postSubscriptions.notifyComments,
+      notifyStatusChanges: postSubscriptions.notifyStatusChanges,
     })
     .from(votes)
     .innerJoin(principal, eq(principal.id, votes.principalId))
     .leftJoin(user, eq(user.id, principal.userId))
+    .leftJoin(
+      postSubscriptions,
+      and(
+        eq(postSubscriptions.postId, votes.postId),
+        eq(postSubscriptions.principalId, votes.principalId)
+      )
+    )
     .where(eq(votes.postId, postId))
     .orderBy(desc(votes.createdAt))
 
-  return rows
+  return rows.map((row) => ({
+    principalId: row.principalId,
+    displayName: row.displayName,
+    email: row.email,
+    avatarUrl: row.avatarUrl,
+    sourceType: row.sourceType,
+    sourceExternalUrl: row.sourceExternalUrl,
+    createdAt: row.createdAt,
+    subscriptionLevel: levelFromFlags(
+      row.notifyComments ?? false,
+      row.notifyStatusChanges ?? false
+    ),
+  }))
 }

--- a/apps/web/src/lib/server/domains/subscriptions/__tests__/subscription.types.test.ts
+++ b/apps/web/src/lib/server/domains/subscriptions/__tests__/subscription.types.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { levelFromFlags } from '../subscription.types'
+
+describe('levelFromFlags', () => {
+  it('returns "all" when both flags are true', () => {
+    expect(levelFromFlags(true, true)).toBe('all')
+  })
+
+  it('returns "status_only" when only notifyStatusChanges is true', () => {
+    expect(levelFromFlags(false, true)).toBe('status_only')
+  })
+
+  it('returns "none" when both flags are false', () => {
+    expect(levelFromFlags(false, false)).toBe('none')
+  })
+
+  it('returns "none" when only notifyComments is true', () => {
+    // Edge case: comments without status changes treated as none
+    expect(levelFromFlags(true, false)).toBe('none')
+  })
+})

--- a/apps/web/src/lib/server/domains/subscriptions/subscription.service.ts
+++ b/apps/web/src/lib/server/domains/subscriptions/subscription.service.ts
@@ -32,12 +32,13 @@ import {
 } from '@/lib/server/db'
 import type { PrincipalId, PostId } from '@quackback/ids'
 import { randomUUID } from 'crypto'
-import type {
-  SubscriptionReason,
-  Subscriber,
-  Subscription,
-  NotificationPreferencesData,
-  SubscriptionLevel,
+import {
+  levelFromFlags,
+  type SubscriptionReason,
+  type Subscriber,
+  type Subscription,
+  type NotificationPreferencesData,
+  type SubscriptionLevel,
 } from './subscription.types'
 
 // Re-export types for backwards compatibility
@@ -169,20 +170,12 @@ export async function getSubscriptionStatus(
     }
   }
 
-  // Determine level from flags
-  let level: SubscriptionLevel = 'none'
-  if (subscription.notifyComments && subscription.notifyStatusChanges) {
-    level = 'all'
-  } else if (subscription.notifyStatusChanges) {
-    level = 'status_only'
-  }
-
   return {
     subscribed: true,
     notifyComments: subscription.notifyComments,
     notifyStatusChanges: subscription.notifyStatusChanges,
     reason: subscription.reason as SubscriptionReason,
-    level,
+    level: levelFromFlags(subscription.notifyComments, subscription.notifyStatusChanges),
   }
 }
 

--- a/apps/web/src/lib/server/domains/subscriptions/subscription.types.ts
+++ b/apps/web/src/lib/server/domains/subscriptions/subscription.types.ts
@@ -37,6 +37,16 @@ export interface Subscription {
  */
 export type SubscriptionLevel = 'all' | 'status_only' | 'none'
 
+/** Derive a SubscriptionLevel from the two boolean notification columns */
+export function levelFromFlags(
+  notifyComments: boolean,
+  notifyStatusChanges: boolean
+): SubscriptionLevel {
+  if (notifyComments && notifyStatusChanges) return 'all'
+  if (notifyStatusChanges) return 'status_only'
+  return 'none'
+}
+
 export interface NotificationPreferencesData {
   emailStatusChange: boolean
   emailNewComment: boolean

--- a/apps/web/src/lib/server/functions/subscriptions.ts
+++ b/apps/web/src/lib/server/functions/subscriptions.ts
@@ -4,7 +4,7 @@
 
 import { z } from 'zod'
 import { createServerFn } from '@tanstack/react-start'
-import { type PostId } from '@quackback/ids'
+import { type PostId, type PrincipalId } from '@quackback/ids'
 import { requireAuth } from './auth-helpers'
 import {
   getSubscriptionStatus,
@@ -109,6 +109,46 @@ export const updateSubscriptionLevelFn = createServerFn({ method: 'POST' })
       return { postId: data.postId }
     } catch (error) {
       console.error(`[fn:subscriptions] ❌ updateSubscriptionLevelFn failed:`, error)
+      throw error
+    }
+  })
+
+// Admin mutation: update any voter's subscription level
+const adminUpdateVoterSubscriptionSchema = z.object({
+  postId: z.string(),
+  principalId: z.string(),
+  level: z.enum(['all', 'status_only', 'none']),
+})
+
+export type AdminUpdateVoterSubscriptionInput = z.infer<typeof adminUpdateVoterSubscriptionSchema>
+
+export const adminUpdateVoterSubscriptionFn = createServerFn({ method: 'POST' })
+  .inputValidator(adminUpdateVoterSubscriptionSchema)
+  .handler(async ({ data }) => {
+    console.log(
+      `[fn:subscriptions] adminUpdateVoterSubscriptionFn: postId=${data.postId} principalId=${data.principalId} level=${data.level}`
+    )
+    try {
+      await requireAuth({ roles: ['admin', 'member'] })
+
+      const targetPrincipalId = data.principalId as PrincipalId
+      const targetPostId = data.postId as PostId
+
+      if (data.level === 'none') {
+        await unsubscribeFromPost(targetPrincipalId, targetPostId)
+      } else {
+        await subscribeToPost(targetPrincipalId, targetPostId, 'manual')
+        await updateSubscriptionLevel(
+          targetPrincipalId,
+          targetPostId,
+          data.level as SubscriptionLevel
+        )
+      }
+
+      console.log(`[fn:subscriptions] adminUpdateVoterSubscriptionFn: updated`)
+      return { postId: data.postId, principalId: data.principalId, level: data.level }
+    } catch (error) {
+      console.error(`[fn:subscriptions] ❌ adminUpdateVoterSubscriptionFn failed:`, error)
       throw error
     }
   })

--- a/apps/web/src/routes/auth.reset-password.tsx
+++ b/apps/web/src/routes/auth.reset-password.tsx
@@ -1,0 +1,144 @@
+import { createFileRoute, Link, useSearch } from '@tanstack/react-router'
+import { useState } from 'react'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { FormError } from '@/components/shared/form-error'
+import { ArrowPathIcon, CheckCircleIcon } from '@heroicons/react/24/solid'
+import { authClient } from '@/lib/server/auth/client'
+
+export const Route = createFileRoute('/auth/reset-password')({
+  validateSearch: (search: Record<string, unknown>) => ({
+    token: (search.token as string) || '',
+    error: (search.error as string) || '',
+  }),
+  component: ResetPasswordPage,
+})
+
+function ResetPasswordPage() {
+  const { token, error: urlError } = useSearch({ from: '/auth/reset-password' })
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [error, setError] = useState(
+    urlError === 'INVALID_TOKEN' ? 'This reset link is invalid or has expired.' : ''
+  )
+  const [loading, setLoading] = useState(false)
+  const [success, setSuccess] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+
+    if (!token) {
+      setError('Missing reset token. Please use the link from your email.')
+      return
+    }
+    if (newPassword.length < 8) {
+      setError('Password must be at least 8 characters')
+      return
+    }
+    if (newPassword !== confirmPassword) {
+      setError('Passwords do not match')
+      return
+    }
+
+    setLoading(true)
+    try {
+      const result = await authClient.resetPassword({
+        newPassword,
+        token,
+      })
+      if (result.error) {
+        throw new Error(result.error.message || 'Failed to reset password')
+      }
+      setSuccess(true)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to reset password')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (success) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="w-full max-w-md space-y-8 px-4 text-center">
+          <CheckCircleIcon className="h-12 w-12 text-green-500 mx-auto" />
+          <h1 className="text-2xl font-bold">Password reset</h1>
+          <p className="text-muted-foreground">Your password has been updated successfully.</p>
+          <Link to="/auth/login">
+            <Button className="w-full">Sign in</Button>
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="w-full max-w-md space-y-8 px-4">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold">Set a new password</h1>
+          <p className="mt-2 text-muted-foreground">Enter your new password below.</p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && <FormError message={error} />}
+
+          <div className="space-y-2">
+            <label htmlFor="new-password" className="text-sm font-medium">
+              New password
+            </label>
+            <Input
+              id="new-password"
+              type="password"
+              placeholder="At least 8 characters"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              disabled={loading || !token}
+              autoComplete="new-password"
+              autoFocus
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label htmlFor="confirm-password" className="text-sm font-medium">
+              Confirm password
+            </label>
+            <Input
+              id="confirm-password"
+              type="password"
+              placeholder="Re-enter your password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              disabled={loading || !token}
+              autoComplete="new-password"
+            />
+          </div>
+
+          <Button
+            type="submit"
+            disabled={
+              loading || !token || newPassword.length < 8 || newPassword !== confirmPassword
+            }
+            className="w-full"
+          >
+            {loading ? (
+              <>
+                <ArrowPathIcon className="mr-2 h-4 w-4 animate-spin" />
+                Resetting password...
+              </>
+            ) : (
+              'Reset password'
+            )}
+          </Button>
+        </form>
+
+        <p className="text-center text-sm text-muted-foreground">
+          <Link to="/auth/login" className="font-medium text-primary hover:underline">
+            Back to sign in
+          </Link>
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/packages/email/src/__tests__/email.test.ts
+++ b/packages/email/src/__tests__/email.test.ts
@@ -6,6 +6,7 @@ import {
   sendSigninCodeEmail,
   sendStatusChangeEmail,
   sendNewCommentEmail,
+  sendPasswordResetEmail,
 } from '../index'
 
 /** Save and restore env vars around each test. */
@@ -122,6 +123,14 @@ describe('console mode returns { sent: false }', () => {
       isTeamMember: false,
       workspaceName: 'TestWorkspace',
       unsubscribeUrl: 'https://example.com/unsubscribe',
+    })
+    expect(result).toEqual({ sent: false })
+  })
+
+  it('sendPasswordResetEmail returns { sent: false }', async () => {
+    const result = await sendPasswordResetEmail({
+      to: 'test@example.com',
+      resetLink: 'https://example.com/auth/reset-password?token=abc',
     })
     expect(result).toEqual({ sent: false })
   })

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -18,6 +18,7 @@ import { StatusChangeEmail } from './templates/status-change'
 import { NewCommentEmail } from './templates/new-comment'
 import { ChangelogPublishedEmail } from './templates/changelog-published'
 import { FeedbackLinkedEmail } from './templates/feedback-linked'
+import { PasswordResetEmail } from './templates/password-reset'
 
 /**
  * Get environment variable at runtime.
@@ -253,6 +254,38 @@ export async function sendSigninCodeEmail(params: SendSigninCodeParams): Promise
 }
 
 // ============================================================================
+// Password Reset Email
+// ============================================================================
+
+interface SendPasswordResetParams {
+  to: string
+  resetLink: string
+}
+
+export async function sendPasswordResetEmail(
+  params: SendPasswordResetParams
+): Promise<EmailResult> {
+  const { to, resetLink } = params
+
+  if (getProvider() === 'console') {
+    console.log('\n┌────────────────────────────────────────────────────────────')
+    console.log('│ [DEV] Password Reset Email')
+    console.log('├────────────────────────────────────────────────────────────')
+    console.log(`│ To: ${to}`)
+    console.log(`│ Reset link: ${resetLink}`)
+    console.log('└────────────────────────────────────────────────────────────\n')
+    return { sent: false }
+  }
+
+  console.log(`[Email] Sending password reset to ${to}`)
+  return sendEmail({
+    to,
+    subject: 'Reset your Quackback password',
+    react: PasswordResetEmail({ resetLink }),
+  })
+}
+
+// ============================================================================
 // Status Change Email
 // ============================================================================
 
@@ -458,3 +491,4 @@ export { StatusChangeEmail } from './templates/status-change'
 export { NewCommentEmail } from './templates/new-comment'
 export { ChangelogPublishedEmail } from './templates/changelog-published'
 export { FeedbackLinkedEmail } from './templates/feedback-linked'
+export { PasswordResetEmail } from './templates/password-reset'

--- a/packages/email/src/templates/password-reset.tsx
+++ b/packages/email/src/templates/password-reset.tsx
@@ -1,0 +1,63 @@
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Img,
+  Link,
+  Preview,
+  Section,
+  Text,
+} from '@react-email/components'
+import { layout, typography, button, utils, branding } from './shared-styles'
+
+interface PasswordResetEmailProps {
+  resetLink: string
+}
+
+const LOGO_URL = 'https://quackback.io/logo.png'
+
+export function PasswordResetEmail({ resetLink }: PasswordResetEmailProps) {
+  return (
+    <Html>
+      <Head />
+      <Preview>Reset your Quackback password</Preview>
+      <Body style={layout.main}>
+        <Container style={layout.container}>
+          {/* Logo */}
+          <Section style={branding.logoContainer}>
+            <Img src={LOGO_URL} alt="Quackback" style={branding.logo} />
+          </Section>
+
+          {/* Content */}
+          <Heading style={{ ...typography.h1, textAlign: 'center' }}>Reset your password</Heading>
+          <Text style={{ ...typography.text, textAlign: 'center' }}>
+            Click the button below to set a new password. This link expires in 24 hours.
+          </Text>
+
+          {/* CTA Button */}
+          <Section style={{ textAlign: 'center', margin: '32px 0' }}>
+            <Button style={button.primary} href={resetLink}>
+              Reset Password
+            </Button>
+          </Section>
+
+          {/* Fallback Link */}
+          <Text style={typography.textSmall}>
+            Or copy and paste this link into your browser:{' '}
+            <Link href={resetLink} style={utils.link}>
+              {resetLink}
+            </Link>
+          </Text>
+
+          {/* Footer */}
+          <Text style={typography.footer}>
+            If you didn&apos;t request a password reset, you can safely ignore this email.
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  )
+}


### PR DESCRIPTION
## Summary

- **Link-based password reset**: Replaced OTP-based forgot-password flow with Better-Auth's built-in `requestPasswordReset`/`resetPassword` using 24-hour expiry tokens. New `/auth/reset-password` route, password reset email template, and updated auth forms show a "check your email" confirmation.
- **Profile password management**: Added `PasswordForm` component to user settings that auto-detects whether the user has a credential account - shows "Change password" (with current password) or "Set password" (for OAuth/OTP-only users).
- **Voter subscription controls**: Admin voters modal now shows subscription level badges with dropdown to change notification preferences per voter. Includes optimistic updates and new `adminUpdateVoterSubscriptionFn` server function.
- **Code quality fixes**: Extracted `levelFromFlags` helper to deduplicate subscription level derivation, fixed missing early return in `sendResetPassword` when email is not configured, derived dropdown items from `SUBSCRIPTION_LABELS` constant.

## Test plan
- [x] All 666 unit tests pass
- [x] TypeScript typecheck passes
- [x] New tests for `sendPasswordResetEmail` (console mode) and `levelFromFlags` helper
- [ ] Manual: Request password reset, verify email received with 24h expiry link
- [ ] Manual: Use reset link to set new password, verify redirect to login
- [ ] Manual: Change password from profile settings (existing password users)
- [ ] Manual: Set password from profile settings (OAuth-only users)
- [ ] Manual: Change voter subscription level in voters modal, verify optimistic update