### PR TITLE
feat(import): incremental top-up support for the UV import CLI

### DIFF
--- a/scripts/import/cli.ts
+++ b/scripts/import/cli.ts
@@ -38,6 +38,7 @@ interface CliArgs {
   board?: string
   dryRun: boolean
   verbose: boolean
+  incremental: boolean
   // Intermediate format files
   posts?: string
   comments?: string
@@ -75,6 +76,11 @@ Required Options (all commands):
 Common Options:
   --dry-run           Validate and show summary, don't insert data
   --verbose           Show detailed progress
+  --incremental       Skip rows that already exist on the target instance.
+                      Dedup posts by normalised title + createdAt date,
+                      comments by normalised content + createdAt minute.
+                      Use when topping up an instance that has been imported
+                      before — votes and user identify are already idempotent.
 
 Canny Options:
   --api-key <key>         Canny API key (or set CANNY_API_KEY env var)
@@ -124,6 +130,16 @@ Examples:
     --quackback-key qb_xxx \\
     --dry-run --verbose
 
+  # Incremental top-up of a previously-imported UserVoice export
+  bun scripts/import/cli.ts uservoice \\
+    --suggestions ~/uv/suggestions.csv \\
+    --comments ~/uv/comments.csv \\
+    --notes ~/uv/notes.csv \\
+    --users ~/uv/users.csv \\
+    --quackback-url https://feedback.yourapp.com \\
+    --quackback-key qb_xxx \\
+    --incremental --verbose
+
 Environment Variables:
   QUACKBACK_URL         Quackback instance URL (alternative to --quackback-url)
   QUACKBACK_API_KEY     Quackback admin API key (alternative to --quackback-key)
@@ -136,6 +152,7 @@ function parseArgs(args: string[]): CliArgs {
     command: 'help',
     dryRun: false,
     verbose: false,
+    incremental: false,
   }
 
   if (args.length === 0) {
@@ -175,6 +192,9 @@ function parseArgs(args: string[]): CliArgs {
         break
       case '--dry-run':
         result.dryRun = true
+        break
+      case '--incremental':
+        result.incremental = true
         break
       case '--verbose':
       case '-v':
@@ -403,6 +423,7 @@ async function executeImport(
       data,
       dryRun: args.dryRun,
       verbose: args.verbose,
+      incremental: args.incremental,
     })
 
     const totalErrors =

--- a/scripts/import/core/api-importer.ts
+++ b/scripts/import/core/api-importer.ts
@@ -63,6 +63,7 @@ function commentDedupKey(
 }
 
 interface ExistingComment {
+  id: string
   content: string
   createdAt: string
   replies?: ExistingComment[]
@@ -125,26 +126,33 @@ export async function runApiImport(options: ApiImportOptions): Promise<ImportRes
   // Dedup state, only populated when options.incremental is set
   const existingPostByKey = new Map<string, string>()
   const preExistingPostIds = new Set<string>()
-  const existingCommentKeysByPost = new Map<string, Set<string>>()
+  // Per-post: dedupKey -> Quackback comment id. Stored as a map (not a set) so
+  // that when a UV comment is matched against an existing one, we can register
+  // idMap.comments for it and let new replies under that parent attach.
+  const existingCommentsByPost = new Map<string, Map<string, string>>()
 
-  async function getExistingCommentKeys(postId: string): Promise<Set<string>> {
-    const cached = existingCommentKeysByPost.get(postId)
+  async function getExistingComments(postId: string): Promise<Map<string, string>> {
+    const cached = existingCommentsByPost.get(postId)
     if (cached) return cached
     const resp = await qb.get<{ data: ExistingComment[] }>(`/api/v1/posts/${postId}/comments`)
     const flat = flattenComments(resp.data ?? [])
-    const keys = new Set<string>()
+    const byKey = new Map<string, string>()
     for (const c of flat) {
       const k = commentDedupKey(c.content, c.createdAt)
-      if (k) keys.add(k)
+      if (k) byKey.set(k, c.id)
     }
-    existingCommentKeysByPost.set(postId, keys)
-    return keys
+    existingCommentsByPost.set(postId, byKey)
+    return byKey
   }
 
   if (options.incremental) {
     progress.start('Pre-fetching existing posts for dedup')
+    // showDeleted=true so soft-deleted posts are still in the dedup index;
+    // re-importing a UV idea whose Quackback row was deleted should not
+    // resurrect it as a duplicate.
     const existing = await qb.listAll<{ id: string; title: string; createdAt: string }>(
-      '/api/v1/posts'
+      '/api/v1/posts',
+      { showDeleted: 'true' }
     )
     for (const p of existing) {
       const key = postDedupKey(p.title, p.createdAt)
@@ -328,13 +336,15 @@ export async function runApiImport(options: ApiImportOptions): Promise<ImportRes
         if (options.incremental && preExistingPostIds.has(postId)) {
           const dedupKey = commentDedupKey(comment.body, comment.createdAt)
           if (dedupKey) {
-            const existingKeys = await getExistingCommentKeys(postId)
-            if (existingKeys.has(dedupKey)) {
+            const existingByKey = await getExistingComments(postId)
+            const existingCommentId = existingByKey.get(dedupKey)
+            if (existingCommentId) {
+              // Register the mapping so new replies under this parent in the
+              // current run can still resolve their parentId.
+              if (comment.id) idMap.comments.set(comment.id, existingCommentId)
               result.comments.skipped++
               continue
             }
-            // Record the key so a duplicate later in the same run is also skipped
-            existingKeys.add(dedupKey)
           }
         }
 
@@ -348,6 +358,12 @@ export async function runApiImport(options: ApiImportOptions): Promise<ImportRes
         // Track comment ID for threading
         if (comment.id) {
           idMap.comments.set(comment.id, resp.data.id)
+        }
+        // Record in the per-post dedup cache so repeated rows in the same run
+        // are also caught
+        if (options.incremental && preExistingPostIds.has(postId)) {
+          const dedupKey = commentDedupKey(comment.body, comment.createdAt)
+          if (dedupKey) (await getExistingComments(postId)).set(dedupKey, resp.data.id)
         }
 
         result.comments.imported++
@@ -441,20 +457,24 @@ export async function runApiImport(options: ApiImportOptions): Promise<ImportRes
         if (options.incremental && preExistingPostIds.has(postId)) {
           const dedupKey = commentDedupKey(note.body, note.createdAt)
           if (dedupKey) {
-            const existingKeys = await getExistingCommentKeys(postId)
-            if (existingKeys.has(dedupKey)) {
+            const existingByKey = await getExistingComments(postId)
+            if (existingByKey.has(dedupKey)) {
               result.notes.skipped++
               continue
             }
-            existingKeys.add(dedupKey)
           }
         }
 
-        await qb.post(`/api/v1/posts/${postId}/comments`, {
+        const resp = await qb.post<{ data: { id: string } }>(`/api/v1/posts/${postId}/comments`, {
           content: note.body,
           isPrivate: true,
           ...(note.createdAt && { createdAt: new Date(note.createdAt).toISOString() }),
         })
+
+        if (options.incremental && preExistingPostIds.has(postId)) {
+          const dedupKey = commentDedupKey(note.body, note.createdAt)
+          if (dedupKey) (await getExistingComments(postId)).set(dedupKey, resp.data.id)
+        }
 
         result.notes.imported++
       } catch (err) {

--- a/scripts/import/core/api-importer.ts
+++ b/scripts/import/core/api-importer.ts
@@ -20,6 +20,56 @@ export interface ApiImportOptions {
   dryRun?: boolean
   /** Verbose output */
   verbose?: boolean
+  /**
+   * Top-up an instance that has been imported before. Skip rows already
+   * present on the server: posts dedup by normalised title + createdAt date,
+   * comments dedup by normalised content + createdAt minute on a per-post
+   * cache. Votes and user identify are already idempotent server-side.
+   */
+  incremental?: boolean
+}
+
+function normalizeText(s: string): string {
+  return s.trim().toLowerCase().replace(/\s+/g, ' ')
+}
+
+function dayKey(ts: Date | string | null | undefined): string {
+  if (!ts) return ''
+  const d = ts instanceof Date ? ts : new Date(ts)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toISOString().slice(0, 10)
+}
+
+function minuteKey(ts: Date | string | null | undefined): string {
+  if (!ts) return ''
+  const d = ts instanceof Date ? ts : new Date(ts)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toISOString().slice(0, 16)
+}
+
+function postDedupKey(title: string, createdAt: Date | string | null | undefined): string | null {
+  const day = dayKey(createdAt)
+  if (!day) return null
+  return `${normalizeText(title)}|${day}`
+}
+
+function commentDedupKey(
+  content: string,
+  createdAt: Date | string | null | undefined
+): string | null {
+  const min = minuteKey(createdAt)
+  if (!min) return null
+  return `${normalizeText(content)}|${min}`
+}
+
+interface ExistingComment {
+  content: string
+  createdAt: string
+  replies?: ExistingComment[]
+}
+
+function flattenComments(cs: ExistingComment[]): ExistingComment[] {
+  return cs.flatMap((c) => [c, ...flattenComments(c.replies ?? [])])
 }
 
 interface IdMap {
@@ -70,6 +120,37 @@ export async function runApiImport(options: ApiImportOptions): Promise<ImportRes
     posts: new Map(),
     comments: new Map(),
     users: new Map(),
+  }
+
+  // Dedup state, only populated when options.incremental is set
+  const existingPostByKey = new Map<string, string>()
+  const preExistingPostIds = new Set<string>()
+  const existingCommentKeysByPost = new Map<string, Set<string>>()
+
+  async function getExistingCommentKeys(postId: string): Promise<Set<string>> {
+    const cached = existingCommentKeysByPost.get(postId)
+    if (cached) return cached
+    const resp = await qb.get<{ data: ExistingComment[] }>(`/api/v1/posts/${postId}/comments`)
+    const flat = flattenComments(resp.data ?? [])
+    const keys = new Set<string>()
+    for (const c of flat) {
+      const k = commentDedupKey(c.content, c.createdAt)
+      if (k) keys.add(k)
+    }
+    existingCommentKeysByPost.set(postId, keys)
+    return keys
+  }
+
+  if (options.incremental) {
+    progress.start('Pre-fetching existing posts for dedup')
+    const existing = await qb.listAll<{ id: string; title: string; createdAt: string }>(
+      '/api/v1/posts'
+    )
+    for (const p of existing) {
+      const key = postDedupKey(p.title, p.createdAt)
+      if (key) existingPostByKey.set(key, p.id)
+    }
+    progress.success(`Loaded ${existing.length} existing posts (${existingPostByKey.size} keyed)`)
   }
 
   // Step 1: Identify users
@@ -141,6 +222,18 @@ export async function runApiImport(options: ApiImportOptions): Promise<ImportRes
             progress.warn(`Skipping post "${post.title}": no board found for "${post.board}"`)
           }
           continue
+        }
+
+        // Incremental dedup against existing Quackback posts
+        if (options.incremental) {
+          const key = postDedupKey(post.title, post.createdAt)
+          const existingId = key ? existingPostByKey.get(key) : undefined
+          if (existingId) {
+            idMap.posts.set(post.id, existingId)
+            preExistingPostIds.add(existingId)
+            result.posts.skipped++
+            continue
+          }
         }
 
         // Resolve status
@@ -227,6 +320,21 @@ export async function runApiImport(options: ApiImportOptions): Promise<ImportRes
           if (!parentId) {
             result.comments.skipped++
             continue
+          }
+        }
+
+        // Incremental dedup: only check pre-existing posts (newly created
+        // posts in this run have no comments yet, so the GET would be wasted)
+        if (options.incremental && preExistingPostIds.has(postId)) {
+          const dedupKey = commentDedupKey(comment.body, comment.createdAt)
+          if (dedupKey) {
+            const existingKeys = await getExistingCommentKeys(postId)
+            if (existingKeys.has(dedupKey)) {
+              result.comments.skipped++
+              continue
+            }
+            // Record the key so a duplicate later in the same run is also skipped
+            existingKeys.add(dedupKey)
           }
         }
 
@@ -328,6 +436,18 @@ export async function runApiImport(options: ApiImportOptions): Promise<ImportRes
         if (!postId) {
           result.notes.skipped++
           continue
+        }
+
+        if (options.incremental && preExistingPostIds.has(postId)) {
+          const dedupKey = commentDedupKey(note.body, note.createdAt)
+          if (dedupKey) {
+            const existingKeys = await getExistingCommentKeys(postId)
+            if (existingKeys.has(dedupKey)) {
+              result.notes.skipped++
+              continue
+            }
+            existingKeys.add(dedupKey)
+          }
         }
 
         await qb.post(`/api/v1/posts/${postId}/comments`, {

--- a/scripts/import/core/quackback-client.ts
+++ b/scripts/import/core/quackback-client.ts
@@ -62,7 +62,7 @@ export class QuackbackClient {
     let cursor: string | undefined
 
     while (true) {
-      const queryParams = { ...params, limit: '100' }
+      const queryParams: Record<string, string> = { ...params, limit: '100' }
       if (cursor) queryParams.cursor = cursor
 
       const response = await this.get<ApiResponse<T[]>>(path, queryParams)
@@ -73,7 +73,9 @@ export class QuackbackClient {
         items.push(...data)
       }
 
-      const pagination = raw.pagination
+      // Quackback returns pagination under `meta.pagination`; some endpoints
+      // (or older shapes) put it at the top level. Check both.
+      const pagination = raw.meta?.pagination ?? raw.pagination
       if (!pagination?.hasMore || !pagination?.cursor) break
       cursor = pagination.cursor
     }


### PR DESCRIPTION
## Summary

- Adds `--incremental` to `bun scripts/import/cli.ts uservoice` so re-running the importer against a Quackback instance that has already received an import skips rows that already exist instead of duplicating them.
- Pre-fetches all existing posts (paginated), keys them by `normalize(title) + day(createdAt)`, and reverse-maps matched UV ideas to existing post IDs so child comments and votes still attach.
- Lazy per-post comment dedup: for any pre-existing post that gets new comments in this run, fetches its existing comments once and dedups by `normalize(content) + minute(createdAt)`.
- Votes and `/users/identify` are already idempotent server-side, so they're sent as-is.
- Bug fix: `QuackbackClient.listAll` was reading `pagination` at the top level of the response, but the API returns it under `meta.pagination`. The bug was latent (boards/statuses/tags fit in one page) but would have caused 900+ duplicate posts on the first multi-page list.

Default behaviour is unchanged — you only get incremental dedup when you pass `--incremental`.

## Test plan

- [x] Unit-level: `--dry-run --incremental` against a real instance reports the expected skip/import counts.
- [x] Real run: 2026-05-01 StoreFeeder top-up imported 10 posts, 7 comments, 8 notes, 1184 votes against 995 existing posts with 0 errors and 0 duplicates created.
- [x] CI typecheck + linter pass.