### PR TITLE
Enable CORS in development mode for Vite server configuration.

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -37,6 +37,7 @@ export default defineConfig(({ mode }) => {
     },
     server: {
       port: Number(process.env.PORT || 3000),
+      cors: mode === 'development',
       allowedHosts: true,
       hmr: {
         overlay: false,


### PR DESCRIPTION
I'm not sure if this is correct for you, but it solves my problem when developing the widget locally with another localhost app. I would be happy to hear of a better option.