### PR TITLE
Added CSS classes for iframe and iframe wrapper in sdk-template for customization by external application

### DIFF
--- a/apps/web/src/lib/shared/widget/__tests__/sdk-template.test.ts
+++ b/apps/web/src/lib/shared/widget/__tests__/sdk-template.test.ts
@@ -88,6 +88,12 @@ describe('buildWidgetSDK', () => {
     expect(result).toContain('Feedback Widget')
   })
 
+  it('should add CSS classes to iframe wrapper and iframe', () => {
+    const result = buildWidgetSDK('https://feedback.acme.com')
+    expect(result).toContain('quackback-widget-iframe-wrapper')
+    expect(result).toContain('quackback-widget-iframe')
+  })
+
   it('should support mobile detection', () => {
     const result = buildWidgetSDK('https://feedback.acme.com')
     expect(result).toContain('window.innerWidth < 640')

--- a/apps/web/src/lib/shared/widget/sdk-template.ts
+++ b/apps/web/src/lib/shared/widget/sdk-template.ts
@@ -195,6 +195,8 @@ export function buildWidgetSDK(baseUrl: string, theme?: WidgetTheme): string {
         boxShadow: "0 -8px 30px rgba(0,0,0,0.12)",
         transform: "translateY(100%)",
         transition: "transform 300ms cubic-bezier(0.4,0,0.2,1)",
+      }, {
+        className: "quackback-widget-iframe-wrapper",
       });
     } else {
       panel = createElement("div", {
@@ -212,6 +214,8 @@ export function buildWidgetSDK(baseUrl: string, theme?: WidgetTheme): string {
         transform: "scale(0.95)",
         transformOrigin: placement === "left" ? "bottom left" : "bottom right",
         transition: "opacity 200ms ease-out, transform 200ms ease-out",
+      }, {
+        className: "quackback-widget-iframe-wrapper",
       });
     }
 
@@ -225,6 +229,7 @@ export function buildWidgetSDK(baseUrl: string, theme?: WidgetTheme): string {
       src: iframeUrl,
       title: "Feedback Widget",
       sandbox: "allow-scripts allow-forms allow-same-origin allow-popups",
+      className: "quackback-widget-iframe",
     });
 
     panel.appendChild(iframe);


### PR DESCRIPTION
This feature simplifies the management of widget size and placement.

BIG widget example :D

<img width="1431" height="1239" alt="image" src="https://github.com/user-attachments/assets/86e84e4c-be33-48f1-93ac-efab6ad17229" />
