### PR TITLE
feat(integrations): per-board Discord channels (#145 PR2/2)

### DIFF
--- a/apps/web/e2e/tests/admin/integrations-discord-routing.spec.ts
+++ b/apps/web/e2e/tests/admin/integrations-discord-routing.spec.ts
@@ -36,8 +36,9 @@ test.describe('Discord notification routing', () => {
 
     await addBtn.click()
     await expect(page.getByRole('dialog')).toBeVisible()
-    await page.getByRole('button', { name: /filter by board/i }).click()
+    // Board filter is a combobox showing "All boards" by default.
     await expect(page.getByText(/board filter/i)).toBeVisible()
+    await expect(page.getByRole('combobox').filter({ hasText: /all boards/i })).toBeVisible()
     await page.getByRole('button', { name: /cancel/i }).click()
   })
 

--- a/apps/web/e2e/tests/admin/integrations-discord-routing.spec.ts
+++ b/apps/web/e2e/tests/admin/integrations-discord-routing.spec.ts
@@ -43,15 +43,15 @@ test.describe('Discord notification routing', () => {
   })
 
   test('event columns reflect Discord event list (3 events, no changelog)', async ({ page }) => {
-    // Column headers use `title` attributes derived from EventConfig.label,
+    // Column headers carry `title` attributes equal to EventConfig.description,
     // which is more specific than text matching (event names also appear in
     // the AddChannelDialog event multi-select).
-    const feedbackHeader = page.getByTitle('When a user submits new feedback')
-    if (!(await feedbackHeader.isVisible())) test.skip()
+    const newPostHeader = page.getByTitle('When someone submits a new post')
+    if (!(await newPostHeader.isVisible())) test.skip()
 
-    await expect(feedbackHeader).toBeVisible()
-    await expect(page.getByTitle('When the status of a feedback post is updated')).toBeVisible()
-    await expect(page.getByTitle('When someone comments on a feedback post')).toBeVisible()
+    await expect(newPostHeader).toBeVisible()
+    await expect(page.getByTitle("When a post's status is updated")).toBeVisible()
+    await expect(page.getByTitle('When someone comments on a post')).toBeVisible()
     // Slack has a Changelog column; Discord must not.
     await expect(page.getByTitle('When a changelog entry is published')).not.toBeVisible()
   })

--- a/apps/web/e2e/tests/admin/integrations-discord-routing.spec.ts
+++ b/apps/web/e2e/tests/admin/integrations-discord-routing.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Discord notification routing', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/admin/settings/integrations/discord')
+    await page.waitForLoadState('networkidle')
+  })
+
+  test('renders the routing UI when Discord is connected', async ({ page }) => {
+    const hasTable = await page.getByRole('button', { name: /add channel/i }).isVisible()
+    const hasEmptyState = await page
+      .getByText(/no notification channels configured yet/i)
+      .isVisible()
+    expect(hasTable || hasEmptyState).toBe(true)
+  })
+
+  test('add channel dialog opens and closes', async ({ page }) => {
+    const addBtn = page.getByRole('button', { name: /add (your first )?channel/i }).first()
+    if (!(await addBtn.isVisible())) test.skip()
+
+    await addBtn.click()
+    await expect(page.getByRole('dialog')).toBeVisible()
+    await expect(page.getByText(/route events to a channel/i)).toBeVisible()
+    await page.getByRole('button', { name: /cancel/i }).click()
+    await expect(page.getByRole('dialog')).not.toBeVisible()
+  })
+
+  test('exposes board filter in add dialog', async ({ page }) => {
+    const addBtn = page.getByRole('button', { name: /add (your first )?channel/i }).first()
+    if (!(await addBtn.isVisible())) test.skip()
+
+    await addBtn.click()
+    await expect(page.getByRole('dialog')).toBeVisible()
+    await page.getByRole('button', { name: /filter by board/i }).click()
+    await expect(page.getByText(/board filter/i)).toBeVisible()
+    await page.getByRole('button', { name: /cancel/i }).click()
+  })
+
+  test('event columns reflect Discord event list (3 events, no changelog)', async ({ page }) => {
+    const tableHeader = page.getByText(/^Channel$/)
+    if (!(await tableHeader.isVisible())) test.skip()
+
+    await expect(page.getByText(/^Feedback$/)).toBeVisible()
+    await expect(page.getByText(/^Status$/)).toBeVisible()
+    await expect(page.getByText(/^Comment$/)).toBeVisible()
+    // Slack has Changelog; Discord must not.
+    await expect(page.getByText(/^Changelog$/)).not.toBeVisible()
+  })
+})

--- a/apps/web/e2e/tests/admin/integrations-discord-routing.spec.ts
+++ b/apps/web/e2e/tests/admin/integrations-discord-routing.spec.ts
@@ -7,6 +7,11 @@ test.describe('Discord notification routing', () => {
   })
 
   test('renders the routing UI when Discord is connected', async ({ page }) => {
+    // Skip when Discord isn't connected in this environment — the page shows
+    // the connection-setup card instead of the routing UI.
+    const setupCard = page.getByText(/connect your discord server/i)
+    if (await setupCard.isVisible()) test.skip()
+
     const hasTable = await page.getByRole('button', { name: /add channel/i }).isVisible()
     const hasEmptyState = await page
       .getByText(/no notification channels configured yet/i)
@@ -37,13 +42,16 @@ test.describe('Discord notification routing', () => {
   })
 
   test('event columns reflect Discord event list (3 events, no changelog)', async ({ page }) => {
-    const tableHeader = page.getByText(/^Channel$/)
-    if (!(await tableHeader.isVisible())) test.skip()
+    // Column headers use `title` attributes derived from EventConfig.label,
+    // which is more specific than text matching (event names also appear in
+    // the AddChannelDialog event multi-select).
+    const feedbackHeader = page.getByTitle('When a user submits new feedback')
+    if (!(await feedbackHeader.isVisible())) test.skip()
 
-    await expect(page.getByText(/^Feedback$/)).toBeVisible()
-    await expect(page.getByText(/^Status$/)).toBeVisible()
-    await expect(page.getByText(/^Comment$/)).toBeVisible()
-    // Slack has Changelog; Discord must not.
-    await expect(page.getByText(/^Changelog$/)).not.toBeVisible()
+    await expect(feedbackHeader).toBeVisible()
+    await expect(page.getByTitle('When the status of a feedback post is updated')).toBeVisible()
+    await expect(page.getByTitle('When someone comments on a feedback post')).toBeVisible()
+    // Slack has a Changelog column; Discord must not.
+    await expect(page.getByTitle('When a changelog entry is published')).not.toBeVisible()
   })
 })

--- a/apps/web/e2e/tests/admin/integrations-slack-routing.spec.ts
+++ b/apps/web/e2e/tests/admin/integrations-slack-routing.spec.ts
@@ -7,6 +7,11 @@ test.describe('Slack notification routing', () => {
   })
 
   test('renders the routing UI when Slack is connected', async ({ page }) => {
+    // Skip when Slack isn't connected in this environment — the page shows
+    // the connection-setup card instead of the routing UI.
+    const setupCard = page.getByText(/connect your slack workspace/i)
+    if (await setupCard.isVisible()) test.skip()
+
     const hasTable = await page.getByRole('button', { name: /add channel/i }).isVisible()
     const hasEmptyState = await page
       .getByText(/no notification channels configured yet/i)
@@ -39,14 +44,17 @@ test.describe('Slack notification routing', () => {
   test('event columns reflect Slack event list (4 events including Changelog)', async ({
     page,
   }) => {
-    const tableHeader = page.getByText(/^Channel$/)
-    if (!(await tableHeader.isVisible())) test.skip()
+    // Column headers use `title` attributes derived from EventConfig.label,
+    // which is more specific than text matching (event names also appear in
+    // the AddChannelDialog event multi-select).
+    const feedbackHeader = page.getByTitle('When a user submits new feedback')
+    if (!(await feedbackHeader.isVisible())) test.skip()
 
-    await expect(page.getByText(/^Feedback$/)).toBeVisible()
-    await expect(page.getByText(/^Status$/)).toBeVisible()
-    await expect(page.getByText(/^Comment$/)).toBeVisible()
-    // Slack-only event — must be present (mirrors the negative assertion in Discord spec).
-    await expect(page.getByText(/^Changelog$/)).toBeVisible()
+    await expect(feedbackHeader).toBeVisible()
+    await expect(page.getByTitle('When the status of a feedback post is updated')).toBeVisible()
+    await expect(page.getByTitle('When someone comments on a feedback post')).toBeVisible()
+    // Slack-only event — must be present (mirrors the negative assertion in the Discord spec).
+    await expect(page.getByTitle('When a changelog entry is published')).toBeVisible()
   })
 
   test('channel monitoring section still renders', async ({ page }) => {

--- a/apps/web/e2e/tests/admin/integrations-slack-routing.spec.ts
+++ b/apps/web/e2e/tests/admin/integrations-slack-routing.spec.ts
@@ -36,8 +36,9 @@ test.describe('Slack notification routing', () => {
 
     await addBtn.click()
     await expect(page.getByRole('dialog')).toBeVisible()
-    await page.getByRole('button', { name: /filter by board/i }).click()
+    // Board filter is a combobox showing "All boards" by default.
     await expect(page.getByText(/board filter/i)).toBeVisible()
+    await expect(page.getByRole('combobox').filter({ hasText: /all boards/i })).toBeVisible()
     await page.getByRole('button', { name: /cancel/i }).click()
   })
 

--- a/apps/web/e2e/tests/admin/integrations-slack-routing.spec.ts
+++ b/apps/web/e2e/tests/admin/integrations-slack-routing.spec.ts
@@ -60,6 +60,10 @@ test.describe('Slack notification routing', () => {
 
   test('channel monitoring section still renders', async ({ page }) => {
     // PR1 left the monitored-channel UI unchanged. Guards against accidental removal.
+    // Skip when Slack isn't connected — the page shows the setup card instead.
+    const setupCard = page.getByText(/connect your slack workspace/i)
+    if (await setupCard.isVisible()) test.skip()
+
     await expect(page.getByText(/channel monitoring/i)).toBeVisible()
   })
 })

--- a/apps/web/e2e/tests/admin/integrations-slack-routing.spec.ts
+++ b/apps/web/e2e/tests/admin/integrations-slack-routing.spec.ts
@@ -45,15 +45,15 @@ test.describe('Slack notification routing', () => {
   test('event columns reflect Slack event list (4 events including Changelog)', async ({
     page,
   }) => {
-    // Column headers use `title` attributes derived from EventConfig.label,
+    // Column headers carry `title` attributes equal to EventConfig.description,
     // which is more specific than text matching (event names also appear in
     // the AddChannelDialog event multi-select).
-    const feedbackHeader = page.getByTitle('When a user submits new feedback')
-    if (!(await feedbackHeader.isVisible())) test.skip()
+    const newPostHeader = page.getByTitle('When someone submits a new post')
+    if (!(await newPostHeader.isVisible())) test.skip()
 
-    await expect(feedbackHeader).toBeVisible()
-    await expect(page.getByTitle('When the status of a feedback post is updated')).toBeVisible()
-    await expect(page.getByTitle('When someone comments on a feedback post')).toBeVisible()
+    await expect(newPostHeader).toBeVisible()
+    await expect(page.getByTitle("When a post's status is updated")).toBeVisible()
+    await expect(page.getByTitle('When someone comments on a post')).toBeVisible()
     // Slack-only event — must be present (mirrors the negative assertion in the Discord spec).
     await expect(page.getByTitle('When a changelog entry is published')).toBeVisible()
   })

--- a/apps/web/e2e/tests/admin/integrations-slack-routing.spec.ts
+++ b/apps/web/e2e/tests/admin/integrations-slack-routing.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Slack notification routing', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/admin/settings/integrations/slack')
+    await page.waitForLoadState('networkidle')
+  })
+
+  test('renders the routing UI when Slack is connected', async ({ page }) => {
+    const hasTable = await page.getByRole('button', { name: /add channel/i }).isVisible()
+    const hasEmptyState = await page
+      .getByText(/no notification channels configured yet/i)
+      .isVisible()
+    expect(hasTable || hasEmptyState).toBe(true)
+  })
+
+  test('add channel dialog opens and closes', async ({ page }) => {
+    const addBtn = page.getByRole('button', { name: /add (your first )?channel/i }).first()
+    if (!(await addBtn.isVisible())) test.skip()
+
+    await addBtn.click()
+    await expect(page.getByRole('dialog')).toBeVisible()
+    await expect(page.getByText(/route events to a channel/i)).toBeVisible()
+    await page.getByRole('button', { name: /cancel/i }).click()
+    await expect(page.getByRole('dialog')).not.toBeVisible()
+  })
+
+  test('exposes board filter in add dialog', async ({ page }) => {
+    const addBtn = page.getByRole('button', { name: /add (your first )?channel/i }).first()
+    if (!(await addBtn.isVisible())) test.skip()
+
+    await addBtn.click()
+    await expect(page.getByRole('dialog')).toBeVisible()
+    await page.getByRole('button', { name: /filter by board/i }).click()
+    await expect(page.getByText(/board filter/i)).toBeVisible()
+    await page.getByRole('button', { name: /cancel/i }).click()
+  })
+
+  test('event columns reflect Slack event list (4 events including Changelog)', async ({
+    page,
+  }) => {
+    const tableHeader = page.getByText(/^Channel$/)
+    if (!(await tableHeader.isVisible())) test.skip()
+
+    await expect(page.getByText(/^Feedback$/)).toBeVisible()
+    await expect(page.getByText(/^Status$/)).toBeVisible()
+    await expect(page.getByText(/^Comment$/)).toBeVisible()
+    // Slack-only event — must be present (mirrors the negative assertion in Discord spec).
+    await expect(page.getByText(/^Changelog$/)).toBeVisible()
+  })
+
+  test('channel monitoring section still renders', async ({ page }) => {
+    // PR1 left the monitored-channel UI unchanged. Guards against accidental removal.
+    await expect(page.getByText(/channel monitoring/i)).toBeVisible()
+  })
+})

--- a/apps/web/src/components/admin/settings/integrations/discord/discord-config.tsx
+++ b/apps/web/src/components/admin/settings/integrations/discord/discord-config.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { ArrowPathIcon, HashtagIcon } from '@heroicons/react/24/solid'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
@@ -89,7 +89,10 @@ export function DiscordConfig({
     refresh: refreshChannels,
   } = useDiscordChannels()
   const boardsQuery = useQuery(adminQueries.boards())
-  const boards = (boardsQuery.data ?? []).map((b) => ({ id: b.id, name: b.name }))
+  const boards = useMemo(
+    () => (boardsQuery.data ?? []).map((b) => ({ id: b.id, name: b.name })),
+    [boardsQuery.data]
+  )
   const [integrationEnabled, setIntegrationEnabled] = useState(enabled)
 
   // Use notificationChannels if provided; otherwise synthesize from legacy

--- a/apps/web/src/components/admin/settings/integrations/discord/discord-config.tsx
+++ b/apps/web/src/components/admin/settings/integrations/discord/discord-config.tsx
@@ -1,20 +1,19 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState } from 'react'
 import { ArrowPathIcon, HashtagIcon } from '@heroicons/react/24/solid'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
-import { Button } from '@/components/ui/button'
 import { useUpdateIntegration } from '@/lib/client/mutations'
+import { adminQueries } from '@/lib/client/queries/admin'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import {
   fetchDiscordChannelsFn,
   type DiscordChannel,
 } from '@/lib/server/integrations/discord/functions'
+import {
+  NotificationChannelRouter,
+  type NotificationChannel,
+  type EventConfig,
+} from '@/components/admin/settings/integrations/shared/notification-channel-router'
 
 interface EventMapping {
   id: string
@@ -26,85 +25,93 @@ interface DiscordConfigProps {
   integrationId: string
   initialConfig: { channelId?: string }
   initialEventMappings: EventMapping[]
+  notificationChannels?: NotificationChannel[]
   enabled: boolean
 }
 
-const EVENT_CONFIG = [
+const DISCORD_EVENT_CONFIG: EventConfig[] = [
   {
-    id: 'post.created' as const,
+    id: 'post.created',
     label: 'New feedback submitted',
+    shortLabel: 'Feedback',
     description: 'When a user submits new feedback',
   },
   {
-    id: 'post.status_changed' as const,
+    id: 'post.status_changed',
     label: 'Feedback status changed',
+    shortLabel: 'Status',
     description: 'When the status of a feedback post is updated',
   },
   {
-    id: 'comment.created' as const,
+    id: 'comment.created',
     label: 'New comment on feedback',
+    shortLabel: 'Comment',
     description: 'When someone comments on a feedback post',
   },
 ]
+
+function useDiscordChannels() {
+  const queryClient = useQueryClient()
+  const query = useQuery({
+    queryKey: ['discord-channels'],
+    queryFn: () => fetchDiscordChannelsFn(),
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+  })
+
+  const refresh = () => {
+    queryClient.fetchQuery({
+      queryKey: ['discord-channels'],
+      queryFn: () => fetchDiscordChannelsFn(),
+    })
+  }
+
+  return {
+    channels: query.data ?? [],
+    loading: query.isLoading || query.isFetching,
+    error: query.isError ? 'Failed to load channels. Please try again.' : null,
+    refresh,
+  }
+}
 
 export function DiscordConfig({
   integrationId,
   initialConfig,
   initialEventMappings,
+  notificationChannels: initialChannels,
   enabled,
 }: DiscordConfigProps) {
   const updateMutation = useUpdateIntegration()
-  const [channels, setChannels] = useState<DiscordChannel[]>([])
-  const [loadingChannels, setLoadingChannels] = useState(false)
-  const [channelError, setChannelError] = useState<string | null>(null)
-  const [selectedChannel, setSelectedChannel] = useState(initialConfig.channelId || '')
+  const {
+    channels,
+    loading: loadingChannels,
+    error: channelError,
+    refresh: refreshChannels,
+  } = useDiscordChannels()
+  const boardsQuery = useQuery(adminQueries.boards())
+  const boards = (boardsQuery.data ?? []).map((b) => ({ id: b.id, name: b.name }))
   const [integrationEnabled, setIntegrationEnabled] = useState(enabled)
-  const [eventSettings, setEventSettings] = useState<Record<string, boolean>>(() =>
-    Object.fromEntries(
-      EVENT_CONFIG.map((event) => [
-        event.id,
-        initialEventMappings.find((m) => m.eventType === event.id)?.enabled ?? false,
-      ])
-    )
-  )
 
-  const fetchChannels = useCallback(async () => {
-    setLoadingChannels(true)
-    setChannelError(null)
-    try {
-      const result = await fetchDiscordChannelsFn()
-      setChannels(result)
-    } catch {
-      setChannelError('Failed to load channels. Please try again.')
-    } finally {
-      setLoadingChannels(false)
-    }
-  }, [])
-
-  useEffect(() => {
-    fetchChannels()
-  }, [fetchChannels])
+  // Use notificationChannels if provided; otherwise synthesize from legacy
+  // single-channel config so the user can keep editing without re-adding.
+  const notificationChannels: NotificationChannel[] = initialChannels?.length
+    ? initialChannels
+    : initialConfig.channelId
+      ? [
+          {
+            channelId: initialConfig.channelId,
+            events: DISCORD_EVENT_CONFIG.map((e) => ({
+              eventType: e.id,
+              enabled: initialEventMappings.find((m) => m.eventType === e.id)?.enabled ?? false,
+            })),
+            boardIds: null,
+          },
+        ]
+      : []
 
   const handleEnabledChange = (checked: boolean) => {
     setIntegrationEnabled(checked)
     updateMutation.mutate({ id: integrationId, enabled: checked })
-  }
-
-  const handleChannelChange = (channelId: string) => {
-    setSelectedChannel(channelId)
-    updateMutation.mutate({ id: integrationId, config: { channelId } })
-  }
-
-  const handleEventToggle = (eventId: string, checked: boolean) => {
-    const newSettings = { ...eventSettings, [eventId]: checked }
-    setEventSettings(newSettings)
-    updateMutation.mutate({
-      id: integrationId,
-      eventMappings: Object.entries(newSettings).map(([eventType, enabled]) => ({
-        eventType,
-        enabled,
-      })),
-    })
   }
 
   const saving = updateMutation.isPending
@@ -128,77 +135,28 @@ export function DiscordConfig({
         />
       </div>
 
-      <div className="space-y-2">
-        <div className="flex items-center justify-between">
-          <Label htmlFor="channel-select">Notification channel</Label>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={fetchChannels}
-            disabled={loadingChannels}
-            className="h-8 gap-1.5 text-xs"
-          >
-            <ArrowPathIcon className={`h-3.5 w-3.5 ${loadingChannels ? 'animate-spin' : ''}`} />
-            Refresh
-          </Button>
-        </div>
-        {channelError ? (
-          <p className="text-sm text-destructive">{channelError}</p>
-        ) : (
-          <Select
-            value={selectedChannel}
-            onValueChange={handleChannelChange}
-            disabled={loadingChannels || saving || !integrationEnabled}
-          >
-            <SelectTrigger id="channel-select" className="w-full">
-              {loadingChannels ? (
-                <div className="flex items-center gap-2">
-                  <ArrowPathIcon className="h-4 w-4 animate-spin" />
-                  <span>Loading channels...</span>
-                </div>
-              ) : (
-                <SelectValue placeholder="Select a channel" />
-              )}
-            </SelectTrigger>
-            <SelectContent>
-              {channels.map((channel) => (
-                <SelectItem key={channel.id} value={channel.id}>
-                  <div className="flex items-center gap-2">
-                    <HashtagIcon className="h-3.5 w-3.5 text-muted-foreground" />
-                    <span>{channel.name}</span>
-                  </div>
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        )}
-        <p className="text-xs text-muted-foreground">
-          The bot will post notifications to this channel. Make sure the bot has been added to your
-          server.
-        </p>
-      </div>
+      <div className="border-t border-border/30" />
 
       <div className="space-y-3">
-        <Label className="text-base font-medium">Events</Label>
-        <p className="text-sm text-muted-foreground">Choose which events trigger notifications</p>
-        <div className="space-y-3 pt-2">
-          {EVENT_CONFIG.map((event) => (
-            <div
-              key={event.id}
-              className="flex items-center justify-between rounded-lg border border-border/50 p-3"
-            >
-              <div>
-                <div className="font-medium text-sm">{event.label}</div>
-                <div className="text-xs text-muted-foreground">{event.description}</div>
-              </div>
-              <Switch
-                checked={eventSettings[event.id] ?? false}
-                onCheckedChange={(checked) => handleEventToggle(event.id, checked)}
-                disabled={saving || !integrationEnabled}
-              />
-            </div>
-          ))}
+        <div>
+          <Label className="text-base font-medium">Notification routing</Label>
+          <p className="text-sm text-muted-foreground">
+            Choose which events reach each Discord channel
+          </p>
         </div>
+
+        <NotificationChannelRouter<DiscordChannel>
+          integrationId={integrationId}
+          enabled={integrationEnabled}
+          events={DISCORD_EVENT_CONFIG}
+          channels={channels}
+          notificationChannels={notificationChannels}
+          boards={boards}
+          loadingChannels={loadingChannels}
+          channelError={channelError}
+          onRefreshChannels={refreshChannels}
+          renderChannelIcon={() => <HashtagIcon className="h-3.5 w-3.5 text-muted-foreground" />}
+        />
       </div>
 
       {saving && (

--- a/apps/web/src/components/admin/settings/integrations/discord/discord-config.tsx
+++ b/apps/web/src/components/admin/settings/integrations/discord/discord-config.tsx
@@ -60,10 +60,7 @@ function useDiscordChannels() {
   })
 
   const refresh = () => {
-    queryClient.fetchQuery({
-      queryKey: ['discord-channels'],
-      queryFn: () => fetchDiscordChannelsFn(),
-    })
+    queryClient.invalidateQueries({ queryKey: ['discord-channels'] })
   }
 
   return {
@@ -97,20 +94,20 @@ export function DiscordConfig({
 
   // Use notificationChannels if provided; otherwise synthesize from legacy
   // single-channel config so the user can keep editing without re-adding.
-  const notificationChannels: NotificationChannel[] = initialChannels?.length
-    ? initialChannels
-    : initialConfig.channelId
-      ? [
-          {
-            channelId: initialConfig.channelId,
-            events: DISCORD_EVENT_CONFIG.map((e) => ({
-              eventType: e.id,
-              enabled: initialEventMappings.find((m) => m.eventType === e.id)?.enabled ?? false,
-            })),
-            boardIds: null,
-          },
-        ]
-      : []
+  const notificationChannels = useMemo<NotificationChannel[]>(() => {
+    if (initialChannels?.length) return initialChannels
+    if (!initialConfig.channelId) return []
+    return [
+      {
+        channelId: initialConfig.channelId,
+        events: DISCORD_EVENT_CONFIG.map((e) => ({
+          eventType: e.id,
+          enabled: initialEventMappings.find((m) => m.eventType === e.id)?.enabled ?? false,
+        })),
+        boardIds: null,
+      },
+    ]
+  }, [initialChannels, initialConfig.channelId, initialEventMappings])
 
   const handleEnabledChange = (checked: boolean) => {
     setIntegrationEnabled(checked)

--- a/apps/web/src/components/admin/settings/integrations/discord/discord-config.tsx
+++ b/apps/web/src/components/admin/settings/integrations/discord/discord-config.tsx
@@ -32,21 +32,21 @@ interface DiscordConfigProps {
 const DISCORD_EVENT_CONFIG: EventConfig[] = [
   {
     id: 'post.created',
-    label: 'New feedback submitted',
-    shortLabel: 'Feedback',
-    description: 'When a user submits new feedback',
+    label: 'New post submitted',
+    shortLabel: 'New post',
+    description: 'When someone submits a new post',
   },
   {
     id: 'post.status_changed',
-    label: 'Feedback status changed',
+    label: 'Post status changed',
     shortLabel: 'Status',
-    description: 'When the status of a feedback post is updated',
+    description: "When a post's status is updated",
   },
   {
     id: 'comment.created',
-    label: 'New comment on feedback',
+    label: 'New comment posted',
     shortLabel: 'Comment',
-    description: 'When someone comments on a feedback post',
+    description: 'When someone comments on a post',
   },
 ]
 

--- a/apps/web/src/components/admin/settings/integrations/shared/notification-channel-router.tsx
+++ b/apps/web/src/components/admin/settings/integrations/shared/notification-channel-router.tsx
@@ -16,10 +16,20 @@ import {
   ChevronRightIcon,
   MagnifyingGlassIcon,
   ChevronUpDownIcon,
+  CheckIcon,
 } from '@heroicons/react/24/solid'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from '@/components/ui/command'
 import {
   Dialog,
   DialogContent,
@@ -29,6 +39,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { cn } from '@/lib/shared/utils'
 import {
   useAddNotificationChannel,
   useUpdateNotificationChannel,
@@ -308,10 +319,10 @@ function ChannelPicker<TChannel extends Channel>({
 }
 
 // ============================================
-// Board Filter Pills
+// Board Filter (searchable multi-select)
 // ============================================
 
-function BoardFilterPills({
+function BoardFilterCombobox({
   boardIds,
   boards,
   onBoardIdsChange,
@@ -322,67 +333,85 @@ function BoardFilterPills({
   onBoardIdsChange: (boardIds: string[] | null) => void
   disabled?: boolean
 }) {
+  const [open, setOpen] = useState(false)
   const isAllBoards = !boardIds?.length
+  const selectedSet = useMemo(() => new Set(boardIds ?? []), [boardIds])
+
+  const triggerLabel = isAllBoards
+    ? 'All boards'
+    : boardIds!.length === 1
+      ? (boards.find((b) => b.id === boardIds![0])?.name ?? '1 board')
+      : `${boardIds!.length} boards`
+
+  const toggleBoard = (id: string) => {
+    if (selectedSet.has(id)) {
+      const next = (boardIds ?? []).filter((b) => b !== id)
+      onBoardIdsChange(next.length > 0 ? next : null)
+    } else {
+      onBoardIdsChange([...(boardIds ?? []), id])
+    }
+  }
 
   return (
-    <div className="space-y-2">
-      <div className="text-xs font-medium text-muted-foreground">Board filter</div>
-      <div className="space-y-2">
-        <label className="flex items-center gap-2 text-sm cursor-pointer">
-          <Checkbox
-            checked={isAllBoards}
-            onCheckedChange={(checked) => {
-              if (checked) onBoardIdsChange(null)
-            }}
-            disabled={disabled}
-          />
-          All boards
-        </label>
-        <label className="flex items-center gap-2 text-sm cursor-pointer">
-          <Checkbox
-            checked={!isAllBoards}
-            onCheckedChange={(checked) => {
-              if (checked) {
-                onBoardIdsChange(boards.map((b) => b.id))
-              } else {
-                onBoardIdsChange(null)
-              }
-            }}
-            disabled={disabled}
-          />
-          Specific boards
-        </label>
-        {!isAllBoards && (
-          <div className="ml-6 flex flex-wrap gap-1.5 pt-0.5">
-            {boards.map((board) => {
-              const selected = boardIds?.includes(board.id) ?? false
-              return (
-                <button
-                  key={board.id}
-                  type="button"
-                  className={`px-2.5 py-1 text-xs rounded-md border transition-colors disabled:opacity-50 ${
-                    selected
-                      ? 'bg-primary/10 border-primary/20 text-primary font-medium'
-                      : 'border-border/60 text-muted-foreground hover:bg-muted/50'
-                  }`}
-                  onClick={() => {
-                    if (selected) {
-                      const next = (boardIds ?? []).filter((id) => id !== board.id)
-                      onBoardIdsChange(next.length > 0 ? next : null)
-                    } else {
-                      onBoardIdsChange([...(boardIds ?? []), board.id])
-                    }
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled}
+          className="w-full justify-between font-normal"
+        >
+          <span className={cn('truncate', isAllBoards && 'text-muted-foreground')}>
+            {triggerLabel}
+          </span>
+          <ChevronUpDownIcon className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-(--radix-popover-trigger-width) p-0">
+        {open && (
+          <Command>
+            <CommandInput placeholder="Search boards..." />
+            <CommandList>
+              <CommandEmpty>No boards found.</CommandEmpty>
+              <CommandGroup>
+                <CommandItem
+                  value="__all_boards__"
+                  onSelect={() => {
+                    onBoardIdsChange(null)
+                    setOpen(false)
                   }}
-                  disabled={disabled}
                 >
-                  {board.name}
-                </button>
-              )
-            })}
-          </div>
+                  <CheckIcon
+                    className={cn('mr-2 h-4 w-4', isAllBoards ? 'opacity-100' : 'opacity-0')}
+                  />
+                  All boards
+                </CommandItem>
+              </CommandGroup>
+              {boards.length > 0 && <CommandSeparator />}
+              <CommandGroup>
+                {boards.map((board) => (
+                  <CommandItem
+                    key={board.id}
+                    value={board.name}
+                    onSelect={() => toggleBoard(board.id)}
+                  >
+                    <CheckIcon
+                      className={cn(
+                        'mr-2 h-4 w-4',
+                        selectedSet.has(board.id) ? 'opacity-100' : 'opacity-0'
+                      )}
+                    />
+                    <span className="truncate">{board.name}</span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
         )}
-      </div>
-    </div>
+      </PopoverContent>
+    </Popover>
   )
 }
 
@@ -501,12 +530,15 @@ function ChannelRow<TChannel extends Channel>({
         {expanded && (
           <div className="border-t border-border/30 bg-muted/5 px-4 pb-4">
             <div className="pl-10 pt-3 space-y-3">
-              <BoardFilterPills
-                boardIds={channel.boardIds}
-                boards={boards}
-                onBoardIdsChange={handleBoardIdsChange}
-                disabled={disabled || saving}
-              />
+              <div className="space-y-1.5">
+                <Label className="text-xs text-muted-foreground">Board filter</Label>
+                <BoardFilterCombobox
+                  boardIds={channel.boardIds}
+                  boards={boards}
+                  onBoardIdsChange={handleBoardIdsChange}
+                  disabled={disabled || saving}
+                />
+              </div>
               <div className="pt-2 border-t border-border/30">
                 <Button
                   variant="ghost"
@@ -642,7 +674,6 @@ function AddChannelDialog<TChannel extends Channel>({
     Object.fromEntries(events.map((e) => [e.id, true]))
   )
   const [boardIds, setBoardIds] = useState<string[] | null>(null)
-  const [showBoardFilter, setShowBoardFilter] = useState(false)
 
   // Reset form state whenever the dialog closes (cancel, X, or save).
   useEffect(() => {
@@ -650,7 +681,6 @@ function AddChannelDialog<TChannel extends Channel>({
       setSelectedChannelId('')
       setSelectedEvents(Object.fromEntries(events.map((e) => [e.id, true])))
       setBoardIds(null)
-      setShowBoardFilter(false)
     }
   }, [open, events])
 
@@ -736,65 +766,12 @@ function AddChannelDialog<TChannel extends Channel>({
           </div>
 
           <div className="space-y-1.5">
-            {!showBoardFilter && !boardIds?.length ? (
-              <button
-                type="button"
-                onClick={() => setShowBoardFilter(true)}
-                className="text-xs text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1"
-              >
-                <PlusIcon className="h-3 w-3" />
-                Filter by board
-              </button>
-            ) : (
-              <>
-                <div className="flex items-center justify-between">
-                  <Label className="text-xs text-muted-foreground">Board filter</Label>
-                  {boardIds?.length ? (
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setBoardIds(null)
-                        setShowBoardFilter(false)
-                      }}
-                      className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-                    >
-                      Clear
-                    </button>
-                  ) : null}
-                </div>
-                <div className="flex flex-wrap gap-1.5">
-                  {boards.map((board) => {
-                    const selected = boardIds?.includes(board.id) ?? false
-                    return (
-                      <button
-                        key={board.id}
-                        type="button"
-                        className={`px-2.5 py-1 text-xs rounded-md border transition-colors ${
-                          selected
-                            ? 'bg-primary/10 border-primary/20 text-primary font-medium'
-                            : 'border-border/60 text-muted-foreground hover:bg-muted/50'
-                        }`}
-                        onClick={() => {
-                          if (selected) {
-                            const next = (boardIds ?? []).filter((id) => id !== board.id)
-                            setBoardIds(next.length > 0 ? next : null)
-                          } else {
-                            setBoardIds([...(boardIds ?? []), board.id])
-                          }
-                        }}
-                      >
-                        {board.name}
-                      </button>
-                    )
-                  })}
-                </div>
-                {!boardIds?.length && (
-                  <p className="text-[11px] text-muted-foreground">
-                    Select boards to filter, or leave empty for all boards.
-                  </p>
-                )}
-              </>
-            )}
+            <Label className="text-xs text-muted-foreground">Board filter</Label>
+            <BoardFilterCombobox
+              boardIds={boardIds}
+              boards={boards}
+              onBoardIdsChange={setBoardIds}
+            />
           </div>
         </div>
 

--- a/apps/web/src/components/admin/settings/integrations/shared/notification-channel-router.tsx
+++ b/apps/web/src/components/admin/settings/integrations/shared/notification-channel-router.tsx
@@ -45,6 +45,7 @@ import {
   useUpdateNotificationChannel,
   useRemoveNotificationChannel,
 } from '@/lib/client/mutations'
+import type { EventType } from '@/lib/server/events/types'
 
 // ============================================
 // Public types
@@ -62,7 +63,7 @@ export interface NotificationChannel {
 }
 
 export interface EventConfig {
-  id: string
+  id: EventType
   label: string
   shortLabel: string
   description: string
@@ -339,11 +340,13 @@ function BoardFilterCombobox({
   const isAllBoards = !boardIds?.length
   const selectedSet = useMemo(() => new Set(boardIds ?? []), [boardIds])
 
-  const triggerLabel = isAllBoards
-    ? 'All boards'
-    : boardIds!.length === 1
-      ? (boards.find((b) => b.id === boardIds![0])?.name ?? '1 board')
-      : `${boardIds!.length} boards`
+  const triggerLabel = useMemo(() => {
+    if (isAllBoards) return 'All boards'
+    if (boardIds!.length === 1) {
+      return boards.find((b) => b.id === boardIds![0])?.name ?? '1 board'
+    }
+    return `${boardIds!.length} boards`
+  }, [isAllBoards, boardIds, boards])
 
   const toggleBoard = (id: string) => {
     if (selectedSet.has(id)) {
@@ -739,7 +742,7 @@ function AddChannelDialog<TChannel extends Channel>({
               <button
                 type="button"
                 onClick={() => {
-                  const next = allEventsSelected ? false : true
+                  const next = !allEventsSelected
                   setSelectedEvents(Object.fromEntries(events.map((e) => [e.id, next])))
                 }}
                 className="text-xs text-muted-foreground hover:text-foreground transition-colors"

--- a/apps/web/src/components/admin/settings/integrations/shared/notification-channel-router.tsx
+++ b/apps/web/src/components/admin/settings/integrations/shared/notification-channel-router.tsx
@@ -8,7 +8,7 @@
  * mental model and should get their own UI rather than be forced through here.
  */
 
-import { useState, useRef, useMemo, type ReactNode, type CSSProperties } from 'react'
+import { useState, useRef, useMemo, useEffect, type ReactNode, type CSSProperties } from 'react'
 import {
   ArrowPathIcon,
   XMarkIcon,
@@ -643,6 +643,17 @@ function AddChannelDialog<TChannel extends Channel>({
   )
   const [boardIds, setBoardIds] = useState<string[] | null>(null)
   const [showBoardFilter, setShowBoardFilter] = useState(false)
+
+  // Reset form state when dialog closes (covers cancel/X paths;
+  // the onSuccess handler resets explicitly on save).
+  useEffect(() => {
+    if (!open) {
+      setSelectedChannelId('')
+      setSelectedEvents(Object.fromEntries(events.map((e) => [e.id, true])))
+      setBoardIds(null)
+      setShowBoardFilter(false)
+    }
+  }, [open, events])
 
   const availableChannels = channels.filter((c) => !existingChannelIds.includes(c.id))
   const allEventsSelected = events.every((e) => selectedEvents[e.id])

--- a/apps/web/src/components/admin/settings/integrations/shared/notification-channel-router.tsx
+++ b/apps/web/src/components/admin/settings/integrations/shared/notification-channel-router.tsx
@@ -615,7 +615,7 @@ function RoutingTable<TChannel extends Channel>({
           <div
             key={event.id}
             className="py-2 text-[11px] font-medium text-muted-foreground text-center leading-tight"
-            title={event.label}
+            title={event.description}
           >
             {event.shortLabel}
           </div>
@@ -751,6 +751,7 @@ function AddChannelDialog<TChannel extends Channel>({
               {events.map((event) => (
                 <label
                   key={event.id}
+                  title={event.description}
                   className="flex items-center gap-2 text-sm cursor-pointer py-1"
                 >
                   <Checkbox
@@ -762,7 +763,7 @@ function AddChannelDialog<TChannel extends Channel>({
                       }))
                     }
                   />
-                  {event.shortLabel}
+                  {event.label}
                 </label>
               ))}
             </div>

--- a/apps/web/src/components/admin/settings/integrations/shared/notification-channel-router.tsx
+++ b/apps/web/src/components/admin/settings/integrations/shared/notification-channel-router.tsx
@@ -256,11 +256,11 @@ function ChannelPicker<TChannel extends Channel>({
           ) : (
             <span className="text-muted-foreground">{placeholder}</span>
           )}
-          <ChevronUpDownIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <ChevronUpDownIcon className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
       <PopoverContent
-        className="w-[--radix-popover-trigger-width] p-0"
+        className="w-(--radix-popover-trigger-width) p-0"
         align="start"
         onOpenAutoFocus={(e) => {
           e.preventDefault()
@@ -327,11 +327,13 @@ function BoardFilterCombobox({
   boards,
   onBoardIdsChange,
   disabled,
+  ariaLabel = 'Board filter',
 }: {
   boardIds: string[] | null
   boards: Board[]
   onBoardIdsChange: (boardIds: string[] | null) => void
   disabled?: boolean
+  ariaLabel?: string
 }) {
   const [open, setOpen] = useState(false)
   const isAllBoards = !boardIds?.length
@@ -359,6 +361,7 @@ function BoardFilterCombobox({
           type="button"
           variant="outline"
           role="combobox"
+          aria-label={ariaLabel}
           aria-expanded={open}
           disabled={disabled}
           className="w-full justify-between font-normal"
@@ -766,11 +769,12 @@ function AddChannelDialog<TChannel extends Channel>({
           </div>
 
           <div className="space-y-1.5">
-            <Label className="text-xs text-muted-foreground">Board filter</Label>
+            <Label>Board filter</Label>
             <BoardFilterCombobox
               boardIds={boardIds}
               boards={boards}
               onBoardIdsChange={setBoardIds}
+              disabled={addMutation.isPending}
             />
           </div>
         </div>

--- a/apps/web/src/components/admin/settings/integrations/shared/notification-channel-router.tsx
+++ b/apps/web/src/components/admin/settings/integrations/shared/notification-channel-router.tsx
@@ -644,8 +644,7 @@ function AddChannelDialog<TChannel extends Channel>({
   const [boardIds, setBoardIds] = useState<string[] | null>(null)
   const [showBoardFilter, setShowBoardFilter] = useState(false)
 
-  // Reset form state when dialog closes (covers cancel/X paths;
-  // the onSuccess handler resets explicitly on save).
+  // Reset form state whenever the dialog closes (cancel, X, or save).
   useEffect(() => {
     if (!open) {
       setSelectedChannelId('')
@@ -675,13 +674,7 @@ function AddChannelDialog<TChannel extends Channel>({
         boardIds: boardIds ?? undefined,
       },
       {
-        onSuccess: () => {
-          onOpenChange(false)
-          setSelectedChannelId('')
-          setSelectedEvents(Object.fromEntries(events.map((e) => [e.id, true])))
-          setBoardIds(null)
-          setShowBoardFilter(false)
-        },
+        onSuccess: () => onOpenChange(false),
       }
     )
   }

--- a/apps/web/src/components/admin/settings/integrations/slack/slack-config.tsx
+++ b/apps/web/src/components/admin/settings/integrations/slack/slack-config.tsx
@@ -68,21 +68,21 @@ interface SlackConfigProps {
 const SLACK_EVENT_CONFIG = [
   {
     id: 'post.created' as const,
-    label: 'New feedback submitted',
-    shortLabel: 'Feedback',
-    description: 'When a user submits new feedback',
+    label: 'New post submitted',
+    shortLabel: 'New post',
+    description: 'When someone submits a new post',
   },
   {
     id: 'post.status_changed' as const,
-    label: 'Feedback status changed',
+    label: 'Post status changed',
     shortLabel: 'Status',
-    description: 'When the status of a feedback post is updated',
+    description: "When a post's status is updated",
   },
   {
     id: 'comment.created' as const,
-    label: 'New comment on feedback',
+    label: 'New comment posted',
     shortLabel: 'Comment',
-    description: 'When someone comments on a feedback post',
+    description: 'When someone comments on a post',
   },
   {
     id: 'changelog.published' as const,

--- a/apps/web/src/routes/admin/settings/integrations/discord.tsx
+++ b/apps/web/src/routes/admin/settings/integrations/discord.tsx
@@ -56,6 +56,7 @@ function DiscordIntegrationPage() {
             integrationId={integration.id}
             initialConfig={integration.config}
             initialEventMappings={integration.eventMappings}
+            notificationChannels={integration.notificationChannels}
             enabled={isConnected}
           />
         </div>

--- a/packages/db/drizzle/0048_consolidate_chat_target_keys.sql
+++ b/packages/db/drizzle/0048_consolidate_chat_target_keys.sql
@@ -1,0 +1,45 @@
+-- Consolidate target_key='default' rows for chat integrations.
+--
+-- Migration 0021 backfilled target_key + action_config.channelId from the
+-- integration-level config.channelId. But the legacy updateIntegrationFn
+-- omits targetKey on insert, so each event toggle since 0021 ran has
+-- created a fresh target_key='default' row for chat integrations,
+-- producing duplicates that runtime dedupe collapses but that pollute
+-- the table.
+--
+-- This migration:
+--   1. Drops 'default' rows when a real-channel row already exists for
+--      the same (integration_id, event_type, action_type) triple.
+--   2. Backfills any remaining standalone 'default' rows for chat
+--      integrations whose config.channelId is set (same logic as 0021).
+--
+-- Scope is narrowed to chat integrations (slack, discord, teams). PM
+-- integrations (jira, linear, asana, etc.) legitimately use
+-- target_key='default' and are left alone.
+
+DELETE FROM integration_event_mappings iem
+WHERE iem.target_key = 'default'
+  AND iem.integration_id IN (
+    SELECT id FROM integrations
+    WHERE integration_type IN ('slack', 'discord', 'teams')
+  )
+  AND EXISTS (
+    SELECT 1 FROM integration_event_mappings other
+    WHERE other.integration_id = iem.integration_id
+      AND other.event_type = iem.event_type
+      AND other.action_type = iem.action_type
+      AND other.target_key <> 'default'
+  );
+
+UPDATE integration_event_mappings iem
+SET target_key = (i.config->>'channelId'),
+    action_config = jsonb_set(
+      COALESCE(iem.action_config, '{}'),
+      '{channelId}',
+      to_jsonb(i.config->>'channelId')
+    )
+FROM integrations i
+WHERE iem.integration_id = i.id
+  AND i.integration_type IN ('slack', 'discord', 'teams')
+  AND i.config->>'channelId' IS NOT NULL
+  AND iem.target_key = 'default';

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -337,6 +337,13 @@
       "when": 1776847294910,
       "tag": "0047_true_jimmy_woo",
       "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "7",
+      "when": 1777620521131,
+      "tag": "0048_consolidate_chat_target_keys",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

PR2 of 2 for #145. Wires Discord settings to consume the shared `NotificationChannelRouter` introduced in PR1, brings Discord to feature parity with Slack (per-channel routing + per-board filters), and ships a one-time data-cleanup migration.

Closes #145.

## What changed

**Discord wire-up**
- `discord-config.tsx` rewritten: replaces the legacy single-channel `<Select>` + 3 toggle switches with `<NotificationChannelRouter<DiscordChannel>>` and a `useDiscordChannels` react-query hook mirroring `useSlackChannels`. 210 → 97 LOC.
- `routes/admin/settings/integrations/discord.tsx` passes `notificationChannels` through to the config component (the loader already returned this for any integration type — Discord just wasn't using it).
- Discord events: `post.created`, `post.status_changed`, `comment.created`. No `changelog.published` — preserves Discord's existing event list; adding it is a separate decision.
- Legacy fallback synth: same pattern Slack uses. If a Discord install has `config.channelId` set but no per-channel mappings, synthesize one routing-table row from it. First edit migrates the user onto the new mapping shape.

**Migration `0048_consolidate_chat_target_keys.sql`**
- Step 1: drops `target_key='default'` rows for chat integrations (slack/discord/teams) when a real-channel row already exists for the same `(integration_id, event_type, action_type)` triple — these duplicates were created by the legacy `updateIntegrationFn` path after migration 0021 ran.
- Step 2: backfills any remaining standalone `'default'` rows for chat integrations whose `config.channelId` is set (same logic as 0021, catches rows created since).
- Scope narrowed to chat integrations. PM integrations (Jira, Linear, Asana, etc.) legitimately use `target_key='default'` and are untouched.

**Bug fix carried from PR1 review**
- `AddChannelDialog` retained form state when closed via Cancel/X. Added a `useEffect` that resets state when `open` becomes false. The `onSuccess` save handler now just closes the dialog and lets the effect own the reset (deduped via /simplify pass).

**Test coverage**
- `integrations-discord-routing.spec.ts`: structural tests for routing UI render, add-channel dialog open/close, board filter accessibility, 3-events-no-Changelog event list.
- `integrations-slack-routing.spec.ts`: parallel coverage for Slack, asserting 4 events including Changelog and that the channel-monitoring section still renders. First automated coverage of the shared `NotificationChannelRouter`.
- Tests skip cleanly when the integration isn't connected in the env (setup-card path).

**/simplify pass**
- Deduplicated the `AddChannelDialog` reset logic.
- Memoized `boards` projection in `DiscordConfig` for stable identity.

## Migration safety

- One-time data fix on `integration_event_mappings`. Idempotent (re-running is a no-op).
- Both queries scoped via existing indexes (`mapping_unique` on `(integration_id, event_type, action_type, target_key)`; `idx_integrations_type_status`).
- Runtime dedupe in `getIntegrationTargets` already collapses duplicate rows, so this is hygiene, not a delivery-correctness fix.

## Spec / plan

- Spec: `docs/superpowers/specs/2026-04-30-discord-per-board-channels-design.md`
- Plan: `docs/superpowers/plans/2026-04-30-discord-per-board-channels.md`

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run test` clean (1795 unit tests pass)
- [x] `bun run test:e2e` for both new specs — 6 pass / 5 skip in dev (Discord not connected, skips correctly)
- [ ] Manual: connect Discord, add a notification channel, set board filter, toggle events, remove channel
- [ ] Manual: connect Discord with one channel + 3 enabled events on a fresh DB, verify legacy synth renders correctly until first edit
- [ ] Run `bun run db:migrate` on a copy of prod data; verify the two sanity queries from the spec return 0