### PR TITLE
test(hooks): run use-debounced-value under happy-dom

### DIFF
--- a/apps/web/src/lib/client/hooks/__tests__/use-debounced-value.test.ts
+++ b/apps/web/src/lib/client/hooks/__tests__/use-debounced-value.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /**
  * `useDebouncedValue` — regression test for the bug that landed in the
  * audit-log filter UI: when this hook was implemented with `useMemo`


### PR DESCRIPTION
## Summary

Fixes the red `main` CI run. `use-debounced-value.test.ts` uses `renderHook`, which needs a DOM, but the root vitest config defaults to `environment: 'node'`. Adds the per-file `// @vitest-environment happy-dom` annotation (same pattern as `use-public-filters.test.ts`).

## Test plan

- [x] `use-debounced-value.test.ts` passes 4/4 locally
- [x] No other suite affected (`bun run typecheck` clean)