### PR TITLE
[AI] Enhance session handling by adding fallback to direct database lookup…s for Better Auth unrecognized sessions. Fix session verification in useEnsureAnonSession through cookie validation.

### DIFF
--- a/apps/web/src/lib/client/hooks/use-ensure-anon-session.ts
+++ b/apps/web/src/lib/client/hooks/use-ensure-anon-session.ts
@@ -4,18 +4,17 @@
  * Returns a stable callback that:
  * - Returns true immediately if a session already exists
  * - Creates an anonymous session via Better Auth if none exists
- * - Waits for the cookie to commit, then invalidates the router
+ * - Waits for the session cookie to be available via a verification request
  * - Returns false if session creation fails
  *
  * Used by AuthVoteButton, PostCard, and AuthCommentsSection.
  */
 
 import { useCallback, useEffect, useRef } from 'react'
-import { useRouter, useRouteContext } from '@tanstack/react-router'
+import { useRouteContext } from '@tanstack/react-router'
 import { authClient } from '@/lib/server/auth/client'
 
 export function useEnsureAnonSession(): () => Promise<boolean> {
-  const router = useRouter()
   const { session } = useRouteContext({ from: '__root__' })
   const hasSessionRef = useRef(!!session?.user)
 
@@ -31,14 +30,22 @@ export function useEnsureAnonSession(): () => Promise<boolean> {
         console.error('[anon-session] Anonymous sign-in failed:', result.error)
         return false
       }
+
+      // Verify the session is actually available by fetching it.
+      // The browser sets the cookie after the response, but we need to ensure
+      // subsequent fetch requests include it. authClient.getSession() makes a
+      // request that will include the new cookie, verifying it's working.
+      const sessionResult = await authClient.getSession()
+      if (sessionResult.error || !sessionResult.data?.user) {
+        console.error('[anon-session] Session verification failed:', sessionResult.error)
+        return false
+      }
+
       hasSessionRef.current = true
-      // Let the browser commit the session cookie before proceeding
-      await new Promise((r) => setTimeout(r, 0))
-      router.invalidate()
       return true
     } catch (error) {
       console.error('[anon-session] Anonymous sign-in failed:', error)
       return false
     }
-  }, [router])
+  }, [])
 }

--- a/apps/web/src/lib/server/functions/auth-helpers.ts
+++ b/apps/web/src/lib/server/functions/auth-helpers.ts
@@ -10,7 +10,7 @@ import type { Role } from '@/lib/server/auth'
 import { auth } from '@/lib/server/auth'
 import { getRequestHeaders } from '@tanstack/react-start/server'
 import { getSettings } from './workspace'
-import { db, principal, eq } from '@/lib/server/db'
+import { db, principal, session, eq, gt, and } from '@/lib/server/db'
 
 // Type alias for session result
 type SessionResult = Awaited<ReturnType<typeof auth.api.getSession>>
@@ -35,17 +35,99 @@ export function hasSessionCookie(): boolean {
 export function hasAuthCredentials(): boolean {
   const headers = getRequestHeaders()
   const cookie = headers.get('cookie') ?? ''
-  const auth = headers.get('authorization') ?? ''
-  return cookie.includes('better-auth.session_token') || auth.startsWith('Bearer ')
+  const authHeader = headers.get('authorization') ?? ''
+  return cookie.includes('better-auth.session_token') || authHeader.startsWith('Bearer ')
 }
 
 /**
  * Get session directly from better-auth (not through server function).
  * This avoids nested server function call issues.
+ *
+ * Falls back to direct database lookup if Better Auth doesn't recognize the session.
+ * This handles sessions created by /api/widget/identify which bypass Better Auth's
+ * internal session creation.
  */
 async function getSessionDirect(): Promise<SessionResult | null> {
   try {
-    return await auth.api.getSession({ headers: getRequestHeaders() })
+    const headers = getRequestHeaders()
+    const cookieHeader = headers.get('cookie') ?? ''
+    const authHeader = headers.get('authorization') ?? ''
+
+    // Try Better Auth's getSession first
+    const baSession = await auth.api.getSession({ headers })
+    if (baSession?.user) {
+      return baSession
+    }
+
+    // Better Auth didn't find a session - try direct DB lookup as fallback
+    // This handles sessions created by widget identify endpoint
+
+    // Check for Bearer token (widget auth)
+    if (authHeader.startsWith('Bearer ')) {
+      const token = authHeader.slice(7)
+      const sessionRecord = await db.query.session.findFirst({
+        where: and(eq(session.token, token), gt(session.expiresAt, new Date())),
+        with: { user: true },
+      })
+      if (sessionRecord?.user) {
+        return {
+          user: {
+            id: sessionRecord.user.id,
+            email: sessionRecord.user.email ?? '',
+            name: sessionRecord.user.name,
+            image: sessionRecord.user.image,
+            emailVerified: sessionRecord.user.emailVerified,
+            createdAt: sessionRecord.user.createdAt,
+            updatedAt: sessionRecord.user.updatedAt,
+          },
+          session: {
+            id: sessionRecord.id,
+            userId: sessionRecord.userId,
+            expiresAt: sessionRecord.expiresAt,
+            token: sessionRecord.token,
+            createdAt: sessionRecord.createdAt,
+            updatedAt: sessionRecord.updatedAt,
+            ipAddress: sessionRecord.ipAddress,
+            userAgent: sessionRecord.userAgent,
+          },
+        }
+      }
+    }
+
+    // Check for session cookie (portal auth with widget-created session)
+    const tokenMatch = cookieHeader.match(/better-auth\.session_token=([^;]+)/)
+    if (tokenMatch?.[1]) {
+      const tokenValue = tokenMatch[1]
+      const sessionRecord = await db.query.session.findFirst({
+        where: and(eq(session.token, tokenValue), gt(session.expiresAt, new Date())),
+        with: { user: true },
+      })
+      if (sessionRecord?.user) {
+        return {
+          user: {
+            id: sessionRecord.user.id,
+            email: sessionRecord.user.email ?? '',
+            name: sessionRecord.user.name,
+            image: sessionRecord.user.image,
+            emailVerified: sessionRecord.user.emailVerified,
+            createdAt: sessionRecord.user.createdAt,
+            updatedAt: sessionRecord.user.updatedAt,
+          },
+          session: {
+            id: sessionRecord.id,
+            userId: sessionRecord.userId,
+            expiresAt: sessionRecord.expiresAt,
+            token: sessionRecord.token,
+            createdAt: sessionRecord.createdAt,
+            updatedAt: sessionRecord.updatedAt,
+            ipAddress: sessionRecord.ipAddress,
+            userAgent: sessionRecord.userAgent,
+          },
+        }
+      }
+    }
+
+    return null
   } catch (error) {
     console.error('[auth] Failed to get session:', error)
     return null


### PR DESCRIPTION
**Root Cause:** 
Sessions created by /api/widget/identify (used for widget SSO) bypass Better Auth's internal session creation. The session exists in the database with a valid token, but Better Auth's getSession() couldn't find it because it uses its own cookie reading mechanism.

**Fix**: Modified getSessionDirect() in apps/web/src/lib/server/functions/auth-helpers.ts to:
1. First try Better Auth's getSession() for sessions created through normal auth flows
2. Fall back to direct database lookup for:
2.1. Bearer tokens (widget auth)
2.2. Session cookies that Better Auth doesn't recognize (widget-created sessions)

This allows voting to work for users who authenticate via the widget's /api/widget/identify endpoint.