### PR TITLE
Link post author to admin user profile in metadata sidebar

### DIFF
--- a/apps/web/src/components/admin/feedback/post-modal.tsx
+++ b/apps/web/src/components/admin/feedback/post-modal.tsx
@@ -474,6 +474,7 @@ function PostModalContent({
               board={post.board}
               authorName={post.authorName}
               authorAvatarUrl={(post.principalId && post.avatarUrls?.[post.principalId]) || null}
+              authorPrincipalId={post.principalId}
               createdAt={new Date(post.createdAt)}
               tags={post.tags}
               roadmaps={postRoadmaps}

--- a/apps/web/src/components/admin/roadmap-modal.tsx
+++ b/apps/web/src/components/admin/roadmap-modal.tsx
@@ -196,6 +196,7 @@ function RoadmapModalContent({ postId, currentUser, onClose }: RoadmapModalConte
               board={post.board}
               authorName={post.authorName}
               authorAvatarUrl={(post.principalId && post.avatarUrls?.[post.principalId]) || null}
+              authorPrincipalId={post.principalId}
               createdAt={new Date(post.createdAt)}
               tags={post.tags}
               roadmaps={postRoadmaps}

--- a/apps/web/src/components/public/post-detail/metadata-sidebar.tsx
+++ b/apps/web/src/components/public/post-detail/metadata-sidebar.tsx
@@ -76,6 +76,8 @@ interface MetadataSidebarProps {
   board: { name: string; slug: string }
   authorName: string | null
   authorAvatarUrl?: string | null
+  /** Principal ID of the author (used to link to admin user detail) */
+  authorPrincipalId?: string | null
   createdAt: Date
   tags?: Array<{ id: string; name: string; color: string }>
   roadmaps?: Array<{ id: string; name: string; slug: string }>
@@ -114,6 +116,7 @@ export function MetadataSidebar({
   board,
   authorName,
   authorAvatarUrl,
+  authorPrincipalId,
   createdAt,
   tags = [],
   roadmaps = [],
@@ -479,15 +482,35 @@ export function MetadataSidebar({
             <UserIcon className="h-4 w-4" />
             <span>Author</span>
           </div>
-          <div className="flex items-center gap-1.5">
-            <Avatar className="h-5 w-5">
-              {authorAvatarUrl && (
-                <AvatarImage src={authorAvatarUrl} alt={authorName || 'Author'} />
-              )}
-              <AvatarFallback className="text-[9px]">{getInitials(authorName)}</AvatarFallback>
-            </Avatar>
-            <span className="text-sm font-medium text-foreground">{authorName || 'Anonymous'}</span>
-          </div>
+          {canEdit && authorPrincipalId ? (
+            <Link
+              to="/admin/users"
+              search={{ selected: authorPrincipalId }}
+              className="flex items-center gap-1.5 hover:opacity-80 transition-opacity"
+            >
+              <Avatar className="h-5 w-5">
+                {authorAvatarUrl && (
+                  <AvatarImage src={authorAvatarUrl} alt={authorName || 'Author'} />
+                )}
+                <AvatarFallback className="text-[9px]">{getInitials(authorName)}</AvatarFallback>
+              </Avatar>
+              <span className="text-sm font-medium text-foreground underline decoration-muted-foreground/30 underline-offset-2">
+                {authorName || 'Anonymous'}
+              </span>
+            </Link>
+          ) : (
+            <div className="flex items-center gap-1.5">
+              <Avatar className="h-5 w-5">
+                {authorAvatarUrl && (
+                  <AvatarImage src={authorAvatarUrl} alt={authorName || 'Author'} />
+                )}
+                <AvatarFallback className="text-[9px]">{getInitials(authorName)}</AvatarFallback>
+              </Avatar>
+              <span className="text-sm font-medium text-foreground">
+                {authorName || 'Anonymous'}
+              </span>
+            </div>
+          )}
         </div>
 
         {/* Subscribe section - hidden in admin mode */}


### PR DESCRIPTION
## Summary

- The author field in the post metadata sidebar now links to the admin users page (`/admin/users?selected=<principalId>`) when viewed in admin context
- Clicking the author name navigates to the users page with that user pre-selected in the detail panel
- Works in both the feedback inbox post modal and roadmap post modal
- Portal (public) view is unchanged - author name remains plain text

## Test plan
- [x] Open a post in the admin feedback inbox, verify author name is underlined and clickable
- [x] Click the author name, verify it navigates to `/admin/users` with the correct user selected
- [x] Open a post from the roadmap view, verify the same linking behavior
- [x] View a post on the public portal, verify author name is plain text (no link)
- [x] Verify anonymous posts (no principalId) show "Anonymous" without a link