### PR TITLE
refactor(integrations): extract NotificationChannelRouter (#145 PR1/2)

### DIFF
--- a/apps/web/src/components/admin/settings/integrations/shared/notification-channel-router.tsx
+++ b/apps/web/src/components/admin/settings/integrations/shared/notification-channel-router.tsx
@@ -8,7 +8,7 @@
  * mental model and should get their own UI rather than be forced through here.
  */
 
-import { useState, useRef, useMemo, type ReactNode } from 'react'
+import { useState, useRef, useMemo, type ReactNode, type CSSProperties } from 'react'
 import {
   ArrowPathIcon,
   XMarkIcon,
@@ -149,8 +149,16 @@ function getBoardSummary(channel: NotificationChannel, boards: Board[]): string 
   return `${channel.boardIds.length} boards`
 }
 
-function tableGrid(eventCount: number) {
-  return `grid-cols-[minmax(0,1fr)${'_5rem'.repeat(eventCount)}]`
+/**
+ * Inline grid-template-columns for the routing table.
+ *
+ * Built as inline style instead of a `grid-cols-[...]` Tailwind class because
+ * Tailwind's JIT scanner only emits CSS for class strings it sees literally
+ * in source — a dynamic template-literal class wouldn't get its CSS generated
+ * and the grid would silently collapse.
+ */
+function tableGridStyle(eventCount: number): CSSProperties {
+  return { gridTemplateColumns: `minmax(0,1fr) ${'5rem '.repeat(eventCount).trim()}` }
 }
 
 // ============================================
@@ -451,7 +459,8 @@ function ChannelRow<TChannel extends Channel>({
     <>
       <div className={hasBorder ? 'border-b border-border/50' : ''}>
         <div
-          className={`grid ${tableGrid(events.length)} items-center hover:bg-muted/10 transition-colors cursor-pointer`}
+          className="grid items-center hover:bg-muted/10 transition-colors cursor-pointer"
+          style={tableGridStyle(events.length)}
           onClick={onToggleExpand}
         >
           <div className="flex items-center gap-2 px-4 py-3">
@@ -561,7 +570,8 @@ function RoutingTable<TChannel extends Channel>({
   return (
     <div className="rounded-lg border border-border/50 overflow-hidden">
       <div
-        className={`grid ${tableGrid(events.length)} items-end bg-muted/40 border-b border-border/50`}
+        className="grid items-end bg-muted/40 border-b border-border/50"
+        style={tableGridStyle(events.length)}
       >
         <div className="px-4 py-2 text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
           Channel

--- a/apps/web/src/components/admin/settings/integrations/shared/notification-channel-router.tsx
+++ b/apps/web/src/components/admin/settings/integrations/shared/notification-channel-router.tsx
@@ -8,8 +8,6 @@
  * mental model and should get their own UI rather than be forced through here.
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 import { useState, useRef, useMemo, type ReactNode } from 'react'
 import {
   ArrowPathIcon,
@@ -85,7 +83,10 @@ export function NotificationChannelRouter<TChannel extends Channel>(
   props: NotificationChannelRouterProps<TChannel>
 ) {
   const [addDialogOpen, setAddDialogOpen] = useState(false)
-  const existingChannelIds = props.notificationChannels.map((c) => c.channelId)
+  const existingChannelIds = useMemo(
+    () => props.notificationChannels.map((c) => c.channelId),
+    [props.notificationChannels]
+  )
 
   return (
     <div className="space-y-3">
@@ -135,7 +136,25 @@ export function NotificationChannelRouter<TChannel extends Channel>(
 }
 
 // ============================================
-// Internal components (stubs) — see Task 1.2 for full bodies
+// Helpers
+// ============================================
+
+function getBoardSummary(channel: NotificationChannel, boards: Board[]): string {
+  if (!channel.boardIds?.length) return 'All boards'
+  if (channel.boardIds.length === 1) {
+    return boards.find((b) => b.id === channel.boardIds![0])?.name ?? '1 board'
+  }
+  const firstName = boards.find((b) => b.id === channel.boardIds![0])?.name
+  if (firstName) return `${firstName} + ${channel.boardIds.length - 1} more`
+  return `${channel.boardIds.length} boards`
+}
+
+function tableGrid(eventCount: number) {
+  return `grid-cols-[minmax(0,1fr)${'_5rem'.repeat(eventCount)}]`
+}
+
+// ============================================
+// Internal component interfaces
 // ============================================
 
 interface RoutingTableProps<TChannel extends Channel> {
@@ -162,10 +181,621 @@ interface AddChannelDialogProps<TChannel extends Channel> {
   onRefreshChannels: () => void
 }
 
-function RoutingTable<TChannel extends Channel>(_props: RoutingTableProps<TChannel>): null {
-  return null
+// ============================================
+// Searchable Channel Picker
+// ============================================
+
+function ChannelPicker<TChannel extends Channel>({
+  channels,
+  value,
+  onSelect,
+  loading,
+  onRefresh,
+  renderChannelIcon,
+  placeholder = 'Select a channel...',
+}: {
+  channels: TChannel[]
+  value: string
+  onSelect: (channelId: string) => void
+  loading?: boolean
+  onRefresh?: () => void
+  renderChannelIcon: (channel: TChannel | undefined) => ReactNode
+  placeholder?: string
+}) {
+  const [open, setOpen] = useState(false)
+  const [search, setSearch] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const selected = channels.find((c) => c.id === value)
+  const filtered = useMemo(
+    () =>
+      search
+        ? channels.filter((c) => c.name.toLowerCase().includes(search.toLowerCase()))
+        : channels,
+    [channels, search]
+  )
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className="w-full justify-between font-normal"
+        >
+          {loading ? (
+            <span className="flex items-center gap-2 text-muted-foreground">
+              <ArrowPathIcon className="h-4 w-4 animate-spin" />
+              Loading channels...
+            </span>
+          ) : selected ? (
+            <span className="flex items-center gap-2">
+              {renderChannelIcon(selected)}
+              {selected.name}
+            </span>
+          ) : (
+            <span className="text-muted-foreground">{placeholder}</span>
+          )}
+          <ChevronUpDownIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-[--radix-popover-trigger-width] p-0"
+        align="start"
+        onOpenAutoFocus={(e) => {
+          e.preventDefault()
+          inputRef.current?.focus()
+        }}
+      >
+        <div className="flex items-center gap-2 border-b px-3 py-2">
+          <MagnifyingGlassIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <input
+            ref={inputRef}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search channels..."
+            className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          />
+          {onRefresh && (
+            <button
+              type="button"
+              onClick={onRefresh}
+              disabled={loading}
+              className="text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
+              title="Refresh channels"
+            >
+              <ArrowPathIcon className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
+            </button>
+          )}
+        </div>
+        <div className="max-h-[200px] overflow-y-auto p-1">
+          {filtered.length === 0 ? (
+            <div className="px-2 py-4 text-center text-sm text-muted-foreground">
+              {search ? 'No channels match your search.' : 'No channels available.'}
+            </div>
+          ) : (
+            filtered.map((channel) => (
+              <button
+                key={channel.id}
+                type="button"
+                className={`flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm transition-colors ${
+                  channel.id === value ? 'bg-accent text-accent-foreground' : 'hover:bg-muted/50'
+                }`}
+                onClick={() => {
+                  onSelect(channel.id)
+                  setOpen(false)
+                  setSearch('')
+                }}
+              >
+                {renderChannelIcon(channel)}
+                <span className="truncate">{channel.name}</span>
+              </button>
+            ))
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
 }
 
-function AddChannelDialog<TChannel extends Channel>(_props: AddChannelDialogProps<TChannel>): null {
-  return null
+// ============================================
+// Board Filter Pills
+// ============================================
+
+function BoardFilterPills({
+  boardIds,
+  boards,
+  onBoardIdsChange,
+  disabled,
+}: {
+  boardIds: string[] | null
+  boards: Board[]
+  onBoardIdsChange: (boardIds: string[] | null) => void
+  disabled?: boolean
+}) {
+  const isAllBoards = !boardIds?.length
+
+  return (
+    <div className="space-y-2">
+      <div className="text-xs font-medium text-muted-foreground">Board filter</div>
+      <div className="space-y-2">
+        <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <Checkbox
+            checked={isAllBoards}
+            onCheckedChange={(checked) => {
+              if (checked) onBoardIdsChange(null)
+            }}
+            disabled={disabled}
+          />
+          All boards
+        </label>
+        <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <Checkbox
+            checked={!isAllBoards}
+            onCheckedChange={(checked) => {
+              if (checked) {
+                onBoardIdsChange(boards.map((b) => b.id))
+              } else {
+                onBoardIdsChange(null)
+              }
+            }}
+            disabled={disabled}
+          />
+          Specific boards
+        </label>
+        {!isAllBoards && (
+          <div className="ml-6 flex flex-wrap gap-1.5 pt-0.5">
+            {boards.map((board) => {
+              const selected = boardIds?.includes(board.id) ?? false
+              return (
+                <button
+                  key={board.id}
+                  type="button"
+                  className={`px-2.5 py-1 text-xs rounded-md border transition-colors disabled:opacity-50 ${
+                    selected
+                      ? 'bg-primary/10 border-primary/20 text-primary font-medium'
+                      : 'border-border/60 text-muted-foreground hover:bg-muted/50'
+                  }`}
+                  onClick={() => {
+                    if (selected) {
+                      const next = (boardIds ?? []).filter((id) => id !== board.id)
+                      onBoardIdsChange(next.length > 0 ? next : null)
+                    } else {
+                      onBoardIdsChange([...(boardIds ?? []), board.id])
+                    }
+                  }}
+                  disabled={disabled}
+                >
+                  {board.name}
+                </button>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ============================================
+// Channel Row (table row with expandable detail)
+// ============================================
+
+function ChannelRow<TChannel extends Channel>({
+  channel,
+  channelInfo,
+  integrationId,
+  disabled,
+  expanded,
+  onToggleExpand,
+  boards,
+  hasBorder,
+  events,
+  renderChannelIcon,
+}: {
+  channel: NotificationChannel
+  channelInfo: TChannel | undefined
+  integrationId: string
+  disabled: boolean
+  expanded: boolean
+  onToggleExpand: () => void
+  boards: Board[]
+  hasBorder: boolean
+  events: EventConfig[]
+  renderChannelIcon: (c: TChannel | undefined) => ReactNode
+}) {
+  const updateMutation = useUpdateNotificationChannel()
+  const removeMutation = useRemoveNotificationChannel()
+  const [confirmRemove, setConfirmRemove] = useState(false)
+
+  const channelName = channelInfo?.name || channel.channelId
+  const saving = updateMutation.isPending
+  const hasFilter = !!channel.boardIds?.length
+
+  const handleEventToggle = (eventId: string, checked: boolean) => {
+    updateMutation.mutate({
+      integrationId,
+      channelId: channel.channelId,
+      events: events.map((e) => ({
+        eventType: e.id,
+        enabled:
+          e.id === eventId
+            ? checked
+            : (channel.events.find((ev) => ev.eventType === e.id)?.enabled ?? false),
+      })),
+      boardIds: channel.boardIds,
+    })
+  }
+
+  const handleBoardIdsChange = (boardIds: string[] | null) => {
+    updateMutation.mutate({
+      integrationId,
+      channelId: channel.channelId,
+      events: events.map((e) => ({
+        eventType: e.id,
+        enabled: channel.events.find((ev) => ev.eventType === e.id)?.enabled ?? false,
+      })),
+      boardIds,
+    })
+  }
+
+  const handleRemove = () => {
+    removeMutation.mutate(
+      { integrationId, channelId: channel.channelId },
+      { onSuccess: () => setConfirmRemove(false) }
+    )
+  }
+
+  return (
+    <>
+      <div className={hasBorder ? 'border-b border-border/50' : ''}>
+        <div
+          className={`grid ${tableGrid(events.length)} items-center hover:bg-muted/10 transition-colors cursor-pointer`}
+          onClick={onToggleExpand}
+        >
+          <div className="flex items-center gap-2 px-4 py-3">
+            <ChevronRightIcon
+              className={`h-3 w-3 text-muted-foreground shrink-0 transition-transform duration-150 ${
+                expanded ? 'rotate-90' : ''
+              }`}
+            />
+            {renderChannelIcon(channelInfo)}
+            <div className="min-w-0 flex items-center gap-2">
+              <span className="text-sm font-medium truncate">{channelName}</span>
+              {hasFilter && (
+                <span className="text-[11px] text-muted-foreground shrink-0">
+                  {getBoardSummary(channel, boards)}
+                </span>
+              )}
+            </div>
+          </div>
+
+          {events.map((event) => {
+            const enabled = channel.events.find((e) => e.eventType === event.id)?.enabled ?? false
+            return (
+              <div
+                key={event.id}
+                className="flex justify-center py-3"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <Checkbox
+                  checked={enabled}
+                  onCheckedChange={(checked) => handleEventToggle(event.id, checked === true)}
+                  disabled={disabled || saving}
+                />
+              </div>
+            )
+          })}
+        </div>
+
+        {expanded && (
+          <div className="border-t border-border/30 bg-muted/5 px-4 pb-4">
+            <div className="pl-10 pt-3 space-y-3">
+              <BoardFilterPills
+                boardIds={channel.boardIds}
+                boards={boards}
+                onBoardIdsChange={handleBoardIdsChange}
+                disabled={disabled || saving}
+              />
+              <div className="pt-2 border-t border-border/30">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 text-xs text-muted-foreground hover:text-destructive"
+                  onClick={() => setConfirmRemove(true)}
+                  disabled={disabled}
+                >
+                  <XMarkIcon className="h-3.5 w-3.5 mr-1" />
+                  Remove channel
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <Dialog open={confirmRemove} onOpenChange={setConfirmRemove}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Remove notification channel</DialogTitle>
+            <DialogDescription>
+              Stop sending notifications to #{channelName}? This will delete all event mappings for
+              this channel.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmRemove(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleRemove}
+              disabled={removeMutation.isPending}
+            >
+              {removeMutation.isPending ? 'Removing...' : 'Remove'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
+
+// ============================================
+// Routing Table
+// ============================================
+
+function RoutingTable<TChannel extends Channel>({
+  channels: notificationChannels,
+  channelInfoList,
+  integrationId,
+  disabled,
+  boards,
+  events,
+  renderChannelIcon,
+  onAddChannel,
+}: RoutingTableProps<TChannel>) {
+  const [expandedId, setExpandedId] = useState<string | null>(null)
+
+  return (
+    <div className="rounded-lg border border-border/50 overflow-hidden">
+      <div
+        className={`grid ${tableGrid(events.length)} items-end bg-muted/40 border-b border-border/50`}
+      >
+        <div className="px-4 py-2 text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
+          Channel
+        </div>
+        {events.map((event) => (
+          <div
+            key={event.id}
+            className="py-2 text-[11px] font-medium text-muted-foreground text-center leading-tight"
+            title={event.label}
+          >
+            {event.shortLabel}
+          </div>
+        ))}
+      </div>
+
+      {notificationChannels.map((nc, idx) => (
+        <ChannelRow<TChannel>
+          key={nc.channelId}
+          channel={nc}
+          channelInfo={channelInfoList.find((c) => c.id === nc.channelId)}
+          integrationId={integrationId}
+          disabled={disabled}
+          expanded={expandedId === nc.channelId}
+          onToggleExpand={() =>
+            setExpandedId((prev) => (prev === nc.channelId ? null : nc.channelId))
+          }
+          boards={boards}
+          hasBorder={idx < notificationChannels.length - 1 || expandedId === nc.channelId}
+          events={events}
+          renderChannelIcon={renderChannelIcon}
+        />
+      ))}
+
+      {onAddChannel && (
+        <button
+          type="button"
+          className="flex items-center gap-1.5 px-4 py-2.5 text-sm text-muted-foreground hover:text-foreground hover:bg-muted/10 transition-colors w-full border-t border-border/50"
+          onClick={onAddChannel}
+          disabled={disabled}
+        >
+          <PlusIcon className="h-3.5 w-3.5" />
+          Add channel
+        </button>
+      )}
+    </div>
+  )
+}
+
+// ============================================
+// Add Channel Dialog
+// ============================================
+
+function AddChannelDialog<TChannel extends Channel>({
+  open,
+  onOpenChange,
+  integrationId,
+  channels,
+  loadingChannels,
+  existingChannelIds,
+  boards,
+  events,
+  renderChannelIcon,
+  onRefreshChannels,
+}: AddChannelDialogProps<TChannel>) {
+  const addMutation = useAddNotificationChannel()
+  const [selectedChannelId, setSelectedChannelId] = useState('')
+  const [selectedEvents, setSelectedEvents] = useState<Record<string, boolean>>(() =>
+    Object.fromEntries(events.map((e) => [e.id, true]))
+  )
+  const [boardIds, setBoardIds] = useState<string[] | null>(null)
+  const [showBoardFilter, setShowBoardFilter] = useState(false)
+
+  const availableChannels = channels.filter((c) => !existingChannelIds.includes(c.id))
+  const allEventsSelected = events.every((e) => selectedEvents[e.id])
+  const noEventsSelected = events.every((e) => !selectedEvents[e.id])
+
+  const handleSave = () => {
+    if (!selectedChannelId) return
+    const eventsToSave = Object.entries(selectedEvents)
+      .filter(([, enabled]) => enabled)
+      .map(([eventType]) => eventType)
+
+    if (eventsToSave.length === 0) return
+
+    addMutation.mutate(
+      {
+        integrationId,
+        channelId: selectedChannelId,
+        events: eventsToSave,
+        boardIds: boardIds ?? undefined,
+      },
+      {
+        onSuccess: () => {
+          onOpenChange(false)
+          setSelectedChannelId('')
+          setSelectedEvents(Object.fromEntries(events.map((e) => [e.id, true])))
+          setBoardIds(null)
+          setShowBoardFilter(false)
+        },
+      }
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Add notification channel</DialogTitle>
+          <DialogDescription>Route events to a channel.</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label>Channel</Label>
+            <ChannelPicker<TChannel>
+              channels={availableChannels}
+              value={selectedChannelId}
+              onSelect={setSelectedChannelId}
+              loading={loadingChannels}
+              onRefresh={onRefreshChannels}
+              renderChannelIcon={renderChannelIcon}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between">
+              <Label>Events</Label>
+              <button
+                type="button"
+                onClick={() => {
+                  const next = allEventsSelected ? false : true
+                  setSelectedEvents(Object.fromEntries(events.map((e) => [e.id, next])))
+                }}
+                className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {allEventsSelected ? 'Deselect all' : 'Select all'}
+              </button>
+            </div>
+            <div className="grid grid-cols-2 gap-x-4 gap-y-1.5">
+              {events.map((event) => (
+                <label
+                  key={event.id}
+                  className="flex items-center gap-2 text-sm cursor-pointer py-1"
+                >
+                  <Checkbox
+                    checked={selectedEvents[event.id] ?? true}
+                    onCheckedChange={(checked) =>
+                      setSelectedEvents((prev) => ({
+                        ...prev,
+                        [event.id]: checked === true,
+                      }))
+                    }
+                  />
+                  {event.shortLabel}
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            {!showBoardFilter && !boardIds?.length ? (
+              <button
+                type="button"
+                onClick={() => setShowBoardFilter(true)}
+                className="text-xs text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1"
+              >
+                <PlusIcon className="h-3 w-3" />
+                Filter by board
+              </button>
+            ) : (
+              <>
+                <div className="flex items-center justify-between">
+                  <Label className="text-xs text-muted-foreground">Board filter</Label>
+                  {boardIds?.length ? (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setBoardIds(null)
+                        setShowBoardFilter(false)
+                      }}
+                      className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                    >
+                      Clear
+                    </button>
+                  ) : null}
+                </div>
+                <div className="flex flex-wrap gap-1.5">
+                  {boards.map((board) => {
+                    const selected = boardIds?.includes(board.id) ?? false
+                    return (
+                      <button
+                        key={board.id}
+                        type="button"
+                        className={`px-2.5 py-1 text-xs rounded-md border transition-colors ${
+                          selected
+                            ? 'bg-primary/10 border-primary/20 text-primary font-medium'
+                            : 'border-border/60 text-muted-foreground hover:bg-muted/50'
+                        }`}
+                        onClick={() => {
+                          if (selected) {
+                            const next = (boardIds ?? []).filter((id) => id !== board.id)
+                            setBoardIds(next.length > 0 ? next : null)
+                          } else {
+                            setBoardIds([...(boardIds ?? []), board.id])
+                          }
+                        }}
+                      >
+                        {board.name}
+                      </button>
+                    )
+                  })}
+                </div>
+                {!boardIds?.length && (
+                  <p className="text-[11px] text-muted-foreground">
+                    Select boards to filter, or leave empty for all boards.
+                  </p>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSave}
+            disabled={!selectedChannelId || noEventsSelected || addMutation.isPending}
+          >
+            {addMutation.isPending ? 'Adding...' : 'Add channel'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
 }

--- a/apps/web/src/components/admin/settings/integrations/shared/notification-channel-router.tsx
+++ b/apps/web/src/components/admin/settings/integrations/shared/notification-channel-router.tsx
@@ -1,0 +1,171 @@
+/**
+ * Routing UI for chat-style integrations (Slack, Discord, Teams).
+ *
+ * Lets admins pick a destination channel per event with optional board filter.
+ *
+ * NOT for ticket-creation integrations (Jira, Linear, Asana) or
+ * broadcast/digest integrations (email, webhooks). Those have a different
+ * mental model and should get their own UI rather than be forced through here.
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+import { useState, useRef, useMemo, type ReactNode } from 'react'
+import {
+  ArrowPathIcon,
+  XMarkIcon,
+  PlusIcon,
+  ChevronRightIcon,
+  MagnifyingGlassIcon,
+  ChevronUpDownIcon,
+} from '@heroicons/react/24/solid'
+import { Label } from '@/components/ui/label'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import {
+  useAddNotificationChannel,
+  useUpdateNotificationChannel,
+  useRemoveNotificationChannel,
+} from '@/lib/client/mutations'
+
+// ============================================
+// Public types
+// ============================================
+
+export interface Channel {
+  id: string
+  name: string
+}
+
+export interface NotificationChannel {
+  channelId: string
+  events: { eventType: string; enabled: boolean }[]
+  boardIds: string[] | null
+}
+
+export interface EventConfig {
+  id: string
+  label: string
+  shortLabel: string
+  description: string
+}
+
+export interface Board {
+  id: string
+  name: string
+}
+
+interface NotificationChannelRouterProps<TChannel extends Channel> {
+  integrationId: string
+  enabled: boolean
+  events: EventConfig[]
+  channels: TChannel[]
+  notificationChannels: NotificationChannel[]
+  boards: Board[]
+  loadingChannels: boolean
+  channelError: string | null
+  onRefreshChannels: () => void
+  renderChannelIcon: (channel: TChannel | undefined) => ReactNode
+}
+
+// ============================================
+// Public component
+// ============================================
+
+export function NotificationChannelRouter<TChannel extends Channel>(
+  props: NotificationChannelRouterProps<TChannel>
+) {
+  const [addDialogOpen, setAddDialogOpen] = useState(false)
+  const existingChannelIds = props.notificationChannels.map((c) => c.channelId)
+
+  return (
+    <div className="space-y-3">
+      {props.channelError && <p className="text-sm text-destructive">{props.channelError}</p>}
+
+      {props.notificationChannels.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-border/50 p-8 text-center">
+          <p className="text-sm text-muted-foreground">No notification channels configured yet.</p>
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-3 gap-1.5"
+            onClick={() => setAddDialogOpen(true)}
+            disabled={!props.enabled}
+          >
+            <PlusIcon className="h-3.5 w-3.5" />
+            Add your first channel
+          </Button>
+        </div>
+      ) : (
+        <RoutingTable<TChannel>
+          channels={props.notificationChannels}
+          channelInfoList={props.channels}
+          integrationId={props.integrationId}
+          disabled={!props.enabled}
+          boards={props.boards}
+          events={props.events}
+          renderChannelIcon={props.renderChannelIcon}
+          onAddChannel={props.enabled ? () => setAddDialogOpen(true) : undefined}
+        />
+      )}
+
+      <AddChannelDialog<TChannel>
+        open={addDialogOpen}
+        onOpenChange={setAddDialogOpen}
+        integrationId={props.integrationId}
+        channels={props.channels}
+        loadingChannels={props.loadingChannels}
+        existingChannelIds={existingChannelIds}
+        boards={props.boards}
+        events={props.events}
+        renderChannelIcon={props.renderChannelIcon}
+        onRefreshChannels={props.onRefreshChannels}
+      />
+    </div>
+  )
+}
+
+// ============================================
+// Internal components (stubs) — see Task 1.2 for full bodies
+// ============================================
+
+interface RoutingTableProps<TChannel extends Channel> {
+  channels: NotificationChannel[]
+  channelInfoList: TChannel[]
+  integrationId: string
+  disabled: boolean
+  boards: Board[]
+  events: EventConfig[]
+  renderChannelIcon: (channel: TChannel | undefined) => ReactNode
+  onAddChannel?: () => void
+}
+
+interface AddChannelDialogProps<TChannel extends Channel> {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  integrationId: string
+  channels: TChannel[]
+  loadingChannels: boolean
+  existingChannelIds: string[]
+  boards: Board[]
+  events: EventConfig[]
+  renderChannelIcon: (channel: TChannel | undefined) => ReactNode
+  onRefreshChannels: () => void
+}
+
+function RoutingTable<TChannel extends Channel>(_props: RoutingTableProps<TChannel>): null {
+  return null
+}
+
+function AddChannelDialog<TChannel extends Channel>(_props: AddChannelDialogProps<TChannel>): null {
+  return null
+}

--- a/apps/web/src/components/admin/settings/integrations/slack/slack-config.tsx
+++ b/apps/web/src/components/admin/settings/integrations/slack/slack-config.tsx
@@ -550,7 +550,7 @@ export function SlackConfig({
 
         <NotificationChannelRouter<SlackChannel>
           integrationId={integrationId}
-          enabled={integrationEnabled && !saving}
+          enabled={integrationEnabled}
           events={SLACK_EVENT_CONFIG}
           channels={channels}
           notificationChannels={notificationChannels}

--- a/apps/web/src/components/admin/settings/integrations/slack/slack-config.tsx
+++ b/apps/web/src/components/admin/settings/integrations/slack/slack-config.tsx
@@ -5,14 +5,12 @@ import {
   LockClosedIcon,
   XMarkIcon,
   PlusIcon,
-  ChevronRightIcon,
   MagnifyingGlassIcon,
   ChevronUpDownIcon,
 } from '@heroicons/react/24/solid'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import { Button } from '@/components/ui/button'
-import { Checkbox } from '@/components/ui/checkbox'
 import {
   Select,
   SelectContent,
@@ -31,9 +29,6 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import {
   useUpdateIntegration,
-  useAddNotificationChannel,
-  useUpdateNotificationChannel,
-  useRemoveNotificationChannel,
   useAddMonitoredChannel,
   useUpdateMonitoredChannel,
   useRemoveMonitoredChannel,
@@ -41,16 +36,14 @@ import {
 import { adminQueries } from '@/lib/client/queries/admin'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { fetchSlackChannelsFn, type SlackChannel } from '@/lib/server/integrations/slack/functions'
+import {
+  NotificationChannelRouter,
+  type NotificationChannel,
+} from '@/components/admin/settings/integrations/shared/notification-channel-router'
 
 // ============================================
 // Types
 // ============================================
-
-interface NotificationChannel {
-  channelId: string
-  events: { eventType: string; enabled: boolean }[]
-  boardIds: string[] | null
-}
 
 interface MonitoredChannel {
   channelId: string
@@ -99,9 +92,6 @@ const SLACK_EVENT_CONFIG = [
   },
 ]
 
-/** Grid: flexible channel column + 4 fixed event columns */
-const TABLE_GRID = 'grid-cols-[minmax(0,1fr)_5rem_5rem_5rem_5rem]'
-
 // ============================================
 // Helpers
 // ============================================
@@ -109,20 +99,6 @@ const TABLE_GRID = 'grid-cols-[minmax(0,1fr)_5rem_5rem_5rem_5rem]'
 function ChannelIcon({ isPrivate }: { isPrivate: boolean }) {
   const Icon = isPrivate ? LockClosedIcon : HashtagIcon
   return <Icon className="h-3.5 w-3.5 text-muted-foreground" />
-}
-
-function getBoardSummary(
-  channel: NotificationChannel,
-  boards: { id: string; name: string }[]
-): string {
-  if (!channel.boardIds?.length) return 'All boards'
-  if (channel.boardIds.length === 1) {
-    return boards.find((b) => b.id === channel.boardIds![0])?.name ?? '1 board'
-  }
-  // Show first board name + count
-  const firstName = boards.find((b) => b.id === channel.boardIds![0])?.name
-  if (firstName) return `${firstName} + ${channel.boardIds.length - 1} more`
-  return `${channel.boardIds.length} boards`
 }
 
 function useSlackChannels() {
@@ -264,531 +240,6 @@ function ChannelPicker({
     </Popover>
   )
 }
-
-// ============================================
-// Board Filter Pills
-// ============================================
-
-function BoardFilterPills({
-  boardIds,
-  boards,
-  onBoardIdsChange,
-  disabled,
-}: {
-  boardIds: string[] | null
-  boards: { id: string; name: string }[]
-  onBoardIdsChange: (boardIds: string[] | null) => void
-  disabled?: boolean
-}) {
-  const isAllBoards = !boardIds?.length
-
-  return (
-    <div className="space-y-2">
-      <div className="text-xs font-medium text-muted-foreground">Board filter</div>
-      <div className="space-y-2">
-        {/* All boards radio */}
-        <label className="flex items-center gap-2 text-sm cursor-pointer">
-          <Checkbox
-            checked={isAllBoards}
-            onCheckedChange={(checked) => {
-              if (checked) onBoardIdsChange(null)
-            }}
-            disabled={disabled}
-          />
-          All boards
-        </label>
-        {/* Specific boards radio */}
-        <label className="flex items-center gap-2 text-sm cursor-pointer">
-          <Checkbox
-            checked={!isAllBoards}
-            onCheckedChange={(checked) => {
-              if (checked) {
-                // Select all boards individually to start
-                onBoardIdsChange(boards.map((b) => b.id))
-              } else {
-                onBoardIdsChange(null)
-              }
-            }}
-            disabled={disabled}
-          />
-          Specific boards
-        </label>
-        {/* Board list — only shown when "Specific boards" is selected */}
-        {!isAllBoards && (
-          <div className="ml-6 flex flex-wrap gap-1.5 pt-0.5">
-            {boards.map((board) => {
-              const selected = boardIds?.includes(board.id) ?? false
-              return (
-                <button
-                  key={board.id}
-                  type="button"
-                  className={`px-2.5 py-1 text-xs rounded-md border transition-colors disabled:opacity-50 ${
-                    selected
-                      ? 'bg-primary/10 border-primary/20 text-primary font-medium'
-                      : 'border-border/60 text-muted-foreground hover:bg-muted/50'
-                  }`}
-                  onClick={() => {
-                    if (selected) {
-                      const next = (boardIds ?? []).filter((id) => id !== board.id)
-                      // If deselecting last board, go back to "All boards"
-                      onBoardIdsChange(next.length > 0 ? next : null)
-                    } else {
-                      onBoardIdsChange([...(boardIds ?? []), board.id])
-                    }
-                  }}
-                  disabled={disabled}
-                >
-                  {board.name}
-                </button>
-              )
-            })}
-          </div>
-        )}
-      </div>
-    </div>
-  )
-}
-
-// ============================================
-// Channel Row (table row with expandable detail)
-// ============================================
-
-function ChannelRow({
-  channel,
-  channelInfo,
-  integrationId,
-  disabled,
-  expanded,
-  onToggleExpand,
-  boards,
-  hasBorder,
-}: {
-  channel: NotificationChannel
-  channelInfo: SlackChannel | undefined
-  integrationId: string
-  disabled: boolean
-  expanded: boolean
-  onToggleExpand: () => void
-  boards: { id: string; name: string }[]
-  hasBorder: boolean
-}) {
-  const updateMutation = useUpdateNotificationChannel()
-  const removeMutation = useRemoveNotificationChannel()
-  const [confirmRemove, setConfirmRemove] = useState(false)
-
-  const channelName = channelInfo?.name || channel.channelId
-  const isPrivate = channelInfo?.isPrivate ?? false
-  const saving = updateMutation.isPending
-  const hasFilter = !!channel.boardIds?.length
-
-  const handleEventToggle = (eventId: string, checked: boolean) => {
-    updateMutation.mutate({
-      integrationId,
-      channelId: channel.channelId,
-      events: SLACK_EVENT_CONFIG.map((e) => ({
-        eventType: e.id,
-        enabled:
-          e.id === eventId
-            ? checked
-            : (channel.events.find((ev) => ev.eventType === e.id)?.enabled ?? false),
-      })),
-      boardIds: channel.boardIds,
-    })
-  }
-
-  const handleBoardIdsChange = (boardIds: string[] | null) => {
-    updateMutation.mutate({
-      integrationId,
-      channelId: channel.channelId,
-      events: SLACK_EVENT_CONFIG.map((e) => ({
-        eventType: e.id,
-        enabled: channel.events.find((ev) => ev.eventType === e.id)?.enabled ?? false,
-      })),
-      boardIds,
-    })
-  }
-
-  const handleRemove = () => {
-    removeMutation.mutate(
-      { integrationId, channelId: channel.channelId },
-      { onSuccess: () => setConfirmRemove(false) }
-    )
-  }
-
-  return (
-    <>
-      <div className={hasBorder ? 'border-b border-border/50' : ''}>
-        {/* Main row — full-row hover */}
-        <div
-          className={`grid ${TABLE_GRID} items-center hover:bg-muted/10 transition-colors cursor-pointer`}
-          onClick={onToggleExpand}
-        >
-          {/* Channel cell */}
-          <div className="flex items-center gap-2 px-4 py-3">
-            <ChevronRightIcon
-              className={`h-3 w-3 text-muted-foreground shrink-0 transition-transform duration-150 ${
-                expanded ? 'rotate-90' : ''
-              }`}
-            />
-            <ChannelIcon isPrivate={isPrivate} />
-            <div className="min-w-0 flex items-center gap-2">
-              <span className="text-sm font-medium truncate">{channelName}</span>
-              {hasFilter && (
-                <span className="text-[11px] text-muted-foreground shrink-0">
-                  {getBoardSummary(channel, boards)}
-                </span>
-              )}
-            </div>
-          </div>
-
-          {/* Event toggle cells */}
-          {SLACK_EVENT_CONFIG.map((event) => {
-            const enabled = channel.events.find((e) => e.eventType === event.id)?.enabled ?? false
-            return (
-              <div
-                key={event.id}
-                className="flex justify-center py-3"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <Checkbox
-                  checked={enabled}
-                  onCheckedChange={(checked) => handleEventToggle(event.id, checked === true)}
-                  disabled={disabled || saving}
-                />
-              </div>
-            )
-          })}
-        </div>
-
-        {/* Expanded detail — board filter + remove */}
-        {expanded && (
-          <div className="border-t border-border/30 bg-muted/5 px-4 pb-4">
-            <div className="pl-10 pt-3 space-y-3">
-              <BoardFilterPills
-                boardIds={channel.boardIds}
-                boards={boards}
-                onBoardIdsChange={handleBoardIdsChange}
-                disabled={disabled || saving}
-              />
-              <div className="pt-2 border-t border-border/30">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-7 text-xs text-muted-foreground hover:text-destructive"
-                  onClick={() => setConfirmRemove(true)}
-                  disabled={disabled}
-                >
-                  <XMarkIcon className="h-3.5 w-3.5 mr-1" />
-                  Remove channel
-                </Button>
-              </div>
-            </div>
-          </div>
-        )}
-      </div>
-
-      {/* Remove confirmation */}
-      <Dialog open={confirmRemove} onOpenChange={setConfirmRemove}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>Remove notification channel</DialogTitle>
-            <DialogDescription>
-              Stop sending notifications to #{channelName}? This will delete all event mappings for
-              this channel.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setConfirmRemove(false)}>
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={handleRemove}
-              disabled={removeMutation.isPending}
-            >
-              {removeMutation.isPending ? 'Removing...' : 'Remove'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </>
-  )
-}
-
-// ============================================
-// Routing Table
-// ============================================
-
-function RoutingTable({
-  channels: notificationChannels,
-  channelInfoList,
-  integrationId,
-  disabled,
-  boards,
-  onAddChannel,
-}: {
-  channels: NotificationChannel[]
-  channelInfoList: SlackChannel[]
-  integrationId: string
-  disabled: boolean
-  boards: { id: string; name: string }[]
-  onAddChannel?: () => void
-}) {
-  const [expandedId, setExpandedId] = useState<string | null>(null)
-
-  return (
-    <div className="rounded-lg border border-border/50 overflow-hidden">
-      {/* Header */}
-      <div className={`grid ${TABLE_GRID} items-end bg-muted/40 border-b border-border/50`}>
-        <div className="px-4 py-2 text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
-          Channel
-        </div>
-        {SLACK_EVENT_CONFIG.map((event) => (
-          <div
-            key={event.id}
-            className="py-2 text-[11px] font-medium text-muted-foreground text-center leading-tight"
-            title={event.label}
-          >
-            {event.shortLabel}
-          </div>
-        ))}
-      </div>
-
-      {/* Channel rows */}
-      {notificationChannels.map((nc, idx) => (
-        <ChannelRow
-          key={nc.channelId}
-          channel={nc}
-          channelInfo={channelInfoList.find((c) => c.id === nc.channelId)}
-          integrationId={integrationId}
-          disabled={disabled}
-          expanded={expandedId === nc.channelId}
-          onToggleExpand={() =>
-            setExpandedId((prev) => (prev === nc.channelId ? null : nc.channelId))
-          }
-          boards={boards}
-          hasBorder={idx < notificationChannels.length - 1 || expandedId === nc.channelId}
-        />
-      ))}
-
-      {/* Add channel row — inside table */}
-      {onAddChannel && (
-        <button
-          type="button"
-          className="flex items-center gap-1.5 px-4 py-2.5 text-sm text-muted-foreground hover:text-foreground hover:bg-muted/10 transition-colors w-full border-t border-border/50"
-          onClick={onAddChannel}
-          disabled={disabled}
-        >
-          <PlusIcon className="h-3.5 w-3.5" />
-          Add channel
-        </button>
-      )}
-    </div>
-  )
-}
-
-// ============================================
-// Add Channel Dialog
-// ============================================
-
-function AddChannelDialog({
-  open,
-  onOpenChange,
-  integrationId,
-  channels,
-  loadingChannels,
-  existingChannelIds,
-  boards,
-  onRefreshChannels,
-}: {
-  open: boolean
-  onOpenChange: (open: boolean) => void
-  integrationId: string
-  channels: SlackChannel[]
-  loadingChannels: boolean
-  existingChannelIds: string[]
-  boards: { id: string; name: string }[]
-  onRefreshChannels: () => void
-}) {
-  const addMutation = useAddNotificationChannel()
-  const [selectedChannelId, setSelectedChannelId] = useState('')
-  const [selectedEvents, setSelectedEvents] = useState<Record<string, boolean>>(() =>
-    Object.fromEntries(SLACK_EVENT_CONFIG.map((e) => [e.id, true]))
-  )
-  const [boardIds, setBoardIds] = useState<string[] | null>(null)
-  const [showBoardFilter, setShowBoardFilter] = useState(false)
-
-  const availableChannels = channels.filter((c) => !existingChannelIds.includes(c.id))
-  const allEventsSelected = SLACK_EVENT_CONFIG.every((e) => selectedEvents[e.id])
-  const noEventsSelected = SLACK_EVENT_CONFIG.every((e) => !selectedEvents[e.id])
-
-  const handleSave = () => {
-    if (!selectedChannelId) return
-    const events = Object.entries(selectedEvents)
-      .filter(([, enabled]) => enabled)
-      .map(([eventType]) => eventType)
-
-    if (events.length === 0) return
-
-    addMutation.mutate(
-      {
-        integrationId,
-        channelId: selectedChannelId,
-        events,
-        boardIds: boardIds ?? undefined,
-      },
-      {
-        onSuccess: () => {
-          onOpenChange(false)
-          setSelectedChannelId('')
-          setSelectedEvents(Object.fromEntries(SLACK_EVENT_CONFIG.map((e) => [e.id, true])))
-          setBoardIds(null)
-          setShowBoardFilter(false)
-        },
-      }
-    )
-  }
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>Add notification channel</DialogTitle>
-          <DialogDescription>Route events to a Slack channel.</DialogDescription>
-        </DialogHeader>
-
-        <div className="space-y-4">
-          {/* Channel selector */}
-          <div className="space-y-1.5">
-            <Label>Channel</Label>
-            <ChannelPicker
-              channels={availableChannels}
-              value={selectedChannelId}
-              onSelect={setSelectedChannelId}
-              loading={loadingChannels}
-              onRefresh={onRefreshChannels}
-            />
-          </div>
-
-          {/* Events — compact 2-column grid */}
-          <div className="space-y-1.5">
-            <div className="flex items-center justify-between">
-              <Label>Events</Label>
-              <button
-                type="button"
-                onClick={() => {
-                  const next = allEventsSelected ? false : true
-                  setSelectedEvents(Object.fromEntries(SLACK_EVENT_CONFIG.map((e) => [e.id, next])))
-                }}
-                className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-              >
-                {allEventsSelected ? 'Deselect all' : 'Select all'}
-              </button>
-            </div>
-            <div className="grid grid-cols-2 gap-x-4 gap-y-1.5">
-              {SLACK_EVENT_CONFIG.map((event) => (
-                <label
-                  key={event.id}
-                  className="flex items-center gap-2 text-sm cursor-pointer py-1"
-                >
-                  <Checkbox
-                    checked={selectedEvents[event.id] ?? true}
-                    onCheckedChange={(checked) =>
-                      setSelectedEvents((prev) => ({
-                        ...prev,
-                        [event.id]: checked === true,
-                      }))
-                    }
-                  />
-                  {event.shortLabel}
-                </label>
-              ))}
-            </div>
-          </div>
-
-          {/* Board filter — collapsed by default */}
-          <div className="space-y-1.5">
-            {!showBoardFilter && !boardIds?.length ? (
-              <button
-                type="button"
-                onClick={() => setShowBoardFilter(true)}
-                className="text-xs text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1"
-              >
-                <PlusIcon className="h-3 w-3" />
-                Filter by board
-              </button>
-            ) : (
-              <>
-                <div className="flex items-center justify-between">
-                  <Label className="text-xs text-muted-foreground">Board filter</Label>
-                  {boardIds?.length ? (
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setBoardIds(null)
-                        setShowBoardFilter(false)
-                      }}
-                      className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-                    >
-                      Clear
-                    </button>
-                  ) : null}
-                </div>
-                <div className="flex flex-wrap gap-1.5">
-                  {boards.map((board) => {
-                    const selected = boardIds?.includes(board.id) ?? false
-                    return (
-                      <button
-                        key={board.id}
-                        type="button"
-                        className={`px-2.5 py-1 text-xs rounded-md border transition-colors ${
-                          selected
-                            ? 'bg-primary/10 border-primary/20 text-primary font-medium'
-                            : 'border-border/60 text-muted-foreground hover:bg-muted/50'
-                        }`}
-                        onClick={() => {
-                          if (selected) {
-                            const next = (boardIds ?? []).filter((id) => id !== board.id)
-                            setBoardIds(next.length > 0 ? next : null)
-                          } else {
-                            setBoardIds([...(boardIds ?? []), board.id])
-                          }
-                        }}
-                      >
-                        {board.name}
-                      </button>
-                    )
-                  })}
-                </div>
-                {!boardIds?.length && (
-                  <p className="text-[11px] text-muted-foreground">
-                    Select boards to filter, or leave empty for all boards.
-                  </p>
-                )}
-              </>
-            )}
-          </div>
-        </div>
-
-        <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button
-            onClick={handleSave}
-            disabled={!selectedChannelId || noEventsSelected || addMutation.isPending}
-          >
-            {addMutation.isPending ? 'Adding...' : 'Add channel'}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  )
-}
-
-// ============================================
-// Main Component
-// ============================================
 
 // ============================================
 // Monitored Channel Row
@@ -1036,7 +487,6 @@ export function SlackConfig({
   const boardsQuery = useQuery(adminQueries.boards())
   const boards = (boardsQuery.data ?? []).map((b) => ({ id: b.id, name: b.name }))
   const [integrationEnabled, setIntegrationEnabled] = useState(enabled)
-  const [addDialogOpen, setAddDialogOpen] = useState(false)
   const [addMonitorDialogOpen, setAddMonitorDialogOpen] = useState(false)
 
   // Use notificationChannels if available, otherwise fall back to legacy single-channel
@@ -1056,7 +506,6 @@ export function SlackConfig({
       : []
 
   const monitoredChannels = initialMonitoredChannels ?? []
-  const existingChannelIds = notificationChannels.map((c) => c.channelId)
   const existingMonitoredIds = monitoredChannels.map((c) => c.channelId)
 
   // Check if the integration has the required scopes for channel monitoring
@@ -1099,34 +548,21 @@ export function SlackConfig({
           </p>
         </div>
 
-        {channelError && <p className="text-sm text-destructive">{channelError}</p>}
-
-        {notificationChannels.length === 0 ? (
-          <div className="rounded-lg border border-dashed border-border/50 p-8 text-center">
-            <p className="text-sm text-muted-foreground">
-              No notification channels configured yet.
-            </p>
-            <Button
-              variant="outline"
-              size="sm"
-              className="mt-3 gap-1.5"
-              onClick={() => setAddDialogOpen(true)}
-              disabled={!integrationEnabled}
-            >
-              <PlusIcon className="h-3.5 w-3.5" />
-              Add your first channel
-            </Button>
-          </div>
-        ) : (
-          <RoutingTable
-            channels={notificationChannels}
-            channelInfoList={channels}
-            integrationId={integrationId}
-            disabled={!integrationEnabled || saving}
-            boards={boards}
-            onAddChannel={integrationEnabled ? () => setAddDialogOpen(true) : undefined}
-          />
-        )}
+        <NotificationChannelRouter<SlackChannel>
+          integrationId={integrationId}
+          enabled={integrationEnabled && !saving}
+          events={SLACK_EVENT_CONFIG}
+          channels={channels}
+          notificationChannels={notificationChannels}
+          boards={boards}
+          loadingChannels={loadingChannels}
+          channelError={channelError}
+          onRefreshChannels={refreshChannels}
+          renderChannelIcon={(channel) => {
+            const Icon = channel?.isPrivate ? LockClosedIcon : HashtagIcon
+            return <Icon className="h-3.5 w-3.5 text-muted-foreground" />
+          }}
+        />
       </div>
 
       <div className="border-t border-border/30" />
@@ -1213,18 +649,6 @@ export function SlackConfig({
           {updateMutation.error?.message || 'Failed to save changes'}
         </div>
       )}
-
-      {/* Add Notification Channel Dialog */}
-      <AddChannelDialog
-        open={addDialogOpen}
-        onOpenChange={setAddDialogOpen}
-        integrationId={integrationId}
-        channels={channels}
-        loadingChannels={loadingChannels}
-        existingChannelIds={existingChannelIds}
-        boards={boards}
-        onRefreshChannels={refreshChannels}
-      />
 
       {/* Add Monitored Channel Dialog */}
       <AddMonitoredChannelDialog

--- a/docs/superpowers/plans/2026-04-30-discord-per-board-channels.md
+++ b/docs/superpowers/plans/2026-04-30-discord-per-board-channels.md
@@ -29,7 +29,8 @@
 **Create:**
 
 - `packages/db/drizzle/0048_consolidate_chat_target_keys.sql` — one-time data cleanup migration.
-- `apps/web/e2e/tests/admin/integrations-discord-routing.spec.ts` — new E2E coverage.
+- `apps/web/e2e/tests/admin/integrations-discord-routing.spec.ts` — new E2E coverage for Discord (3 events).
+- `apps/web/e2e/tests/admin/integrations-slack-routing.spec.ts` — new E2E coverage for Slack (4 events, public/private icons). Sibling spec so the shared `NotificationChannelRouter` is exercised through both consumers.
 
 **Modify:**
 
@@ -872,11 +873,14 @@ git commit -m "feat(integrations): pass notificationChannels to DiscordConfig"
 
 ---
 
-### Task 2.5: Write Discord routing E2E spec
+### Task 2.5: Write routing E2E specs (Discord + Slack)
 
 **Files:**
 
 - Create: `apps/web/e2e/tests/admin/integrations-discord-routing.spec.ts`
+- Create: `apps/web/e2e/tests/admin/integrations-slack-routing.spec.ts`
+
+**Why both:** The shared `NotificationChannelRouter` introduced in PR1 had zero direct test coverage. Writing parallel specs for both consumers exercises the generic `<TChannel extends Channel>` shape with two different channel types and confirms the per-consumer event lists differ correctly (Discord: 3 events, no Changelog; Slack: 4 events including Changelog, plus public/private icon variation).
 
 - [ ] **Step 1: Inspect existing E2E patterns**
 
@@ -886,9 +890,9 @@ Read `apps/web/e2e/tests/admin/notifications.spec.ts` (or another spec in that d
 - How the test fixtures and helpers are imported (`@playwright/test`, project helpers, etc.).
 - The base URL convention.
 
-This determines the imports and fixtures used below — adapt to match the project's existing pattern.
+This determines the imports and fixtures used in both specs below — adapt to match the project's existing pattern.
 
-- [ ] **Step 2: Create the spec file**
+- [ ] **Step 2: Create the Discord routing spec**
 
 Create `apps/web/e2e/tests/admin/integrations-discord-routing.spec.ts`:
 
@@ -948,17 +952,82 @@ test.describe('Discord notification routing', () => {
 
 These tests cover the structural surface — empty state vs routing table render, add-channel dialog open/close, board filter accessibility, and Discord-specific event-list (3 events, no Changelog). They don't drive a full add-channel flow because that requires Discord channel data which depends on environment seeding.
 
-- [ ] **Step 3: Run the new E2E spec**
+- [ ] **Step 3: Create the Slack routing spec**
 
-Run: `bun run test:e2e --grep "Discord notification routing"`
+Create `apps/web/e2e/tests/admin/integrations-slack-routing.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test'
+
+test.describe('Slack notification routing', () => {
+  test.beforeEach(async ({ page }) => {
+    // Same auth pattern as the Discord sibling.
+    await page.goto('/admin/settings/integrations/slack')
+  })
+
+  test('renders the routing UI when Slack is connected', async ({ page }) => {
+    const hasTable = await page.getByRole('button', { name: /add channel/i }).isVisible()
+    const hasEmptyState = await page
+      .getByText(/no notification channels configured yet/i)
+      .isVisible()
+    expect(hasTable || hasEmptyState).toBe(true)
+  })
+
+  test('add channel dialog opens and closes', async ({ page }) => {
+    const addBtn = page.getByRole('button', { name: /add (your first )?channel/i }).first()
+    await addBtn.click()
+    await expect(page.getByRole('dialog')).toBeVisible()
+    // Same shared component renders the same dialog title and description for Slack.
+    await expect(page.getByText(/route events to a channel/i)).toBeVisible()
+    await page.getByRole('button', { name: /cancel/i }).click()
+    await expect(page.getByRole('dialog')).not.toBeVisible()
+  })
+
+  test('exposes board filter in add dialog', async ({ page }) => {
+    await page
+      .getByRole('button', { name: /add (your first )?channel/i })
+      .first()
+      .click()
+    await expect(page.getByRole('dialog')).toBeVisible()
+    await page.getByRole('button', { name: /filter by board/i }).click()
+    await expect(page.getByText(/board filter/i)).toBeVisible()
+    await page.getByRole('button', { name: /cancel/i }).click()
+  })
+
+  test('event columns reflect Slack event list (4 events including Changelog)', async ({
+    page,
+  }) => {
+    const tableHeader = page.getByText(/^Channel$/)
+    if (await tableHeader.isVisible()) {
+      await expect(page.getByText(/^Feedback$/)).toBeVisible()
+      await expect(page.getByText(/^Status$/)).toBeVisible()
+      await expect(page.getByText(/^Comment$/)).toBeVisible()
+      // Slack-only event — must be present (mirrors the negative assertion in the Discord spec).
+      await expect(page.getByText(/^Changelog$/)).toBeVisible()
+    }
+  })
+
+  test('channel monitoring section still renders', async ({ page }) => {
+    // PR1 left the monitored-channel UI unchanged. This guards against the
+    // refactor accidentally removing it.
+    await expect(page.getByText(/channel monitoring/i)).toBeVisible()
+  })
+})
+```
+
+The 4-events-including-Changelog assertion is the symmetric proof against the Discord spec's 3-events-no-Changelog assertion. Together they prove the shared component's `events` prop is wired correctly through both consumers. The "channel monitoring section still renders" test is a small safety net — it would catch a refactor that accidentally deleted the Slack-only monitoring UI.
+
+- [ ] **Step 4: Run both new specs**
+
+Run: `bun run test:e2e --grep "(Discord|Slack) notification routing"`
 (Or whatever the project's E2E command is — check the root `package.json` if unsure.)
-Expected: passes. If the test environment doesn't have Discord connected, some tests may skip naturally via the `if (await tableHeader.isVisible())` guards. That's acceptable — the structural assertions still cover what they can.
+Expected: passes. If the test environment doesn't have one of the integrations connected, the table-conditional tests skip naturally via the `if (await tableHeader.isVisible())` guards. The structural assertions (page renders, dialog opens, etc.) still cover what they can.
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
-git add apps/web/e2e/tests/admin/integrations-discord-routing.spec.ts
-git commit -m "test(integrations): e2e for Discord notification routing"
+git add apps/web/e2e/tests/admin/integrations-discord-routing.spec.ts apps/web/e2e/tests/admin/integrations-slack-routing.spec.ts
+git commit -m "test(integrations): e2e for chat-routing UI (Discord + Slack)"
 ```
 
 ---
@@ -1022,7 +1091,7 @@ Spec: `docs/superpowers/specs/2026-04-30-discord-per-board-channels-design.md`
 - [ ] `bun run typecheck` clean
 - [ ] `bun run lint` clean
 - [ ] `bun run test` clean
-- [ ] `bun run test:e2e` clean (new `integrations-discord-routing.spec.ts` passes)
+- [ ] `bun run test:e2e` clean (new `integrations-discord-routing.spec.ts` and `integrations-slack-routing.spec.ts` pass)
 - [ ] Manual: add a Discord notification channel, set board filter, toggle events, remove channel
 - [ ] Manual: legacy fallback — existing Discord install with one configured channel renders as one row in the new UI without action
 
@@ -1048,7 +1117,7 @@ EOF
 - Migration step 2 (backfill remaining) → Task 2.1 step 2.
 - Discord route loader pass-through → Task 2.4.
 - Discord legacy-fallback synth → Task 2.3 step 4.
-- E2E coverage → Task 2.5.
+- E2E coverage (Discord + Slack) → Task 2.5.
 - Slack parity gate → Task 1.3 step 6 (manual smoke).
 
 **Placeholder scan:** No "TBD" / "TODO" / "implement later" / "appropriate error handling" patterns. Code blocks include the actual code where applicable; ports reference exact line ranges in `slack-config.tsx` rather than restating ~600 LOC verbatim — acceptable for a refactor task.

--- a/docs/superpowers/plans/2026-04-30-discord-per-board-channels.md
+++ b/docs/superpowers/plans/2026-04-30-discord-per-board-channels.md
@@ -1,0 +1,1061 @@
+# Discord per-board channels Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring Discord notification config to feature parity with Slack — per-channel routing with per-board filters — by extracting a chat-scoped shared component, then wiring Discord through it.
+
+**Architecture:** Two PRs with a hard checkpoint between them. PR1 extracts `NotificationChannelRouter` from `slack-config.tsx` into a shared file and refactors Slack to consume it (zero UX change). PR2 wires Discord's route + config component to the shared component, adds a one-time migration to consolidate stale `target_key='default'` rows on chat integrations, and deletes the legacy Discord single-channel UI.
+
+**Tech Stack:** TanStack Start, React, Tailwind v4 + shadcn/ui, Drizzle, Postgres, react-query, @heroicons/react, Playwright (E2E), Bun.
+
+**Spec:** `docs/superpowers/specs/2026-04-30-discord-per-board-channels-design.md`
+
+---
+
+## File structure
+
+### PR1 — Extract + Slack refactor
+
+**Create:**
+
+- `apps/web/src/components/admin/settings/integrations/shared/notification-channel-router.tsx` — chat-scoped routing UI. Exports `NotificationChannelRouter` and shared types `Channel`, `NotificationChannel`, `EventConfig`. Internal: `RoutingTable`, `ChannelRow`, `BoardFilterPills`, `AddChannelDialog`, `ChannelPicker`.
+
+**Modify:**
+
+- `apps/web/src/components/admin/settings/integrations/slack/slack-config.tsx` — delete extracted code, render `<NotificationChannelRouter>`, pass Slack-specific `renderChannelIcon` and `events`. Keep `useSlackChannels`, `MonitoredChannelRow`, `AddMonitoredChannelDialog`, scopes check, integration toggle, `SLACK_EVENT_CONFIG`, legacy fallback synth.
+
+### PR2 — Discord per-board + migration
+
+**Create:**
+
+- `packages/db/drizzle/0048_consolidate_chat_target_keys.sql` — one-time data cleanup migration.
+- `apps/web/e2e/tests/admin/integrations-discord-routing.spec.ts` — new E2E coverage.
+
+**Modify:**
+
+- `apps/web/src/routes/admin/settings/integrations/discord.tsx` — pass `notificationChannels` prop.
+- `apps/web/src/components/admin/settings/integrations/discord/discord-config.tsx` — replace body with `<NotificationChannelRouter>`. Add `useDiscordChannels` hook. Define `DISCORD_EVENT_CONFIG`. Delete legacy single-channel form.
+
+---
+
+## Phase 1 — PR1: Extract NotificationChannelRouter
+
+### Task 1.1: Create shared component skeleton with types and docstring
+
+**Files:**
+
+- Create: `apps/web/src/components/admin/settings/integrations/shared/notification-channel-router.tsx`
+
+- [ ] **Step 1: Create the shared file with header, types, and exported component signature**
+
+Create `apps/web/src/components/admin/settings/integrations/shared/notification-channel-router.tsx`:
+
+```tsx
+/**
+ * Routing UI for chat-style integrations (Slack, Discord, Teams).
+ *
+ * Lets admins pick a destination channel per event with optional board filter.
+ *
+ * NOT for ticket-creation integrations (Jira, Linear, Asana) or
+ * broadcast/digest integrations (email, webhooks). Those have a different
+ * mental model and should get their own UI rather than be forced through here.
+ */
+
+import { useState, useRef, useMemo, type ReactNode } from 'react'
+import {
+  ArrowPathIcon,
+  XMarkIcon,
+  PlusIcon,
+  ChevronRightIcon,
+  MagnifyingGlassIcon,
+  ChevronUpDownIcon,
+} from '@heroicons/react/24/solid'
+import { Label } from '@/components/ui/label'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import {
+  useAddNotificationChannel,
+  useUpdateNotificationChannel,
+  useRemoveNotificationChannel,
+} from '@/lib/client/mutations'
+
+// ============================================
+// Public types
+// ============================================
+
+export interface Channel {
+  id: string
+  name: string
+}
+
+export interface NotificationChannel {
+  channelId: string
+  events: { eventType: string; enabled: boolean }[]
+  boardIds: string[] | null
+}
+
+export interface EventConfig {
+  id: string
+  label: string
+  shortLabel: string
+  description: string
+}
+
+export interface Board {
+  id: string
+  name: string
+}
+
+interface NotificationChannelRouterProps<TChannel extends Channel> {
+  integrationId: string
+  enabled: boolean
+  events: EventConfig[]
+  channels: TChannel[]
+  notificationChannels: NotificationChannel[]
+  boards: Board[]
+  loadingChannels: boolean
+  channelError: string | null
+  onRefreshChannels: () => void
+  renderChannelIcon: (channel: TChannel | undefined) => ReactNode
+}
+
+// ============================================
+// Public component
+// ============================================
+
+export function NotificationChannelRouter<TChannel extends Channel>(
+  props: NotificationChannelRouterProps<TChannel>
+) {
+  const [addDialogOpen, setAddDialogOpen] = useState(false)
+  const existingChannelIds = props.notificationChannels.map((c) => c.channelId)
+
+  return (
+    <div className="space-y-3">
+      {props.channelError && <p className="text-sm text-destructive">{props.channelError}</p>}
+
+      {props.notificationChannels.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-border/50 p-8 text-center">
+          <p className="text-sm text-muted-foreground">No notification channels configured yet.</p>
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-3 gap-1.5"
+            onClick={() => setAddDialogOpen(true)}
+            disabled={!props.enabled}
+          >
+            <PlusIcon className="h-3.5 w-3.5" />
+            Add your first channel
+          </Button>
+        </div>
+      ) : (
+        <RoutingTable<TChannel>
+          channels={props.notificationChannels}
+          channelInfoList={props.channels}
+          integrationId={props.integrationId}
+          disabled={!props.enabled}
+          boards={props.boards}
+          events={props.events}
+          renderChannelIcon={props.renderChannelIcon}
+          onAddChannel={props.enabled ? () => setAddDialogOpen(true) : undefined}
+        />
+      )}
+
+      <AddChannelDialog<TChannel>
+        open={addDialogOpen}
+        onOpenChange={setAddDialogOpen}
+        integrationId={props.integrationId}
+        channels={props.channels}
+        loadingChannels={props.loadingChannels}
+        existingChannelIds={existingChannelIds}
+        boards={props.boards}
+        events={props.events}
+        renderChannelIcon={props.renderChannelIcon}
+        onRefreshChannels={props.onRefreshChannels}
+      />
+    </div>
+  )
+}
+
+// Internal components below — see Task 1.2 for full bodies.
+function RoutingTable<TChannel extends Channel>(_props: unknown): null {
+  return null
+}
+function AddChannelDialog<TChannel extends Channel>(_props: unknown): null {
+  return null
+}
+```
+
+These two stub functions are placeholders we'll fill in Task 1.2. They're typed as returning `null` so the file typechecks.
+
+- [ ] **Step 2: Verify the file typechecks**
+
+Run: `bun run typecheck`
+Expected: passes (no new errors). The stubs are unused at this point.
+
+- [ ] **Step 3: Commit the skeleton**
+
+```bash
+git add apps/web/src/components/admin/settings/integrations/shared/notification-channel-router.tsx
+git commit -m "feat(integrations): add NotificationChannelRouter skeleton"
+```
+
+---
+
+### Task 1.2: Port routing-table internals from slack-config.tsx
+
+**Files:**
+
+- Modify: `apps/web/src/components/admin/settings/integrations/shared/notification-channel-router.tsx`
+
+Port the existing internal components from `apps/web/src/components/admin/settings/integrations/slack/slack-config.tsx`. Keep behavior identical; only change is making `events`, `channels`, and `renderChannelIcon` come from props instead of module-scope constants.
+
+- [ ] **Step 1: Port `getBoardSummary` helper**
+
+Add at the top of the file (after the public component):
+
+```tsx
+function getBoardSummary(channel: NotificationChannel, boards: Board[]): string {
+  if (!channel.boardIds?.length) return 'All boards'
+  if (channel.boardIds.length === 1) {
+    return boards.find((b) => b.id === channel.boardIds![0])?.name ?? '1 board'
+  }
+  const firstName = boards.find((b) => b.id === channel.boardIds![0])?.name
+  if (firstName) return `${firstName} + ${channel.boardIds.length - 1} more`
+  return `${channel.boardIds.length} boards`
+}
+
+const TABLE_GRID_BASE = 'grid-cols-[minmax(0,1fr)'
+function tableGrid(eventCount: number) {
+  return `${TABLE_GRID_BASE}${'_5rem'.repeat(eventCount)}]`
+}
+```
+
+The grid is dynamic now — Slack has 4 events, Discord has 3. The fixed `_5rem_5rem_5rem_5rem` from the Slack file becomes a function of event count.
+
+- [ ] **Step 2: Port `ChannelPicker`**
+
+Replace the stub. Copy verbatim from `slack-config.tsx:156-266` (function `ChannelPicker`), but:
+
+- Make it generic: `function ChannelPicker<TChannel extends Channel>(props: { channels: TChannel[]; value: string; onSelect: (id: string) => void; loading?: boolean; onRefresh?: () => void; renderChannelIcon: (c: TChannel | undefined) => ReactNode; placeholder?: string })`.
+- Replace `<ChannelIcon isPrivate={selected.isPrivate} />` and `<ChannelIcon isPrivate={channel.isPrivate} />` with `{props.renderChannelIcon(selected)}` and `{props.renderChannelIcon(channel)}`.
+- Drop the local `ChannelIcon` helper — caller provides the renderer.
+
+- [ ] **Step 3: Port `BoardFilterPills`**
+
+Copy verbatim from `slack-config.tsx:272-350`. No parameter changes needed — already takes `boards` as a prop. Just paste it in.
+
+- [ ] **Step 4: Port `ChannelRow`**
+
+Copy from `slack-config.tsx:356-516`. Changes:
+
+- Add `events: EventConfig[]` and `renderChannelIcon: (c: TChannel | undefined) => ReactNode` to the props.
+- Replace `SLACK_EVENT_CONFIG` references with `events` (the prop).
+- Replace `<ChannelIcon isPrivate={isPrivate} />` with `{renderChannelIcon(channelInfo)}`.
+- Drop the `isPrivate` derivation — the caller's renderer handles privacy.
+- Replace `TABLE_GRID` constant references with `tableGrid(events.length)`.
+
+- [ ] **Step 5: Port `RoutingTable`**
+
+Replace the stub. Copy from `slack-config.tsx:522-588`. Changes:
+
+- Add `events: EventConfig[]`, `renderChannelIcon`, generic `<TChannel extends Channel>` to props.
+- Replace `SLACK_EVENT_CONFIG.map(...)` for headers with `events.map(...)`.
+- Replace `TABLE_GRID` with `tableGrid(events.length)`.
+- Pass `events` and `renderChannelIcon` down to `ChannelRow`.
+
+- [ ] **Step 6: Port `AddChannelDialog`**
+
+Replace the stub. Copy from `slack-config.tsx:594-787`. Changes:
+
+- Add `events: EventConfig[]`, `renderChannelIcon`, generic `<TChannel extends Channel>` to props.
+- Replace `SLACK_EVENT_CONFIG` references with `events`.
+- Replace `<ChannelPicker>` instantiation with the generic version, passing `renderChannelIcon`.
+- The dialog description currently reads "Route events to a Slack channel." Change to "Route events to a channel."
+
+- [ ] **Step 7: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: passes.
+
+- [ ] **Step 8: Run lint**
+
+Run: `bun run lint`
+Expected: passes.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/web/src/components/admin/settings/integrations/shared/notification-channel-router.tsx
+git commit -m "feat(integrations): port routing-table internals into NotificationChannelRouter"
+```
+
+---
+
+### Task 1.3: Refactor slack-config.tsx to consume the shared component
+
+**Files:**
+
+- Modify: `apps/web/src/components/admin/settings/integrations/slack/slack-config.tsx`
+
+- [ ] **Step 1: Add imports for the shared component**
+
+At the top of `slack-config.tsx`, add:
+
+```tsx
+import {
+  NotificationChannelRouter,
+  type NotificationChannel as SharedNotificationChannel,
+} from '@/components/admin/settings/integrations/shared/notification-channel-router'
+import { HashtagIcon, LockClosedIcon } from '@heroicons/react/24/solid'
+```
+
+- [ ] **Step 2: Delete extracted internals from slack-config.tsx**
+
+Remove from `slack-config.tsx`:
+
+- `function ChannelIcon` (lines ~109-112)
+- `function getBoardSummary` (lines ~114-126)
+- `function ChannelPicker` (lines ~156-266)
+- `function BoardFilterPills` (lines ~272-350)
+- `function ChannelRow` (lines ~356-516)
+- `function RoutingTable` (lines ~522-588)
+- `function AddChannelDialog` (lines ~594-787)
+- The `TABLE_GRID` constant (line ~103)
+- The local `interface NotificationChannel` (lines ~49-53) — replace with re-export from shared module if used in this file's exported types, otherwise drop
+- Unused imports (e.g., `Popover`, `MagnifyingGlassIcon`, `ChevronUpDownIcon`, `ChevronRightIcon`) once the internals are gone — let `bun run lint` flag them
+
+Keep:
+
+- `useAddNotificationChannel` / `useUpdateNotificationChannel` / `useRemoveNotificationChannel` are no longer needed in this file (the shared component owns them) — remove those imports.
+- `useAddMonitoredChannel` / `useUpdateMonitoredChannel` / `useRemoveMonitoredChannel` stay (Slack-only).
+- Everything related to monitored channels: `MonitoredChannel` type, `MonitoredChannelRow`, `AddMonitoredChannelDialog`, the monitoring section of `SlackConfig`.
+- `SLACK_EVENT_CONFIG` stays here (Slack-specific event list).
+- `useSlackChannels` stays here.
+- The legacy fallback synth in `SlackConfig` (lines ~1043-1056) stays.
+
+- [ ] **Step 3: Replace the routing UI in `SlackConfig` with `<NotificationChannelRouter>`**
+
+Find the Notification Routing section in `SlackConfig` (lines ~1093-1130). Replace the conditional `<RoutingTable>` / empty-state block with:
+
+```tsx
+<NotificationChannelRouter<SlackChannel>
+  integrationId={integrationId}
+  enabled={integrationEnabled}
+  events={SLACK_EVENT_CONFIG}
+  channels={channels}
+  notificationChannels={notificationChannels}
+  boards={boards}
+  loadingChannels={loadingChannels}
+  channelError={channelError}
+  onRefreshChannels={refreshChannels}
+  renderChannelIcon={(channel) => {
+    const Icon = channel?.isPrivate ? LockClosedIcon : HashtagIcon
+    return <Icon className="h-3.5 w-3.5 text-muted-foreground" />
+  }}
+/>
+```
+
+The "Notification routing" `Label` heading and description above it stay. The empty state inside the conditional moves into the shared component, so that branch is now unconditional.
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: passes. Fix any unused-import errors by deleting them.
+
+- [ ] **Step 5: Run lint**
+
+Run: `bun run lint`
+Expected: passes.
+
+- [ ] **Step 6: Manual smoke test the Slack settings page**
+
+Run the dev server: `bun run dev`
+
+In the browser at `/admin/settings/integrations/slack` (assuming Slack is connected in the seeded data):
+
+- Open the page — routing table renders.
+- Expand a channel row — board filter pills render, "Remove channel" button visible.
+- Toggle a board pill — saves silently (network tab shows `updateNotificationChannelFn` 200).
+- Click "Add channel" — dialog opens, channel picker works, search works, board filter section toggles.
+- Save a new channel — table re-renders with the new row.
+- Remove a channel via expanded row → confirmation dialog → confirm — row disappears.
+
+If anything looks visually different from `main`, stop and inspect — the goal is zero UX change.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/components/admin/settings/integrations/slack/slack-config.tsx
+git commit -m "refactor(integrations): consume NotificationChannelRouter from slack-config"
+```
+
+---
+
+### Task 1.4: Open PR1
+
+- [ ] **Step 1: Push the branch and open the PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --title "refactor(integrations): extract NotificationChannelRouter (#145 PR1/2)" --body "$(cat <<'EOF'
+## Summary
+- Extracts the routing-table UI from `slack-config.tsx` into a chat-scoped shared component at `components/admin/settings/integrations/shared/notification-channel-router.tsx`.
+- Refactors Slack to consume it. Zero UX change.
+
+This is PR1 of 2 for #145 (Discord per-board channels). PR2 wires Discord through this shared component and adds a one-time data-cleanup migration.
+
+Spec: `docs/superpowers/specs/2026-04-30-discord-per-board-channels-design.md`
+
+## Test plan
+- [ ] `bun run typecheck` clean
+- [ ] `bun run lint` clean
+- [ ] Slack settings page: add channel, toggle event, set board filter, remove channel — visually identical to main
+EOF
+)"
+```
+
+---
+
+## CHECKPOINT 1 — PR1 review and merge
+
+**Do not proceed to Phase 2 until PR1 is merged.**
+
+PR2 builds on the merged shared component. Starting Phase 2 before PR1 lands creates rebase pain and muddies the bisect surface for any regression.
+
+When PR1 is merged:
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b discord-per-board-pr2
+```
+
+---
+
+## Phase 2 — PR2: Discord per-board + migration
+
+### Task 2.1: Write the data-cleanup migration
+
+**Files:**
+
+- Create: `packages/db/drizzle/0048_consolidate_chat_target_keys.sql`
+
+- [ ] **Step 1: Verify the next migration number**
+
+Run: `ls packages/db/drizzle/*.sql | tail -3`
+Expected: latest is `0047_*.sql`. The new migration is `0048_*`.
+
+If a higher number exists, bump accordingly.
+
+- [ ] **Step 2: Create the migration**
+
+Create `packages/db/drizzle/0048_consolidate_chat_target_keys.sql`:
+
+```sql
+-- Consolidate target_key='default' rows for chat integrations.
+--
+-- Migration 0021 backfilled target_key + action_config.channelId from the
+-- integration-level config.channelId. But the legacy updateIntegrationFn
+-- omits targetKey on insert, so each event toggle since 0021 ran has
+-- created a fresh target_key='default' row for chat integrations,
+-- producing duplicates that runtime dedupe collapses but that pollute
+-- the table.
+--
+-- This migration:
+--   1. Drops 'default' rows when a real-channel row already exists for
+--      the same (integration_id, event_type, action_type) triple.
+--   2. Backfills any remaining standalone 'default' rows for chat
+--      integrations whose config.channelId is set (same logic as 0021).
+--
+-- Scope is narrowed to chat integrations (slack, discord, teams). PM
+-- integrations (jira, linear, asana, etc.) legitimately use
+-- target_key='default' and are left alone.
+
+DELETE FROM integration_event_mappings iem
+WHERE iem.target_key = 'default'
+  AND iem.integration_id IN (
+    SELECT id FROM integrations
+    WHERE integration_type IN ('slack', 'discord', 'teams')
+  )
+  AND EXISTS (
+    SELECT 1 FROM integration_event_mappings other
+    WHERE other.integration_id = iem.integration_id
+      AND other.event_type = iem.event_type
+      AND other.action_type = iem.action_type
+      AND other.target_key <> 'default'
+  );
+
+UPDATE integration_event_mappings iem
+SET target_key = (i.config->>'channelId'),
+    action_config = jsonb_set(
+      COALESCE(iem.action_config, '{}'),
+      '{channelId}',
+      to_jsonb(i.config->>'channelId')
+    )
+FROM integrations i
+WHERE iem.integration_id = i.id
+  AND i.integration_type IN ('slack', 'discord', 'teams')
+  AND i.config->>'channelId' IS NOT NULL
+  AND iem.target_key = 'default';
+```
+
+- [ ] **Step 3: Update the drizzle journal**
+
+Drizzle tracks migrations in `packages/db/drizzle/meta/_journal.json`. Open it and append a new entry to the `entries` array, matching the surrounding format. The `idx` field should equal the migration number, `tag` is the filename without the `.sql` extension, and `when` is `Date.now()`.
+
+Example to mimic (adjust `idx`, `when`, and `tag` to match your file):
+
+```json
+{
+  "idx": 48,
+  "version": "7",
+  "when": <epoch_ms>,
+  "tag": "0048_consolidate_chat_target_keys",
+  "breakpoints": true
+}
+```
+
+- [ ] **Step 4: Apply the migration locally**
+
+Run: `bun run db:migrate`
+Expected: drizzle reports the new migration applied. No errors.
+
+- [ ] **Step 5: Verify the migration's effect**
+
+Connect to the local Postgres (whatever method the project uses — `psql`, drizzle-kit studio, etc.) and check:
+
+```sql
+-- Should be 0 if migration ran cleanly: any 'default' row where a
+-- real-channel row exists for the same event on a chat integration.
+SELECT COUNT(*)
+FROM integration_event_mappings iem
+JOIN integrations i ON i.id = iem.integration_id
+WHERE iem.target_key = 'default'
+  AND i.integration_type IN ('slack', 'discord', 'teams')
+  AND EXISTS (
+    SELECT 1 FROM integration_event_mappings other
+    WHERE other.integration_id = iem.integration_id
+      AND other.event_type = iem.event_type
+      AND other.action_type = iem.action_type
+      AND other.target_key <> 'default'
+  );
+```
+
+Expected: `count = 0`.
+
+```sql
+-- Should be 0: chat integration with config.channelId set but a
+-- 'default' mapping that wasn't backfilled.
+SELECT COUNT(*)
+FROM integration_event_mappings iem
+JOIN integrations i ON i.id = iem.integration_id
+WHERE iem.target_key = 'default'
+  AND i.integration_type IN ('slack', 'discord', 'teams')
+  AND i.config->>'channelId' IS NOT NULL;
+```
+
+Expected: `count = 0`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/db/drizzle/0048_consolidate_chat_target_keys.sql packages/db/drizzle/meta/_journal.json
+git commit -m "feat(db): consolidate chat-integration target_key='default' rows"
+```
+
+---
+
+### Task 2.2: Add useDiscordChannels hook
+
+**Files:**
+
+- Modify: `apps/web/src/components/admin/settings/integrations/discord/discord-config.tsx`
+
+- [ ] **Step 1: Add the hook above the component**
+
+In `discord-config.tsx`, replace the existing `fetchChannels`/`useEffect` channel-loading code inside the component with a top-level hook. Add this above the `DiscordConfig` function:
+
+```tsx
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+
+function useDiscordChannels() {
+  const queryClient = useQueryClient()
+  const query = useQuery({
+    queryKey: ['discord-channels'],
+    queryFn: () => fetchDiscordChannelsFn(),
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    retry: 1,
+  })
+
+  const refresh = () => {
+    queryClient.fetchQuery({
+      queryKey: ['discord-channels'],
+      queryFn: () => fetchDiscordChannelsFn(),
+    })
+  }
+
+  return {
+    channels: query.data ?? [],
+    loading: query.isLoading || query.isFetching,
+    error: query.isError ? 'Failed to load channels. Please try again.' : null,
+    refresh,
+  }
+}
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: passes (the hook is unused but valid; we'll use it in Task 2.3).
+
+- [ ] **Step 3: Don't commit yet** — Task 2.3 modifies the same file. Combined commit at end of 2.3.
+
+---
+
+### Task 2.3: Replace DiscordConfig body with NotificationChannelRouter
+
+**Files:**
+
+- Modify: `apps/web/src/components/admin/settings/integrations/discord/discord-config.tsx`
+
+- [ ] **Step 1: Update the props interface**
+
+Replace the `DiscordConfigProps` interface near the top of the file:
+
+```tsx
+interface DiscordConfigProps {
+  integrationId: string
+  initialConfig: { channelId?: string }
+  initialEventMappings: { id: string; eventType: string; enabled: boolean }[]
+  notificationChannels?: NotificationChannel[]
+  enabled: boolean
+}
+```
+
+The `notificationChannels` prop is new; the rest are unchanged.
+
+- [ ] **Step 2: Add imports**
+
+Add to the top of the file:
+
+```tsx
+import { HashtagIcon } from '@heroicons/react/24/solid'
+import {
+  NotificationChannelRouter,
+  type NotificationChannel,
+  type EventConfig,
+} from '@/components/admin/settings/integrations/shared/notification-channel-router'
+import { useQuery as useBoardsQuery } from '@tanstack/react-query'
+import { adminQueries } from '@/lib/client/queries/admin'
+```
+
+(If `useQuery` is already imported from Task 2.2, alias the new import or just reuse — don't duplicate.)
+
+- [ ] **Step 3: Define DISCORD_EVENT_CONFIG**
+
+Replace the existing `EVENT_CONFIG` constant with:
+
+```tsx
+const DISCORD_EVENT_CONFIG: EventConfig[] = [
+  {
+    id: 'post.created',
+    label: 'New feedback submitted',
+    shortLabel: 'Feedback',
+    description: 'When a user submits new feedback',
+  },
+  {
+    id: 'post.status_changed',
+    label: 'Feedback status changed',
+    shortLabel: 'Status',
+    description: 'When the status of a feedback post is updated',
+  },
+  {
+    id: 'comment.created',
+    label: 'New comment on feedback',
+    shortLabel: 'Comment',
+    description: 'When someone comments on a feedback post',
+  },
+]
+```
+
+Note: only 3 events. No `changelog.published` — that's a deliberate omission; adding it is a separate decision per the spec.
+
+- [ ] **Step 4: Replace the component body**
+
+Replace the entire `DiscordConfig` function with:
+
+```tsx
+export function DiscordConfig({
+  integrationId,
+  initialConfig,
+  initialEventMappings,
+  notificationChannels: initialChannels,
+  enabled,
+}: DiscordConfigProps) {
+  const updateMutation = useUpdateIntegration()
+  const {
+    channels,
+    loading: loadingChannels,
+    error: channelError,
+    refresh: refreshChannels,
+  } = useDiscordChannels()
+  const boardsQuery = useBoardsQuery(adminQueries.boards())
+  const boards = (boardsQuery.data ?? []).map((b) => ({ id: b.id, name: b.name }))
+  const [integrationEnabled, setIntegrationEnabled] = useState(enabled)
+
+  // Use notificationChannels if available; otherwise synthesize from legacy
+  // single-channel config so the user can keep editing without re-adding.
+  const notificationChannels: NotificationChannel[] = initialChannels?.length
+    ? initialChannels
+    : initialConfig.channelId
+      ? [
+          {
+            channelId: initialConfig.channelId,
+            events: DISCORD_EVENT_CONFIG.map((e) => ({
+              eventType: e.id,
+              enabled: initialEventMappings.find((m) => m.eventType === e.id)?.enabled ?? false,
+            })),
+            boardIds: null,
+          },
+        ]
+      : []
+
+  const handleEnabledChange = (checked: boolean) => {
+    setIntegrationEnabled(checked)
+    updateMutation.mutate({ id: integrationId, enabled: checked })
+  }
+
+  const saving = updateMutation.isPending
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <Label htmlFor="enabled-toggle" className="text-base font-medium">
+            Notifications enabled
+          </Label>
+          <p className="text-sm text-muted-foreground">
+            Turn off to pause all Discord notifications
+          </p>
+        </div>
+        <Switch
+          id="enabled-toggle"
+          checked={integrationEnabled}
+          onCheckedChange={handleEnabledChange}
+          disabled={saving}
+        />
+      </div>
+
+      <div className="border-t border-border/30" />
+
+      <div className="space-y-3">
+        <div>
+          <Label className="text-base font-medium">Notification routing</Label>
+          <p className="text-sm text-muted-foreground">
+            Choose which events reach each Discord channel
+          </p>
+        </div>
+
+        <NotificationChannelRouter<DiscordChannel>
+          integrationId={integrationId}
+          enabled={integrationEnabled}
+          events={DISCORD_EVENT_CONFIG}
+          channels={channels}
+          notificationChannels={notificationChannels}
+          boards={boards}
+          loadingChannels={loadingChannels}
+          channelError={channelError}
+          onRefreshChannels={refreshChannels}
+          renderChannelIcon={() => <HashtagIcon className="h-3.5 w-3.5 text-muted-foreground" />}
+        />
+      </div>
+
+      {saving && (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <ArrowPathIcon className="h-4 w-4 animate-spin" />
+          <span>Saving...</span>
+        </div>
+      )}
+
+      {updateMutation.isError && (
+        <div className="text-sm text-destructive">
+          {updateMutation.error?.message || 'Failed to save changes'}
+        </div>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 5: Delete unused imports**
+
+Remove from `discord-config.tsx` (now unused after the rewrite):
+
+- `useEffect`, `useCallback` from React
+- `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `SelectValue` from shadcn
+- `Button` (likely unused now)
+- `EVENT_CONFIG` constant — replaced by `DISCORD_EVENT_CONFIG`
+
+Let `bun run lint` flag anything missed.
+
+- [ ] **Step 6: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: passes.
+
+- [ ] **Step 7: Run lint**
+
+Run: `bun run lint`
+Expected: passes.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web/src/components/admin/settings/integrations/discord/discord-config.tsx
+git commit -m "feat(integrations): wire Discord to NotificationChannelRouter"
+```
+
+---
+
+### Task 2.4: Pass notificationChannels through the Discord route
+
+**Files:**
+
+- Modify: `apps/web/src/routes/admin/settings/integrations/discord.tsx`
+
+- [ ] **Step 1: Update the JSX prop wiring**
+
+Open `apps/web/src/routes/admin/settings/integrations/discord.tsx`. Find the `<DiscordConfig>` element (around line 55) and add `notificationChannels`:
+
+```tsx
+<DiscordConfig
+  integrationId={integration.id}
+  initialConfig={integration.config}
+  initialEventMappings={integration.eventMappings}
+  notificationChannels={integration.notificationChannels}
+  enabled={integration.status === 'active'}
+/>
+```
+
+(Verify the `enabled` prop name matches the actual existing code — it may be passed differently. The change is only to add the new line.)
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: passes. The loader (`fetchIntegrationByType`) already returns `notificationChannels` for any integration type, so the prop is available without further loader changes.
+
+- [ ] **Step 3: Manual smoke test**
+
+Run: `bun run dev`
+
+At `/admin/settings/integrations/discord` (Discord must be connected in seeded data; if not, connect it first via the OAuth flow):
+
+- Page renders.
+- If Discord has a `config.channelId` set: routing table shows one row with the existing channel, all current events reflected.
+- If no channel set: empty state with "Add your first channel" button.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/routes/admin/settings/integrations/discord.tsx
+git commit -m "feat(integrations): pass notificationChannels to DiscordConfig"
+```
+
+---
+
+### Task 2.5: Write Discord routing E2E spec
+
+**Files:**
+
+- Create: `apps/web/e2e/tests/admin/integrations-discord-routing.spec.ts`
+
+- [ ] **Step 1: Inspect existing E2E patterns**
+
+Read `apps/web/e2e/tests/admin/notifications.spec.ts` (or another spec in that directory) to understand:
+
+- How tests authenticate / what `beforeEach` setup looks like.
+- How the test fixtures and helpers are imported (`@playwright/test`, project helpers, etc.).
+- The base URL convention.
+
+This determines the imports and fixtures used below — adapt to match the project's existing pattern.
+
+- [ ] **Step 2: Create the spec file**
+
+Create `apps/web/e2e/tests/admin/integrations-discord-routing.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test'
+
+test.describe('Discord notification routing', () => {
+  test.beforeEach(async ({ page }) => {
+    // Adapt to project auth helper. Common pattern in this repo:
+    // login as demo@example.com via the seeded session, then navigate.
+    await page.goto('/admin/settings/integrations/discord')
+  })
+
+  test('renders the routing UI when Discord is connected', async ({ page }) => {
+    // Either the empty state or the routing table is visible.
+    const hasTable = await page.getByRole('button', { name: /add channel/i }).isVisible()
+    const hasEmptyState = await page
+      .getByText(/no notification channels configured yet/i)
+      .isVisible()
+    expect(hasTable || hasEmptyState).toBe(true)
+  })
+
+  test('add channel dialog opens and closes', async ({ page }) => {
+    const addBtn = page.getByRole('button', { name: /add (your first )?channel/i }).first()
+    await addBtn.click()
+    await expect(page.getByRole('dialog')).toBeVisible()
+    await expect(page.getByText(/route events to a channel/i)).toBeVisible()
+    await page.getByRole('button', { name: /cancel/i }).click()
+    await expect(page.getByRole('dialog')).not.toBeVisible()
+  })
+
+  test('exposes board filter in add dialog', async ({ page }) => {
+    await page
+      .getByRole('button', { name: /add (your first )?channel/i })
+      .first()
+      .click()
+    await expect(page.getByRole('dialog')).toBeVisible()
+    // Board filter is collapsed by default; clicking expands it.
+    await page.getByRole('button', { name: /filter by board/i }).click()
+    await expect(page.getByText(/board filter/i)).toBeVisible()
+    await page.getByRole('button', { name: /cancel/i }).click()
+  })
+
+  test('event columns reflect Discord event list (3 events, no changelog)', async ({ page }) => {
+    // Skip if no rows are configured; the column headers only appear in the table.
+    const tableHeader = page.getByText(/^Channel$/)
+    if (await tableHeader.isVisible()) {
+      await expect(page.getByText(/^Feedback$/)).toBeVisible()
+      await expect(page.getByText(/^Status$/)).toBeVisible()
+      await expect(page.getByText(/^Comment$/)).toBeVisible()
+      // Slack has Changelog; Discord must not.
+      await expect(page.getByText(/^Changelog$/)).not.toBeVisible()
+    }
+  })
+})
+```
+
+These tests cover the structural surface — empty state vs routing table render, add-channel dialog open/close, board filter accessibility, and Discord-specific event-list (3 events, no Changelog). They don't drive a full add-channel flow because that requires Discord channel data which depends on environment seeding.
+
+- [ ] **Step 3: Run the new E2E spec**
+
+Run: `bun run test:e2e --grep "Discord notification routing"`
+(Or whatever the project's E2E command is — check the root `package.json` if unsure.)
+Expected: passes. If the test environment doesn't have Discord connected, some tests may skip naturally via the `if (await tableHeader.isVisible())` guards. That's acceptable — the structural assertions still cover what they can.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/e2e/tests/admin/integrations-discord-routing.spec.ts
+git commit -m "test(integrations): e2e for Discord notification routing"
+```
+
+---
+
+### Task 2.6: Final verification
+
+- [ ] **Step 1: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: passes.
+
+- [ ] **Step 2: Run lint**
+
+Run: `bun run lint`
+Expected: passes.
+
+- [ ] **Step 3: Run unit/integration tests**
+
+Run: `bun run test`
+Expected: passes. No new unit tests are required; backend logic is untouched.
+
+- [ ] **Step 4: Run full E2E suite**
+
+Run: `bun run test:e2e`
+Expected: passes. The existing Discord smoke reference in `getting-started.spec.ts:41` (which only checks the literal string "Connect GitHub, Slack, or Discord") is unaffected. The new spec runs alongside.
+
+- [ ] **Step 5: Manual smoke test, full flow**
+
+Run: `bun run dev`
+
+At `/admin/settings/integrations/discord` (Discord must be connected):
+
+- Routing table renders with the existing single channel as one row (legacy fallback or post-migration data).
+- Click "Add channel" → pick a channel → select events → add board filter → save. New row appears.
+- Expand the new row, change board filter pills, watch network for `updateNotificationChannelFn` 200.
+- Toggle event checkboxes on the row, watch network for updates.
+- Remove the new row via the expanded "Remove channel" button. Row disappears.
+- Toggle the integration enable/disable switch — disables interaction with the routing table.
+
+If anything fails, debug before opening the PR.
+
+---
+
+### Task 2.7: Open PR2
+
+- [ ] **Step 1: Push the branch and open the PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --title "feat(integrations): per-board Discord channels (#145 PR2/2)" --body "$(cat <<'EOF'
+## Summary
+- Wires Discord's settings UI to the shared `NotificationChannelRouter` (added in PR1).
+- Adds migration `0048_consolidate_chat_target_keys.sql` to clean up duplicate `target_key='default'` rows produced by the legacy update path on chat integrations.
+- Deletes the legacy single-channel Discord form.
+
+Closes #145.
+
+Spec: `docs/superpowers/specs/2026-04-30-discord-per-board-channels-design.md`
+
+## Test plan
+- [ ] `bun run typecheck` clean
+- [ ] `bun run lint` clean
+- [ ] `bun run test` clean
+- [ ] `bun run test:e2e` clean (new `integrations-discord-routing.spec.ts` passes)
+- [ ] Manual: add a Discord notification channel, set board filter, toggle events, remove channel
+- [ ] Manual: legacy fallback — existing Discord install with one configured channel renders as one row in the new UI without action
+
+## Migration
+- Drops `target_key='default'` rows where a real-channel row already exists for the same `(integration_id, event_type, action_type)` triple on chat integrations.
+- Backfills any remaining 'default' rows for chat integrations whose `config.channelId` is set.
+- PM integrations untouched.
+EOF
+)"
+```
+
+---
+
+## Self-review
+
+**Spec coverage:**
+
+- D1 (extract scoped) → Task 1.1 docstring + Task 1.2 generic component.
+- D2 (legacy fallback synth) → Task 2.3 step 4 (synth block).
+- D3 (no flag) → no task; absence is the implementation.
+- D4 (two PRs) → Phase 1 / Phase 2 split with hard checkpoint.
+- Migration step 1 (delete duplicates) → Task 2.1 step 2.
+- Migration step 2 (backfill remaining) → Task 2.1 step 2.
+- Discord route loader pass-through → Task 2.4.
+- Discord legacy-fallback synth → Task 2.3 step 4.
+- E2E coverage → Task 2.5.
+- Slack parity gate → Task 1.3 step 6 (manual smoke).
+
+**Placeholder scan:** No "TBD" / "TODO" / "implement later" / "appropriate error handling" patterns. Code blocks include the actual code where applicable; ports reference exact line ranges in `slack-config.tsx` rather than restating ~600 LOC verbatim — acceptable for a refactor task.
+
+**Type consistency:**
+
+- `NotificationChannel.channelId: string`, `events: { eventType; enabled }[]`, `boardIds: string[] | null` — used consistently across the shared component, Slack, and Discord.
+- `EventConfig.id` is `string` everywhere it appears.
+- `Channel` is `{ id; name }`; both `SlackChannel` and `DiscordChannel` extend it via the generic constraint.
+- `renderChannelIcon` signature `(channel: TChannel | undefined) => ReactNode` matches across the public API and internal `RoutingTable` / `ChannelRow` / `AddChannelDialog`.

--- a/docs/superpowers/specs/2026-04-30-discord-per-board-channels-design.md
+++ b/docs/superpowers/specs/2026-04-30-discord-per-board-channels-design.md
@@ -1,0 +1,232 @@
+# Discord per-board channels — design
+
+**Issue:** [QuackbackIO/quackback#145](https://github.com/QuackbackIO/quackback/issues/145)
+
+**Status:** approved, ready for plan
+
+## Summary
+
+Bring Discord's notification config to feature parity with Slack: per-channel routing with optional per-board filters. Backend already supports this for any integration; only Discord's UI is the legacy single-channel form.
+
+The work splits into two PRs:
+
+1. **PR1** — extract a shared `NotificationChannelRouter` component, refactor Slack to consume it. Zero UX change for Slack; pure refactor.
+2. **PR2** — wire Discord's route loader and config component to use the shared component. Add a one-time data-cleanup migration. Delete the legacy single-channel form.
+
+## What already works (no changes)
+
+- `integration_event_mappings.filters` (jsonb) stores `{ boardIds: string[] }` per mapping.
+- `getIntegrationTargets` in `apps/web/src/lib/server/events/targets.ts:186-194` filters mappings by `boardIds` for any integration type.
+- `addNotificationChannelFn` / `updateNotificationChannelFn` / `removeNotificationChannelFn` in `apps/web/src/lib/server/functions/integrations.ts` accept `boardIds` and key off `integrationId` — fully reusable for Discord.
+- `fetchIntegrationByType` in `apps/web/src/lib/server/functions/admin.ts:423-459` returns `notificationChannels` for any integration, including Discord.
+- The Discord hook handler (`apps/web/src/lib/server/integrations/discord/hook.ts`) reads `channelId` from `target` — multi-mapping fan-out delivers correctly with no changes.
+- Migration 0021 already backfilled `target_key` and `action_config.channelId` from integration-level `config.channelId` for all integrations.
+
+## What's missing
+
+1. `apps/web/src/routes/admin/settings/integrations/discord.tsx:55` doesn't pass `notificationChannels` to `<DiscordConfig>`.
+2. `apps/web/src/components/admin/settings/integrations/discord/discord-config.tsx` is the legacy single-channel UI: one `<Select>` for channel, three event toggles. No board filter, no multi-channel.
+3. `slack-config.tsx` (1242 LOC) embeds the routing-table UI in-file. Copying it for Discord would duplicate ~600 LOC.
+
+## Decisions
+
+|     | Decision                                                                                     | Rationale                                                                                                                                                      |
+| --- | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | Extract shared component, scoped to chat-style integrations                                  | Avoid copy-paste at N=2; Teams is the obvious next consumer; PM integrations don't fit this pattern and shouldn't share it                                     |
+| D2  | Synthesize one `NotificationChannel` from `initialConfig.channelId` when loader returns none | Mirrors Slack's pattern (`slack-config.tsx:1043-1056`); handles "channel set, no event toggles yet" UX; migration covers data debt separately                  |
+| D3  | No feature flag                                                                              | Slack didn't gate it; backend is exercised in prod; change is purely additive                                                                                  |
+| D4  | Two PRs — refactor first, feature second                                                     | PR1 is mechanically simple but touches a 1242-line file; reviewable as pure refactor with E2E parity. PR2 is the user-facing change. Bisectable on regression. |
+
+## Architecture
+
+### Shared component
+
+**File:** `apps/web/src/components/admin/settings/integrations/shared/notification-channel-router.tsx`
+
+**Top-of-file docstring:**
+
+> Routing UI for chat-style integrations — pick a destination channel per event with optional board filter. Not for ticket-creation integrations (Jira, Linear, etc.) or broadcast/digest integrations.
+
+**Public component:** `NotificationChannelRouter`
+
+**Internal components** (not exported): `RoutingTable`, `ChannelRow`, `BoardFilterPills`, `AddChannelDialog`, `ChannelPicker`.
+
+**Props:**
+
+```ts
+type Channel = { id: string; name: string }
+
+type NotificationChannel = {
+  channelId: string
+  events: { eventType: string; enabled: boolean }[]
+  boardIds: string[] | null
+}
+
+type Props<TChannel extends Channel> = {
+  integrationId: string
+  enabled: boolean
+  events: { id: string; label: string; shortLabel: string; description: string }[]
+  channels: TChannel[]
+  notificationChannels: NotificationChannel[]
+  boards: { id: string; name: string }[]
+  loadingChannels: boolean
+  channelError: string | null
+  onRefreshChannels: () => void
+  renderChannelIcon?: (channel: TChannel) => ReactNode
+}
+```
+
+Mutation hooks (`useAddNotificationChannel`, `useUpdateNotificationChannel`, `useRemoveNotificationChannel`) are integration-agnostic and used directly.
+
+### What stays per-integration
+
+**Slack-only** (in `slack-config.tsx`):
+
+- `useSlackChannels` (Slack-specific cache key + fetch fn).
+- `MonitoredChannelRow`, `AddMonitoredChannelDialog` (channel monitoring with AI screening).
+- Monitoring-scopes check (`channels:history`).
+- Public/private channel icon renderer (passed as `renderChannelIcon` prop).
+- `SLACK_EVENT_CONFIG` (4 events including `changelog.published`).
+
+**Discord-only** (in `discord-config.tsx`):
+
+- `useDiscordChannels` (mirrors `useSlackChannels` pattern).
+- Hashtag icon renderer (passed as `renderChannelIcon`).
+- `DISCORD_EVENT_CONFIG` (3 events: `post.created`, `post.status_changed`, `comment.created`). No `changelog.published` — keep parity with Discord's existing event list.
+
+## PR1 — Extract + Slack refactor
+
+**New files:**
+
+- `apps/web/src/components/admin/settings/integrations/shared/notification-channel-router.tsx`
+
+**Modified:**
+
+- `apps/web/src/components/admin/settings/integrations/slack/slack-config.tsx`:
+  - Delete: `RoutingTable`, `ChannelRow`, `BoardFilterPills`, `AddChannelDialog`, `ChannelPicker`, `getBoardSummary`, `ChannelIcon`, `TABLE_GRID`.
+  - Keep: `useSlackChannels`, `MonitoredChannelRow`, `AddMonitoredChannelDialog`, scopes check, integration enable/disable toggle, legacy-fallback synth, `SLACK_EVENT_CONFIG`.
+  - Render `<NotificationChannelRouter>` for the routing section.
+  - Pass a `renderChannelIcon` rendering hash/lock for Slack public/private channels.
+
+**Behavior:** zero UX change. Same DOM, same flows, same E2E pass.
+
+**Diff size:** ~600 LOC moved into the new file. `slack-config.tsx` shrinks from ~1242 → ~700 LOC.
+
+**Acceptance:**
+
+- All existing Slack E2E tests pass without modification.
+- Visual diff on the Slack settings page matches `main`.
+- `bun run typecheck` and `bun run lint` clean.
+
+## PR2 — Discord per-board
+
+### Code changes
+
+**Modified:**
+
+- `apps/web/src/routes/admin/settings/integrations/discord.tsx`:
+  - Pass `notificationChannels={integration.notificationChannels}` through to `<DiscordConfig>`. (Loader already returns this.)
+
+- `apps/web/src/components/admin/settings/integrations/discord/discord-config.tsx`:
+  - Replace body. New shape:
+    - Integration enable/disable toggle (kept).
+    - `<NotificationChannelRouter>` for routing.
+  - Add `useDiscordChannels` hook (react-query, 5-min `staleTime`, refresh fn — mirrors `useSlackChannels`).
+  - Define `DISCORD_EVENT_CONFIG` (the existing 3 events).
+  - Pass `renderChannelIcon` for hashtag icon.
+  - Legacy-fallback synth: identical pattern to `slack-config.tsx:1043-1056` — synthesize one `NotificationChannel` from `initialConfig.channelId` if `notificationChannels` is empty.
+  - Delete the old single-channel `<Select>`, the per-event `<Switch>` list, the old `eventSettings` state, the `handleChannelChange`/`handleEventToggle` handlers.
+
+- `apps/web/src/components/admin/settings/integrations/discord/discord-connection-actions.tsx`: unchanged.
+
+### Data migration
+
+`packages/db/drizzle/0048_consolidate_chat_target_keys.sql`:
+
+```sql
+-- Step 1: For chat integrations, drop 'default' rows when a real-channel row
+-- exists for the same (integration_id, event_type, action_type) triple.
+DELETE FROM integration_event_mappings iem
+WHERE iem.target_key = 'default'
+  AND iem.integration_id IN (
+    SELECT id FROM integrations
+    WHERE integration_type IN ('slack', 'discord', 'teams')
+  )
+  AND EXISTS (
+    SELECT 1 FROM integration_event_mappings other
+    WHERE other.integration_id = iem.integration_id
+      AND other.event_type = iem.event_type
+      AND other.action_type = iem.action_type
+      AND other.target_key <> 'default'
+  );
+
+-- Step 2: Backfill any remaining 'default' rows for chat integrations
+-- that have config.channelId set (same logic as 0021, catches rows
+-- created since 0021 ran via the legacy updateIntegrationFn path).
+UPDATE integration_event_mappings iem
+SET target_key = (i.config->>'channelId'),
+    action_config = jsonb_set(
+      COALESCE(iem.action_config, '{}'),
+      '{channelId}',
+      to_jsonb(i.config->>'channelId')
+    )
+FROM integrations i
+WHERE iem.integration_id = i.id
+  AND i.integration_type IN ('slack', 'discord', 'teams')
+  AND i.config->>'channelId' IS NOT NULL
+  AND iem.target_key = 'default';
+```
+
+**Scope:** narrowed to chat integrations. PM integrations (Jira, Linear, etc.) legitimately use `target_key='default'` — leave them alone.
+
+**Why both steps:** step 1 handles duplicates created by the legacy bulk update path after 0021 ran; step 2 catches any standalone 'default' rows that 0021 missed (e.g., integration reconnected with a different channel).
+
+### Existing-user behavior
+
+- **Discord with one channel + 3 enabled events**: migration 0021 already moved data into routing-table shape; new migration normalizes any duplicates from subsequent toggles. Loader returns one `NotificationChannel` with that channelId and event mappings. Routing table renders one row, no filter. Identical delivery.
+- **Discord connected, channel set, no events toggled yet**: legacy fallback synth renders one row with all events disabled, ready to toggle. First toggle creates real mapping rows via the new mutations.
+- **Teams**: not in scope. Teams continues hitting `updateIntegrationFn` and creating new `target_key='default'` rows. Runtime dedupe keeps delivery correct. Will be cleaned up when Teams gets the same UI treatment (follow-up).
+
+### Acceptance
+
+New E2E spec `apps/web/e2e/tests/admin/integrations-discord-routing.spec.ts` covering:
+
+- Add a Discord notification channel with all events selected.
+- Toggle events on/off, assert mapping rows update.
+- Set a board filter, assert `filters.boardIds` written.
+- Remove the channel, assert mappings deleted.
+- Legacy-fallback render: integration with `config.channelId` but no real-channel mapping rows — assert one synthesized row appears.
+
+Existing Discord E2E (`getting-started.spec.ts` references) must pass unchanged.
+
+## Risks
+
+| Risk                                                                           | Mitigation                                                                                                |
+| ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
+| Naming drift — someone fits Jira/Linear into `NotificationChannelRouter` later | Top-of-file docstring scopes the contract; PR description repeats it; reviewers enforce                   |
+| Premature abstraction at N=2                                                   | Contract is well-defined; integrations that don't fit get their own UI (correct outcome, not failure)     |
+| Slack regression from PR1 refactor                                             | Pure mechanical extraction; E2E parity is the gate; PR1 reverts cleanly                                   |
+| Discord users with weird mapping state from legacy `updateIntegrationFn`       | Migration consolidates duplicates and backfills standalone 'default' rows                                 |
+| Teams keeps polluting after PR2                                                | Acceptable — runtime dedupe keeps delivery correct; same migration logic cleans up when Teams is migrated |
+
+## Future architecture notes (not in scope)
+
+The work in #145 is a UI extraction with a small data-hygiene migration. The notification system has three larger architectural threads worth tracking as separate initiatives:
+
+1. **Event catalog consolidation** — `lib/server/events/event-catalog.ts` as the single source of `{ id, label, shortLabel, description, supportedTargets }`. Today event labels are duplicated across `slack-config.tsx`, `discord-config.tsx`, email templates, webhook UI. Pays off when adding the next event type or Teams. File as follow-up issue, link from #145.
+
+2. **Target-resolver registry** — `lib/server/events/targets.ts` (723 LOC) hand-rolls integration / subscriber / changelog / webhook / AI / summary resolution. Future shape: `getHookTargets` iterates a registry of `TargetResolver`s, each integration registers its own. Tackle when adding Teams. File as follow-up issue.
+
+3. **Operational health** — per-integration delivery health, retry observability, token-expiry detection, queue depth, rate limiting. The hook handlers already return structured `HookResult`; what's missing is dashboards, alerting, and per-integration health records. Separate initiative; biggest scaling pain at customer-count > ~50.
+
+The data model (`integration_event_mappings` with jsonb `filters` and `action_config`, polymorphic `actionType`) is forward-compatible with all three. This PR doesn't constrain them.
+
+## Out of scope
+
+- Adding `changelog.published` to Discord's event list.
+- Adding new filter types (tags, status, upvote thresholds) — `filters` is jsonb so future-extensible.
+- Teams refactor.
+- PM-integration UI changes.
+- Operational observability work.
+- Refactoring `targets.ts` into a registry.
+- Event catalog consolidation.


### PR DESCRIPTION
## Summary

PR1 of 2 for #145 (per-board Discord channels). Extracts the routing-table UI from `slack-config.tsx` into a chat-scoped shared component at `apps/web/src/components/admin/settings/integrations/shared/notification-channel-router.tsx` and refactors Slack to consume it.

**Zero UX change for Slack** — pure refactor. PR2 will wire Discord through this shared component and add a one-time data-cleanup migration.

`slack-config.tsx` shrinks from 1242 → 666 LOC (-46%). The shared component is 801 LOC of routing-table internals (`RoutingTable`, `ChannelRow`, `BoardFilterPills`, `AddChannelDialog`, `ChannelPicker`) made generic over `TChannel extends Channel` with `events` and `renderChannelIcon` passed via props.

Slack's monitored-channel UI (`MonitoredChannelRow`, `AddMonitoredChannelDialog`) and the `useSlackChannels` hook stay in `slack-config.tsx` — that's Slack-specific (AI screening of channels), not part of the shared chat-routing contract.

This PR also includes the spec and implementation plan for the full #145 work (commits `16990dcd`, `a0f55a17`).

Spec: \`docs/superpowers/specs/2026-04-30-discord-per-board-channels-design.md\`
Plan: \`docs/superpowers/plans/2026-04-30-discord-per-board-channels.md\`

## Known follow-ups (deferred to PR2)

- \`AddChannelDialog\` retains form state when closed via Cancel — pre-existing bug faithfully ported. Fix in PR2 (one \`useEffect\` reset on \`open === false\`).

## Test plan

- [ ] \`bun run typecheck\` clean (verified)
- [ ] \`bun run lint\` clean (verified)
- [ ] Slack settings page (\`/admin/settings/integrations/slack\`): add channel, toggle event, set board filter, remove channel — visually identical to main
- [ ] Channel monitoring section unchanged
- [ ] Integration enable/disable toggle still works