### PR TITLE
feat(comments): edit your own comments

### DIFF
--- a/apps/web/e2e/tests/public/comments.spec.ts
+++ b/apps/web/e2e/tests/public/comments.spec.ts
@@ -118,6 +118,13 @@ test.describe('Unauthenticated user — comments section', () => {
   })
 
   // -------------------------------------------------------------------------
+  test('Edit button is NOT shown to unauthenticated users', async ({ page }) => {
+    const commentItems = page.locator('[id^="comment-"]')
+    if ((await commentItems.count()) === 0) return
+    await expect(page.getByRole('button', { name: /^edit$/i })).toHaveCount(0, { timeout: 5000 })
+  })
+
+  // -------------------------------------------------------------------------
   test('existing comments are visible to unauthenticated users', async ({ page }) => {
     // The comment list is always rendered regardless of auth state.
     // If there are no seed comments we get the empty-state message — either is valid.
@@ -594,6 +601,177 @@ test.describe('Edge cases — comment content', () => {
         .first()
         .locator('textarea[placeholder*="Write a comment" i]')
       await expect(replyTextarea).toBeVisible({ timeout: 5000 })
+    } finally {
+      await page.close()
+    }
+  })
+})
+
+// ===========================================================================
+// COMMENT EDITING (authenticated)
+// ===========================================================================
+test.describe('Comment editing', () => {
+  test.setTimeout(90000)
+
+  let sharedContext: BrowserContext
+
+  test.beforeAll(async ({ browser }) => {
+    sharedContext = await browser.newContext()
+    const page = await sharedContext.newPage()
+    await authenticateViaOTP(page)
+    await page.close()
+  })
+
+  test.afterAll(async () => {
+    if (sharedContext) await sharedContext.close()
+  })
+
+  /** Submit a new comment and return a stable element ID + the unique text used. */
+  async function submitAndLocate(page: Page): Promise<{ elementId: string; uniqueText: string }> {
+    await goToFirstPost(page)
+    const uniqueText = `Edit test ${Date.now()}`
+    const textarea = page.locator('textarea[placeholder*="Write a comment" i]').first()
+    await textarea.fill(uniqueText)
+    await page.getByRole('button', { name: /^comment$/i }).first().click()
+    await expect(textarea).toHaveValue('', { timeout: 10000 })
+    await expect(page.getByText(uniqueText)).toBeVisible({ timeout: 10000 })
+    // Wait for the optimistic placeholder ID to be replaced with a real server ID
+    await page.waitForFunction(() => !document.querySelector('[id*="optimistic"]'))
+    const commentItem = page.locator('[id^="comment-"]').filter({ hasText: uniqueText }).first()
+    const elementId = (await commentItem.getAttribute('id'))!
+    return { elementId, uniqueText }
+  }
+
+  // -------------------------------------------------------------------------
+  test('Edit button is visible on own comments', async () => {
+    const page = await sharedContext.newPage()
+    try {
+      const { uniqueText } = await submitAndLocate(page)
+      const commentItem = page.locator('[id^="comment-"]').filter({ hasText: uniqueText }).first()
+      await expect(commentItem.getByRole('button', { name: /^edit$/i })).toBeVisible({
+        timeout: 5000,
+      })
+    } finally {
+      await page.close()
+    }
+  })
+
+  // -------------------------------------------------------------------------
+  test('clicking Edit opens an inline form with the current content', async () => {
+    const page = await sharedContext.newPage()
+    try {
+      const { elementId, uniqueText } = await submitAndLocate(page)
+      const comment = page.locator(`[id="${elementId}"]`)
+
+      await comment.getByRole('button', { name: /^edit$/i }).click()
+
+      const editTextarea = comment.getByTestId('edit-comment-textarea')
+      await expect(editTextarea).toBeVisible({ timeout: 5000 })
+      await expect(editTextarea).toHaveValue(uniqueText)
+      // Edit button is replaced by Save / Cancel
+      await expect(comment.getByRole('button', { name: /^edit$/i })).not.toBeVisible()
+      await expect(comment.getByRole('button', { name: /^save$/i })).toBeVisible()
+      // The reply form also renders a hidden Cancel, so use first() to target the edit Cancel
+      await expect(comment.getByRole('button', { name: /^cancel$/i }).first()).toBeVisible()
+    } finally {
+      await page.close()
+    }
+  })
+
+  // -------------------------------------------------------------------------
+  test('Cancel closes the edit form and restores the original content', async () => {
+    const page = await sharedContext.newPage()
+    try {
+      const { elementId, uniqueText } = await submitAndLocate(page)
+      const comment = page.locator(`[id="${elementId}"]`)
+
+      await comment.getByRole('button', { name: /^edit$/i }).click()
+      await comment.getByTestId('edit-comment-textarea').fill('should not be saved')
+      await comment.getByRole('button', { name: /^cancel$/i }).first().click()
+
+      await expect(comment.getByTestId('edit-comment-textarea')).not.toBeVisible({ timeout: 5000 })
+      await expect(comment.getByText(uniqueText)).toBeVisible()
+    } finally {
+      await page.close()
+    }
+  })
+
+  // -------------------------------------------------------------------------
+  test('Escape closes the edit form without saving', async () => {
+    const page = await sharedContext.newPage()
+    try {
+      const { elementId, uniqueText } = await submitAndLocate(page)
+      const comment = page.locator(`[id="${elementId}"]`)
+
+      await comment.getByRole('button', { name: /^edit$/i }).click()
+      const editTextarea = comment.getByTestId('edit-comment-textarea')
+      await expect(editTextarea).toBeVisible({ timeout: 5000 })
+
+      await editTextarea.press('Escape')
+
+      await expect(editTextarea).not.toBeVisible({ timeout: 5000 })
+      await expect(comment.getByText(uniqueText)).toBeVisible()
+    } finally {
+      await page.close()
+    }
+  })
+
+  // -------------------------------------------------------------------------
+  test('Save updates the comment and shows an (edited) marker', async () => {
+    const page = await sharedContext.newPage()
+    try {
+      const { elementId, uniqueText } = await submitAndLocate(page)
+      const comment = page.locator(`[id="${elementId}"]`)
+
+      await comment.getByRole('button', { name: /^edit$/i }).click()
+      const editedText = `Edited: ${uniqueText}`
+      await comment.getByTestId('edit-comment-textarea').fill(editedText)
+      await comment.getByRole('button', { name: /^save$/i }).click()
+
+      await expect(comment.getByTestId('edit-comment-textarea')).not.toBeVisible({
+        timeout: 10000,
+      })
+      await expect(comment.getByText(editedText)).toBeVisible({ timeout: 10000 })
+      await expect(comment.getByText('(edited)')).toBeVisible({ timeout: 10000 })
+    } finally {
+      await page.close()
+    }
+  })
+
+  // -------------------------------------------------------------------------
+  test('Cmd+Enter saves the edit', async () => {
+    const page = await sharedContext.newPage()
+    try {
+      const { elementId, uniqueText } = await submitAndLocate(page)
+      const comment = page.locator(`[id="${elementId}"]`)
+
+      await comment.getByRole('button', { name: /^edit$/i }).click()
+      const editedText = `Cmd-Enter edit: ${uniqueText}`
+      const editTextarea = comment.getByTestId('edit-comment-textarea')
+      await editTextarea.fill(editedText)
+      await editTextarea.press('Meta+Enter')
+
+      await expect(editTextarea).not.toBeVisible({ timeout: 10000 })
+      await expect(comment.getByText(editedText)).toBeVisible({ timeout: 10000 })
+      await expect(comment.getByText('(edited)')).toBeVisible({ timeout: 10000 })
+    } finally {
+      await page.close()
+    }
+  })
+
+  // -------------------------------------------------------------------------
+  test('Save button is disabled when the edit content is empty', async () => {
+    const page = await sharedContext.newPage()
+    try {
+      const { elementId } = await submitAndLocate(page)
+      const comment = page.locator(`[id="${elementId}"]`)
+
+      await comment.getByRole('button', { name: /^edit$/i }).click()
+      await comment.getByTestId('edit-comment-textarea').fill('')
+
+      await expect(comment.getByRole('button', { name: /^save$/i })).toBeDisabled({
+        timeout: 5000,
+      })
     } finally {
       await page.close()
     }

--- a/apps/web/e2e/tests/public/comments.spec.ts
+++ b/apps/web/e2e/tests/public/comments.spec.ts
@@ -635,10 +635,17 @@ test.describe('Comment editing', () => {
     await page.getByRole('button', { name: /^comment$/i }).first().click()
     await expect(textarea).toHaveValue('', { timeout: 10000 })
     await expect(page.getByText(uniqueText)).toBeVisible({ timeout: 10000 })
-    // Wait for the optimistic placeholder ID to be replaced with a real server ID
-    await page.waitForFunction(() => !document.querySelector('[id*="optimistic"]'))
+    // Wait for this specific comment to receive a real server ID (not optimistic placeholder)
+    await page.waitForFunction(
+      (text) =>
+        Array.from(document.querySelectorAll('[id^="comment-"]')).some(
+          (el) => el.textContent?.includes(text) && !el.id.includes('optimistic')
+        ),
+      uniqueText
+    )
     const commentItem = page.locator('[id^="comment-"]').filter({ hasText: uniqueText }).first()
-    const elementId = (await commentItem.getAttribute('id'))!
+    const elementId = await commentItem.getAttribute('id')
+    if (!elementId) throw new Error(`Could not resolve element ID for comment: ${uniqueText}`)
     return { elementId, uniqueText }
   }
 

--- a/apps/web/src/components/admin/feedback/detail/post-utils.ts
+++ b/apps/web/src/components/admin/feedback/detail/post-utils.ts
@@ -23,6 +23,7 @@ export function toPortalComments(post: PostDetails): PublicCommentView[] {
     parentId: c.parentId as CommentId | null,
     isTeamMember: c.isTeamMember,
     isPrivate: c.isPrivate,
+    isEdited: false,
     avatarUrl: (c.principalId && post.avatarUrls?.[c.principalId]) || null,
     statusChange: c.statusChange ?? null,
     reactions: c.reactions,

--- a/apps/web/src/components/admin/feedback/detail/post-utils.ts
+++ b/apps/web/src/components/admin/feedback/detail/post-utils.ts
@@ -23,7 +23,7 @@ export function toPortalComments(post: PostDetails): PublicCommentView[] {
     parentId: c.parentId as CommentId | null,
     isTeamMember: c.isTeamMember,
     isPrivate: c.isPrivate,
-    isEdited: false,
+    isEdited: !!c.updatedAt,
     avatarUrl: (c.principalId && post.avatarUrls?.[c.principalId]) || null,
     statusChange: c.statusChange ?? null,
     reactions: c.reactions,

--- a/apps/web/src/components/admin/feedback/suggestions/merge-preview-modal.tsx
+++ b/apps/web/src/components/admin/feedback/suggestions/merge-preview-modal.tsx
@@ -97,6 +97,7 @@ function MergePreviewContent({
           !!c.deletedAt && !!c.deletedByPrincipalId && c.deletedByPrincipalId !== c.principalId,
         parentId: c.parentId as CommentId | null,
         isTeamMember: c.isTeamMember,
+        isEdited: false,
         avatarUrl: c.avatarUrl ?? null,
         statusChange: c.statusChange ?? null,
         reactions: c.reactions,

--- a/apps/web/src/components/admin/feedback/suggestions/merge-preview-modal.tsx
+++ b/apps/web/src/components/admin/feedback/suggestions/merge-preview-modal.tsx
@@ -97,7 +97,7 @@ function MergePreviewContent({
           !!c.deletedAt && !!c.deletedByPrincipalId && c.deletedByPrincipalId !== c.principalId,
         parentId: c.parentId as CommentId | null,
         isTeamMember: c.isTeamMember,
-        isEdited: false,
+        isEdited: !!c.updatedAt,
         avatarUrl: c.avatarUrl ?? null,
         statusChange: c.statusChange ?? null,
         reactions: c.reactions,

--- a/apps/web/src/components/admin/roadmap-modal.tsx
+++ b/apps/web/src/components/admin/roadmap-modal.tsx
@@ -74,6 +74,7 @@ function toPortalPostView(post: PostDetails): PublicPostDetailView {
         !!c.deletedAt && !!c.deletedByPrincipalId && c.deletedByPrincipalId !== c.principalId,
       parentId: c.parentId as CommentId | null,
       isTeamMember: c.isTeamMember,
+      isEdited: false,
       avatarUrl: (c.principalId && post.avatarUrls?.[c.principalId]) || null,
       reactions: c.reactions,
       replies: c.replies.map((r) => ({
@@ -87,6 +88,7 @@ function toPortalPostView(post: PostDetails): PublicPostDetailView {
           !!r.deletedAt && !!r.deletedByPrincipalId && r.deletedByPrincipalId !== r.principalId,
         parentId: r.parentId as CommentId | null,
         isTeamMember: r.isTeamMember,
+        isEdited: false,
         avatarUrl: (r.principalId && post.avatarUrls?.[r.principalId]) || null,
         reactions: r.reactions,
         replies: [],

--- a/apps/web/src/components/admin/roadmap-modal.tsx
+++ b/apps/web/src/components/admin/roadmap-modal.tsx
@@ -26,15 +26,10 @@ import {
 } from '@/lib/client/mutations'
 import { addPostToRoadmapFn, removePostFromRoadmapFn } from '@/lib/server/functions/roadmaps'
 import { Route } from '@/routes/admin/roadmap'
-import {
-  type PostId,
-  type StatusId,
-  type TagId,
-  type RoadmapId,
-  type CommentId,
-} from '@quackback/ids'
+import { type PostId, type StatusId, type TagId, type RoadmapId } from '@quackback/ids'
 import type { PostDetails, CurrentUser } from '@/lib/shared/types'
 import type { PublicPostDetailView } from '@/lib/client/queries/portal-detail'
+import { toPortalComments } from '@/components/admin/feedback/detail/post-utils'
 
 interface RoadmapModalProps {
   postId: string | undefined
@@ -63,37 +58,7 @@ function toPortalPostView(post: PostDetails): PublicPostDetailView {
     board: post.board,
     tags: post.tags,
     roadmaps: [],
-    comments: post.comments.map((c) => ({
-      id: c.id as CommentId,
-      content: c.content,
-      authorName: c.authorName,
-      principalId: c.principalId,
-      createdAt: c.createdAt,
-      deletedAt: c.deletedAt ?? null,
-      isRemovedByTeam:
-        !!c.deletedAt && !!c.deletedByPrincipalId && c.deletedByPrincipalId !== c.principalId,
-      parentId: c.parentId as CommentId | null,
-      isTeamMember: c.isTeamMember,
-      isEdited: !!c.updatedAt,
-      avatarUrl: (c.principalId && post.avatarUrls?.[c.principalId]) || null,
-      reactions: c.reactions,
-      replies: c.replies.map((r) => ({
-        id: r.id as CommentId,
-        content: r.content,
-        authorName: r.authorName,
-        principalId: r.principalId,
-        createdAt: r.createdAt,
-        deletedAt: r.deletedAt ?? null,
-        isRemovedByTeam:
-          !!r.deletedAt && !!r.deletedByPrincipalId && r.deletedByPrincipalId !== r.principalId,
-        parentId: r.parentId as CommentId | null,
-        isTeamMember: r.isTeamMember,
-        isEdited: !!r.updatedAt,
-        avatarUrl: (r.principalId && post.avatarUrls?.[r.principalId]) || null,
-        reactions: r.reactions,
-        replies: [],
-      })),
-    })),
+    comments: toPortalComments(post),
     pinnedComment: post.pinnedComment,
     pinnedCommentId: post.pinnedCommentId,
   }

--- a/apps/web/src/components/admin/roadmap-modal.tsx
+++ b/apps/web/src/components/admin/roadmap-modal.tsx
@@ -74,7 +74,7 @@ function toPortalPostView(post: PostDetails): PublicPostDetailView {
         !!c.deletedAt && !!c.deletedByPrincipalId && c.deletedByPrincipalId !== c.principalId,
       parentId: c.parentId as CommentId | null,
       isTeamMember: c.isTeamMember,
-      isEdited: false,
+      isEdited: !!c.updatedAt,
       avatarUrl: (c.principalId && post.avatarUrls?.[c.principalId]) || null,
       reactions: c.reactions,
       replies: c.replies.map((r) => ({
@@ -88,7 +88,7 @@ function toPortalPostView(post: PostDetails): PublicPostDetailView {
           !!r.deletedAt && !!r.deletedByPrincipalId && r.deletedByPrincipalId !== r.principalId,
         parentId: r.parentId as CommentId | null,
         isTeamMember: r.isTeamMember,
-        isEdited: false,
+        isEdited: !!r.updatedAt,
         avatarUrl: (r.principalId && post.avatarUrls?.[r.principalId]) || null,
         reactions: r.reactions,
         replies: [],

--- a/apps/web/src/components/public/comment-thread.tsx
+++ b/apps/web/src/components/public/comment-thread.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useIntl } from 'react-intl'
 import {
   ArrowRightIcon,
@@ -9,7 +9,7 @@ import {
   LockClosedIcon,
   MapPinIcon,
 } from '@heroicons/react/24/solid'
-import { TrashIcon } from '@heroicons/react/24/outline'
+import { PencilSquareIcon, TrashIcon, CheckIcon, XMarkIcon } from '@heroicons/react/24/outline'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -17,6 +17,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { TimeAgo } from '@/components/ui/time-ago'
 import { REACTION_EMOJIS } from '@/lib/shared/db-types'
 import { addReactionFn, removeReactionFn } from '@/lib/server/functions/comments'
+import { useEditComment } from '@/lib/client/mutations/portal-comments'
 import type { CommentReactionCount } from '@/lib/shared'
 import type { PublicCommentView } from '@/lib/client/queries/portal-detail'
 import { cn, getInitials } from '@/lib/shared/utils'
@@ -298,10 +299,26 @@ function CommentItem({
   const [reactions, setReactions] = useState<CommentReactionCount[]>(comment.reactions)
   const [isPending, setIsPending] = useState(false)
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)
+  const [isEditing, setIsEditing] = useState(false)
+  const [editContent, setEditContent] = useState(comment.content)
+  const [editError, setEditError] = useState<string | null>(null)
+  const editTextareaRef = useRef<HTMLTextAreaElement>(null)
+
+  const editMutation = useEditComment({
+    commentId: comment.id as CommentId,
+    postId,
+  })
 
   useEffect(() => {
     setReactions(comment.reactions)
   }, [comment.reactions])
+
+  useEffect(() => {
+    if (isEditing) {
+      editTextareaRef.current?.focus()
+      editTextareaRef.current?.setSelectionRange(editContent.length, editContent.length)
+    }
+  }, [isEditing])
 
   const isDeleted = !!comment.deletedAt
   const canNest = depth < MAX_NESTING_DEPTH
@@ -315,11 +332,14 @@ function CommentItem({
     depth === 0 &&
     !isDeleted &&
     !comment.isPrivate
-  // Can delete: not already deleted, and user is author or team member
+  // Can edit/delete: not already deleted, and user is author or team member
+  // Server re-checks; client heuristic avoids showing the button to unrelated users
+  const isAuthor = !!user?.principalId && comment.principalId === user.principalId
+  const canEdit = !isDeleted && (isTeamMember || isAuthor)
   const canDelete =
     !isDeleted &&
     !!onDeleteComment &&
-    (isTeamMember || (!!user?.principalId && comment.principalId === user.principalId))
+    (isTeamMember || isAuthor)
   const isBeingDeleted = deletingCommentId === comment.id
   // Can restore: deleted, team member, and restore handler provided
   const canRestore = isDeleted && isTeamMember && !!onRestoreComment
@@ -339,6 +359,18 @@ function CommentItem({
       console.error('Failed to update reaction:', error)
     } finally {
       setIsPending(false)
+    }
+  }
+
+  async function handleSaveEdit(): Promise<void> {
+    const trimmed = editContent.trim()
+    if (!trimmed) return
+    setEditError(null)
+    try {
+      await editMutation.mutateAsync(trimmed)
+      setIsEditing(false)
+    } catch (err) {
+      setEditError(err instanceof Error ? err.message : 'Failed to save edit')
     }
   }
 
@@ -519,12 +551,60 @@ function CommentItem({
             )}
             <span className="text-muted-foreground text-xs">·</span>
             <TimeAgo date={comment.createdAt} className="text-xs text-muted-foreground" />
+            {comment.isEdited && (
+              <span className="text-xs text-muted-foreground/60">
+                {intl.formatMessage({
+                  id: 'portal.commentThread.edited',
+                  defaultMessage: '(edited)',
+                })}
+              </span>
+            )}
           </div>
 
-          {/* Comment content */}
-          <p className="text-sm whitespace-pre-wrap mt-1.5 ms-10 text-foreground/90 leading-relaxed">
-            {comment.content}
-          </p>
+          {/* Comment content — switches to an edit form when isEditing */}
+          {isEditing ? (
+            <div className="mt-1.5 ms-10">
+              <textarea
+                ref={editTextareaRef}
+                value={editContent}
+                onChange={(e) => setEditContent(e.target.value)}
+                onKeyDown={(e) => {
+                  if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') handleSaveEdit()
+                  if (e.key === 'Escape') { setIsEditing(false); setEditContent(comment.content); setEditError(null) }
+                }}
+                rows={3}
+                className="w-full max-w-lg rounded-md border border-border bg-background px-3 py-2 text-sm resize-none focus:outline-none focus:ring-1 focus:ring-ring"
+              />
+              {editError && <p className="text-xs text-destructive mt-1">{editError}</p>}
+              <div className="flex items-center gap-2 mt-2">
+                <Button
+                  size="sm"
+                  className="h-7 px-3 text-xs"
+                  onClick={handleSaveEdit}
+                  disabled={editMutation.isPending || !editContent.trim()}
+                >
+                  <CheckIcon className="h-3 w-3 me-1" />
+                  {editMutation.isPending
+                    ? intl.formatMessage({ id: 'portal.commentThread.saving', defaultMessage: 'Saving…' })
+                    : intl.formatMessage({ id: 'portal.commentThread.save', defaultMessage: 'Save' })}
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 px-3 text-xs"
+                  onClick={() => { setIsEditing(false); setEditContent(comment.content); setEditError(null) }}
+                  disabled={editMutation.isPending}
+                >
+                  <XMarkIcon className="h-3 w-3 me-1" />
+                  {intl.formatMessage({ id: 'portal.commentThread.cancel', defaultMessage: 'Cancel' })}
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm whitespace-pre-wrap mt-1.5 ms-10 text-foreground/90 leading-relaxed">
+              {comment.content}
+            </p>
+          )}
 
           {/* Status change indicator */}
           {comment.statusChange && (
@@ -666,6 +746,19 @@ function CommentItem({
                       id: 'portal.commentThread.restore',
                       defaultMessage: 'Restore',
                     })}
+              </Button>
+            )}
+
+            {/* Edit button */}
+            {canEdit && !isEditing && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 px-2 text-xs text-muted-foreground hover:text-foreground"
+                onClick={() => { setIsEditing(true); setEditContent(comment.content) }}
+              >
+                <PencilSquareIcon className="h-3 w-3 me-1" />
+                {intl.formatMessage({ id: 'portal.commentThread.edit', defaultMessage: 'Edit' })}
               </Button>
             )}
 

--- a/apps/web/src/components/public/comment-thread.tsx
+++ b/apps/web/src/components/public/comment-thread.tsx
@@ -566,6 +566,7 @@ function CommentItem({
             <div className="mt-1.5 ms-10">
               <textarea
                 ref={editTextareaRef}
+                data-testid="edit-comment-textarea"
                 value={editContent}
                 onChange={(e) => setEditContent(e.target.value)}
                 onKeyDown={(e) => {

--- a/apps/web/src/components/public/comment-thread.tsx
+++ b/apps/web/src/components/public/comment-thread.tsx
@@ -316,9 +316,9 @@ function CommentItem({
   useEffect(() => {
     if (isEditing) {
       editTextareaRef.current?.focus()
-      editTextareaRef.current?.setSelectionRange(editContent.length, editContent.length)
+      editTextareaRef.current?.setSelectionRange(comment.content.length, comment.content.length)
     }
-  }, [isEditing])
+  }, [isEditing, comment.content])
 
   const isDeleted = !!comment.deletedAt
   const canNest = depth < MAX_NESTING_DEPTH
@@ -571,7 +571,7 @@ function CommentItem({
                 onChange={(e) => setEditContent(e.target.value)}
                 onKeyDown={(e) => {
                   if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') handleSaveEdit()
-                  if (e.key === 'Escape') { setIsEditing(false); setEditContent(comment.content); setEditError(null) }
+                  else if (e.key === 'Escape') { setIsEditing(false); setEditContent(comment.content); setEditError(null) }
                 }}
                 rows={3}
                 className="w-full max-w-lg rounded-md border border-border bg-background px-3 py-2 text-sm resize-none focus:outline-none focus:ring-1 focus:ring-ring"

--- a/apps/web/src/lib/client/mutations/comments.ts
+++ b/apps/web/src/lib/client/mutations/comments.ts
@@ -209,6 +209,7 @@ export function useAddComment() {
         isTeamMember: !!principalId,
         isPrivate: isPrivate ?? false,
         createdAt: new Date(),
+        updatedAt: null,
         deletedAt: null,
         deletedByPrincipalId: null,
         replies: [],

--- a/apps/web/src/lib/client/queries/portal-detail.ts
+++ b/apps/web/src/lib/client/queries/portal-detail.ts
@@ -22,6 +22,7 @@ export interface PublicCommentView {
   parentId: CommentId | null
   isTeamMember: boolean
   isPrivate?: boolean
+  isEdited: boolean
   avatarUrl: string | null
   statusChange?: CommentStatusChange | null
   replies: PublicCommentView[]

--- a/apps/web/src/lib/server/domains/comments/__tests__/comment-edit.test.ts
+++ b/apps/web/src/lib/server/domains/comments/__tests__/comment-edit.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { CommentId, PrincipalId } from '@quackback/ids'
+import { NotFoundError, ForbiddenError, ValidationError } from '@/lib/shared/errors'
+
+// ── Mock state ────────────────────────────────────────────────────────────────
+
+const mockFindFirst = vi.fn()
+const mockFindMany = vi.fn()
+const mockTransaction = vi.fn()
+const mockDispatchCommentUpdated = vi.fn()
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('@/lib/server/db', () => ({
+  db: {
+    query: {
+      comments: {
+        findFirst: (...args: unknown[]) => mockFindFirst(...args),
+        findMany: (...args: unknown[]) => mockFindMany(...args),
+      },
+    },
+    transaction: (...args: unknown[]) => mockTransaction(...args),
+  },
+  eq: vi.fn(),
+  and: vi.fn(),
+  isNull: vi.fn(),
+  sql: vi.fn(),
+  comments: { id: 'id', parentId: 'parent_id' },
+  commentEditHistory: {},
+  posts: {},
+}))
+
+vi.mock('@/lib/server/events/dispatch', () => ({
+  dispatchCommentUpdated: (...args: unknown[]) => mockDispatchCommentUpdated(...args),
+  buildEventActor: vi.fn(() => ({ type: 'user', id: 'mock_actor' })),
+}))
+
+vi.mock('@/lib/server/domains/activity/activity.service', () => ({
+  createActivity: vi.fn(),
+}))
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const COMMENT_ID = 'comment_test123' as unknown as CommentId
+const AUTHOR_ID = 'principal_author' as unknown as PrincipalId
+const OTHER_ID = 'principal_other' as unknown as PrincipalId
+
+const baseComment = {
+  id: COMMENT_ID,
+  postId: 'post_test',
+  content: 'Original content',
+  principalId: AUTHOR_ID,
+  isTeamMember: false,
+  isPrivate: false,
+  createdAt: new Date('2026-01-01'),
+  updatedAt: null,
+  deletedAt: null,
+  parentId: null,
+  post: {
+    id: 'post_test',
+    title: 'Test Post',
+    board: { id: 'board_test', slug: 'test-board', name: 'Test Board' },
+  },
+}
+
+const updatedComment = {
+  ...baseComment,
+  content: 'Updated content',
+  updatedAt: new Date('2026-01-02'),
+}
+
+const authorActor = { principalId: AUTHOR_ID, role: 'user' as const }
+const adminActor = {
+  principalId: 'principal_admin' as unknown as PrincipalId,
+  role: 'admin' as const,
+}
+
+function makeTx(returningRows: unknown[] = [updatedComment]) {
+  return {
+    insert: vi.fn(() => ({ values: vi.fn().mockResolvedValue(undefined) })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn().mockResolvedValue(returningRows),
+        })),
+      })),
+    })),
+  }
+}
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockFindFirst.mockResolvedValue(baseComment)
+  mockFindMany.mockResolvedValue([])
+  mockTransaction.mockImplementation(
+    async (fn: (tx: ReturnType<typeof makeTx>) => Promise<unknown>) => fn(makeTx())
+  )
+})
+
+// ── canEditComment ────────────────────────────────────────────────────────────
+
+describe('canEditComment', () => {
+  it('allows the author when no team member has replied', async () => {
+    const { canEditComment } = await import('../comment.permissions')
+    expect(await canEditComment(COMMENT_ID, authorActor)).toEqual({ allowed: true })
+  })
+
+  it('allows a team member (admin) to edit any comment', async () => {
+    const { canEditComment } = await import('../comment.permissions')
+    expect(await canEditComment(COMMENT_ID, adminActor)).toEqual({ allowed: true })
+  })
+
+  it('denies a non-author user', async () => {
+    const { canEditComment } = await import('../comment.permissions')
+    const result = await canEditComment(COMMENT_ID, { principalId: OTHER_ID, role: 'user' })
+    expect(result.allowed).toBe(false)
+    expect(result.reason).toMatch(/own comments/i)
+  })
+
+  it('denies editing a deleted comment', async () => {
+    mockFindFirst.mockResolvedValueOnce({ ...baseComment, deletedAt: new Date() })
+    const { canEditComment } = await import('../comment.permissions')
+    const result = await canEditComment(COMMENT_ID, authorActor)
+    expect(result.allowed).toBe(false)
+    expect(result.reason).toMatch(/deleted/i)
+  })
+
+  it('throws NotFoundError when the comment does not exist', async () => {
+    mockFindFirst.mockResolvedValueOnce(null)
+    const { canEditComment } = await import('../comment.permissions')
+    await expect(canEditComment(COMMENT_ID, authorActor)).rejects.toThrow(NotFoundError)
+  })
+
+  it('denies when a team member has already replied', async () => {
+    mockFindMany.mockResolvedValueOnce([
+      { id: 'reply_1', isTeamMember: true, parentId: COMMENT_ID, deletedAt: null },
+    ])
+    const { canEditComment } = await import('../comment.permissions')
+    const result = await canEditComment(COMMENT_ID, authorActor)
+    expect(result.allowed).toBe(false)
+    expect(result.reason).toMatch(/team member/i)
+  })
+})
+
+// ── userEditComment ───────────────────────────────────────────────────────────
+
+describe('userEditComment', () => {
+  it('updates comment content and returns the updated comment', async () => {
+    const { userEditComment } = await import('../comment.permissions')
+    const result = await userEditComment(COMMENT_ID, 'Updated content', authorActor)
+    expect(result.content).toBe('Updated content')
+    expect(result.id).toBe(COMMENT_ID)
+  })
+
+  it('wraps the history insert and content update in a single transaction', async () => {
+    const { userEditComment } = await import('../comment.permissions')
+    await userEditComment(COMMENT_ID, 'Updated content', authorActor)
+    expect(mockTransaction).toHaveBeenCalledOnce()
+  })
+
+  it('inserts an edit history record inside the transaction', async () => {
+    let insertValuesCalled = false
+    mockTransaction.mockImplementation(
+      async (fn: (tx: ReturnType<typeof makeTx>) => Promise<unknown>) => {
+        const tx = makeTx()
+        const origInsert = tx.insert.bind(tx)
+        tx.insert = vi.fn((...args) => {
+          const chain = origInsert(...args)
+          const origValues = chain.values.bind(chain)
+          chain.values = vi.fn((...vArgs) => {
+            insertValuesCalled = true
+            return origValues(...vArgs)
+          })
+          return chain
+        })
+        return fn(tx)
+      }
+    )
+
+    const { userEditComment } = await import('../comment.permissions')
+    await userEditComment(COMMENT_ID, 'Updated content', authorActor)
+    expect(insertValuesCalled).toBe(true)
+  })
+
+  it('dispatches a comment.updated event after the transaction completes', async () => {
+    const { userEditComment } = await import('../comment.permissions')
+    await userEditComment(COMMENT_ID, 'Updated content', authorActor)
+
+    expect(mockDispatchCommentUpdated).toHaveBeenCalledOnce()
+    expect(mockDispatchCommentUpdated).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: COMMENT_ID }),
+      expect.objectContaining({ id: 'post_test', boardId: 'board_test' })
+    )
+  })
+
+  it('does not dispatch event when the transaction fails', async () => {
+    mockTransaction.mockRejectedValue(new Error('DB error'))
+    const { userEditComment } = await import('../comment.permissions')
+    await expect(userEditComment(COMMENT_ID, 'Updated content', authorActor)).rejects.toThrow()
+    expect(mockDispatchCommentUpdated).not.toHaveBeenCalled()
+  })
+
+  it('throws ForbiddenError when the actor is not allowed to edit', async () => {
+    const { userEditComment } = await import('../comment.permissions')
+    await expect(
+      userEditComment(COMMENT_ID, 'Updated', { principalId: OTHER_ID, role: 'user' })
+    ).rejects.toThrow(ForbiddenError)
+  })
+
+  it('throws ValidationError for empty content', async () => {
+    const { userEditComment } = await import('../comment.permissions')
+    await expect(userEditComment(COMMENT_ID, '', authorActor)).rejects.toThrow(ValidationError)
+    await expect(userEditComment(COMMENT_ID, '   ', authorActor)).rejects.toThrow(ValidationError)
+  })
+
+  it('throws ValidationError when content exceeds 5000 characters', async () => {
+    const { userEditComment } = await import('../comment.permissions')
+    await expect(userEditComment(COMMENT_ID, 'x'.repeat(5001), authorActor)).rejects.toThrow(
+      ValidationError
+    )
+  })
+
+  it('throws NotFoundError when the update affects no rows (concurrent deletion race)', async () => {
+    mockTransaction.mockImplementation(
+      async (fn: (tx: ReturnType<typeof makeTx>) => Promise<unknown>) => fn(makeTx([]))
+    )
+    const { userEditComment } = await import('../comment.permissions')
+    await expect(userEditComment(COMMENT_ID, 'Updated', authorActor)).rejects.toThrow(NotFoundError)
+  })
+})

--- a/apps/web/src/lib/server/domains/comments/comment.permissions.ts
+++ b/apps/web/src/lib/server/domains/comments/comment.permissions.ts
@@ -174,7 +174,6 @@ export async function userEditComment(
     throw new ForbiddenError('EDIT_NOT_ALLOWED', permResult.reason || 'Edit not allowed')
   }
 
-  // Get the existing comment with post+board for event dispatch
   const existingComment = await db.query.comments.findFirst({
     where: eq(comments.id, commentId),
     with: { post: { with: { board: true } } },
@@ -216,8 +215,6 @@ export async function userEditComment(
     return result
   })
 
-  const { post } = existingComment
-  const { board } = post
   dispatchCommentUpdated(
     buildEventActor({ principalId: actor.principalId }),
     {
@@ -225,7 +222,12 @@ export async function userEditComment(
       content: updatedComment.content,
       isPrivate: updatedComment.isPrivate ?? undefined,
     },
-    { id: post.id, title: post.title, boardId: board.id, boardSlug: board.slug }
+    {
+      id: existingComment.post.id,
+      title: existingComment.post.title,
+      boardId: existingComment.post.board.id,
+      boardSlug: existingComment.post.board.slug,
+    }
   )
 
   return updatedComment

--- a/apps/web/src/lib/server/domains/comments/comment.permissions.ts
+++ b/apps/web/src/lib/server/domains/comments/comment.permissions.ts
@@ -19,6 +19,7 @@ import { type CommentId, type PrincipalId } from '@quackback/ids'
 import { NotFoundError, ValidationError, ForbiddenError } from '@/lib/shared/errors'
 import { isTeamMember } from '@/lib/shared/roles'
 import { createActivity } from '@/lib/server/domains/activity/activity.service'
+import { dispatchCommentUpdated, buildEventActor } from '@/lib/server/events/dispatch'
 import type { CommentPermissionCheckResult } from './comment.types'
 
 // ============================================================================
@@ -173,12 +174,16 @@ export async function userEditComment(
     throw new ForbiddenError('EDIT_NOT_ALLOWED', permResult.reason || 'Edit not allowed')
   }
 
-  // Get the existing comment
+  // Get the existing comment with post+board for event dispatch
   const existingComment = await db.query.comments.findFirst({
     where: eq(comments.id, commentId),
+    with: { post: { with: { board: true } } },
   })
   if (!existingComment) {
     throw new NotFoundError('COMMENT_NOT_FOUND', `Comment with ID ${commentId} not found`)
+  }
+  if (!existingComment.post || !existingComment.post.board) {
+    throw new NotFoundError('POST_NOT_FOUND', `Post for comment ${commentId} not found`)
   }
 
   // Validate input
@@ -189,7 +194,7 @@ export async function userEditComment(
     throw new ValidationError('VALIDATION_ERROR', 'Content must be 5,000 characters or less')
   }
 
-  return await db.transaction(async (tx) => {
+  const updatedComment = await db.transaction(async (tx) => {
     if (actor.principalId) {
       await tx.insert(commentEditHistory).values({
         commentId,
@@ -198,18 +203,32 @@ export async function userEditComment(
       })
     }
 
-    const [updatedComment] = await tx
+    const [result] = await tx
       .update(comments)
       .set({ content: content.trim(), updatedAt: new Date() })
       .where(eq(comments.id, commentId))
       .returning()
 
-    if (!updatedComment) {
+    if (!result) {
       throw new NotFoundError('COMMENT_NOT_FOUND', `Comment with ID ${commentId} not found`)
     }
 
-    return updatedComment
+    return result
   })
+
+  const { post } = existingComment
+  const { board } = post
+  dispatchCommentUpdated(
+    buildEventActor({ principalId: actor.principalId }),
+    {
+      id: updatedComment.id,
+      content: updatedComment.content,
+      isPrivate: updatedComment.isPrivate ?? undefined,
+    },
+    { id: post.id, title: post.title, boardId: board.id, boardSlug: board.slug }
+  )
+
+  return updatedComment
 }
 
 /**

--- a/apps/web/src/lib/server/domains/comments/comment.permissions.ts
+++ b/apps/web/src/lib/server/domains/comments/comment.permissions.ts
@@ -198,12 +198,9 @@ export async function userEditComment(
     })
   }
 
-  // Update the comment (content only, not timestamps per PRD)
   const [updatedComment] = await db
     .update(comments)
-    .set({
-      content: content.trim(),
-    })
+    .set({ content: content.trim(), updatedAt: new Date() })
     .where(eq(comments.id, commentId))
     .returning()
 

--- a/apps/web/src/lib/server/domains/comments/comment.permissions.ts
+++ b/apps/web/src/lib/server/domains/comments/comment.permissions.ts
@@ -189,26 +189,27 @@ export async function userEditComment(
     throw new ValidationError('VALIDATION_ERROR', 'Content must be 5,000 characters or less')
   }
 
-  // Record edit history (always record for comments)
-  if (actor.principalId) {
-    await db.insert(commentEditHistory).values({
-      commentId,
-      editorPrincipalId: actor.principalId,
-      previousContent: existingComment.content,
-    })
-  }
+  return await db.transaction(async (tx) => {
+    if (actor.principalId) {
+      await tx.insert(commentEditHistory).values({
+        commentId,
+        editorPrincipalId: actor.principalId,
+        previousContent: existingComment.content,
+      })
+    }
 
-  const [updatedComment] = await db
-    .update(comments)
-    .set({ content: content.trim(), updatedAt: new Date() })
-    .where(eq(comments.id, commentId))
-    .returning()
+    const [updatedComment] = await tx
+      .update(comments)
+      .set({ content: content.trim(), updatedAt: new Date() })
+      .where(eq(comments.id, commentId))
+      .returning()
 
-  if (!updatedComment) {
-    throw new NotFoundError('COMMENT_NOT_FOUND', `Comment with ID ${commentId} not found`)
-  }
+    if (!updatedComment) {
+      throw new NotFoundError('COMMENT_NOT_FOUND', `Comment with ID ${commentId} not found`)
+    }
 
-  return updatedComment
+    return updatedComment
+  })
 }
 
 /**

--- a/apps/web/src/lib/server/domains/comments/comment.query.ts
+++ b/apps/web/src/lib/server/domains/comments/comment.query.ts
@@ -103,6 +103,7 @@ export async function getCommentsByPost(
     isTeamMember: comment.isTeamMember,
     isPrivate: comment.isPrivate,
     createdAt: comment.createdAt,
+    updatedAt: comment.updatedAt ?? null,
     deletedAt: comment.deletedAt ?? null,
     deletedByPrincipalId: comment.deletedByPrincipalId ?? null,
     statusChange: toStatusChange(comment.statusChangeFrom, comment.statusChangeTo),

--- a/apps/web/src/lib/server/domains/posts/post.public.detail.ts
+++ b/apps/web/src/lib/server/domains/posts/post.public.detail.ts
@@ -92,6 +92,7 @@ export async function getPublicPostDetail(
       is_team_member: boolean
       is_private: boolean
       created_at: Date | string
+      updated_at: Date | string | null
       deleted_at: Date | string | null
       deleted_by_principal_id: string | null
       avatar_key: string | null
@@ -112,6 +113,7 @@ export async function getPublicPostDetail(
         c.is_team_member,
         c.is_private,
         c.created_at,
+        c.updated_at,
         c.deleted_at,
         c.deleted_by_principal_id,
         m.avatar_key,
@@ -166,6 +168,7 @@ export async function getPublicPostDetail(
     is_team_member: boolean
     is_private: boolean
     created_at: Date | string
+    updated_at: Date | string | null
     deleted_at: Date | string | null
     deleted_by_principal_id: string | null
     avatar_key: string | null
@@ -192,6 +195,7 @@ export async function getPublicPostDetail(
     isTeamMember: comment.is_team_member,
     isPrivate: comment.is_private,
     createdAt: ensureDate(comment.created_at),
+    updatedAt: comment.updated_at ? ensureDate(comment.updated_at) : null,
     deletedAt: comment.deleted_at ? ensureDate(comment.deleted_at) : null,
     deletedByPrincipalId: comment.deleted_by_principal_id,
     avatarUrl: resolveAvatarUrl({
@@ -226,6 +230,7 @@ export async function getPublicPostDetail(
       parentId: node.parentId as CommentId | null,
       isTeamMember: deleted ? false : node.isTeamMember,
       isPrivate: node.isPrivate,
+      isEdited: !deleted && !!node.updatedAt,
       avatarUrl: deleted ? null : (node.avatarUrl ?? null),
       statusChange: deleted ? null : (node.statusChange ?? null),
       replies: node.replies.map(mapToPublicComment),

--- a/apps/web/src/lib/server/domains/posts/post.types.ts
+++ b/apps/web/src/lib/server/domains/posts/post.types.ts
@@ -217,6 +217,7 @@ export interface PublicComment {
   parentId: CommentId | null
   isTeamMember: boolean
   isPrivate: boolean
+  isEdited: boolean
   avatarUrl: string | null
   statusChange?: CommentStatusChange | null
   replies: PublicComment[]

--- a/apps/web/src/lib/server/mcp/__tests__/handler.test.ts
+++ b/apps/web/src/lib/server/mcp/__tests__/handler.test.ts
@@ -164,13 +164,19 @@ vi.mock('@/lib/server/domains/comments/comment.service', () => ({
     },
     post: { id: 'post_test', title: 'Test Post', boardSlug: 'bugs' },
   }),
-  updateComment: vi.fn().mockResolvedValue({
+  deleteComment: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/lib/server/domains/comments/comment.permissions', () => ({
+  userEditComment: vi.fn().mockResolvedValue({
     id: 'comment_new',
     postId: 'post_test',
     content: 'Updated comment',
     updatedAt: new Date('2026-01-02'),
   }),
-  deleteComment: vi.fn().mockResolvedValue(undefined),
+  softDeleteComment: vi.fn().mockResolvedValue(undefined),
+  canEditComment: vi.fn().mockResolvedValue({ allowed: true }),
+  canDeleteComment: vi.fn().mockResolvedValue({ allowed: true }),
 }))
 
 vi.mock('@/lib/server/domains/comments/comment.reactions', () => ({
@@ -512,7 +518,11 @@ describe('MCP HTTP Handler', () => {
       const { verifyApiKey } = await import('@/lib/server/domains/api-keys/api-key.service')
       vi.mocked(verifyApiKey).mockResolvedValue(MOCK_API_KEY)
       const { checkRateLimit } = await import('@/lib/server/domains/api/rate-limit')
-      vi.mocked(checkRateLimit).mockReturnValueOnce({ allowed: false, remaining: 0, retryAfter: 30 })
+      vi.mocked(checkRateLimit).mockReturnValueOnce({
+        allowed: false,
+        remaining: 0,
+        retryAfter: 30,
+      })
 
       const { handleMcpRequest } = await import('../handler')
       const response = await handleMcpRequest(mcpRequest(jsonRpcRequest('initialize')))

--- a/apps/web/src/lib/server/mcp/tools.ts
+++ b/apps/web/src/lib/server/mcp/tools.ts
@@ -54,9 +54,9 @@ import {
 } from '@/lib/server/domains/merge-suggestions/merge-suggestion.service'
 import {
   createComment,
-  updateComment,
   deleteComment,
 } from '@/lib/server/domains/comments/comment.service'
+import { userEditComment } from '@/lib/server/domains/comments/comment.permissions'
 import { addReaction, removeReaction } from '@/lib/server/domains/comments/comment.reactions'
 import {
   createChangelog,
@@ -1238,9 +1238,9 @@ Examples:
       if (scopeDenied) return scopeDenied
       // No team role gate — the service layer allows comment authors OR team members
       try {
-        const result = await updateComment(
+        const result = await userEditComment(
           args.commentId as CommentId,
-          { content: args.content },
+          args.content,
           { principalId: auth.principalId, role: auth.role }
         )
 

--- a/apps/web/src/lib/shared/comment-tree.ts
+++ b/apps/web/src/lib/shared/comment-tree.ts
@@ -54,6 +54,7 @@ export interface CommentWithReactions {
   isTeamMember: boolean
   isPrivate: boolean
   createdAt: Date
+  updatedAt?: Date | null
   deletedAt?: Date | null
   deletedByPrincipalId?: string | null
   avatarUrl?: string | null
@@ -77,6 +78,7 @@ export interface CommentTreeNode {
   isTeamMember: boolean
   isPrivate: boolean
   createdAt: Date
+  updatedAt: Date | null
   deletedAt: Date | null
   deletedByPrincipalId: string | null
   avatarUrl?: string | null
@@ -154,6 +156,7 @@ export function buildCommentTree<T extends CommentWithReactions>(
       isTeamMember: comment.isTeamMember,
       isPrivate: comment.isPrivate,
       createdAt: comment.createdAt,
+      updatedAt: comment.updatedAt ?? null,
       deletedAt: comment.deletedAt ?? null,
       deletedByPrincipalId: comment.deletedByPrincipalId ?? null,
       avatarUrl: comment.avatarUrl,

--- a/apps/web/src/routes/api/v1/comments/$commentId.ts
+++ b/apps/web/src/routes/api/v1/comments/$commentId.ts
@@ -69,7 +69,9 @@ export const Route = createFileRoute('/api/v1/comments/$commentId')({
             })
           }
 
-          const { updateComment } = await import('@/lib/server/domains/comments/comment.service')
+          const { userEditComment } = await import(
+            '@/lib/server/domains/comments/comment.permissions'
+          )
           const { db, principal, eq } = await import('@/lib/server/db')
 
           const principalRecord = await db.query.principal.findFirst({
@@ -77,11 +79,10 @@ export const Route = createFileRoute('/api/v1/comments/$commentId')({
             with: { user: { columns: { name: true } } },
           })
 
-          const result = await updateComment(
-            commentId,
-            { content: parsed.data.content },
-            { principalId, role: (principalRecord?.role as 'admin' | 'member' | 'user') ?? 'user' }
-          )
+          const result = await userEditComment(commentId, parsed.data.content, {
+            principalId,
+            role: (principalRecord?.role as 'admin' | 'member' | 'user') ?? 'user',
+          })
 
           const commentMember = await db.query.principal.findFirst({
             where: eq(principal.id, result.principalId),

--- a/apps/web/src/routes/api/v1/comments/__tests__/$commentId.test.ts
+++ b/apps/web/src/routes/api/v1/comments/__tests__/$commentId.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { CommentId, PrincipalId } from '@quackback/ids'
+import {
+  ForbiddenError,
+  NotFoundError,
+  ValidationError,
+  UnauthorizedError,
+} from '@/lib/shared/errors'
+
+// ── Mock state ────────────────────────────────────────────────────────────────
+
+const mockWithApiKeyAuth = vi.fn()
+const mockParseTypeId = vi.fn()
+const mockUserEditComment = vi.fn()
+const mockSoftDeleteComment = vi.fn()
+const mockGetCommentById = vi.fn()
+const mockPrincipalFindFirst = vi.fn()
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: vi.fn(() => (opts: unknown) => ({ options: opts })),
+}))
+
+vi.mock('@/lib/server/domains/api/auth', () => ({
+  withApiKeyAuth: (...args: unknown[]) => mockWithApiKeyAuth(...args),
+}))
+
+vi.mock('@/lib/server/domains/api/validation', () => ({
+  parseTypeId: (...args: unknown[]) => mockParseTypeId(...args),
+}))
+
+vi.mock('@/lib/server/domains/comments/comment.permissions', () => ({
+  userEditComment: (...args: unknown[]) => mockUserEditComment(...args),
+  softDeleteComment: (...args: unknown[]) => mockSoftDeleteComment(...args),
+}))
+
+vi.mock('@/lib/server/domains/comments/comment.query', () => ({
+  getCommentById: (...args: unknown[]) => mockGetCommentById(...args),
+}))
+
+vi.mock('@/lib/server/db', () => ({
+  db: {
+    query: {
+      principal: {
+        findFirst: (...args: unknown[]) => mockPrincipalFindFirst(...args),
+      },
+    },
+  },
+  principal: { id: 'id', userId: 'user_id' },
+  eq: vi.fn(),
+}))
+
+// ── Route extraction ──────────────────────────────────────────────────────────
+
+import { Route } from '../$commentId'
+
+type MockedHandler = (ctx: {
+  request: Request
+  params?: Record<string, string>
+}) => Promise<Response>
+type MockedRouteShape = { options: { server: { handlers: Record<string, MockedHandler> } } }
+const handlers = (Route as unknown as MockedRouteShape).options.server.handlers
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const COMMENT_ID_STR = 'comment_test123'
+const PRINCIPAL_ID = 'principal_1' as PrincipalId
+
+const mockComment = {
+  id: COMMENT_ID_STR as unknown as CommentId,
+  postId: 'post_test',
+  parentId: null,
+  content: 'Original comment',
+  authorName: 'Test User',
+  authorEmail: 'test@example.com',
+  principalId: PRINCIPAL_ID,
+  isTeamMember: false,
+  isPrivate: false,
+  createdAt: new Date('2026-01-01'),
+  deletedAt: null,
+}
+
+const mockUpdatedComment = {
+  ...mockComment,
+  content: 'Updated comment',
+  updatedAt: new Date('2026-01-02'),
+}
+
+function makeRequest(method: string, body?: unknown): Request {
+  return new Request(`http://localhost/api/v1/comments/${COMMENT_ID_STR}`, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer test-api-key',
+    },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  })
+}
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockWithApiKeyAuth.mockResolvedValue({ principalId: PRINCIPAL_ID, role: 'admin' })
+  mockParseTypeId.mockImplementation((v: unknown) => v)
+  mockUserEditComment.mockResolvedValue(mockUpdatedComment)
+  mockSoftDeleteComment.mockResolvedValue(undefined)
+  mockGetCommentById.mockResolvedValue(mockComment)
+  mockPrincipalFindFirst.mockResolvedValue({
+    role: 'admin',
+    user: { name: 'Test User' },
+  })
+})
+
+// ── PATCH ─────────────────────────────────────────────────────────────────────
+
+describe('PATCH /api/v1/comments/:commentId', () => {
+  it('returns 200 with updated comment on success', async () => {
+    const request = makeRequest('PATCH', { content: 'Updated comment' })
+    const response = await handlers.PATCH({ request, params: { commentId: COMMENT_ID_STR } })
+
+    expect(response.status).toBe(200)
+    const json = await response.json()
+    expect(json.data.id).toBe(COMMENT_ID_STR)
+    expect(json.data.content).toBe('Updated comment')
+    expect(json.data.authorName).toBe('Test User')
+  })
+
+  it('calls userEditComment with commentId, content, and actor role', async () => {
+    const request = makeRequest('PATCH', { content: 'Hello world' })
+    await handlers.PATCH({ request, params: { commentId: COMMENT_ID_STR } })
+
+    expect(mockUserEditComment).toHaveBeenCalledWith(
+      COMMENT_ID_STR,
+      'Hello world',
+      expect.objectContaining({ principalId: PRINCIPAL_ID })
+    )
+  })
+
+  it('returns 400 for empty content (Zod validation)', async () => {
+    const request = makeRequest('PATCH', { content: '' })
+    const response = await handlers.PATCH({ request, params: { commentId: COMMENT_ID_STR } })
+    expect(response.status).toBe(400)
+  })
+
+  it('returns 400 when content field is missing', async () => {
+    const request = makeRequest('PATCH', {})
+    const response = await handlers.PATCH({ request, params: { commentId: COMMENT_ID_STR } })
+    expect(response.status).toBe(400)
+  })
+
+  it('returns 400 for content exceeding 5000 characters (Zod validation)', async () => {
+    const request = makeRequest('PATCH', { content: 'x'.repeat(5001) })
+    const response = await handlers.PATCH({ request, params: { commentId: COMMENT_ID_STR } })
+    expect(response.status).toBe(400)
+  })
+
+  it('returns 401 when API key auth fails', async () => {
+    mockWithApiKeyAuth.mockRejectedValue(new UnauthorizedError('Invalid API key'))
+    const request = makeRequest('PATCH', { content: 'Updated' })
+    const response = await handlers.PATCH({ request, params: { commentId: COMMENT_ID_STR } })
+    expect(response.status).toBe(401)
+  })
+
+  it('returns 400 when comment ID format is invalid', async () => {
+    mockParseTypeId.mockImplementation(() => {
+      throw new ValidationError('VALIDATION_ERROR', 'Invalid comment ID format')
+    })
+    const request = makeRequest('PATCH', { content: 'Updated' })
+    const response = await handlers.PATCH({ request, params: { commentId: 'not-valid' } })
+    expect(response.status).toBe(400)
+  })
+
+  it('returns 403 when userEditComment throws ForbiddenError', async () => {
+    mockUserEditComment.mockRejectedValue(
+      new ForbiddenError('EDIT_NOT_ALLOWED', 'Cannot edit after team member replied')
+    )
+    const request = makeRequest('PATCH', { content: 'Updated' })
+    const response = await handlers.PATCH({ request, params: { commentId: COMMENT_ID_STR } })
+    expect(response.status).toBe(403)
+  })
+
+  it('returns 404 when userEditComment throws NotFoundError', async () => {
+    mockUserEditComment.mockRejectedValue(
+      new NotFoundError('COMMENT_NOT_FOUND', 'Comment not found')
+    )
+    const request = makeRequest('PATCH', { content: 'Updated' })
+    const response = await handlers.PATCH({ request, params: { commentId: COMMENT_ID_STR } })
+    expect(response.status).toBe(404)
+  })
+})
+
+// ── GET ───────────────────────────────────────────────────────────────────────
+
+describe('GET /api/v1/comments/:commentId', () => {
+  it('returns 200 with comment data', async () => {
+    const request = makeRequest('GET')
+    const response = await handlers.GET({ request, params: { commentId: COMMENT_ID_STR } })
+
+    expect(response.status).toBe(200)
+    const json = await response.json()
+    expect(json.data.id).toBe(COMMENT_ID_STR)
+    expect(json.data.content).toBe('Original comment')
+    expect(json.data.principalId).toBe(PRINCIPAL_ID)
+  })
+
+  it('returns 404 when comment does not exist', async () => {
+    mockGetCommentById.mockRejectedValue(
+      new NotFoundError('COMMENT_NOT_FOUND', 'Comment not found')
+    )
+    const request = makeRequest('GET')
+    const response = await handlers.GET({ request, params: { commentId: COMMENT_ID_STR } })
+    expect(response.status).toBe(404)
+  })
+})
+
+// ── DELETE ────────────────────────────────────────────────────────────────────
+
+describe('DELETE /api/v1/comments/:commentId', () => {
+  it('returns 204 on successful deletion', async () => {
+    const request = makeRequest('DELETE')
+    const response = await handlers.DELETE({ request, params: { commentId: COMMENT_ID_STR } })
+    expect(response.status).toBe(204)
+  })
+
+  it('returns 403 when softDeleteComment throws ForbiddenError', async () => {
+    mockSoftDeleteComment.mockRejectedValue(
+      new ForbiddenError('DELETE_NOT_ALLOWED', 'Cannot delete after team member replied')
+    )
+    const request = makeRequest('DELETE')
+    const response = await handlers.DELETE({ request, params: { commentId: COMMENT_ID_STR } })
+    expect(response.status).toBe(403)
+  })
+})

--- a/packages/db/drizzle/0047_true_jimmy_woo.sql
+++ b/packages/db/drizzle/0047_true_jimmy_woo.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "comments" ADD COLUMN "updated_at" timestamp with time zone;

--- a/packages/db/drizzle/meta/0047_snapshot.json
+++ b/packages/db/drizzle/meta/0047_snapshot.json
@@ -1,0 +1,8226 @@
+{
+  "id": "d122b3fa-8ee8-493e-93bd-2e1f33eae94d",
+  "prevId": "fe0c09cd-abe9-45f6-a196-849d38eaa0a0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_status_idx": {
+          "name": "invitation_email_status_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.one_time_token": {
+      "name": "one_time_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "one_time_token_user_id_user_id_fk": {
+          "name": "one_time_token_user_id_user_id_fk",
+          "tableFrom": "one_time_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.principal": {
+      "name": "principal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_key": {
+          "name": "avatar_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_metadata": {
+          "name": "service_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "principal_user_idx": {
+          "name": "principal_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "user_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "principal_role_idx": {
+          "name": "principal_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "principal_type_idx": {
+          "name": "principal_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "principal_role_created_at_idx": {
+          "name": "principal_role_created_at_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "principal_user_id_user_id_fk": {
+          "name": "principal_user_id_user_id_fk",
+          "tableFrom": "principal",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_key": {
+          "name": "logo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favicon_key": {
+          "name": "favicon_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "header_logo_key": {
+          "name": "header_logo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_config": {
+          "name": "auth_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "portal_config": {
+          "name": "portal_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branding_config": {
+          "name": "branding_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_css": {
+          "name": "custom_css",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "developer_config": {
+          "name": "developer_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "header_display_mode": {
+          "name": "header_display_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'logo_and_name'"
+        },
+        "header_display_name": {
+          "name": "header_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_state": {
+          "name": "setup_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "widget_config": {
+          "name": "widget_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "widget_secret": {
+          "name": "widget_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_flags": {
+          "name": "feature_flags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "help_center_config": {
+          "name": "help_center_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_slug_unique": {
+          "name": "settings_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_key": {
+          "name": "image_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_email_idx": {
+          "name": "user_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "email IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boards": {
+      "name": "boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "boards_is_public_idx": {
+          "name": "boards_is_public_idx",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boards_deleted_at_idx": {
+          "name": "boards_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "boards_slug_unique": {
+          "name": "boards_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmaps": {
+      "name": "roadmaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "roadmaps_position_idx": {
+          "name": "roadmaps_position_idx",
+          "columns": [
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "roadmaps_is_public_idx": {
+          "name": "roadmaps_is_public_idx",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "roadmaps_deleted_at_idx": {
+          "name": "roadmaps_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roadmaps_slug_unique": {
+          "name": "roadmaps_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tags_deleted_at_idx": {
+          "name": "tags_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_statuses": {
+      "name": "post_statuses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "show_on_roadmap": {
+          "name": "show_on_roadmap",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "post_statuses_position_idx": {
+          "name": "post_statuses_position_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_statuses_deleted_at_idx": {
+          "name": "post_statuses_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_statuses_slug_unique": {
+          "name": "post_statuses_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment_edit_history": {
+      "name": "comment_edit_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "editor_principal_id": {
+          "name": "editor_principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_content": {
+          "name": "previous_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comment_edit_history_comment_id_idx": {
+          "name": "comment_edit_history_comment_id_idx",
+          "columns": [
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comment_edit_history_created_at_idx": {
+          "name": "comment_edit_history_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comment_edit_history_comment_id_comments_id_fk": {
+          "name": "comment_edit_history_comment_id_comments_id_fk",
+          "tableFrom": "comment_edit_history",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_edit_history_editor_principal_id_principal_id_fk": {
+          "name": "comment_edit_history_editor_principal_id_principal_id_fk",
+          "tableFrom": "comment_edit_history",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "editor_principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment_reactions": {
+      "name": "comment_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comment_reactions_comment_id_idx": {
+          "name": "comment_reactions_comment_id_idx",
+          "columns": [
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comment_reactions_principal_id_idx": {
+          "name": "comment_reactions_principal_id_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comment_reactions_unique_idx": {
+          "name": "comment_reactions_unique_idx",
+          "columns": [
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "emoji",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comment_reactions_comment_id_comments_id_fk": {
+          "name": "comment_reactions_comment_id_comments_id_fk",
+          "tableFrom": "comment_reactions",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_reactions_principal_id_principal_id_fk": {
+          "name": "comment_reactions_principal_id_principal_id_fk",
+          "tableFrom": "comment_reactions",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_team_member": {
+          "name": "is_team_member",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_private": {
+          "name": "is_private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status_change_from_id": {
+          "name": "status_change_from_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_change_to_id": {
+          "name": "status_change_to_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by_principal_id": {
+          "name": "deleted_by_principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "comments_post_id_idx": {
+          "name": "comments_post_id_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_parent_id_idx": {
+          "name": "comments_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_principal_id_idx": {
+          "name": "comments_principal_id_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_created_at_idx": {
+          "name": "comments_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_post_created_at_idx": {
+          "name": "comments_post_created_at_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comments_post_id_posts_id_fk": {
+          "name": "comments_post_id_posts_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comments_principal_id_principal_id_fk": {
+          "name": "comments_principal_id_principal_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "comments_status_change_from_id_post_statuses_id_fk": {
+          "name": "comments_status_change_from_id_post_statuses_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "post_statuses",
+          "columnsFrom": [
+            "status_change_from_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "comments_status_change_to_id_post_statuses_id_fk": {
+          "name": "comments_status_change_to_id_post_statuses_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "post_statuses",
+          "columnsFrom": [
+            "status_change_to_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "comments_deleted_by_principal_id_principal_id_fk": {
+          "name": "comments_deleted_by_principal_id_principal_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "deleted_by_principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_edit_history": {
+      "name": "post_edit_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "editor_principal_id": {
+          "name": "editor_principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_title": {
+          "name": "previous_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_content": {
+          "name": "previous_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_content_json": {
+          "name": "previous_content_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_edit_history_post_id_idx": {
+          "name": "post_edit_history_post_id_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_edit_history_created_at_idx": {
+          "name": "post_edit_history_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_edit_history_post_id_posts_id_fk": {
+          "name": "post_edit_history_post_id_posts_id_fk",
+          "tableFrom": "post_edit_history",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_edit_history_editor_principal_id_principal_id_fk": {
+          "name": "post_edit_history_editor_principal_id_principal_id_fk",
+          "tableFrom": "post_edit_history",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "editor_principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_notes": {
+      "name": "post_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_notes_post_id_idx": {
+          "name": "post_notes_post_id_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_notes_principal_id_idx": {
+          "name": "post_notes_principal_id_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_notes_created_at_idx": {
+          "name": "post_notes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_notes_post_id_posts_id_fk": {
+          "name": "post_notes_post_id_posts_id_fk",
+          "tableFrom": "post_notes",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_notes_principal_id_principal_id_fk": {
+          "name": "post_notes_principal_id_principal_id_fk",
+          "tableFrom": "post_notes",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_roadmaps": {
+      "name": "post_roadmaps",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roadmap_id": {
+          "name": "roadmap_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "post_roadmaps_pk": {
+          "name": "post_roadmaps_pk",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "roadmap_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_roadmaps_post_id_idx": {
+          "name": "post_roadmaps_post_id_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_roadmaps_roadmap_id_idx": {
+          "name": "post_roadmaps_roadmap_id_idx",
+          "columns": [
+            {
+              "expression": "roadmap_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_roadmaps_position_idx": {
+          "name": "post_roadmaps_position_idx",
+          "columns": [
+            {
+              "expression": "roadmap_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_roadmaps_post_id_posts_id_fk": {
+          "name": "post_roadmaps_post_id_posts_id_fk",
+          "tableFrom": "post_roadmaps",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_roadmaps_roadmap_id_roadmaps_id_fk": {
+          "name": "post_roadmaps_roadmap_id_roadmaps_id_fk",
+          "tableFrom": "post_roadmaps",
+          "tableTo": "roadmaps",
+          "columnsFrom": [
+            "roadmap_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_tags": {
+      "name": "post_tags",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "post_tags_pk": {
+          "name": "post_tags_pk",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_tags_post_id_idx": {
+          "name": "post_tags_post_id_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_tags_tag_id_idx": {
+          "name": "post_tags_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_tags_post_id_posts_id_fk": {
+          "name": "post_tags_post_id_posts_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_tags_tag_id_tags_id_fk": {
+          "name": "post_tags_tag_id_tags_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_json": {
+          "name": "content_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_id": {
+          "name": "status_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_principal_id": {
+          "name": "owner_principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pinned_comment_id": {
+          "name": "pinned_comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by_principal_id": {
+          "name": "deleted_by_principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_comments_locked": {
+          "name": "is_comments_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "moderation_state": {
+          "name": "moderation_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'published'"
+        },
+        "widget_metadata": {
+          "name": "widget_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_post_id": {
+          "name": "canonical_post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_by_principal_id": {
+          "name": "merged_by_principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(title, '')), 'A') || setweight(to_tsvector('english', coalesce(content, '')), 'B')",
+            "type": "stored"
+          }
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_updated_at": {
+          "name": "embedding_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_json": {
+          "name": "summary_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_model": {
+          "name": "summary_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_updated_at": {
+          "name": "summary_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_comment_count": {
+          "name": "summary_comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_checked_at": {
+          "name": "merge_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "posts_board_id_idx": {
+          "name": "posts_board_id_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_status_id_idx": {
+          "name": "posts_status_id_idx",
+          "columns": [
+            {
+              "expression": "status_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_principal_id_idx": {
+          "name": "posts_principal_id_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_owner_principal_id_idx": {
+          "name": "posts_owner_principal_id_idx",
+          "columns": [
+            {
+              "expression": "owner_principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_created_at_idx": {
+          "name": "posts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_vote_count_idx": {
+          "name": "posts_vote_count_idx",
+          "columns": [
+            {
+              "expression": "vote_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_board_vote_idx": {
+          "name": "posts_board_vote_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vote_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_board_created_at_idx": {
+          "name": "posts_board_created_at_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_board_status_idx": {
+          "name": "posts_board_status_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_principal_created_at_idx": {
+          "name": "posts_principal_created_at_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_with_status_idx": {
+          "name": "posts_with_status_idx",
+          "columns": [
+            {
+              "expression": "status_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vote_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_search_vector_idx": {
+          "name": "posts_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "posts_deleted_at_idx": {
+          "name": "posts_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_board_deleted_at_idx": {
+          "name": "posts_board_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_moderation_state_idx": {
+          "name": "posts_moderation_state_idx",
+          "columns": [
+            {
+              "expression": "moderation_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_pinned_comment_id_idx": {
+          "name": "posts_pinned_comment_id_idx",
+          "columns": [
+            {
+              "expression": "pinned_comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_canonical_post_id_idx": {
+          "name": "posts_canonical_post_id_idx",
+          "columns": [
+            {
+              "expression": "canonical_post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_board_id_boards_id_fk": {
+          "name": "posts_board_id_boards_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_principal_id_principal_id_fk": {
+          "name": "posts_principal_id_principal_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "posts_status_id_post_statuses_id_fk": {
+          "name": "posts_status_id_post_statuses_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "post_statuses",
+          "columnsFrom": [
+            "status_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_owner_principal_id_principal_id_fk": {
+          "name": "posts_owner_principal_id_principal_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "owner_principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_deleted_by_principal_id_principal_id_fk": {
+          "name": "posts_deleted_by_principal_id_principal_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "deleted_by_principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_merged_by_principal_id_principal_id_fk": {
+          "name": "posts_merged_by_principal_id_principal_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "merged_by_principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vote_count_non_negative": {
+          "name": "vote_count_non_negative",
+          "value": "vote_count >= 0"
+        },
+        "comment_count_non_negative": {
+          "name": "comment_count_non_negative",
+          "value": "comment_count >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_external_url": {
+          "name": "source_external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_suggestion_id": {
+          "name": "feedback_suggestion_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_by_principal_id": {
+          "name": "added_by_principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "votes_post_id_idx": {
+          "name": "votes_post_id_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "votes_principal_post_idx": {
+          "name": "votes_principal_post_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "votes_principal_id_idx": {
+          "name": "votes_principal_id_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "votes_principal_created_at_idx": {
+          "name": "votes_principal_created_at_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "votes_source_type_idx": {
+          "name": "votes_source_type_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "source_type IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "votes_post_id_posts_id_fk": {
+          "name": "votes_post_id_posts_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_principal_id_principal_id_fk": {
+          "name": "votes_principal_id_principal_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_feedback_suggestion_id_feedback_suggestions_id_fk": {
+          "name": "votes_feedback_suggestion_id_feedback_suggestions_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "feedback_suggestions",
+          "columnsFrom": [
+            "feedback_suggestion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "votes_added_by_principal_id_principal_id_fk": {
+          "name": "votes_added_by_principal_id_principal_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "added_by_principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_event_mappings": {
+      "name": "integration_event_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_config": {
+          "name": "action_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_event_mappings_lookup": {
+          "name": "idx_event_mappings_lookup",
+          "columns": [
+            {
+              "expression": "integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_mappings_integration_fk": {
+          "name": "event_mappings_integration_fk",
+          "tableFrom": "integration_event_mappings",
+          "tableTo": "integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mapping_unique": {
+          "name": "mapping_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "integration_id",
+            "event_type",
+            "action_type",
+            "target_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_platform_credentials": {
+      "name": "integration_platform_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "integration_type": {
+          "name": "integration_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secrets": {
+          "name": "secrets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured_by_principal_id": {
+          "name": "configured_by_principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "integration_platform_credentials_configured_by_principal_id_principal_id_fk": {
+          "name": "integration_platform_credentials_configured_by_principal_id_principal_id_fk",
+          "tableFrom": "integration_platform_credentials",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "configured_by_principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "platform_cred_type_unique": {
+          "name": "platform_cred_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "integration_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integrations": {
+      "name": "integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "integration_type": {
+          "name": "integration_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "secrets": {
+          "name": "secrets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "connected_by_principal_id": {
+          "name": "connected_by_principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_integrations_type_status": {
+          "name": "idx_integrations_type_status",
+          "columns": [
+            {
+              "expression": "integration_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integrations_connected_by_principal_id_principal_id_fk": {
+          "name": "integrations_connected_by_principal_id_principal_id_fk",
+          "tableFrom": "integrations",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "connected_by_principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "integrations_principal_id_principal_id_fk": {
+          "name": "integrations_principal_id_principal_id_fk",
+          "tableFrom": "integrations",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "integration_type_unique": {
+          "name": "integration_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "integration_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "error_count_non_negative": {
+          "name": "error_count_non_negative",
+          "value": "error_count >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.slack_channel_monitors": {
+      "name": "slack_channel_monitors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_monitors_lookup": {
+          "name": "idx_slack_monitors_lookup",
+          "columns": [
+            {
+              "expression": "integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_channel_monitors_board_id_boards_id_fk": {
+          "name": "slack_channel_monitors_board_id_boards_id_fk",
+          "tableFrom": "slack_channel_monitors",
+          "tableTo": "boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "slack_monitors_integration_fk": {
+          "name": "slack_monitors_integration_fk",
+          "tableFrom": "slack_channel_monitors",
+          "tableTo": "integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_monitor_channel_unique": {
+          "name": "slack_monitor_channel_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "integration_id",
+            "channel_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.changelog_entries": {
+      "name": "changelog_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_json": {
+          "name": "content_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "changelog_published_at_idx": {
+          "name": "changelog_published_at_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "changelog_principal_id_idx": {
+          "name": "changelog_principal_id_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "changelog_deleted_at_idx": {
+          "name": "changelog_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "changelog_entries_principal_id_principal_id_fk": {
+          "name": "changelog_entries_principal_id_principal_id_fk",
+          "tableFrom": "changelog_entries",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.changelog_entry_posts": {
+      "name": "changelog_entry_posts",
+      "schema": "",
+      "columns": {
+        "changelog_entry_id": {
+          "name": "changelog_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "changelog_entry_posts_pk": {
+          "name": "changelog_entry_posts_pk",
+          "columns": [
+            {
+              "expression": "changelog_entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "changelog_entry_posts_changelog_id_idx": {
+          "name": "changelog_entry_posts_changelog_id_idx",
+          "columns": [
+            {
+              "expression": "changelog_entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "changelog_entry_posts_post_id_idx": {
+          "name": "changelog_entry_posts_post_id_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "changelog_entry_posts_changelog_entry_id_changelog_entries_id_fk": {
+          "name": "changelog_entry_posts_changelog_entry_id_changelog_entries_id_fk",
+          "tableFrom": "changelog_entry_posts",
+          "tableTo": "changelog_entries",
+          "columnsFrom": [
+            "changelog_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "changelog_entry_posts_post_id_posts_id_fk": {
+          "name": "changelog_entry_posts_post_id_posts_id_fk",
+          "tableFrom": "changelog_entry_posts",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.in_app_notifications": {
+      "name": "in_app_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "in_app_notifications_principal_created_idx": {
+          "name": "in_app_notifications_principal_created_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "in_app_notifications_principal_unread_idx": {
+          "name": "in_app_notifications_principal_unread_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "read_at IS NULL AND archived_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "in_app_notifications_post_idx": {
+          "name": "in_app_notifications_post_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "in_app_notifications_principal_id_principal_id_fk": {
+          "name": "in_app_notifications_principal_id_principal_id_fk",
+          "tableFrom": "in_app_notifications",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "in_app_notifications_post_id_posts_id_fk": {
+          "name": "in_app_notifications_post_id_posts_id_fk",
+          "tableFrom": "in_app_notifications",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "in_app_notifications_comment_id_comments_id_fk": {
+          "name": "in_app_notifications_comment_id_comments_id_fk",
+          "tableFrom": "in_app_notifications",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_status_change": {
+          "name": "email_status_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_new_comment": {
+          "name": "email_new_comment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_muted": {
+          "name": "email_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_principal_id_principal_id_fk": {
+          "name": "notification_preferences_principal_id_principal_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_preferences_principal_id_unique": {
+          "name": "notification_preferences_principal_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "principal_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_subscriptions": {
+      "name": "post_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notify_comments": {
+          "name": "notify_comments",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notify_status_changes": {
+          "name": "notify_status_changes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_subscriptions_unique": {
+          "name": "post_subscriptions_unique",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_subscriptions_principal_idx": {
+          "name": "post_subscriptions_principal_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_subscriptions_post_idx": {
+          "name": "post_subscriptions_post_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_subscriptions_post_comments_idx": {
+          "name": "post_subscriptions_post_comments_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "notify_comments = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_subscriptions_post_status_idx": {
+          "name": "post_subscriptions_post_status_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "notify_status_changes = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_subscriptions_post_id_posts_id_fk": {
+          "name": "post_subscriptions_post_id_posts_id_fk",
+          "tableFrom": "post_subscriptions",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_subscriptions_principal_id_principal_id_fk": {
+          "name": "post_subscriptions_principal_id_principal_id_fk",
+          "tableFrom": "post_subscriptions",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.unsubscribe_tokens": {
+      "name": "unsubscribe_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unsubscribe_tokens_principal_idx": {
+          "name": "unsubscribe_tokens_principal_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "unsubscribe_tokens_principal_id_principal_id_fk": {
+          "name": "unsubscribe_tokens_principal_id_principal_id_fk",
+          "tableFrom": "unsubscribe_tokens",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "unsubscribe_tokens_post_id_posts_id_fk": {
+          "name": "unsubscribe_tokens_post_id_posts_id_fk",
+          "tableFrom": "unsubscribe_tokens",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unsubscribe_tokens_token_unique": {
+          "name": "unsubscribe_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_sentiment": {
+      "name": "post_sentiment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sentiment": {
+          "name": "sentiment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "post_sentiment_processed_at_idx": {
+          "name": "post_sentiment_processed_at_idx",
+          "columns": [
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_sentiment_sentiment_idx": {
+          "name": "post_sentiment_sentiment_idx",
+          "columns": [
+            {
+              "expression": "sentiment",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_sentiment_post_id_posts_id_fk": {
+          "name": "post_sentiment_post_id_posts_id_fk",
+          "tableFrom": "post_sentiment",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_sentiment_post_id_unique": {
+          "name": "post_sentiment_post_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_created_by_id_idx": {
+          "name": "api_keys_created_by_id_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_principal_id_idx": {
+          "name": "api_keys_principal_id_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_revoked_at_idx": {
+          "name": "api_keys_revoked_at_idx",
+          "columns": [
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_created_by_id_principal_id_fk": {
+          "name": "api_keys_created_by_id_principal_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "api_keys_principal_id_principal_id_fk": {
+          "name": "api_keys_principal_id_principal_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_ids": {
+          "name": "board_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webhooks_status_idx": {
+          "name": "webhooks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhooks_created_by_id_idx": {
+          "name": "webhooks_created_by_id_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhooks_deleted_at_idx": {
+          "name": "webhooks_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhooks_created_by_id_principal_id_fk": {
+          "name": "webhooks_created_by_id_principal_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_external_links": {
+      "name": "post_external_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integration_type": {
+          "name": "integration_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_display_id": {
+          "name": "external_display_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_external_links_post_id_idx": {
+          "name": "post_external_links_post_id_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_external_links_type_external_id_idx": {
+          "name": "post_external_links_type_external_id_idx",
+          "columns": [
+            {
+              "expression": "integration_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_external_links_post_status_idx": {
+          "name": "post_external_links_post_status_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_external_links_post_fk": {
+          "name": "post_external_links_post_fk",
+          "tableFrom": "post_external_links",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_external_links_integration_fk": {
+          "name": "post_external_links_integration_fk",
+          "tableFrom": "post_external_links",
+          "tableTo": "integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_external_links_type_external_post_unique": {
+          "name": "post_external_links_type_external_post_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "integration_type",
+            "external_id",
+            "post_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.segments": {
+      "name": "segments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "rules": {
+          "name": "rules",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_schedule": {
+          "name": "evaluation_schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_config": {
+          "name": "weight_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "segments_type_idx": {
+          "name": "segments_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "segments_deleted_at_idx": {
+          "name": "segments_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_segments": {
+      "name": "user_segments",
+      "schema": "",
+      "columns": {
+        "principal_id": {
+          "name": "principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "segment_id": {
+          "name": "segment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_segments_pk": {
+          "name": "user_segments_pk",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "segment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_segments_principal_id_idx": {
+          "name": "user_segments_principal_id_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_segments_segment_id_idx": {
+          "name": "user_segments_segment_id_idx",
+          "columns": [
+            {
+              "expression": "segment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_segments_principal_id_principal_id_fk": {
+          "name": "user_segments_principal_id_principal_id_fk",
+          "tableFrom": "user_segments",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_segments_segment_id_segments_id_fk": {
+          "name": "user_segments_segment_id_segments_id_fk",
+          "tableFrom": "user_segments",
+          "tableTo": "segments",
+          "columnsFrom": [
+            "segment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_attribute_definitions": {
+      "name": "user_attribute_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency_code": {
+          "name": "currency_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_attr_key_idx": {
+          "name": "user_attr_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_user_mappings": {
+      "name": "external_user_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_user_id": {
+          "name": "external_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_name": {
+          "name": "external_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_email": {
+          "name": "external_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "external_user_source_idx": {
+          "name": "external_user_source_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "external_user_principal_idx": {
+          "name": "external_user_principal_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_user_mappings_principal_id_principal_id_fk": {
+          "name": "external_user_mappings_principal_id_principal_id_fk",
+          "tableFrom": "external_user_mappings",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_signals": {
+      "name": "feedback_signals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raw_feedback_item_id": {
+          "name": "raw_feedback_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signal_type": {
+          "name": "signal_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "implicit_need": {
+          "name": "implicit_need",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sentiment": {
+          "name": "sentiment",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "urgency": {
+          "name": "urgency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_confidence": {
+          "name": "extraction_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interpretation_confidence": {
+          "name": "interpretation_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_updated_at": {
+          "name": "embedding_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_state": {
+          "name": "processing_state",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_interpretation'"
+        },
+        "extraction_model": {
+          "name": "extraction_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_prompt_version": {
+          "name": "extraction_prompt_version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interpretation_model": {
+          "name": "interpretation_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interpretation_prompt_version": {
+          "name": "interpretation_prompt_version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_signals_raw_idx": {
+          "name": "feedback_signals_raw_idx",
+          "columns": [
+            {
+              "expression": "raw_feedback_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_signals_board_idx": {
+          "name": "feedback_signals_board_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_signals_state_idx": {
+          "name": "feedback_signals_state_idx",
+          "columns": [
+            {
+              "expression": "processing_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_signals_raw_feedback_item_id_raw_feedback_items_id_fk": {
+          "name": "feedback_signals_raw_feedback_item_id_raw_feedback_items_id_fk",
+          "tableFrom": "feedback_signals",
+          "tableTo": "raw_feedback_items",
+          "columnsFrom": [
+            "raw_feedback_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feedback_signals_board_id_boards_id_fk": {
+          "name": "feedback_signals_board_id_boards_id_fk",
+          "tableFrom": "feedback_signals",
+          "tableTo": "boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "extraction_confidence_range": {
+          "name": "extraction_confidence_range",
+          "value": "\"feedback_signals\".\"extraction_confidence\" >= 0 and \"feedback_signals\".\"extraction_confidence\" <= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.feedback_sources": {
+      "name": "feedback_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_mode": {
+          "name": "delivery_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "secrets": {
+          "name": "secrets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_sources_type_idx": {
+          "name": "feedback_sources_type_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_sources_enabled_idx": {
+          "name": "feedback_sources_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_sources_integration_id_integrations_id_fk": {
+          "name": "feedback_sources_integration_id_integrations_id_fk",
+          "tableFrom": "feedback_sources",
+          "tableTo": "integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "feedback_sources_error_count_non_negative": {
+          "name": "feedback_sources_error_count_non_negative",
+          "value": "error_count >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.feedback_suggestions": {
+      "name": "feedback_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "suggestion_type": {
+          "name": "suggestion_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "raw_feedback_item_id": {
+          "name": "raw_feedback_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signal_id": {
+          "name": "signal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_title": {
+          "name": "suggested_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_body": {
+          "name": "suggested_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "similar_posts": {
+          "name": "similar_posts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_post_id": {
+          "name": "result_post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_principal_id": {
+          "name": "resolved_by_principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_suggestions_status_idx": {
+          "name": "feedback_suggestions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_suggestions_type_idx": {
+          "name": "feedback_suggestions_type_idx",
+          "columns": [
+            {
+              "expression": "suggestion_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_suggestions_raw_item_idx": {
+          "name": "feedback_suggestions_raw_item_idx",
+          "columns": [
+            {
+              "expression": "raw_feedback_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_suggestions_created_idx": {
+          "name": "feedback_suggestions_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_suggestions_result_post_idx": {
+          "name": "feedback_suggestions_result_post_idx",
+          "columns": [
+            {
+              "expression": "result_post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_suggestions_signal_idx": {
+          "name": "feedback_suggestions_signal_idx",
+          "columns": [
+            {
+              "expression": "signal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_suggestions_raw_feedback_item_id_raw_feedback_items_id_fk": {
+          "name": "feedback_suggestions_raw_feedback_item_id_raw_feedback_items_id_fk",
+          "tableFrom": "feedback_suggestions",
+          "tableTo": "raw_feedback_items",
+          "columnsFrom": [
+            "raw_feedback_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feedback_suggestions_signal_id_feedback_signals_id_fk": {
+          "name": "feedback_suggestions_signal_id_feedback_signals_id_fk",
+          "tableFrom": "feedback_suggestions",
+          "tableTo": "feedback_signals",
+          "columnsFrom": [
+            "signal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "feedback_suggestions_board_id_boards_id_fk": {
+          "name": "feedback_suggestions_board_id_boards_id_fk",
+          "tableFrom": "feedback_suggestions",
+          "tableTo": "boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "feedback_suggestions_result_post_id_posts_id_fk": {
+          "name": "feedback_suggestions_result_post_id_posts_id_fk",
+          "tableFrom": "feedback_suggestions",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "result_post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "feedback_suggestions_resolved_by_principal_id_principal_id_fk": {
+          "name": "feedback_suggestions_resolved_by_principal_id_principal_id_fk",
+          "tableFrom": "feedback_suggestions",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "resolved_by_principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raw_feedback_items": {
+      "name": "raw_feedback_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_created_at": {
+          "name": "source_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_envelope": {
+          "name": "context_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "processing_state": {
+          "name": "processing_state",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_context'"
+        },
+        "state_changed_at": {
+          "name": "state_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_input_tokens": {
+          "name": "extraction_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_output_tokens": {
+          "name": "extraction_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "raw_feedback_dedupe_idx": {
+          "name": "raw_feedback_dedupe_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raw_feedback_state_idx": {
+          "name": "raw_feedback_state_idx",
+          "columns": [
+            {
+              "expression": "processing_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raw_feedback_source_type_idx": {
+          "name": "raw_feedback_source_type_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raw_feedback_created_idx": {
+          "name": "raw_feedback_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raw_feedback_principal_idx": {
+          "name": "raw_feedback_principal_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raw_feedback_items_source_id_feedback_sources_id_fk": {
+          "name": "raw_feedback_items_source_id_feedback_sources_id_fk",
+          "tableFrom": "raw_feedback_items",
+          "tableTo": "feedback_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "raw_feedback_items_principal_id_principal_id_fk": {
+          "name": "raw_feedback_items_principal_id_principal_id_fk",
+          "tableFrom": "raw_feedback_items",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.merge_suggestions": {
+      "name": "merge_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_post_id": {
+          "name": "source_post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_post_id": {
+          "name": "target_post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "vector_score": {
+          "name": "vector_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fts_score": {
+          "name": "fts_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hybrid_score": {
+          "name": "hybrid_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "llm_confidence": {
+          "name": "llm_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "llm_reasoning": {
+          "name": "llm_reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "llm_model": {
+          "name": "llm_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_principal_id": {
+          "name": "resolved_by_principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "merge_suggestions_source_post_idx": {
+          "name": "merge_suggestions_source_post_idx",
+          "columns": [
+            {
+              "expression": "source_post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "merge_suggestions_target_post_idx": {
+          "name": "merge_suggestions_target_post_idx",
+          "columns": [
+            {
+              "expression": "target_post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "merge_suggestions_status_idx": {
+          "name": "merge_suggestions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "merge_suggestions_created_idx": {
+          "name": "merge_suggestions_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "merge_suggestions_pending_unique_idx": {
+          "name": "merge_suggestions_pending_unique_idx",
+          "columns": [
+            {
+              "expression": "source_post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"merge_suggestions\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "merge_suggestions_source_post_id_posts_id_fk": {
+          "name": "merge_suggestions_source_post_id_posts_id_fk",
+          "tableFrom": "merge_suggestions",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "source_post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "merge_suggestions_target_post_id_posts_id_fk": {
+          "name": "merge_suggestions_target_post_id_posts_id_fk",
+          "tableFrom": "merge_suggestions",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "target_post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "merge_suggestions_resolved_by_principal_id_principal_id_fk": {
+          "name": "merge_suggestions_resolved_by_principal_id_principal_id_fk",
+          "tableFrom": "merge_suggestions",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "resolved_by_principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_activity": {
+      "name": "post_activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_activity_post_id_created_idx": {
+          "name": "post_activity_post_id_created_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_activity_type_idx": {
+          "name": "post_activity_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_activity_post_id_posts_id_fk": {
+          "name": "post_activity_post_id_posts_id_fk",
+          "tableFrom": "post_activity",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_activity_principal_id_principal_id_fk": {
+          "name": "post_activity_principal_id_principal_id_fk",
+          "tableFrom": "post_activity",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_usage_log": {
+      "name": "ai_usage_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pipeline_step": {
+          "name": "pipeline_step",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "call_type": {
+          "name": "call_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_feedback_item_id": {
+          "name": "raw_feedback_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signal_id": {
+          "name": "signal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'success'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_usage_log_step_idx": {
+          "name": "ai_usage_log_step_idx",
+          "columns": [
+            {
+              "expression": "pipeline_step",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_usage_log_created_idx": {
+          "name": "ai_usage_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_usage_log_raw_item_idx": {
+          "name": "ai_usage_log_raw_item_idx",
+          "columns": [
+            {
+              "expression": "raw_feedback_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_log": {
+      "name": "pipeline_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_feedback_item_id": {
+          "name": "raw_feedback_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signal_id": {
+          "name": "signal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggestion_id": {
+          "name": "suggestion_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_log_raw_item_idx": {
+          "name": "pipeline_log_raw_item_idx",
+          "columns": [
+            {
+              "expression": "raw_feedback_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_log_event_type_idx": {
+          "name": "pipeline_log_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_log_created_idx": {
+          "name": "pipeline_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_log_raw_feedback_item_id_raw_feedback_items_id_fk": {
+          "name": "pipeline_log_raw_feedback_item_id_raw_feedback_items_id_fk",
+          "tableFrom": "pipeline_log",
+          "tableTo": "raw_feedback_items",
+          "columnsFrom": [
+            "raw_feedback_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pipeline_log_signal_id_feedback_signals_id_fk": {
+          "name": "pipeline_log_signal_id_feedback_signals_id_fk",
+          "tableFrom": "pipeline_log",
+          "tableTo": "feedback_signals",
+          "columnsFrom": [
+            "signal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pipeline_log_suggestion_id_feedback_suggestions_id_fk": {
+          "name": "pipeline_log_suggestion_id_feedback_suggestions_id_fk",
+          "tableFrom": "pipeline_log",
+          "tableTo": "feedback_suggestions",
+          "columnsFrom": [
+            "suggestion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pipeline_log_post_id_posts_id_fk": {
+          "name": "pipeline_log_post_id_posts_id_fk",
+          "tableFrom": "pipeline_log",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kb_article_feedback": {
+      "name": "kb_article_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "article_id": {
+          "name": "article_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "helpful": {
+          "name": "helpful",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kb_article_feedback_article_id_idx": {
+          "name": "kb_article_feedback_article_id_idx",
+          "columns": [
+            {
+              "expression": "article_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kb_article_feedback_unique_idx": {
+          "name": "kb_article_feedback_unique_idx",
+          "columns": [
+            {
+              "expression": "article_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kb_article_feedback_article_id_kb_articles_id_fk": {
+          "name": "kb_article_feedback_article_id_kb_articles_id_fk",
+          "tableFrom": "kb_article_feedback",
+          "tableTo": "kb_articles",
+          "columnsFrom": [
+            "article_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kb_article_feedback_principal_id_principal_id_fk": {
+          "name": "kb_article_feedback_principal_id_principal_id_fk",
+          "tableFrom": "kb_article_feedback",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kb_articles": {
+      "name": "kb_articles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_json": {
+          "name": "content_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "helpful_count": {
+          "name": "helpful_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "not_helpful_count": {
+          "name": "not_helpful_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(title, '')), 'A') || setweight(to_tsvector('english', coalesce(content, '')), 'B')",
+            "type": "stored"
+          }
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_updated_at": {
+          "name": "embedding_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "kb_articles_slug_idx": {
+          "name": "kb_articles_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kb_articles_category_id_idx": {
+          "name": "kb_articles_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kb_articles_principal_id_idx": {
+          "name": "kb_articles_principal_id_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kb_articles_published_at_idx": {
+          "name": "kb_articles_published_at_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kb_articles_deleted_at_idx": {
+          "name": "kb_articles_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kb_articles_category_published_idx": {
+          "name": "kb_articles_category_published_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kb_articles_category_position_idx": {
+          "name": "kb_articles_category_position_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kb_articles_search_vector_idx": {
+          "name": "kb_articles_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kb_articles_category_id_kb_categories_id_fk": {
+          "name": "kb_articles_category_id_kb_categories_id_fk",
+          "tableFrom": "kb_articles",
+          "tableTo": "kb_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kb_articles_principal_id_principal_id_fk": {
+          "name": "kb_articles_principal_id_principal_id_fk",
+          "tableFrom": "kb_articles",
+          "tableTo": "principal",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kb_categories": {
+      "name": "kb_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "kb_categories_slug_idx": {
+          "name": "kb_categories_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kb_categories_position_idx": {
+          "name": "kb_categories_position_idx",
+          "columns": [
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kb_categories_deleted_at_idx": {
+          "name": "kb_categories_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kb_categories_parent_id_idx": {
+          "name": "kb_categories_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kb_categories_parent_id_kb_categories_id_fk": {
+          "name": "kb_categories_parent_id_kb_categories_id_fk",
+          "tableFrom": "kb_categories",
+          "tableTo": "kb_categories",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analytics_daily_stats": {
+      "name": "analytics_daily_stats",
+      "schema": "",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "new_posts": {
+          "name": "new_posts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "new_votes": {
+          "name": "new_votes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "new_comments": {
+          "name": "new_comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "new_users": {
+          "name": "new_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "posts_by_status": {
+          "name": "posts_by_status",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "posts_by_board": {
+          "name": "posts_by_board",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "posts_by_source": {
+          "name": "posts_by_source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analytics_top_posts": {
+      "name": "analytics_top_posts",
+      "schema": "",
+      "columns": {
+        "period": {
+          "name": "period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "analytics_top_posts_period_rank_pk": {
+          "name": "analytics_top_posts_period_rank_pk",
+          "columns": [
+            "period",
+            "rank"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -330,6 +330,13 @@
       "when": 1776295529864,
       "tag": "0046_military_nebula",
       "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "7",
+      "when": 1776847294910,
+      "tag": "0047_true_jimmy_woo",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/posts.ts
+++ b/packages/db/src/schema/posts.ts
@@ -250,6 +250,7 @@ export const comments = pgTable(
       { onDelete: 'set null' }
     ),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }),
     // Soft delete support
     deletedAt: timestamp('deleted_at', { withTimezone: true }),
     // Who initiated the deletion (self-delete vs team-removed)


### PR DESCRIPTION
## Summary

- Authors can edit their own comments until a team member replies (enforced server-side via \`canEditComment\`)
- Team members can edit any comment
- Every edit is recorded in \`comment_edit_history\` (history insert + update wrapped in a transaction)
- \`updatedAt\` column added to \`comments\` table (migration 0047); \`isEdited: true\` surfaces through the full data pipeline to show an *(edited)* marker in the UI
- Inline edit form in the comment thread: textarea with current content, Save / Cancel buttons, Escape to dismiss, Cmd/Ctrl+Enter to save
- REST \`PATCH /api/v1/comments/:id\` and MCP \`update_comment\` tool both now go through \`userEditComment\` (writes history, enforces permissions, sets \`updatedAt\`)

## Test plan

- [x] Edit button visible only when logged in as author or team member
- [x] Edit button absent for unauthenticated users
- [x] Clicking Edit opens inline textarea pre-filled with current content
- [x] Cancel restores original content, closes form
- [x] Escape closes form without saving
- [x] Save sends updated content to server; *(edited)* marker appears
- [x] Cmd+Enter saves the edit
- [x] Save disabled when content is empty
- [x] 8 new e2e specs covering all of the above (`Comment editing` describe block in `comments.spec.ts`)