### PR TITLE
fix(widget): respect default board setting when opening new post form

### DIFF
--- a/apps/web/src/components/widget/widget-home.tsx
+++ b/apps/web/src/components/widget/widget-home.tsx
@@ -54,6 +54,7 @@ interface WidgetHomeProps {
   initialHasMore?: boolean
   statuses: StatusInfo[]
   boards: BoardInfo[]
+  defaultBoard?: string
   onPostSelect?: (postId: string) => void
   onPostCreated?: (post: {
     id: string
@@ -199,6 +200,7 @@ export function WidgetHome({
   initialHasMore = false,
   statuses,
   boards,
+  defaultBoard,
   onPostSelect,
   onPostCreated,
   anonymousVotingEnabled = true,
@@ -225,7 +227,13 @@ export function WidgetHome({
 
   const [title, setTitle] = useState('')
   const [expanded, setExpanded] = useState(false)
-  const [selectedBoardId, setSelectedBoardId] = useState(boards[0]?.id ?? '')
+  const [selectedBoardId, setSelectedBoardId] = useState(() => {
+    if (defaultBoard) {
+      const match = boards.find((b) => b.slug === defaultBoard)
+      if (match) return match.id
+    }
+    return boards[0]?.id ?? ''
+  })
   const [contentJson, setContentJson] = useState<JSONContent | null>(null)
   const [contentHtml, setContentHtml] = useState('')
   const handleEditorChange = useCallback((json: JSONContent, html: string) => {

--- a/apps/web/src/routes/widget/index.tsx
+++ b/apps/web/src/routes/widget/index.tsx
@@ -77,7 +77,7 @@ export const Route = createFileRoute('/widget/')({
           (settings?.publicWidgetConfig?.tabs?.help ?? false),
       },
       imageUploadsInWidget: settings?.publicWidgetConfig?.imageUploadsInWidget ?? true,
-      defaultBoard: settings?.publicWidgetConfig?.defaultBoard ?? null,
+      defaultBoard: settings?.publicWidgetConfig?.defaultBoard,
     }
   },
   component: WidgetPage,
@@ -292,7 +292,7 @@ function WidgetPage() {
           initialHasMore={postsHasMore}
           statuses={statuses}
           boards={boards}
-          defaultBoard={defaultBoard ?? undefined}
+          defaultBoard={defaultBoard}
           onPostSelect={handlePostSelect}
           onPostCreated={handlePostCreated}
           anonymousVotingEnabled={features.anonymousVoting}

--- a/apps/web/src/routes/widget/index.tsx
+++ b/apps/web/src/routes/widget/index.tsx
@@ -77,6 +77,7 @@ export const Route = createFileRoute('/widget/')({
           (settings?.publicWidgetConfig?.tabs?.help ?? false),
       },
       imageUploadsInWidget: settings?.publicWidgetConfig?.imageUploadsInWidget ?? true,
+      defaultBoard: settings?.publicWidgetConfig?.defaultBoard ?? null,
     }
   },
   component: WidgetPage,
@@ -101,8 +102,17 @@ interface SuccessPost {
 }
 
 function WidgetPage() {
-  const { posts, postsHasMore, statuses, boards, orgSlug, features, tabs, imageUploadsInWidget } =
-    Route.useLoaderData()
+  const {
+    posts,
+    postsHasMore,
+    statuses,
+    boards,
+    orgSlug,
+    features,
+    tabs,
+    imageUploadsInWidget,
+    defaultBoard,
+  } = Route.useLoaderData()
   const { isIdentified, ensureSession } = useWidgetAuth()
   const canVote = isIdentified || features.anonymousVoting
 
@@ -282,6 +292,7 @@ function WidgetPage() {
           initialHasMore={postsHasMore}
           statuses={statuses}
           boards={boards}
+          defaultBoard={defaultBoard ?? undefined}
           onPostSelect={handlePostSelect}
           onPostCreated={handlePostCreated}
           anonymousVotingEnabled={features.anonymousVoting}


### PR DESCRIPTION
## Summary

- The `defaultBoard` slug from `publicWidgetConfig` was never passed to `WidgetHome`, so the board selector always initialised to the first board in the list
- Now the loader exposes `defaultBoard`, passes it through `WidgetPage` to `WidgetHome`, and the lazy `useState` initializer resolves it to the matching board by slug (falling back to first board)

Fixes #140

## Test plan

- [x] Set a non-first board as the default in Settings → Feedback Widget
- [x] Open the widget and click to write a new post — confirm that board is pre-selected in the dropdown
- [ ] With no default board set, confirm the first board is still selected as before