### PR TITLE
feat(api): admin-only authorPrincipalId override for import attribution

### DIFF
--- a/apps/web/src/lib/server/domains/comments/__tests__/comment-create-service.test.ts
+++ b/apps/web/src/lib/server/domains/comments/__tests__/comment-create-service.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Regression guard: createComment must derive is_team_member from author.role.
+ * The import handler's override flips this when authorPrincipalId is given.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CommentId, PostId, PrincipalId } from '@quackback/ids'
+
+const insertedComments: Record<string, unknown>[] = []
+
+vi.mock('@/lib/server/db', async () => {
+  const { sql: realSql } = await vi.importActual<typeof import('drizzle-orm')>('drizzle-orm')
+
+  function chain(label: string) {
+    const c: Record<string, unknown> = {}
+    c.values = vi.fn((row: Record<string, unknown>) => {
+      if (label === 'comments') insertedComments.push(row)
+      return c
+    })
+    c.set = vi.fn(() => c)
+    c.where = vi.fn(() => c)
+    c.returning = vi.fn(async () => {
+      if (label === 'comments') {
+        const last = insertedComments.at(-1) ?? {}
+        return [
+          {
+            id: 'comment_new' as unknown as CommentId,
+            postId: 'post_p' as unknown as PostId,
+            content: 'Hi',
+            parentId: null,
+            principalId: last.principalId,
+            isTeamMember: last.isTeamMember,
+            isPrivate: false,
+            createdAt: new Date(),
+            statusChangeFromId: null,
+            statusChangeToId: null,
+            deletedAt: null,
+          },
+        ]
+      }
+      return []
+    })
+    c.catch = vi.fn().mockReturnValue(Promise.resolve())
+    return c
+  }
+
+  const tx = {
+    insert: vi.fn((table: { __name?: string }) => chain(table?.__name ?? 'unknown')),
+    update: vi.fn(() => chain('posts')),
+  }
+
+  return {
+    db: {
+      query: {
+        posts: {
+          findFirst: vi.fn().mockResolvedValue({
+            id: 'post_p',
+            title: 'P',
+            boardId: 'board_b',
+            statusId: 'status_open',
+            isCommentsLocked: false,
+            board: { id: 'board_b', slug: 'b' },
+          }),
+        },
+        comments: { findFirst: vi.fn(), findMany: vi.fn().mockResolvedValue([]) },
+        postStatuses: {
+          findFirst: vi.fn().mockResolvedValue({ id: 'status_open', name: 'Open' }),
+        },
+      },
+      transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn(tx)),
+    },
+    eq: vi.fn(),
+    and: vi.fn(),
+    isNull: vi.fn(),
+    asc: vi.fn(),
+    sql: realSql,
+    comments: { __name: 'comments', id: 'id', postId: 'postId', parentId: 'parentId' },
+    posts: { __name: 'posts', id: 'id', commentCount: 'comment_count' },
+    boards: { id: 'id' },
+    postStatuses: { id: 'id' },
+    postActivity: {},
+    commentReactions: {},
+    commentEditHistory: {},
+  }
+})
+
+vi.mock('@/lib/server/domains/subscriptions/subscription.service', () => ({
+  subscribeToPost: vi.fn(),
+}))
+vi.mock('@/lib/server/events/dispatch', () => ({
+  dispatchCommentCreated: vi.fn(),
+  dispatchCommentUpdated: vi.fn(),
+  dispatchCommentDeleted: vi.fn(),
+  dispatchPostStatusChanged: vi.fn(),
+  buildEventActor: vi.fn(() => ({})),
+}))
+vi.mock('@/lib/server/domains/activity/activity.service', () => ({
+  createActivity: vi.fn(),
+}))
+vi.mock('@/lib/shared', () => ({
+  buildCommentTree: vi.fn(() => []),
+  aggregateReactions: vi.fn(() => []),
+  toStatusChange: vi.fn(),
+}))
+
+describe('createComment isTeamMember derivation', () => {
+  beforeEach(() => {
+    insertedComments.length = 0
+  })
+
+  it('marks comment as team-member when author.role is admin', async () => {
+    const { createComment } = await import('../comment.service')
+    await createComment(
+      { postId: 'post_p' as unknown as PostId, content: 'Hi' },
+      { principalId: 'principal_admin' as unknown as PrincipalId, role: 'admin' },
+      { skipDispatch: true }
+    )
+    expect(insertedComments[0]).toMatchObject({ isTeamMember: true })
+  })
+
+  it('does NOT mark comment as team-member when author.role is user', async () => {
+    const { createComment } = await import('../comment.service')
+    await createComment(
+      { postId: 'post_p' as unknown as PostId, content: 'Hi' },
+      { principalId: 'principal_uv' as unknown as PrincipalId, role: 'user' },
+      { skipDispatch: true }
+    )
+    expect(insertedComments[0]).toMatchObject({ isTeamMember: false })
+  })
+})

--- a/apps/web/src/lib/server/domains/comments/__tests__/comment-create-service.test.ts
+++ b/apps/web/src/lib/server/domains/comments/__tests__/comment-create-service.test.ts
@@ -88,18 +88,7 @@ vi.mock('@/lib/server/domains/subscriptions/subscription.service', () => ({
 }))
 vi.mock('@/lib/server/events/dispatch', () => ({
   dispatchCommentCreated: vi.fn(),
-  dispatchCommentUpdated: vi.fn(),
-  dispatchCommentDeleted: vi.fn(),
-  dispatchPostStatusChanged: vi.fn(),
   buildEventActor: vi.fn(() => ({})),
-}))
-vi.mock('@/lib/server/domains/activity/activity.service', () => ({
-  createActivity: vi.fn(),
-}))
-vi.mock('@/lib/shared', () => ({
-  buildCommentTree: vi.fn(() => []),
-  aggregateReactions: vi.fn(() => []),
-  toStatusChange: vi.fn(),
 }))
 
 describe('createComment isTeamMember derivation', () => {
@@ -112,6 +101,16 @@ describe('createComment isTeamMember derivation', () => {
     await createComment(
       { postId: 'post_p' as unknown as PostId, content: 'Hi' },
       { principalId: 'principal_admin' as unknown as PrincipalId, role: 'admin' },
+      { skipDispatch: true }
+    )
+    expect(insertedComments[0]).toMatchObject({ isTeamMember: true })
+  })
+
+  it('marks comment as team-member when author.role is member', async () => {
+    const { createComment } = await import('../comment.service')
+    await createComment(
+      { postId: 'post_p' as unknown as PostId, content: 'Hi' },
+      { principalId: 'principal_member' as unknown as PrincipalId, role: 'member' },
       { skipDispatch: true }
     )
     expect(insertedComments[0]).toMatchObject({ isTeamMember: true })

--- a/apps/web/src/lib/server/domains/posts/__tests__/post-create-service.test.ts
+++ b/apps/web/src/lib/server/domains/posts/__tests__/post-create-service.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Regression guard: createPost must derive the auto-upvote (and the row's
+ * principal_id) from author.principalId, so the import handler's override
+ * lands on every attributed row.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { BoardId, PrincipalId, StatusId } from '@quackback/ids'
+
+const insertedRows: Record<string, unknown[]> = { posts: [], votes: [], postTags: [] }
+const subscribeToPost = vi.fn()
+
+vi.mock('@/lib/server/db', async () => {
+  const { sql: realSql } = await vi.importActual<typeof import('drizzle-orm')>('drizzle-orm')
+
+  function chain(label: string) {
+    const c: Record<string, unknown> = {}
+    c.values = vi.fn((row: unknown) => {
+      insertedRows[label] = (insertedRows[label] ?? []).concat(row)
+      return c
+    })
+    c.returning = vi.fn(async () => {
+      if (label === 'posts') {
+        return [
+          {
+            id: 'post_new' as unknown,
+            boardId: 'board_b' as unknown,
+            statusId: 'status_open' as unknown,
+            title: 'New post',
+            content: 'Body',
+            principalId: (insertedRows.posts.at(-1) as { principalId: string }).principalId,
+            voteCount: 1,
+            commentCount: 0,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        ]
+      }
+      return []
+    })
+    return c
+  }
+
+  return {
+    db: {
+      query: {
+        boards: {
+          findFirst: vi
+            .fn()
+            .mockResolvedValue({ id: 'board_b', slug: 'feedback', name: 'Feedback' }),
+        },
+        postStatuses: {
+          findFirst: vi.fn().mockResolvedValue({ id: 'status_open', name: 'Open' }),
+        },
+      },
+      transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
+        const tx = {
+          insert: vi.fn((table: { __name?: string }) => {
+            const label =
+              table === undefined
+                ? 'unknown'
+                : (table.__name ?? (table as { [k: string]: unknown }).name ?? 'posts')
+            return chain(typeof label === 'string' ? label : 'posts')
+          }),
+        }
+        return fn(tx)
+      }),
+      select: vi.fn(() => ({ from: vi.fn(() => ({ where: vi.fn().mockResolvedValue([]) })) })),
+    },
+    boards: { id: 'board_id' },
+    posts: { __name: 'posts', id: 'post_id' },
+    postStatuses: { id: 'status_id' },
+    postTags: { __name: 'postTags' },
+    votes: { __name: 'votes' },
+    eq: vi.fn(),
+    sql: realSql,
+  }
+})
+
+vi.mock('@/lib/server/domains/subscriptions/subscription.service', () => ({
+  subscribeToPost: (...args: unknown[]) => subscribeToPost(...args),
+}))
+
+vi.mock('@/lib/server/events/dispatch', () => ({
+  dispatchPostCreated: vi.fn(),
+  buildEventActor: vi.fn(() => ({})),
+}))
+
+vi.mock('@/lib/server/domains/activity/activity.service', () => ({
+  createActivity: vi.fn(),
+}))
+
+vi.mock('@/lib/server/markdown-tiptap', () => ({
+  markdownToTiptapJson: vi.fn(() => ({})),
+}))
+
+vi.mock('@/lib/server/content/rehost-images', () => ({
+  rehostExternalImages: vi.fn(async (json: unknown) => json),
+}))
+
+describe('createPost author attribution', () => {
+  beforeEach(() => {
+    insertedRows.posts.length = 0
+    insertedRows.votes.length = 0
+    insertedRows.postTags.length = 0
+    subscribeToPost.mockClear()
+  })
+
+  it('attributes the post row, the auto-upvote, and the subscription to author.principalId', async () => {
+    const { createPost } = await import('../post.service')
+
+    const overridePrincipal = 'principal_override' as unknown as PrincipalId
+    await createPost(
+      {
+        boardId: 'board_b' as unknown as BoardId,
+        title: 'New post',
+        content: 'Body',
+        statusId: 'status_open' as unknown as StatusId,
+      },
+      { principalId: overridePrincipal }
+    )
+
+    const postRow = insertedRows.posts[0] as { principalId: PrincipalId }
+    const voteRow = insertedRows.votes[0] as { principalId: PrincipalId }
+    expect(postRow.principalId).toBe(overridePrincipal)
+    expect(voteRow.principalId).toBe(overridePrincipal)
+    expect(subscribeToPost).toHaveBeenCalledWith(overridePrincipal, 'post_new', 'author')
+  })
+})

--- a/apps/web/src/lib/server/domains/posts/__tests__/post-create-service.test.ts
+++ b/apps/web/src/lib/server/domains/posts/__tests__/post-create-service.test.ts
@@ -58,7 +58,7 @@ vi.mock('@/lib/server/db', async () => {
             const label =
               table === undefined
                 ? 'unknown'
-                : (table.__name ?? (table as { [k: string]: unknown }).name ?? 'posts')
+                : (table.__name ?? (table as { [k: string]: unknown }).name ?? 'unknown')
             return chain(typeof label === 'string' ? label : 'posts')
           }),
         }

--- a/apps/web/src/routes/api/v1/posts/$postId.comments.ts
+++ b/apps/web/src/routes/api/v1/posts/$postId.comments.ts
@@ -9,6 +9,7 @@ import {
   handleDomainError,
 } from '@/lib/server/domains/api/responses'
 import { parseTypeId, parseOptionalTypeId } from '@/lib/server/domains/api/validation'
+import type { Role } from '@/lib/shared/roles'
 import type { PostId, CommentId, PrincipalId } from '@quackback/ids'
 
 // Input validation schema
@@ -145,7 +146,7 @@ export const Route = createFileRoute('/api/v1/posts/$postId/comments')({
               displayName: principalRecord.displayName ?? undefined,
               name: principalRecord.user?.name,
               email: principalRecord.user?.email ?? undefined,
-              role: principalRecord.role as 'admin' | 'member' | 'user',
+              role: principalRecord.role as Role,
             },
             { skipDispatch: auth.importMode }
           )

--- a/apps/web/src/routes/api/v1/posts/$postId.comments.ts
+++ b/apps/web/src/routes/api/v1/posts/$postId.comments.ts
@@ -1,7 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { z } from 'zod'
 import { withApiKeyAuth } from '@/lib/server/domains/api/auth'
-import { InternalError } from '@/lib/shared/errors'
+import { InternalError, NotFoundError, ValidationError } from '@/lib/shared/errors'
 import {
   successResponse,
   createdResponse,
@@ -9,7 +9,7 @@ import {
   handleDomainError,
 } from '@/lib/server/domains/api/responses'
 import { parseTypeId, parseOptionalTypeId } from '@/lib/server/domains/api/validation'
-import type { PostId, CommentId } from '@quackback/ids'
+import type { PostId, CommentId, PrincipalId } from '@quackback/ids'
 
 // Input validation schema
 const createCommentSchema = z.object({
@@ -17,6 +17,7 @@ const createCommentSchema = z.object({
   parentId: z.string().optional().nullable(),
   isPrivate: z.boolean().optional(),
   createdAt: z.string().datetime().optional(),
+  authorPrincipalId: z.string().optional(),
 })
 
 export const Route = createFileRoute('/api/v1/posts/$postId/comments')({
@@ -66,7 +67,6 @@ export const Route = createFileRoute('/api/v1/posts/$postId/comments')({
       POST: async ({ request, params }) => {
         try {
           const auth = await withApiKeyAuth(request, { role: 'team' })
-          const { principalId } = auth
 
           const postId = parseTypeId<PostId>(params.postId, 'post', 'post ID')
 
@@ -79,19 +79,50 @@ export const Route = createFileRoute('/api/v1/posts/$postId/comments')({
             })
           }
 
-          const parentId = parseOptionalTypeId<CommentId>(parsed.data.parentId, 'comment', 'parent ID')
+          const parentId = parseOptionalTypeId<CommentId>(
+            parsed.data.parentId,
+            'comment',
+            'parent ID'
+          )
+
+          // Admin-only override; mirrors the createdAt gate further down.
+          const overridePrincipalId =
+            auth.role === 'admin'
+              ? parseOptionalTypeId<PrincipalId>(
+                  parsed.data.authorPrincipalId,
+                  'principal',
+                  'authorPrincipalId'
+                )
+              : undefined
+          const targetPrincipalId = overridePrincipalId ?? auth.principalId
 
           const { createComment } = await import('@/lib/server/domains/comments/comment.service')
           const { db, principal, eq } = await import('@/lib/server/db')
 
           const principalRecord = await db.query.principal.findFirst({
-            where: eq(principal.id, principalId),
+            where: eq(principal.id, targetPrincipalId),
             columns: { id: true, displayName: true, role: true, type: true },
             with: { user: { columns: { id: true, name: true, email: true } } },
           })
 
           if (!principalRecord) {
-            throw new InternalError('PRINCIPAL_NOT_FOUND', 'Principal record missing for verified API key')
+            if (overridePrincipalId) {
+              throw new NotFoundError(
+                'PRINCIPAL_NOT_FOUND',
+                `Principal ${targetPrincipalId} not found`
+              )
+            }
+            throw new InternalError(
+              'PRINCIPAL_NOT_FOUND',
+              'Principal record missing for verified API key'
+            )
+          }
+
+          if (overridePrincipalId && principalRecord.type === 'service') {
+            throw new ValidationError(
+              'INVALID_AUTHOR',
+              'authorPrincipalId may not reference a service principal'
+            )
           }
 
           // Only admins can set createdAt (for imports)
@@ -109,7 +140,7 @@ export const Route = createFileRoute('/api/v1/posts/$postId/comments')({
               createdAt,
             },
             {
-              principalId,
+              principalId: targetPrincipalId,
               userId: principalRecord.user?.id,
               displayName: principalRecord.displayName ?? undefined,
               name: principalRecord.user?.name,

--- a/apps/web/src/routes/api/v1/posts/__tests__/$postId.comments.test.ts
+++ b/apps/web/src/routes/api/v1/posts/__tests__/$postId.comments.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PrincipalId, PostId } from '@quackback/ids'
+
+const mockWithApiKeyAuth = vi.fn()
+const mockCreateComment = vi.fn()
+const mockPrincipalFindFirst = vi.fn()
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: vi.fn(() => (opts: unknown) => ({ options: opts })),
+}))
+vi.mock('@/lib/server/domains/api/auth', () => ({
+  withApiKeyAuth: (...args: unknown[]) => mockWithApiKeyAuth(...args),
+}))
+vi.mock('@/lib/server/domains/comments/comment.service', () => ({
+  createComment: (...args: unknown[]) => mockCreateComment(...args),
+}))
+vi.mock('@/lib/server/db', () => ({
+  db: {
+    query: {
+      principal: { findFirst: (...args: unknown[]) => mockPrincipalFindFirst(...args) },
+    },
+  },
+  principal: { id: 'id' },
+  eq: vi.fn(),
+}))
+
+import { Route } from '../$postId.comments'
+
+type RouteOpts = { server: { handlers: { POST: (...args: unknown[]) => Promise<Response> } } }
+const POST = (Route as unknown as { options: RouteOpts }).options.server.handlers.POST
+
+const ADMIN_KEY_PRINCIPAL = 'principal_01kqhxq697fvgat0fn8rr1r7ew' as unknown as PrincipalId
+const OVERRIDE_PRINCIPAL = 'principal_01kqhxq697fvgat0fvps13rmy2' as unknown as PrincipalId
+const SERVICE_PRINCIPAL = 'principal_01kqhxq697fvgat0g3rfzp3971' as unknown as PrincipalId
+const POST_ID = 'post_01kqhxq697fvgat0h1abc12345' as unknown as PostId
+
+const adminAuth = { principalId: ADMIN_KEY_PRINCIPAL, role: 'admin', importMode: false }
+const memberAuth = { principalId: ADMIN_KEY_PRINCIPAL, role: 'member', importMode: false }
+
+const apiKeyHolderRecord = {
+  id: ADMIN_KEY_PRINCIPAL,
+  displayName: 'API Key',
+  role: 'admin',
+  type: 'service',
+  user: { id: null, name: 'API Key', email: null },
+}
+const userPrincipalRecord = {
+  id: OVERRIDE_PRINCIPAL,
+  displayName: null,
+  role: 'user',
+  type: 'user',
+  user: { id: 'user_uv', name: 'UV User', email: 'uv@example.com' },
+}
+const servicePrincipalRecord = {
+  id: SERVICE_PRINCIPAL,
+  displayName: 'Other API Key',
+  role: 'admin',
+  type: 'service',
+  user: null,
+}
+
+const fakeComment = {
+  id: 'comment_01kqhxq697fvgat0h1xyz12345',
+  postId: POST_ID,
+  parentId: null,
+  content: 'Hello',
+  principalId: OVERRIDE_PRINCIPAL,
+  isTeamMember: false,
+  isPrivate: false,
+  createdAt: new Date(),
+}
+
+function makeRequest(body: Record<string, unknown>): Request {
+  return new Request(`http://test/api/v1/posts/${POST_ID}/comments`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/v1/posts/:postId/comments authorPrincipalId override', () => {
+  beforeEach(() => {
+    mockWithApiKeyAuth.mockReset()
+    mockCreateComment.mockReset()
+    mockPrincipalFindFirst.mockReset()
+    mockCreateComment.mockResolvedValue({ comment: fakeComment })
+  })
+
+  it('attributes to the override principal for an admin caller', async () => {
+    mockWithApiKeyAuth.mockResolvedValue(adminAuth)
+    mockPrincipalFindFirst.mockResolvedValue(userPrincipalRecord)
+    const res = await POST({
+      request: makeRequest({ content: 'Hello', authorPrincipalId: OVERRIDE_PRINCIPAL }),
+      params: { postId: POST_ID },
+    })
+    expect(res.status).toBe(201)
+    const author = mockCreateComment.mock.calls[0][1]
+    expect(author.principalId).toBe(OVERRIDE_PRINCIPAL)
+    expect(author.role).toBe('user')
+    expect(author.email).toBe('uv@example.com')
+  })
+
+  it('ignores authorPrincipalId for non-admin callers', async () => {
+    mockWithApiKeyAuth.mockResolvedValue(memberAuth)
+    mockPrincipalFindFirst.mockResolvedValue(apiKeyHolderRecord)
+    await POST({
+      request: makeRequest({ content: 'Hello', authorPrincipalId: OVERRIDE_PRINCIPAL }),
+      params: { postId: POST_ID },
+    })
+    const author = mockCreateComment.mock.calls[0][1]
+    expect(author.principalId).toBe(ADMIN_KEY_PRINCIPAL)
+    expect(author.role).toBe('admin')
+  })
+
+  it('returns 404 when authorPrincipalId does not exist', async () => {
+    mockWithApiKeyAuth.mockResolvedValue(adminAuth)
+    mockPrincipalFindFirst.mockResolvedValue(null)
+    const res = await POST({
+      request: makeRequest({ content: 'Hello', authorPrincipalId: OVERRIDE_PRINCIPAL }),
+      params: { postId: POST_ID },
+    })
+    expect(res.status).toBe(404)
+    const json = await res.json()
+    // handleDomainError normalises PRINCIPAL_NOT_FOUND → NOT_FOUND in the response body
+    expect(json.error.code).toBe('NOT_FOUND')
+    expect(mockCreateComment).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when authorPrincipalId points at a service principal', async () => {
+    mockWithApiKeyAuth.mockResolvedValue(adminAuth)
+    mockPrincipalFindFirst.mockResolvedValue(servicePrincipalRecord)
+    const res = await POST({
+      request: makeRequest({ content: 'Hello', authorPrincipalId: SERVICE_PRINCIPAL }),
+      params: { postId: POST_ID },
+    })
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    // handleDomainError normalises INVALID_AUTHOR (a ValidationError) → VALIDATION_ERROR in the response body
+    expect(json.error.code).toBe('VALIDATION_ERROR')
+    expect(mockCreateComment).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 for a malformed authorPrincipalId', async () => {
+    mockWithApiKeyAuth.mockResolvedValue(adminAuth)
+    const res = await POST({
+      request: makeRequest({ content: 'Hello', authorPrincipalId: 'not-a-typeid' }),
+      params: { postId: POST_ID },
+    })
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.error.code).toBe('VALIDATION_ERROR')
+    expect(mockCreateComment).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/routes/api/v1/posts/__tests__/index.test.ts
+++ b/apps/web/src/routes/api/v1/posts/__tests__/index.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { BoardId, PrincipalId } from '@quackback/ids'
+
+const mockWithApiKeyAuth = vi.fn()
+const mockCreatePost = vi.fn()
+const mockPrincipalFindFirst = vi.fn()
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: vi.fn(() => (opts: unknown) => ({ options: opts })),
+}))
+vi.mock('@/lib/server/domains/api/auth', () => ({
+  withApiKeyAuth: (...args: unknown[]) => mockWithApiKeyAuth(...args),
+}))
+vi.mock('@/lib/server/domains/posts/post.service', () => ({
+  createPost: (...args: unknown[]) => mockCreatePost(...args),
+}))
+vi.mock('@/lib/server/db', () => ({
+  db: {
+    query: {
+      principal: { findFirst: (...args: unknown[]) => mockPrincipalFindFirst(...args) },
+    },
+  },
+  principal: { id: 'id', userId: 'user_id' },
+  eq: vi.fn(),
+}))
+
+import { Route } from '../index'
+
+type RouteOpts = { server: { handlers: { POST: (...args: unknown[]) => Promise<Response> } } }
+const POST = (Route as unknown as { options: RouteOpts }).options.server.handlers.POST
+
+const ADMIN_KEY_PRINCIPAL = 'principal_01kqhxq697fvgat0fn8rr1r7ew' as unknown as PrincipalId
+const OVERRIDE_PRINCIPAL = 'principal_01kqhxq697fvgat0fvps13rmy2' as unknown as PrincipalId
+const SERVICE_PRINCIPAL = 'principal_01kqhxq697fvgat0g3rfzp3971' as unknown as PrincipalId
+const BOARD_ID = 'board_01kqhxq697fvgat0geegv834v0' as unknown as BoardId
+
+const adminAuth = { principalId: ADMIN_KEY_PRINCIPAL, role: 'admin', importMode: false }
+const memberAuth = { principalId: ADMIN_KEY_PRINCIPAL, role: 'member', importMode: false }
+
+const apiKeyHolderRecord = {
+  id: ADMIN_KEY_PRINCIPAL,
+  displayName: 'API Key',
+  role: 'admin',
+  type: 'service',
+  user: { id: null, name: 'API Key', email: null },
+}
+const userPrincipalRecord = {
+  id: OVERRIDE_PRINCIPAL,
+  displayName: null,
+  role: 'user',
+  type: 'user',
+  user: { id: 'user_uv', name: 'UV User', email: 'uv@example.com' },
+}
+const servicePrincipalRecord = {
+  id: SERVICE_PRINCIPAL,
+  displayName: 'Other API Key',
+  role: 'admin',
+  type: 'service',
+  user: null,
+}
+
+function makeRequest(body: Record<string, unknown>): Request {
+  return new Request('http://test/api/v1/posts', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/v1/posts authorPrincipalId override', () => {
+  beforeEach(() => {
+    mockWithApiKeyAuth.mockReset()
+    mockCreatePost.mockReset()
+    mockPrincipalFindFirst.mockReset()
+    mockCreatePost.mockResolvedValue({
+      id: 'post_new',
+      title: 'T',
+      content: 'C',
+      voteCount: 1,
+      boardId: BOARD_ID,
+      statusId: 'status_open',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+  })
+
+  it('attributes to the override principal for an admin caller', async () => {
+    mockWithApiKeyAuth.mockResolvedValue(adminAuth)
+    mockPrincipalFindFirst.mockResolvedValue(userPrincipalRecord)
+    const res = await POST({
+      request: makeRequest({
+        boardId: BOARD_ID,
+        title: 'T',
+        content: 'C',
+        authorPrincipalId: OVERRIDE_PRINCIPAL,
+      }),
+    })
+    expect(res.status).toBe(201)
+    const author = mockCreatePost.mock.calls[0][1]
+    expect(author.principalId).toBe(OVERRIDE_PRINCIPAL)
+    expect(author.email).toBe('uv@example.com')
+  })
+
+  it('ignores authorPrincipalId for non-admin callers', async () => {
+    mockWithApiKeyAuth.mockResolvedValue(memberAuth)
+    mockPrincipalFindFirst.mockResolvedValue(apiKeyHolderRecord)
+    await POST({
+      request: makeRequest({
+        boardId: BOARD_ID,
+        title: 'T',
+        content: 'C',
+        authorPrincipalId: OVERRIDE_PRINCIPAL,
+      }),
+    })
+    const author = mockCreatePost.mock.calls[0][1]
+    expect(author.principalId).toBe(ADMIN_KEY_PRINCIPAL)
+  })
+
+  it('returns 404 when authorPrincipalId does not exist', async () => {
+    mockWithApiKeyAuth.mockResolvedValue(adminAuth)
+    mockPrincipalFindFirst.mockResolvedValue(null)
+    const res = await POST({
+      request: makeRequest({
+        boardId: BOARD_ID,
+        title: 'T',
+        content: 'C',
+        authorPrincipalId: OVERRIDE_PRINCIPAL,
+      }),
+    })
+    expect(res.status).toBe(404)
+    const json = await res.json()
+    // handleDomainError normalises PRINCIPAL_NOT_FOUND → NOT_FOUND in the response body
+    expect(json.error.code).toBe('NOT_FOUND')
+    expect(mockCreatePost).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when authorPrincipalId points at a service principal', async () => {
+    mockWithApiKeyAuth.mockResolvedValue(adminAuth)
+    mockPrincipalFindFirst.mockResolvedValue(servicePrincipalRecord)
+    const res = await POST({
+      request: makeRequest({
+        boardId: BOARD_ID,
+        title: 'T',
+        content: 'C',
+        authorPrincipalId: SERVICE_PRINCIPAL,
+      }),
+    })
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    // handleDomainError normalises INVALID_AUTHOR (a ValidationError) → VALIDATION_ERROR in the response body
+    expect(json.error.code).toBe('VALIDATION_ERROR')
+    expect(mockCreatePost).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 for a malformed authorPrincipalId', async () => {
+    mockWithApiKeyAuth.mockResolvedValue(adminAuth)
+    const res = await POST({
+      request: makeRequest({
+        boardId: BOARD_ID,
+        title: 'T',
+        content: 'C',
+        authorPrincipalId: 'not-a-typeid',
+      }),
+    })
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.error.code).toBe('VALIDATION_ERROR')
+    expect(mockCreatePost).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/routes/api/v1/posts/index.ts
+++ b/apps/web/src/routes/api/v1/posts/index.ts
@@ -1,7 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { z } from 'zod'
 import { withApiKeyAuth } from '@/lib/server/domains/api/auth'
-import { InternalError } from '@/lib/shared/errors'
+import { InternalError, NotFoundError, ValidationError } from '@/lib/shared/errors'
 import {
   successResponse,
   createdResponse,
@@ -13,7 +13,7 @@ import {
   parseOptionalTypeId,
   parseTypeIdArray,
 } from '@/lib/server/domains/api/validation'
-import type { BoardId, StatusId, TagId } from '@quackback/ids'
+import type { BoardId, PrincipalId, StatusId, TagId } from '@quackback/ids'
 
 // Input validation schemas
 const createPostSchema = z.object({
@@ -23,6 +23,7 @@ const createPostSchema = z.object({
   statusId: z.string().optional(),
   tagIds: z.array(z.string()).optional(),
   createdAt: z.string().datetime().optional(),
+  authorPrincipalId: z.string().optional(),
 })
 
 export const Route = createFileRoute('/api/v1/posts/')({
@@ -126,7 +127,6 @@ export const Route = createFileRoute('/api/v1/posts/')({
       POST: async ({ request }) => {
         try {
           const auth = await withApiKeyAuth(request, { role: 'team' })
-          const { principalId } = auth
 
           const body = await request.json()
           const parsed = createPostSchema.safeParse(body)
@@ -138,20 +138,51 @@ export const Route = createFileRoute('/api/v1/posts/')({
           }
 
           const boardId = parseTypeId<BoardId>(parsed.data.boardId, 'board', 'board ID')
-          const statusId = parseOptionalTypeId<StatusId>(parsed.data.statusId, 'status', 'status ID')
+          const statusId = parseOptionalTypeId<StatusId>(
+            parsed.data.statusId,
+            'status',
+            'status ID'
+          )
           const tagIds = parseTypeIdArray<TagId>(parsed.data.tagIds, 'tag', 'tag IDs')
+
+          // Admin-only override; mirrors how createdAt is gated below.
+          const overridePrincipalId =
+            auth.role === 'admin'
+              ? parseOptionalTypeId<PrincipalId>(
+                  parsed.data.authorPrincipalId,
+                  'principal',
+                  'authorPrincipalId'
+                )
+              : undefined
+          const targetPrincipalId = overridePrincipalId ?? auth.principalId
 
           const { createPost } = await import('@/lib/server/domains/posts/post.service')
           const { db, principal, eq } = await import('@/lib/server/db')
 
           const principalRecord = await db.query.principal.findFirst({
-            where: eq(principal.id, principalId),
+            where: eq(principal.id, targetPrincipalId),
             columns: { id: true, displayName: true, type: true },
             with: { user: { columns: { id: true, name: true, email: true } } },
           })
 
           if (!principalRecord) {
-            throw new InternalError('PRINCIPAL_NOT_FOUND', 'Principal record missing for verified API key')
+            if (overridePrincipalId) {
+              throw new NotFoundError(
+                'PRINCIPAL_NOT_FOUND',
+                `Principal ${targetPrincipalId} not found`
+              )
+            }
+            throw new InternalError(
+              'PRINCIPAL_NOT_FOUND',
+              'Principal record missing for verified API key'
+            )
+          }
+
+          if (overridePrincipalId && principalRecord.type === 'service') {
+            throw new ValidationError(
+              'INVALID_AUTHOR',
+              'authorPrincipalId may not reference a service principal'
+            )
           }
 
           // Only admins can set createdAt (for imports)
@@ -170,7 +201,7 @@ export const Route = createFileRoute('/api/v1/posts/')({
               createdAt,
             },
             {
-              principalId,
+              principalId: targetPrincipalId,
               userId: principalRecord.user?.id,
               displayName: principalRecord.displayName ?? undefined,
               name: principalRecord.user?.name,

--- a/scripts/import/core/api-importer.ts
+++ b/scripts/import/core/api-importer.ts
@@ -179,6 +179,19 @@ export async function runApiImport(options: ApiImportOptions): Promise<ImportRes
     progress.success(`Loaded ${existing.length} existing posts (${existingPostByKey.size} keyed)`)
   }
 
+  // Used to gate authorPrincipalId on note imports: createComment rejects
+  // private comments from non-team principals (PRIVATE_COMMENT_FORBIDDEN), so
+  // we only attribute notes when the author email is a known team member.
+  const teamMemberEmails = new Set<string>()
+  try {
+    const members = await qb.listAll<{ id: string; email: string | null }>('/api/v1/members')
+    for (const m of members) {
+      if (m.email) teamMemberEmails.add(m.email.toLowerCase())
+    }
+  } catch (err) {
+    if (options.verbose) progress.warn(`Failed to fetch team members: ${err}`)
+  }
+
   // Step 1: Identify users
   if (data.users.length > 0) {
     progress.start(`Identifying ${data.users.length} users`)
@@ -476,17 +489,22 @@ export async function runApiImport(options: ApiImportOptions): Promise<ImportRes
           }
         }
 
-        const authorPrincipalId = await resolveAuthorPrincipal(note.authorEmail)
+        // Only attribute the note to the UV author when their email is a
+        // known team member. Otherwise omit authorPrincipalId so the server
+        // falls back to the API-key holder (admin) — createComment rejects
+        // private comments from non-team principals with PRIVATE_COMMENT_FORBIDDEN.
+        const noteAuthorEmail = note.authorEmail?.toLowerCase()
+        const authorPrincipalId =
+          noteAuthorEmail && teamMemberEmails.has(noteAuthorEmail)
+            ? await resolveAuthorPrincipal(note.authorEmail)
+            : undefined
 
-        const resp = await qb.post<{ data: { id: string } }>(
-          `/api/v1/posts/${postId}/comments`,
-          {
-            content: note.body,
-            isPrivate: true,
-            ...(note.createdAt && { createdAt: new Date(note.createdAt).toISOString() }),
-            ...(authorPrincipalId && { authorPrincipalId }),
-          }
-        )
+        const resp = await qb.post<{ data: { id: string } }>(`/api/v1/posts/${postId}/comments`, {
+          content: note.body,
+          isPrivate: true,
+          ...(note.createdAt && { createdAt: new Date(note.createdAt).toISOString() }),
+          ...(authorPrincipalId && { authorPrincipalId }),
+        })
 
         if (options.incremental && preExistingPostIds.has(postId)) {
           const dedupKey = commentDedupKey(note.body, note.createdAt)

--- a/scripts/import/core/api-importer.ts
+++ b/scripts/import/core/api-importer.ts
@@ -422,23 +422,10 @@ export async function runApiImport(options: ApiImportOptions): Promise<ImportRes
           continue
         }
 
-        // Identify voter on the fly if not already in the map
-        let principalId = idMap.users.get(vote.voterEmail.toLowerCase())
+        const principalId = await resolveAuthorPrincipal(vote.voterEmail)
         if (!principalId) {
-          try {
-            const resp = await qb.post<{ data: { principalId: string } }>(
-              '/api/v1/users/identify',
-              {
-                email: vote.voterEmail,
-                name: vote.voterEmail.split('@')[0],
-              }
-            )
-            principalId = resp.data.principalId
-            idMap.users.set(vote.voterEmail.toLowerCase(), principalId)
-          } catch {
-            result.votes.skipped++
-            continue
-          }
+          result.votes.skipped++
+          continue
         }
 
         await qb.post(`/api/v1/posts/${postId}/vote/proxy`, {

--- a/scripts/import/core/api-importer.ts
+++ b/scripts/import/core/api-importer.ts
@@ -145,6 +145,24 @@ export async function runApiImport(options: ApiImportOptions): Promise<ImportRes
     return byKey
   }
 
+  async function resolveAuthorPrincipal(email: string | undefined): Promise<string | undefined> {
+    if (!email) return undefined
+    const key = email.toLowerCase()
+    const cached = idMap.users.get(key)
+    if (cached) return cached
+    try {
+      const resp = await qb.post<{ data: { principalId: string } }>('/api/v1/users/identify', {
+        email,
+        name: email.split('@')[0],
+      })
+      idMap.users.set(key, resp.data.principalId)
+      return resp.data.principalId
+    } catch (err) {
+      if (options.verbose) progress.warn(`identify failed for ${email}: ${err}`)
+      return undefined
+    }
+  }
+
   if (options.incremental) {
     progress.start('Pre-fetching existing posts for dedup')
     // showDeleted=true so soft-deleted posts are still in the dedup index;
@@ -258,6 +276,8 @@ export async function runApiImport(options: ApiImportOptions): Promise<ImportRes
           }
         }
 
+        const authorPrincipalId = await resolveAuthorPrincipal(post.authorEmail)
+
         const resp = await qb.post<{ data: { id: string } }>('/api/v1/posts', {
           boardId,
           title: post.title,
@@ -265,6 +285,7 @@ export async function runApiImport(options: ApiImportOptions): Promise<ImportRes
           ...(statusId && { statusId }),
           ...(tagIds.length > 0 && { tagIds }),
           ...(post.createdAt && { createdAt: new Date(post.createdAt).toISOString() }),
+          ...(authorPrincipalId && { authorPrincipalId }),
         })
 
         idMap.posts.set(post.id, resp.data.id)
@@ -348,11 +369,14 @@ export async function runApiImport(options: ApiImportOptions): Promise<ImportRes
           }
         }
 
+        const authorPrincipalId = await resolveAuthorPrincipal(comment.authorEmail)
+
         const resp = await qb.post<{ data: { id: string } }>(`/api/v1/posts/${postId}/comments`, {
           content: comment.body,
           ...(parentId && { parentId }),
           ...(comment.isPrivate && { isPrivate: true }),
           ...(comment.createdAt && { createdAt: new Date(comment.createdAt).toISOString() }),
+          ...(authorPrincipalId && { authorPrincipalId }),
         })
 
         // Track comment ID for threading
@@ -465,11 +489,17 @@ export async function runApiImport(options: ApiImportOptions): Promise<ImportRes
           }
         }
 
-        const resp = await qb.post<{ data: { id: string } }>(`/api/v1/posts/${postId}/comments`, {
-          content: note.body,
-          isPrivate: true,
-          ...(note.createdAt && { createdAt: new Date(note.createdAt).toISOString() }),
-        })
+        const authorPrincipalId = await resolveAuthorPrincipal(note.authorEmail)
+
+        const resp = await qb.post<{ data: { id: string } }>(
+          `/api/v1/posts/${postId}/comments`,
+          {
+            content: note.body,
+            isPrivate: true,
+            ...(note.createdAt && { createdAt: new Date(note.createdAt).toISOString() }),
+            ...(authorPrincipalId && { authorPrincipalId }),
+          }
+        )
 
         if (options.incremental && preExistingPostIds.has(postId)) {
           const dedupKey = commentDedupKey(note.body, note.createdAt)


### PR DESCRIPTION
> Stacked on top of #156 (incremental import). Merge that first; this PR's diff is just the changes on top.

## Why

Today `POST /api/v1/posts` and `POST /api/v1/posts/{id}/comments` always attribute new rows to the API-key holder. There is no override. So bulk imports make every post and comment look authored by the admin running the import (and produce a redundant auto-creator vote on every imported post).

We hit this on 2026-05-01 — a UV → StoreFeeder top-up attributed 10 posts, 15 comments, and 10 spurious votes to the admin service principal. Hand-fixed via direct SQL after the fact. This PR lands the structural fix so the next sync (and every fresh import) attributes correctly at insert time.

## What

1. Both REST endpoints accept an admin-only `authorPrincipalId` body field. When set by an admin caller, the route handler resolves THAT principal's record and uses it as the `author` argument to `createPost` / `createComment`. Service code is unchanged — flipping the `author.principalId` flips the post row, the auto-upvote, and the auto-subscription in one shot.
2. Non-admin callers: the field is silently ignored (mirrors how `createdAt` is gated). Validation: 404 if the override principal doesn't exist, 400 if it's a `type='service'` principal, 400 if malformed.
3. The UV importer eagerly upserts every author email through `/users/identify` (cached in `idMap.users`) and threads the resulting principal id onto every post / comment / note POST as `authorPrincipalId`.
4. Two service-layer regression-guard tests pin the contracts the importer now relies on: `createPost`'s author-attribution and `createComment`'s `is_team_member` derivation.

## Files

- `apps/web/src/routes/api/v1/posts/index.ts` + handler test (5 cases)
- `apps/web/src/routes/api/v1/posts/$postId.comments.ts` + handler test (5 cases)
- `apps/web/src/lib/server/domains/posts/__tests__/post-create-service.test.ts` (NEW guard)
- `apps/web/src/lib/server/domains/comments/__tests__/comment-create-service.test.ts` (NEW guard, 3 cases)
- `scripts/import/core/api-importer.ts` (`resolveAuthorPrincipal` helper + 4 call sites; vote loop also dedup'd onto the helper)

## Out of scope

- OpenAPI is intentionally NOT updated. `authorPrincipalId` is admin-only, matching the existing convention for `createdAt` (also absent from the public schema). If we ever surface either as public, surface both with an "Admin-only" annotation.
- Other create endpoints (changelog entries, KB articles) are not changed; the importer doesn't use them.

## Test plan

- [x] 14/14 new tests pass (5 + 5 handler tests, 1 + 3 service guards).
- [x] `apps/web` and `scripts/import` typecheck clean.
- [x] Vote-loop refactor: imported 1184 votes in the prior real run with zero errors; same code path now reuses `resolveAuthorPrincipal`.
- [x] CI green.
- [x] Real sync after merge: verify the next UV top-up attributes correctly without manual fixup.