### PR TITLE
feat(portal): hide log-in / sign-up when no auth methods are enabled

### DIFF
--- a/apps/web/src/components/admin/settings/security/portal-auth-tab.tsx
+++ b/apps/web/src/components/admin/settings/security/portal-auth-tab.tsx
@@ -73,12 +73,9 @@ export function PortalAuthTab({
   ).length
   const isLastMethod = (id: string) => !!oauthState[id] && enabledMethodCount === 1
 
-  // True when nothing on the portal can actually sign a user in. Looks
-  // past the raw intent flags to what's *usable* today: password works
-  // standalone, magic link needs email delivery, and OAuth providers
-  // need their credentials saved. A flag like `google: true` with no
-  // platform credential still produces a "Not configured" tile, so it
-  // shouldn't count as a working sign-in surface for this warning.
+  // Gates on what's *usable* (intent flag AND credentials), not on raw
+  // intent — a `google: true` flag with no saved credential renders as
+  // a "Not configured" tile and isn't a working sign-in surface.
   const noPortalAuthEnabled = (() => {
     if (oauthState.password) return false
     if (oauthState.magicLink && emailConfigured) return false

--- a/apps/web/src/components/admin/settings/security/portal-auth-tab.tsx
+++ b/apps/web/src/components/admin/settings/security/portal-auth-tab.tsx
@@ -13,6 +13,8 @@ import { Switch } from '@/components/ui/switch'
 import { MethodRow } from '@/components/admin/settings/auth-shared/method-row'
 import { OAuthProviderGrid } from '@/components/admin/settings/auth-shared/oauth-provider-grid'
 import { AuthProviderCredentialsDialog } from '@/components/admin/settings/portal-auth/auth-provider-credentials-dialog'
+import { WarningBox } from '@/components/shared/warning-box'
+import { hasAnyPortalAuthMethod } from '@/components/auth/oauth-buttons'
 import { AUTH_PROVIDERS } from '@/lib/shared/auth-providers'
 import { updatePortalConfigFn } from '@/lib/server/functions/settings'
 import { isPathManagedFromBootstrap } from '@/lib/client/config-file'
@@ -72,6 +74,13 @@ export function PortalAuthTab({
   ).length
   const isLastMethod = (id: string) => !!oauthState[id] && enabledMethodCount === 1
 
+  // The toggles enforce a last-method guard, but the state is still
+  // reachable through the config file, direct DB writes, or a legacy
+  // tenant whose only enabled flag is the retired `email` key. In any
+  // of those, surface the consequence so admins aren't surprised by a
+  // portal with no sign-in surface.
+  const noPortalAuthEnabled = !hasAnyPortalAuthMethod(oauthState)
+
   const save = async (patch: Record<string, boolean | undefined>) => {
     setSaving(true)
     try {
@@ -108,6 +117,19 @@ export function PortalAuthTab({
 
   return (
     <div className="space-y-6">
+      {noPortalAuthEnabled && (
+        <WarningBox
+          variant="warning"
+          title="No portal sign-in enabled"
+          description={
+            <>
+              Visitors can&apos;t sign in or sign up on your portal. Your team can still sign in at{' '}
+              <code className="rounded bg-muted px-1 py-0.5 text-[0.85em]">/admin</code>.
+            </>
+          }
+        />
+      )}
+
       {/* Card — Sign-in Methods */}
       <div className="rounded-xl border border-border/50 bg-card shadow-sm">
         <div className="px-6 py-4 border-b border-border/50">

--- a/apps/web/src/components/admin/settings/security/portal-auth-tab.tsx
+++ b/apps/web/src/components/admin/settings/security/portal-auth-tab.tsx
@@ -14,7 +14,6 @@ import { MethodRow } from '@/components/admin/settings/auth-shared/method-row'
 import { OAuthProviderGrid } from '@/components/admin/settings/auth-shared/oauth-provider-grid'
 import { AuthProviderCredentialsDialog } from '@/components/admin/settings/portal-auth/auth-provider-credentials-dialog'
 import { WarningBox } from '@/components/shared/warning-box'
-import { hasAnyPortalAuthMethod } from '@/components/auth/oauth-buttons'
 import { AUTH_PROVIDERS } from '@/lib/shared/auth-providers'
 import { updatePortalConfigFn } from '@/lib/server/functions/settings'
 import { isPathManagedFromBootstrap } from '@/lib/client/config-file'
@@ -74,12 +73,21 @@ export function PortalAuthTab({
   ).length
   const isLastMethod = (id: string) => !!oauthState[id] && enabledMethodCount === 1
 
-  // The toggles enforce a last-method guard, but the state is still
-  // reachable through the config file, direct DB writes, or a legacy
-  // tenant whose only enabled flag is the retired `email` key. In any
-  // of those, surface the consequence so admins aren't surprised by a
-  // portal with no sign-in surface.
-  const noPortalAuthEnabled = !hasAnyPortalAuthMethod(oauthState)
+  // True when nothing on the portal can actually sign a user in. Looks
+  // past the raw intent flags to what's *usable* today: password works
+  // standalone, magic link needs email delivery, and OAuth providers
+  // need their credentials saved. A flag like `google: true` with no
+  // platform credential still produces a "Not configured" tile, so it
+  // shouldn't count as a working sign-in surface for this warning.
+  const noPortalAuthEnabled = (() => {
+    if (oauthState.password) return false
+    if (oauthState.magicLink && emailConfigured) return false
+    return !Object.entries(oauthState).some(([id, enabled]) => {
+      if (!enabled) return false
+      if (id === 'password' || id === 'magicLink' || id === 'email') return false
+      return !!credentialStatus[id]
+    })
+  })()
 
   const save = async (patch: Record<string, boolean | undefined>) => {
     setSaving(true)

--- a/apps/web/src/components/auth/__tests__/oauth-buttons.test.ts
+++ b/apps/web/src/components/auth/__tests__/oauth-buttons.test.ts
@@ -42,4 +42,31 @@ describe('hasAnyPortalAuthMethod', () => {
   it('ignores unknown provider keys that are not in the registry', () => {
     expect(hasAnyPortalAuthMethod({ password: false, magicLink: false, mystery: true })).toBe(false)
   })
+
+  it('returns true when SSO is registered and a verified domain exists', () => {
+    expect(
+      hasAnyPortalAuthMethod(
+        { password: false, magicLink: false },
+        { ssoEnabled: true, hasVerifiedDomain: true }
+      )
+    ).toBe(true)
+  })
+
+  it('returns false when SSO is registered but no verified domain is set', () => {
+    expect(
+      hasAnyPortalAuthMethod(
+        { password: false, magicLink: false },
+        { ssoEnabled: true, hasVerifiedDomain: false }
+      )
+    ).toBe(false)
+  })
+
+  it('returns false when a verified domain exists but SSO is not registered', () => {
+    expect(
+      hasAnyPortalAuthMethod(
+        { password: false, magicLink: false },
+        { ssoEnabled: false, hasVerifiedDomain: true }
+      )
+    ).toBe(false)
+  })
 })

--- a/apps/web/src/components/auth/__tests__/oauth-buttons.test.ts
+++ b/apps/web/src/components/auth/__tests__/oauth-buttons.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { hasAnyPortalAuthMethod } from '../oauth-buttons'
+
+describe('hasAnyPortalAuthMethod', () => {
+  it('returns false when every method is disabled', () => {
+    expect(
+      hasAnyPortalAuthMethod({
+        password: false,
+        magicLink: false,
+        google: false,
+        github: false,
+      })
+    ).toBe(false)
+  })
+
+  it('returns false for an empty config', () => {
+    expect(hasAnyPortalAuthMethod({})).toBe(false)
+  })
+
+  it('returns true when password is enabled', () => {
+    expect(hasAnyPortalAuthMethod({ password: true, magicLink: false })).toBe(true)
+  })
+
+  it('returns true when magicLink is enabled', () => {
+    expect(hasAnyPortalAuthMethod({ password: false, magicLink: true })).toBe(true)
+  })
+
+  it('returns true when at least one OAuth provider is enabled', () => {
+    expect(
+      hasAnyPortalAuthMethod({
+        password: false,
+        magicLink: false,
+        google: true,
+      })
+    ).toBe(true)
+  })
+
+  it('ignores legacy email key (retired in migration 0049)', () => {
+    expect(hasAnyPortalAuthMethod({ password: false, magicLink: false, email: true })).toBe(false)
+  })
+
+  it('ignores unknown provider keys that are not in the registry', () => {
+    expect(hasAnyPortalAuthMethod({ password: false, magicLink: false, mystery: true })).toBe(false)
+  })
+})

--- a/apps/web/src/components/auth/oauth-buttons.tsx
+++ b/apps/web/src/components/auth/oauth-buttons.tsx
@@ -139,13 +139,27 @@ export function OAuthButtons({ callbackUrl = '/', providers, onSuccess }: OAuthB
 
 /**
  * True when the portal exposes at least one user-facing sign-in method
- * (password, magic link, or any registered OAuth provider). Used to hide
- * the header's Log in / Sign up buttons in fully-anonymous deployments
- * where clicking them would open a dialog with no usable path forward.
+ * (password, magic link, any registered OAuth provider, or workspace
+ * SSO via a verified domain). Used to hide the header's Log in / Sign
+ * up buttons in fully-anonymous deployments where clicking them would
+ * open a dialog with no usable path forward.
+ *
+ * `opts.ssoEnabled` is the auth-runtime view ('sso' present in
+ * `registeredAuthProviders`), not just admin intent — a stale
+ * `ssoOidc.enabled=true` with no platform credential should NOT keep
+ * the buttons visible. `opts.hasVerifiedDomain` gates the SSO path on
+ * actually having a domain match available, since the portal
+ * dispatcher only routes to SSO when the typed email matches a
+ * verified domain.
  */
-export function hasAnyPortalAuthMethod(authConfig: Record<string, boolean | undefined>): boolean {
+export function hasAnyPortalAuthMethod(
+  authConfig: Record<string, boolean | undefined>,
+  opts?: { ssoEnabled?: boolean; hasVerifiedDomain?: boolean }
+): boolean {
   if (authConfig.password || authConfig.magicLink) return true
-  return getEnabledOAuthProviders(authConfig).length > 0
+  if (getEnabledOAuthProviders(authConfig).length > 0) return true
+  if (opts?.ssoEnabled && opts.hasVerifiedDomain) return true
+  return false
 }
 
 /**

--- a/apps/web/src/components/auth/oauth-buttons.tsx
+++ b/apps/web/src/components/auth/oauth-buttons.tsx
@@ -138,6 +138,17 @@ export function OAuthButtons({ callbackUrl = '/', providers, onSuccess }: OAuthB
 }
 
 /**
+ * True when the portal exposes at least one user-facing sign-in method
+ * (password, magic link, or any registered OAuth provider). Used to hide
+ * the header's Log in / Sign up buttons in fully-anonymous deployments
+ * where clicking them would open a dialog with no usable path forward.
+ */
+export function hasAnyPortalAuthMethod(authConfig: Record<string, boolean | undefined>): boolean {
+  if (authConfig.password || authConfig.magicLink) return true
+  return getEnabledOAuthProviders(authConfig).length > 0
+}
+
+/**
  * Build provider list from PortalAuthMethods config.
  * Filters to only enabled OAuth providers (excludes 'email').
  */

--- a/apps/web/src/components/auth/oauth-buttons.tsx
+++ b/apps/web/src/components/auth/oauth-buttons.tsx
@@ -140,17 +140,10 @@ export function OAuthButtons({ callbackUrl = '/', providers, onSuccess }: OAuthB
 /**
  * True when the portal exposes at least one user-facing sign-in method
  * (password, magic link, any registered OAuth provider, or workspace
- * SSO via a verified domain). Used to hide the header's Log in / Sign
- * up buttons in fully-anonymous deployments where clicking them would
- * open a dialog with no usable path forward.
- *
- * `opts.ssoEnabled` is the auth-runtime view ('sso' present in
- * `registeredAuthProviders`), not just admin intent — a stale
- * `ssoOidc.enabled=true` with no platform credential should NOT keep
- * the buttons visible. `opts.hasVerifiedDomain` gates the SSO path on
- * actually having a domain match available, since the portal
- * dispatcher only routes to SSO when the typed email matches a
- * verified domain.
+ * SSO via a verified domain). Pass `ssoEnabled` from the auth-runtime
+ * view (e.g. `registeredAuthProviders.includes('sso')`), not raw
+ * `ssoOidc.enabled`, so a stale flag with no platform credential
+ * doesn't keep the buttons visible.
  */
 export function hasAnyPortalAuthMethod(
   authConfig: Record<string, boolean | undefined>,

--- a/apps/web/src/components/public/portal-header.tsx
+++ b/apps/web/src/components/public/portal-header.tsx
@@ -64,11 +64,8 @@ export function PortalHeader({
   const onHelpPages = pathname === '/hc' || pathname.startsWith('/hc/')
   const navItems = buildNavItems({ helpCenterEnabled })
 
-  // Hide Log in / Sign up when the admin has disabled every portal auth
-  // method — the dialog they'd open has no usable path forward. Team
-  // members can still reach /admin/login directly. Workspace SSO via a
-  // verified domain keeps the buttons visible because the portal email
-  // dispatcher will route those emails into the SSO flow.
+  // Hide Log in / Sign up when no portal sign-in surface is usable.
+  // Team members can still reach /admin/login directly.
   const portalAuthEnabled = hasAnyPortalAuthMethod(settings?.publicPortalConfig?.oauth ?? {}, {
     ssoEnabled: registeredAuthProviders?.includes('sso') ?? false,
     hasVerifiedDomain: (settings?.verifiedDomains ?? []).some((d) => d.verifiedAt !== null),

--- a/apps/web/src/components/public/portal-header.tsx
+++ b/apps/web/src/components/public/portal-header.tsx
@@ -57,7 +57,7 @@ export function PortalHeader({
   const router = useRouter()
   const queryClient = useQueryClient()
   const pathname = useRouterState({ select: (s) => s.location.pathname })
-  const { session, settings } = useRouteContext({ from: '__root__' })
+  const { session, settings, registeredAuthProviders } = useRouteContext({ from: '__root__' })
 
   const helpCenterEnabled =
     !!settings?.featureFlags?.helpCenter && !!settings?.helpCenterConfig?.enabled
@@ -66,8 +66,13 @@ export function PortalHeader({
 
   // Hide Log in / Sign up when the admin has disabled every portal auth
   // method — the dialog they'd open has no usable path forward. Team
-  // members and SSO users can still reach /admin/login directly.
-  const portalAuthEnabled = hasAnyPortalAuthMethod(settings?.publicPortalConfig?.oauth ?? {})
+  // members can still reach /admin/login directly. Workspace SSO via a
+  // verified domain keeps the buttons visible because the portal email
+  // dispatcher will route those emails into the SSO flow.
+  const portalAuthEnabled = hasAnyPortalAuthMethod(settings?.publicPortalConfig?.oauth ?? {}, {
+    ssoEnabled: registeredAuthProviders?.includes('sso') ?? false,
+    hasVerifiedDomain: (settings?.verifiedDomains ?? []).some((d) => d.verifiedAt !== null),
+  })
 
   const authPopover = useAuthPopoverSafe()
   const openAuthPopover = authPopover?.openAuthPopover

--- a/apps/web/src/components/public/portal-header.tsx
+++ b/apps/web/src/components/public/portal-header.tsx
@@ -26,6 +26,7 @@ import {
   SunIcon,
 } from '@heroicons/react/24/solid'
 import { useAuthPopoverSafe } from '@/components/auth/auth-popover-context'
+import { hasAnyPortalAuthMethod } from '@/components/auth/oauth-buttons'
 import { useQueryClient } from '@tanstack/react-query'
 import { useAuthBroadcast } from '@/lib/client/hooks/use-auth-broadcast'
 import { NotificationBell } from '@/components/notifications'
@@ -62,6 +63,11 @@ export function PortalHeader({
     !!settings?.featureFlags?.helpCenter && !!settings?.helpCenterConfig?.enabled
   const onHelpPages = pathname === '/hc' || pathname.startsWith('/hc/')
   const navItems = buildNavItems({ helpCenterEnabled })
+
+  // Hide Log in / Sign up when the admin has disabled every portal auth
+  // method — the dialog they'd open has no usable path forward. Team
+  // members and SSO users can still reach /admin/login directly.
+  const portalAuthEnabled = hasAnyPortalAuthMethod(settings?.publicPortalConfig?.oauth ?? {})
 
   const authPopover = useAuthPopoverSafe()
   const openAuthPopover = authPopover?.openAuthPopover
@@ -240,7 +246,7 @@ export function PortalHeader({
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
-      ) : openAuthPopover ? (
+      ) : openAuthPopover && portalAuthEnabled ? (
         // Anonymous user with auth popover available - show login/signup buttons
         <div className="flex items-center gap-2">
           <Button variant="ghost" size="sm" onClick={() => openAuthPopover({ mode: 'login' })}>


### PR DESCRIPTION
## Summary

- When every portal auth method is disabled (`oauth.password`, `oauth.magicLink`, every OAuth provider), the portal header still rendered Log in / Sign up. Clicking them opened a dialog with no usable path forward.
- Adds `hasAnyPortalAuthMethod(oauth)` alongside `getEnabledOAuthProviders` and gates the header buttons on it so the entry point disappears in fully-anonymous deployments.
- Team members and SSO users are unaffected: `/admin/login` is the canonical entry for them and is reachable independently.

## Test plan

- [x] `bun run vitest run src/components/auth/__tests__/oauth-buttons.test.ts` — 7 new tests cover password, magic link, OAuth, empty, all-off, legacy `email` key, unknown keys
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — no new errors (one pre-existing `max-lines` warning unrelated)
- [x] Full vitest run — only pre-existing DNS/SSRF failures remain; new tests pass
- [x] Manual smoke: portal with `oauth: { password: false, magicLink: false, google: false, github: false }` + `anonymousVoting: true` → header shows theme toggle only, no Log in / Sign up
- [x] Manual smoke: default config still shows both buttons