### PR TITLE
feat(comments): render markdown in comment bodies

### DIFF
--- a/apps/web/e2e/tests/public/comments.spec.ts
+++ b/apps/web/e2e/tests/public/comments.spec.ts
@@ -188,9 +188,7 @@ test.describe('Unauthenticated user — comments section', () => {
   })
 
   // -------------------------------------------------------------------------
-  test('comments are sorted most-recent-first (newest comment appears first)', async ({
-    page,
-  }) => {
+  test('comments are sorted most-recent-first (newest comment appears first)', async ({ page }) => {
     const commentItems = page.locator('[id^="comment-"]')
     const count = await commentItems.count()
     if (count < 2) return // need at least two comments to test ordering
@@ -218,7 +216,8 @@ test.describe('Unauthenticated user — comments section', () => {
     // Navigate through posts until we find one with exactly 1 comment,
     // or accept that the seed data may not have exactly 1.  We verify the
     // grammar rule by checking whatever post we land on.
-    const headingText = (await page.getByRole('heading', { name: /\d+ comments?/i }).textContent()) ?? ''
+    const headingText =
+      (await page.getByRole('heading', { name: /\d+ comments?/i }).textContent()) ?? ''
     const match = headingText.match(/^(\d+)\s+(.+)$/)
     if (!match) return
 
@@ -319,7 +318,7 @@ test.describe('Authenticated user — comment form and submission', () => {
   })
 
   // -------------------------------------------------------------------------
-  test('after submit: new comment shows current user\'s name', async () => {
+  test("after submit: new comment shows current user's name", async () => {
     const page = await sharedContext.newPage()
     try {
       await goToFirstPost(page)
@@ -328,7 +327,10 @@ test.describe('Authenticated user — comment form and submission', () => {
       const textarea = page.locator('textarea[placeholder*="Write a comment" i]').first()
       await textarea.fill(uniqueText)
 
-      await page.getByRole('button', { name: /^comment$/i }).first().click()
+      await page
+        .getByRole('button', { name: /^comment$/i })
+        .first()
+        .click()
       await expect(textarea).toHaveValue('', { timeout: 10000 })
 
       // Find the newly rendered comment
@@ -356,7 +358,10 @@ test.describe('Authenticated user — comment form and submission', () => {
       const textarea = page.locator('textarea[placeholder*="Write a comment" i]').first()
       await textarea.fill(`Count increment test ${Date.now()}`)
 
-      await page.getByRole('button', { name: /^comment$/i }).first().click()
+      await page
+        .getByRole('button', { name: /^comment$/i })
+        .first()
+        .click()
       await expect(textarea).toHaveValue('', { timeout: 10000 })
 
       // Heading count must be beforeCount + 1
@@ -485,7 +490,10 @@ test.describe('Edge cases — comment content', () => {
       const textarea = page.locator('textarea[placeholder*="Write a comment" i]').first()
       await textarea.fill(longText)
 
-      await page.getByRole('button', { name: /^comment$/i }).first().click()
+      await page
+        .getByRole('button', { name: /^comment$/i })
+        .first()
+        .click()
       await expect(textarea).toHaveValue('', { timeout: 10000 })
 
       // The full text (or at least its start) should appear in the list
@@ -505,7 +513,10 @@ test.describe('Edge cases — comment content', () => {
       const textarea = page.locator('textarea[placeholder*="Write a comment" i]').first()
       await textarea.fill(specialText)
 
-      await page.getByRole('button', { name: /^comment$/i }).first().click()
+      await page
+        .getByRole('button', { name: /^comment$/i })
+        .first()
+        .click()
       await expect(textarea).toHaveValue('', { timeout: 10000 })
 
       // The emoji and text must render in the DOM (not escaped HTML entities visible as raw text)
@@ -528,7 +539,10 @@ test.describe('Edge cases — comment content', () => {
       const textarea = page.locator('textarea[placeholder*="Write a comment" i]').first()
       await textarea.fill(multiLineText)
 
-      await page.getByRole('button', { name: /^comment$/i }).first().click()
+      await page
+        .getByRole('button', { name: /^comment$/i })
+        .first()
+        .click()
       await expect(textarea).toHaveValue('', { timeout: 10000 })
 
       // Both line fragments must appear in the rendered comment
@@ -632,7 +646,10 @@ test.describe('Comment editing', () => {
     const uniqueText = `Edit test ${Date.now()}`
     const textarea = page.locator('textarea[placeholder*="Write a comment" i]').first()
     await textarea.fill(uniqueText)
-    await page.getByRole('button', { name: /^comment$/i }).first().click()
+    await page
+      .getByRole('button', { name: /^comment$/i })
+      .first()
+      .click()
     await expect(textarea).toHaveValue('', { timeout: 10000 })
     await expect(page.getByText(uniqueText)).toBeVisible({ timeout: 10000 })
     // Wait for this specific comment to receive a real server ID (not optimistic placeholder)
@@ -694,7 +711,10 @@ test.describe('Comment editing', () => {
 
       await comment.getByRole('button', { name: /^edit$/i }).click()
       await comment.getByTestId('edit-comment-textarea').fill('should not be saved')
-      await comment.getByRole('button', { name: /^cancel$/i }).first().click()
+      await comment
+        .getByRole('button', { name: /^cancel$/i })
+        .first()
+        .click()
 
       await expect(comment.getByTestId('edit-comment-textarea')).not.toBeVisible({ timeout: 5000 })
       await expect(comment.getByText(uniqueText)).toBeVisible()
@@ -779,6 +799,66 @@ test.describe('Comment editing', () => {
       await expect(comment.getByRole('button', { name: /^save$/i })).toBeDisabled({
         timeout: 5000,
       })
+    } finally {
+      await page.close()
+    }
+  })
+})
+
+// ===========================================================================
+// MARKDOWN RENDERING (authenticated)
+// ===========================================================================
+test.describe('Markdown comment rendering', () => {
+  test.setTimeout(90000)
+
+  let sharedContext: BrowserContext
+
+  test.beforeAll(async ({ browser }) => {
+    sharedContext = await browser.newContext()
+    const page = await sharedContext.newPage()
+    await authenticateViaOTP(page)
+    await page.close()
+  })
+
+  test.afterAll(async () => {
+    if (sharedContext) await sharedContext.close()
+  })
+
+  // -------------------------------------------------------------------------
+  test('markdown comment body renders as formatted DOM (heading, bold, link)', async () => {
+    const page = await sharedContext.newPage()
+    try {
+      await goToFirstPost(page)
+
+      // Unique marker keeps this test isolated from other comments in the list
+      const marker = `md-${Date.now()}`
+      const markdownBody = `## My heading ${marker}\n\nThis is **bold ${marker}** and a [link ${marker}](https://example.com).`
+
+      const textarea = page.locator('textarea[placeholder*="Write a comment" i]').first()
+      await textarea.fill(markdownBody)
+
+      // Submit via Ctrl+Enter (matches the existing keyboard-submit tests)
+      await textarea.press('Control+Enter')
+      await expect(textarea).toHaveValue('', { timeout: 10000 })
+
+      // Scope assertions to the new comment node so we don't collide with
+      // any markdown rendered by other comments / page chrome.
+      const newComment = page
+        .locator('[id^="comment-"]')
+        .filter({ hasText: `My heading ${marker}` })
+        .first()
+      await expect(newComment).toBeVisible({ timeout: 10000 })
+
+      // Heading rendered as <h2>
+      await expect(newComment.locator('h2', { hasText: `My heading ${marker}` })).toBeVisible()
+
+      // Bold marker rendered as <strong>
+      await expect(newComment.locator('strong', { hasText: `bold ${marker}` })).toBeVisible()
+
+      // Link rendered as <a href="https://example.com">
+      const link = newComment.locator('a', { hasText: `link ${marker}` })
+      await expect(link).toBeVisible()
+      await expect(link).toHaveAttribute('href', 'https://example.com')
     } finally {
       await page.close()
     }

--- a/apps/web/e2e/tests/public/comments.spec.ts
+++ b/apps/web/e2e/tests/public/comments.spec.ts
@@ -855,10 +855,11 @@ test.describe('Markdown comment rendering', () => {
       // Bold marker rendered as <strong>
       await expect(newComment.locator('strong', { hasText: `bold ${marker}` })).toBeVisible()
 
-      // Link rendered as <a href="https://example.com">
+      // Link rendered as <a href="https://example.com/"> — sanitizeUrl normalizes
+      // hrefs through URL.href, which appends a trailing slash on bare hostnames.
       const link = newComment.locator('a', { hasText: `link ${marker}` })
       await expect(link).toBeVisible()
-      await expect(link).toHaveAttribute('href', 'https://example.com')
+      await expect(link).toHaveAttribute('href', 'https://example.com/')
     } finally {
       await page.close()
     }

--- a/apps/web/src/components/public/__tests__/comment-content.test.tsx
+++ b/apps/web/src/components/public/__tests__/comment-content.test.tsx
@@ -31,10 +31,21 @@ describe('hasMarkdownTokens', () => {
     expect(hasMarkdownTokens('use `npm i` first')).toBe(true)
   })
 
-  it('detects bold and italic markers', () => {
+  it('detects bold and strikethrough markers', () => {
     expect(hasMarkdownTokens('this is **bold**')).toBe(true)
     expect(hasMarkdownTokens('this is __bold__')).toBe(true)
     expect(hasMarkdownTokens('this is ~~strike~~')).toBe(true)
+  })
+
+  it('detects single-delimiter italic', () => {
+    expect(hasMarkdownTokens('this is *italic*')).toBe(true)
+    expect(hasMarkdownTokens('this is _italic_')).toBe(true)
+  })
+
+  it('does not flag bare asterisks or underscores inside words', () => {
+    expect(hasMarkdownTokens('a*b*c')).toBe(false)
+    expect(hasMarkdownTokens('snake_case_variable')).toBe(false)
+    expect(hasMarkdownTokens('3 * 4 = 12')).toBe(false)
   })
 
   it('detects link syntax', () => {
@@ -62,6 +73,11 @@ describe('<CommentContent>', () => {
   it('renders bold via markdown syntax', () => {
     const { container } = render(<CommentContent content="this is **bold** here" />)
     expect(container.querySelector('strong')).not.toBeNull()
+  })
+
+  it('renders italic via single-asterisk markdown syntax', () => {
+    const { container } = render(<CommentContent content="this is *italic* here" />)
+    expect(container.querySelector('em')).not.toBeNull()
   })
 
   it('does not render an <img> for image markdown', () => {

--- a/apps/web/src/components/public/__tests__/comment-content.test.tsx
+++ b/apps/web/src/components/public/__tests__/comment-content.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+import { render } from '@testing-library/react'
+import { CommentContent, hasMarkdownTokens } from '../comment-content'
+
+describe('hasMarkdownTokens', () => {
+  it('returns false for empty string', () => {
+    expect(hasMarkdownTokens('')).toBe(false)
+  })
+
+  it('returns false for plain prose', () => {
+    expect(hasMarkdownTokens('Just a normal sentence without formatting.')).toBe(false)
+  })
+
+  it('detects headings', () => {
+    expect(hasMarkdownTokens('## Heading')).toBe(true)
+    expect(hasMarkdownTokens('# Top\n\nbody')).toBe(true)
+  })
+
+  it('detects bullet and ordered lists at line start', () => {
+    expect(hasMarkdownTokens('- item')).toBe(true)
+    expect(hasMarkdownTokens('* item')).toBe(true)
+    expect(hasMarkdownTokens('1. item')).toBe(true)
+  })
+
+  it('detects fenced code', () => {
+    expect(hasMarkdownTokens('```ts\nconst x = 1\n```')).toBe(true)
+  })
+
+  it('detects inline code', () => {
+    expect(hasMarkdownTokens('use `npm i` first')).toBe(true)
+  })
+
+  it('detects bold and italic markers', () => {
+    expect(hasMarkdownTokens('this is **bold**')).toBe(true)
+    expect(hasMarkdownTokens('this is __bold__')).toBe(true)
+    expect(hasMarkdownTokens('this is ~~strike~~')).toBe(true)
+  })
+
+  it('detects link syntax', () => {
+    expect(hasMarkdownTokens('see [docs](https://x.com)')).toBe(true)
+  })
+
+  it('detects blockquotes', () => {
+    expect(hasMarkdownTokens('> quoted')).toBe(true)
+  })
+})
+
+describe('<CommentContent>', () => {
+  it('renders plain text in the fast-path wrapper', () => {
+    const { container } = render(<CommentContent content="plain comment" />)
+    const p = container.querySelector('p.whitespace-pre-wrap')
+    expect(p?.textContent).toBe('plain comment')
+    expect(container.querySelector('h1, h2, h3, ul, strong')).toBeNull()
+  })
+
+  it('renders markdown headings', () => {
+    const { container } = render(<CommentContent content={'## Heading\n\nbody'} />)
+    expect(container.querySelector('h2')).not.toBeNull()
+  })
+
+  it('renders bold via markdown syntax', () => {
+    const { container } = render(<CommentContent content="this is **bold** here" />)
+    expect(container.querySelector('strong')).not.toBeNull()
+  })
+
+  it('does not render an <img> for image markdown', () => {
+    const { container } = render(<CommentContent content="![alt](https://x.com/y.png)" />)
+    expect(container.querySelector('img')).toBeNull()
+  })
+
+  it('does not render a <table> for table markdown', () => {
+    const { container } = render(<CommentContent content={'| a | b |\n|---|---|\n| 1 | 2 |'} />)
+    expect(container.querySelector('table')).toBeNull()
+  })
+
+  it('does not render a <script> for embedded HTML', () => {
+    const { container } = render(<CommentContent content={'<script>alert(1)</script>\n\nHello'} />)
+    expect(container.querySelector('script')).toBeNull()
+  })
+
+  it('applies a className override', () => {
+    const { container } = render(<CommentContent content="plain" className="my-extra" />)
+    expect(container.querySelector('.my-extra')).not.toBeNull()
+  })
+})

--- a/apps/web/src/components/public/comment-content.tsx
+++ b/apps/web/src/components/public/comment-content.tsx
@@ -34,8 +34,10 @@ export function hasMarkdownTokens(text: string): boolean {
 export function CommentContent({ content, className }: CommentContentProps) {
   const isMarkdown = hasMarkdownTokens(content)
   const json = useMemo(
+    // isMarkdown is derived synchronously from content
+
     () => (isMarkdown ? commentMarkdownToTiptapJson(content) : null),
-    [content, isMarkdown]
+    [content]
   )
   if (!isMarkdown || !json) {
     return <p className={cn('whitespace-pre-wrap', className)}>{content}</p>

--- a/apps/web/src/components/public/comment-content.tsx
+++ b/apps/web/src/components/public/comment-content.tsx
@@ -1,5 +1,7 @@
+import { useMemo } from 'react'
 import { commentMarkdownToTiptapJson } from '@/lib/server/markdown-tiptap'
 import { RichTextContent } from '@/components/ui/rich-text-editor'
+import { cn } from '@/lib/shared/utils'
 
 interface CommentContentProps {
   content: string
@@ -8,23 +10,35 @@ interface CommentContentProps {
 
 // False positives just take the slow path; false negatives would render
 // markdown as plaintext, so this regex biases generous.
+const BLOCK_RX = /(^|\n)(#{1,3} |[-*+] |\d+\. |> |```)/
+const BOLD_RX = /\*\*|__/
+const STRIKE_RX = /~~/
+const INLINE_CODE_RX = /`[^`\n]/
+const ITALIC_STAR_RX = /(?<![\w*])\*[^*\s][^*\n]*\*(?!\w)/
+const ITALIC_UNDERSCORE_RX = /(?<![\w_])_[^_\s][^_\n]*_(?!\w)/
+const LINK_RX = /\[[^\]\n]+\]\([^)\n]+\)/
+
 export function hasMarkdownTokens(text: string): boolean {
   if (!text) return false
-  const blockRx = /(^|\n)(#{1,3} |[-*+] |\d+\. |> |```)/
-  const inlineRx =
-    /\*\*|__|~~|`[^`\n]|(?<![\w*])\*[^*\s][^*\n]*\*(?!\w)|(?<![\w_])_[^_\s][^_\n]*_(?!\w)/
-  const linkRx = /\[[^\]\n]+\]\([^)\n]+\)/
-  return blockRx.test(text) || inlineRx.test(text) || linkRx.test(text)
+  return (
+    BLOCK_RX.test(text) ||
+    BOLD_RX.test(text) ||
+    STRIKE_RX.test(text) ||
+    INLINE_CODE_RX.test(text) ||
+    ITALIC_STAR_RX.test(text) ||
+    ITALIC_UNDERSCORE_RX.test(text) ||
+    LINK_RX.test(text)
+  )
 }
 
 export function CommentContent({ content, className }: CommentContentProps) {
-  if (!hasMarkdownTokens(content)) {
-    return (
-      <div className={className}>
-        <p className="whitespace-pre-wrap">{content}</p>
-      </div>
-    )
+  const isMarkdown = hasMarkdownTokens(content)
+  const json = useMemo(
+    () => (isMarkdown ? commentMarkdownToTiptapJson(content) : null),
+    [content, isMarkdown]
+  )
+  if (!isMarkdown || !json) {
+    return <p className={cn('whitespace-pre-wrap', className)}>{content}</p>
   }
-  const json = commentMarkdownToTiptapJson(content)
   return <RichTextContent content={json} className={className} />
 }

--- a/apps/web/src/components/public/comment-content.tsx
+++ b/apps/web/src/components/public/comment-content.tsx
@@ -1,19 +1,18 @@
 import { commentMarkdownToTiptapJson } from '@/lib/server/markdown-tiptap'
 import { RichTextContent } from '@/components/ui/rich-text-editor'
-import { cn } from '@/lib/shared/utils'
 
 interface CommentContentProps {
   content: string
   className?: string
 }
 
-// Cheap heuristic — returns true if `text` plausibly contains any markdown
-// token we care about. False positives just take the slow path; false negatives
-// would render markdown as plaintext, so the regex biases generous.
+// False positives just take the slow path; false negatives would render
+// markdown as plaintext, so this regex biases generous.
 export function hasMarkdownTokens(text: string): boolean {
   if (!text) return false
   const blockRx = /(^|\n)(#{1,3} |[-*+] |\d+\. |> |```)/
-  const inlineRx = /\*\*|__|~~|`[^`\n]/
+  const inlineRx =
+    /\*\*|__|~~|`[^`\n]|(?<![\w*])\*[^*\s][^*\n]*\*(?!\w)|(?<![\w_])_[^_\s][^_\n]*_(?!\w)/
   const linkRx = /\[[^\]\n]+\]\([^)\n]+\)/
   return blockRx.test(text) || inlineRx.test(text) || linkRx.test(text)
 }
@@ -27,5 +26,5 @@ export function CommentContent({ content, className }: CommentContentProps) {
     )
   }
   const json = commentMarkdownToTiptapJson(content)
-  return <RichTextContent content={json} className={cn(className)} />
+  return <RichTextContent content={json} className={className} />
 }

--- a/apps/web/src/components/public/comment-content.tsx
+++ b/apps/web/src/components/public/comment-content.tsx
@@ -1,0 +1,31 @@
+import { commentMarkdownToTiptapJson } from '@/lib/server/markdown-tiptap'
+import { RichTextContent } from '@/components/ui/rich-text-editor'
+import { cn } from '@/lib/shared/utils'
+
+interface CommentContentProps {
+  content: string
+  className?: string
+}
+
+// Cheap heuristic — returns true if `text` plausibly contains any markdown
+// token we care about. False positives just take the slow path; false negatives
+// would render markdown as plaintext, so the regex biases generous.
+export function hasMarkdownTokens(text: string): boolean {
+  if (!text) return false
+  const blockRx = /(^|\n)(#{1,3} |[-*+] |\d+\. |> |```)/
+  const inlineRx = /\*\*|__|~~|`[^`\n]/
+  const linkRx = /\[[^\]\n]+\]\([^)\n]+\)/
+  return blockRx.test(text) || inlineRx.test(text) || linkRx.test(text)
+}
+
+export function CommentContent({ content, className }: CommentContentProps) {
+  if (!hasMarkdownTokens(content)) {
+    return (
+      <div className={className}>
+        <p className="whitespace-pre-wrap">{content}</p>
+      </div>
+    )
+  }
+  const json = commentMarkdownToTiptapJson(content)
+  return <RichTextContent content={json} className={cn(className)} />
+}

--- a/apps/web/src/components/public/comment-form.tsx
+++ b/apps/web/src/components/public/comment-form.tsx
@@ -21,6 +21,7 @@ import { signOut } from '@/lib/client/auth-client'
 import { useRouter, useRouteContext } from '@tanstack/react-router'
 import { useAuthBroadcast } from '@/lib/client/hooks/use-auth-broadcast'
 import { cn } from '@/lib/shared/utils'
+import { MarkdownSupportedHint } from './markdown-supported-hint'
 import type { PostId, CommentId } from '@quackback/ids'
 
 export type CreateCommentMutation = UseMutationResult<
@@ -206,6 +207,9 @@ export function CommentForm({
                       {...field}
                     />
                   </FormControl>
+                  <div className="px-3 pt-1 pb-0.5">
+                    <MarkdownSupportedHint />
+                  </div>
                   <FormMessage className="px-3" />
                 </FormItem>
               )}
@@ -429,6 +433,9 @@ export function CommentForm({
                   {...field}
                 />
               </FormControl>
+              <div className="px-3 pt-1 pb-0.5">
+                <MarkdownSupportedHint />
+              </div>
               <FormMessage />
             </FormItem>
           )}

--- a/apps/web/src/components/public/comment-thread.tsx
+++ b/apps/web/src/components/public/comment-thread.tsx
@@ -24,6 +24,7 @@ import type { CommentReactionCount } from '@/lib/shared'
 import type { PublicCommentView } from '@/lib/client/queries/portal-detail'
 import { cn, getInitials } from '@/lib/shared/utils'
 import { StatusBadge } from '@/components/ui/status-badge'
+import { CommentContent } from '@/components/public/comment-content'
 import { CommentForm, type CreateCommentMutation } from './comment-form'
 import type { CommentId, PostId, PrincipalId } from '@quackback/ids'
 
@@ -659,9 +660,10 @@ function CommentItem({
               </div>
             </div>
           ) : (
-            <p className="text-sm whitespace-pre-wrap mt-1.5 ms-10 text-foreground/90 leading-relaxed">
-              {comment.content}
-            </p>
+            <CommentContent
+              content={comment.content}
+              className="text-sm mt-1.5 ms-10 text-foreground/90 leading-relaxed"
+            />
           )}
 
           {/* Status change indicator */}

--- a/apps/web/src/components/public/markdown-supported-hint.tsx
+++ b/apps/web/src/components/public/markdown-supported-hint.tsx
@@ -1,0 +1,42 @@
+import { useIntl } from 'react-intl'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/shared/utils'
+
+interface Props {
+  className?: string
+}
+
+export function MarkdownSupportedHint({ className }: Props) {
+  const intl = useIntl()
+  const label = intl.formatMessage({
+    id: 'comments.markdownHint.label',
+    defaultMessage: 'Markdown supported',
+  })
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            className={cn(
+              'text-[10px] text-muted-foreground/70 hover:text-muted-foreground transition-colors',
+              className
+            )}
+          >
+            {label}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="text-xs">
+          <ul className="space-y-0.5 font-mono">
+            <li>**bold** *italic*</li>
+            <li>## heading</li>
+            <li>- list item</li>
+            <li>`code` ```fenced```</li>
+            <li>[link](url)</li>
+            <li>{'> quote'}</li>
+          </ul>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}

--- a/apps/web/src/components/public/pinned-comment.tsx
+++ b/apps/web/src/components/public/pinned-comment.tsx
@@ -4,6 +4,7 @@ import { Badge } from '@/components/ui/badge'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { TimeAgo } from '@/components/ui/time-ago'
 import { getInitials } from '@/lib/shared/utils/string'
+import { CommentContent } from '@/components/public/comment-content'
 import type { PinnedCommentView } from '@/lib/client/queries/portal-detail'
 
 interface PinnedCommentProps {
@@ -35,9 +36,10 @@ export function PinnedComment({ comment, workspaceName }: PinnedCommentProps) {
             <span className="text-muted-foreground">·</span>
             <TimeAgo date={comment.createdAt} className="text-xs text-muted-foreground" />
           </div>
-          <p className="text-sm text-foreground/90 whitespace-pre-wrap leading-relaxed">
-            {comment.content}
-          </p>
+          <CommentContent
+            content={comment.content}
+            className="text-sm text-foreground/90 leading-relaxed"
+          />
         </div>
       </div>
     </div>

--- a/apps/web/src/components/widget/widget-comment-form.tsx
+++ b/apps/web/src/components/widget/widget-comment-form.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react'
 import { useIntl, FormattedMessage } from 'react-intl'
 import { useWidgetAuth } from './widget-auth-provider'
+import { MarkdownSupportedHint } from '@/components/public/markdown-supported-hint'
 
 interface WidgetUser {
   id: string
@@ -104,6 +105,9 @@ export function WidgetCommentForm({
           }
         }}
       />
+      <div className="mt-1 ms-0.5">
+        <MarkdownSupportedHint />
+      </div>
 
       {!isIdentified ? (
         <div className="flex items-center gap-1.5 mt-1.5">

--- a/apps/web/src/components/widget/widget-comment-list.tsx
+++ b/apps/web/src/components/widget/widget-comment-list.tsx
@@ -14,6 +14,7 @@ import { REACTION_EMOJIS } from '@/lib/shared/db-types'
 import { addReactionFn, removeReactionFn } from '@/lib/server/functions/comments'
 import { getWidgetAuthHeaders } from '@/lib/client/widget-auth'
 import { getInitials, cn } from '@/lib/shared/utils'
+import { CommentContent } from '@/components/public/comment-content'
 import type { PublicCommentView } from '@/lib/client/queries/portal-detail'
 import type { CommentReactionCount } from '@/lib/shared'
 
@@ -253,9 +254,10 @@ function WidgetCommentItem({
         </div>
 
         {/* Content */}
-        <p className="text-xs text-foreground/90 whitespace-pre-wrap mt-1 ms-7 leading-relaxed">
-          {comment.content}
-        </p>
+        <CommentContent
+          content={comment.content}
+          className="text-xs text-foreground/90 mt-1 ms-7 leading-relaxed"
+        />
 
         {/* Actions row: collapse, reactions, emoji picker, reply */}
         <div className="flex items-center gap-1 mt-1.5 ms-7">

--- a/apps/web/src/components/widget/widget-comment-list.tsx
+++ b/apps/web/src/components/widget/widget-comment-list.tsx
@@ -15,6 +15,7 @@ import { addReactionFn, removeReactionFn } from '@/lib/server/functions/comments
 import { getWidgetAuthHeaders } from '@/lib/client/widget-auth'
 import { getInitials, cn } from '@/lib/shared/utils'
 import { CommentContent } from '@/components/public/comment-content'
+import { MarkdownSupportedHint } from '@/components/public/markdown-supported-hint'
 import type { PublicCommentView } from '@/lib/client/queries/portal-detail'
 import type { CommentReactionCount } from '@/lib/shared'
 
@@ -366,6 +367,9 @@ function WidgetCommentItem({
                     }
                   }}
                 />
+                <div className="mt-1 ms-0.5">
+                  <MarkdownSupportedHint />
+                </div>
                 <button
                   type="button"
                   onClick={handleSubmitReply}

--- a/apps/web/src/lib/server/__tests__/markdown-tiptap.test.ts
+++ b/apps/web/src/lib/server/__tests__/markdown-tiptap.test.ts
@@ -213,6 +213,12 @@ describe('commentMarkdownToTiptapJson', () => {
     expect(json.toLowerCase()).not.toContain('javascript:')
   })
 
+  test('data: links are stripped', () => {
+    const result = commentMarkdownToTiptapJson('[click](data:text/html,<h1>x</h1>)')
+    const json = JSON.stringify(result)
+    expect(json.toLowerCase()).not.toContain('data:')
+  })
+
   test('script tags in markdown do not produce script nodes', () => {
     const result = commentMarkdownToTiptapJson('<script>alert(1)</script>\n\nHello')
     const json = JSON.stringify(result)

--- a/apps/web/src/lib/server/__tests__/markdown-tiptap.test.ts
+++ b/apps/web/src/lib/server/__tests__/markdown-tiptap.test.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect } from 'vitest'
-import { markdownToTiptapJson, tiptapJsonToMarkdown } from '../markdown-tiptap'
+import {
+  markdownToTiptapJson,
+  tiptapJsonToMarkdown,
+  commentMarkdownToTiptapJson,
+} from '../markdown-tiptap'
 
 describe('markdownToTiptapJson', () => {
   test('converts a simple paragraph', () => {
@@ -170,5 +174,54 @@ describe('tiptapJsonToMarkdown', () => {
     expect(roundTripped).toContain('**bold**')
     expect(roundTripped).toContain('Item 1')
     expect(roundTripped).toContain('Item 2')
+  })
+})
+
+describe('commentMarkdownToTiptapJson', () => {
+  test('plain text becomes a paragraph', () => {
+    const result = commentMarkdownToTiptapJson('Hello world')
+    expect(result.type).toBe('doc')
+    expect(result.content![0].type).toBe('paragraph')
+  })
+
+  test('renders headings, bold, italic, lists, code, links', () => {
+    const md =
+      '## Heading\n\n**bold** and *italic*\n\n- one\n- two\n\n`inline` and [link](https://example.com)'
+    const result = commentMarkdownToTiptapJson(md)
+    const types = new Set(result.content!.map((n) => n.type))
+    expect(types.has('heading')).toBe(true)
+    expect(types.has('bulletList')).toBe(true)
+    expect(types.has('paragraph')).toBe(true)
+  })
+
+  test('image markdown does not produce an image node', () => {
+    const result = commentMarkdownToTiptapJson('![alt](https://example.com/x.png)')
+    const hasImage = JSON.stringify(result).includes('"type":"image"')
+    expect(hasImage).toBe(false)
+  })
+
+  test('table markdown does not produce a table node', () => {
+    const md = '| a | b |\n|---|---|\n| 1 | 2 |'
+    const result = commentMarkdownToTiptapJson(md)
+    const hasTable = JSON.stringify(result).includes('"type":"table"')
+    expect(hasTable).toBe(false)
+  })
+
+  test('javascript: links are stripped or escaped', () => {
+    const result = commentMarkdownToTiptapJson('[click](javascript:alert(1))')
+    const json = JSON.stringify(result)
+    expect(json.toLowerCase()).not.toContain('javascript:')
+  })
+
+  test('script tags in markdown do not produce script nodes', () => {
+    const result = commentMarkdownToTiptapJson('<script>alert(1)</script>\n\nHello')
+    const json = JSON.stringify(result)
+    expect(json).not.toContain('"type":"script"')
+  })
+
+  test('single newline becomes a hard break (GFM)', () => {
+    const result = commentMarkdownToTiptapJson('line one\nline two')
+    const json = JSON.stringify(result)
+    expect(json).toContain('"type":"hardBreak"')
   })
 })

--- a/apps/web/src/lib/server/markdown-tiptap.ts
+++ b/apps/web/src/lib/server/markdown-tiptap.ts
@@ -20,6 +20,7 @@ import TableCell from '@tiptap/extension-table-cell'
 import TableHeader from '@tiptap/extension-table-header'
 import type { TiptapContent } from '@/lib/server/db'
 import type { JSONContent } from '@tiptap/core'
+import { sanitizeTiptapContent } from '@/lib/server/sanitize-tiptap'
 
 /**
  * Server-safe extensions for markdown conversion.
@@ -91,32 +92,10 @@ const commentManager = new MarkdownManager({
   markedOptions: { gfm: true, breaks: true },
 })
 
-const DANGEROUS_HREF = /^\s*(javascript|data|vbscript):/i
-
-// TipTap's Link extension does not sanitize hrefs on the markdown parse path,
-// so walk the JSON and blank any href matching a dangerous scheme.
-function stripDangerousLinkHrefs(node: JSONContent): void {
-  if (Array.isArray(node.marks)) {
-    for (const mark of node.marks) {
-      if (
-        mark.type === 'link' &&
-        typeof mark.attrs?.href === 'string' &&
-        DANGEROUS_HREF.test(mark.attrs.href)
-      ) {
-        mark.attrs.href = ''
-      }
-    }
-  }
-  if (Array.isArray(node.content)) {
-    for (const child of node.content) stripDangerousLinkHrefs(child)
-  }
-}
-
 /**
  * Parse a comment-style markdown string into TipTap JSON.
  */
 export function commentMarkdownToTiptapJson(markdown: string): TiptapContent {
   const json = commentManager.parse(markdown) as TiptapContent
-  stripDangerousLinkHrefs(json as JSONContent)
-  return json
+  return sanitizeTiptapContent(json) as TiptapContent
 }

--- a/apps/web/src/lib/server/markdown-tiptap.ts
+++ b/apps/web/src/lib/server/markdown-tiptap.ts
@@ -93,6 +93,8 @@ const commentManager = new MarkdownManager({
 
 const DANGEROUS_HREF = /^\s*(javascript|data|vbscript):/i
 
+// TipTap's Link extension does not sanitize hrefs on the markdown parse path,
+// so walk the JSON and blank any href matching a dangerous scheme.
 function stripDangerousLinkHrefs(node: JSONContent): void {
   if (Array.isArray(node.marks)) {
     for (const mark of node.marks) {

--- a/apps/web/src/lib/server/markdown-tiptap.ts
+++ b/apps/web/src/lib/server/markdown-tiptap.ts
@@ -70,3 +70,51 @@ export function markdownToTiptapJson(markdown: string): TiptapContent {
 export function tiptapJsonToMarkdown(json: TiptapContent | JSONContent): string {
   return manager.serialize(json as JSONContent)
 }
+
+/**
+ * Slim extension set for comments — no images, no tables, no YouTube.
+ * Comments are short, dense, and inline; we want the safe subset only.
+ */
+const COMMENT_EXTENSIONS = [
+  StarterKit.configure({
+    heading: { levels: [1, 2, 3] },
+    hardBreak: { keepMarks: true },
+  }),
+  Link.configure({ openOnClick: false, autolink: true }),
+  Underline,
+  TaskList,
+  TaskItem.configure({ nested: true }),
+]
+
+const commentManager = new MarkdownManager({
+  extensions: COMMENT_EXTENSIONS,
+  markedOptions: { gfm: true, breaks: true },
+})
+
+const DANGEROUS_HREF = /^\s*(javascript|data|vbscript):/i
+
+function stripDangerousLinkHrefs(node: JSONContent): void {
+  if (Array.isArray(node.marks)) {
+    for (const mark of node.marks) {
+      if (
+        mark.type === 'link' &&
+        typeof mark.attrs?.href === 'string' &&
+        DANGEROUS_HREF.test(mark.attrs.href)
+      ) {
+        mark.attrs.href = ''
+      }
+    }
+  }
+  if (Array.isArray(node.content)) {
+    for (const child of node.content) stripDangerousLinkHrefs(child)
+  }
+}
+
+/**
+ * Parse a comment-style markdown string into TipTap JSON.
+ */
+export function commentMarkdownToTiptapJson(markdown: string): TiptapContent {
+  const json = commentManager.parse(markdown) as TiptapContent
+  stripDangerousLinkHrefs(json as JSONContent)
+  return json
+}


### PR DESCRIPTION
## Summary

- Comments now parse markdown (`## headings`, `**bold**`, `*italic*`, lists, links, inline + fenced code, blockquotes) across the portal thread, pinned comment, and widget list. No schema change, no API contract change, no editor change.
- A new `<CommentContent>` component fast-paths plaintext (no markdown tokens) and parses markdown via a slim TipTap `MarkdownManager` (no images, no tables, no YouTube). Parsed JSON runs through the existing `sanitizeTiptapContent` (stricter http/https/mailto URL allowlist) before `RichTextContent` renders with DOMPurify defense-in-depth.
- Both comment textareas (portal team-composer + default, widget top-level + inline reply) now show a tiny tooltip-backed "Markdown supported" hint listing the supported syntax.

## Test Plan

- [ ] Unit: `cd apps/web && bun run vitest run src/lib/server/__tests__/markdown-tiptap.test.ts src/components/public/__tests__/comment-content.test.tsx` (44 passing locally)
- [ ] Visual: open a portal feedback post, comment with a heading, bold, italic, list, and link, confirm it renders formatted in the thread, the pinned comment, and the widget list
- [ ] Visual: post a plain "+1" comment, confirm it still renders as before (whitespace-pre-wrap fast path)
- [ ] Security: comment a `[click](javascript:alert(1))` link, confirm no `javascript:` href reaches the DOM
- [ ] E2E: `cd apps/web && bun run test:e2e --grep "markdown"` (note: a pre-existing `getOtpCode` import in `comments.spec.ts` currently blocks the suite from loading locally, unrelated to this branch)