### PR TITLE
fix(settings): invalidate cache after setupState writes

### DIFF
--- a/apps/web/src/lib/server/functions/boards.ts
+++ b/apps/web/src/lib/server/functions/boards.ts
@@ -16,6 +16,7 @@ import {
   updateBoard,
   deleteBoard,
 } from '@/lib/server/domains/boards/board.service'
+import { invalidateSettingsCache } from '@/lib/server/domains/settings/settings.helpers'
 
 // ============================================
 // Schemas
@@ -217,6 +218,7 @@ export const createBoardsBatchFn = createServerFn({ method: 'POST' })
           .update(settings)
           .set({ setupState: JSON.stringify(updatedState) })
           .where(eq(settings.id, currentSettings.id))
+        await invalidateSettingsCache()
         console.log(`[fn:boards] createBoardsBatchFn: onboarding complete, setupState updated`)
       }
     }

--- a/apps/web/src/lib/server/functions/onboarding.ts
+++ b/apps/web/src/lib/server/functions/onboarding.ts
@@ -9,6 +9,7 @@ import { getSettings } from './workspace'
 import { syncPrincipalProfile } from '@/lib/server/domains/principals/principal.service'
 import { listBoards } from '@/lib/server/domains/boards/board.service'
 import { db, settings, principal, user, postStatuses, eq, DEFAULT_STATUSES } from '@/lib/server/db'
+import { invalidateSettingsCache } from '@/lib/server/domains/settings/settings.helpers'
 import { slugify } from '@/lib/shared/utils'
 
 /**
@@ -270,6 +271,7 @@ export const setupWorkspaceFn = createServerFn({ method: 'POST' })
         )
       }
 
+      await invalidateSettingsCache()
       console.log(
         `[fn:onboarding] setupWorkspaceFn: id=${finalSettings!.id}, slug=${finalSettings!.slug}`
       )
@@ -368,6 +370,7 @@ export const saveUseCaseFn = createServerFn({ method: 'POST' })
           }
         }
 
+        await invalidateSettingsCache()
         console.log(`[fn:onboarding] saveUseCaseFn: saved useCase=${data.useCase}`)
       } else {
         // Fresh self-hosted install: create minimal settings to store useCase
@@ -406,6 +409,7 @@ export const saveUseCaseFn = createServerFn({ method: 'POST' })
           console.log(`[fn:onboarding] saveUseCaseFn: created admin member for first user`)
         }
 
+        await invalidateSettingsCache()
         console.log(
           `[fn:onboarding] saveUseCaseFn: created initial settings with useCase=${data.useCase}`
         )


### PR DESCRIPTION
## Summary

The three onboarding mutators that write to `settings.setupState` skip `invalidateSettingsCache()`. Every other settings writer in the codebase (auth config, portal config, developer config, widget config, media, widget helpers) invalidates after each write. Onboarding violated the invariant.

## Bug this fixes

1. User loads any page that hits `__root.tsx` beforeLoad → `getBootstrapData()` → `getTenantSettings()` caches `setupState` in its pre-completion state for 300s
2. User completes workspace + boards steps → `setupState.completedAt` persisted to Postgres, but the cache still holds the stale pre-completion copy
3. `/onboarding/complete` reads from DB directly (no cache) → renders "You're all set!" ✓
4. User clicks **Go to dashboard** → `/admin`
5. `__root.tsx` beforeLoad → `getTenantSettings()` → cache hit on stale `setupState` → `isOnboardingComplete = false` → `throw redirect({ to: '/onboarding' })` → loops
6. Stuck until the 300s TTL expires

Reproducible on any fresh install with a populated TenantSettings cache; worked around by flushing Redis/Dragonfly.

## Fix

Add `invalidateSettingsCache()` after every setupState write:

- `setupWorkspaceFn` (`onboarding.ts`) — creates or updates the settings row, sets `steps.workspace = true`
- `saveUseCaseFn` (`onboarding.ts`) — sets `setupState.useCase`
- `createBoardsBatchFn` (`boards.ts`) — sets `steps.boards = true` + `completedAt` (the critical one for the stuck-on-complete symptom)

Invalidation at all three sites (not just the completion one) to match the invariant the rest of the settings domain already enforces.

## Test plan

- [ ] Fresh onboarding flow end-to-end — user reaches dashboard on first "Go to dashboard" click (no wait for TTL)
- [ ] `/onboarding/complete` still renders correctly on the first visit
- [ ] Cache still serves non-setupState fields (branding, auth/portal configs) — not regressed
- [ ] `redis-cli KEYS '*tenant-settings*'` shows the key is gone immediately after each mutator, repopulates on next read