### PR TITLE
Fix widget auth in same-site deployments

### DIFF
--- a/apps/web/src/routes/api/widget/identify.ts
+++ b/apps/web/src/routes/api/widget/identify.ts
@@ -257,35 +257,19 @@ export const Route = createFileRoute('/api/widget/identify')({
         ])
         const votedPostIds = Array.from(votedPostIdSet)
 
-        // Set the session cookie so server functions (requireAuth) work for identified users.
-        // This matches Better Auth's cookie format so auth.api.getSession() can read it.
-        const isSecure = new URL(request.url).protocol === 'https:'
-        const cookieParts = [
-          `better-auth.session_token=${sessionToken}`,
-          'Path=/',
-          'SameSite=Lax',
-          `Max-Age=${Math.floor(SESSION_TTL_MS / 1000)}`,
-        ]
-        if (isSecure) cookieParts.push('Secure')
-
-        return new Response(
-          JSON.stringify({
-            sessionToken,
-            user: {
-              id: userRecord.id,
-              name: userRecord.name,
-              email: userRecord.email,
-              avatarUrl: userRecord.image ?? null,
-            },
-            votedPostIds,
-          }),
-          {
-            headers: {
-              'Content-Type': 'application/json',
-              'Set-Cookie': cookieParts.join('; '),
-            },
-          }
-        )
+        // No Set-Cookie — the widget sends the token as Bearer header.
+        // An unsigned cookie here would poison Better Auth's signed-cookie
+        // lookup in same-site deployments (#99).
+        return Response.json({
+          sessionToken,
+          user: {
+            id: userRecord.id,
+            name: userRecord.name,
+            email: userRecord.email,
+            avatarUrl: userRecord.image ?? null,
+          },
+          votedPostIds,
+        })
       },
     },
   },


### PR DESCRIPTION
## Summary

- Remove the unsigned `Set-Cookie` from `/api/widget/identify` — it was poisoning Better Auth's signed-cookie lookup in same-site deployments (e.g. `localhost:3000` embedding widget from `localhost:3015`)

## Problem

The widget identify endpoint set `Set-Cookie: better-auth.session_token=<raw-uuid>` with `SameSite=Lax`. This cookie was never useful:

- **Cross-site** (e.g. ngrok): browser blocks it entirely
- **Same-site** (e.g. localhost with different ports): browser sends it, and Better Auth's `parseCookies` keeps the first occurrence of each cookie name — so the unsigned cookie shadows the signed one injected by the bearer plugin, causing `getSession()` to return null

The widget already stores the token in memory and sends it as `Authorization: Bearer` via `getWidgetAuthHeaders()`. The bearer plugin handles this correctly when there's no competing unsigned cookie.

## Test plan

- [ ] Deploy with widget embedded cross-origin (e.g. ngrok) — votes/reactions work
- [ ] Deploy with widget same-site on different port — votes/reactions work
- [ ] Existing widget-auth and anonymous-feature-flags tests pass

Fixes #99