### PR TITLE
Fix: the third argument (handler) is lost when it gets into the queue.

### DIFF
--- a/apps/web/src/lib/shared/widget/__tests__/sdk-template.test.ts
+++ b/apps/web/src/lib/shared/widget/__tests__/sdk-template.test.ts
@@ -52,6 +52,11 @@ describe('buildWidgetSDK', () => {
     expect(result).toContain('Quackback.q')
   })
 
+  it('should replay queued commands with the third argument', () => {
+    const result = buildWidgetSDK('https://feedback.acme.com')
+    expect(result).toContain('dispatch(queue[i][0], queue[i][1], queue[i][2]);')
+  })
+
   it('should set correct iframe sandbox attributes', () => {
     const result = buildWidgetSDK('https://feedback.acme.com')
     expect(result).toContain('allow-scripts allow-forms allow-same-origin allow-popups')

--- a/apps/web/src/lib/shared/widget/sdk-template.ts
+++ b/apps/web/src/lib/shared/widget/sdk-template.ts
@@ -517,7 +517,7 @@ export function buildWidgetSDK(baseUrl: string, theme?: WidgetTheme): string {
 
   // Replay queued commands
   for (var i = 0; i < queue.length; i++) {
-    dispatch(queue[i][0], queue[i][1]);
+    dispatch(queue[i][0], queue[i][1], queue[i][2]);
   }
 
   // Listen for responsive changes


### PR DESCRIPTION
It looks like I accidentally created a race. The third parameter (handler) was not passed, so the identify subscription did not work:

```vue
  created () {
    if (!window.Quackback) {
      (function (w, d) {
        if (w.Quackback) return; w.Quackback = function () {
          (w.Quackback.q = w.Quackback.q || []).push(arguments)
        }
        const s = d.createElement('script'); s.async = true
        s.src = 'http://localhost:3015/api/widget/sdk.js'
        s.crossOrigin = 'anonymous'
        d.head.appendChild(s)
      })(window, document)
    }

    Quackback('init')
    Quackback('on', 'identify', (payload) => {
      this.onOpenClick()
    })

    fetch('/identify')
      .then((res) => res.json())
      .then(({ token }) => { Quackback('identify', { ssoToken: token }) })
  },
```