### PR TITLE
fix(changelog): exclude soft-deleted entries from public read paths

### DIFF
--- a/apps/web/src/lib/server/domains/changelog/__tests__/changelog-soft-delete.test.ts
+++ b/apps/web/src/lib/server/domains/changelog/__tests__/changelog-soft-delete.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ChangelogId } from '@quackback/ids'
+
+const mockEntryFindFirst = vi.fn()
+const mockEntryFindMany = vi.fn()
+const mockLinkedPostsFindMany = vi.fn()
+const mockStatusesFindMany = vi.fn()
+
+const mockUpdateSet = vi.fn()
+const mockUpdateWhere = vi.fn()
+const mockUpdateReturning = vi.fn()
+
+const changelogEntriesTable = {
+  id: { name: 'id' },
+  publishedAt: { name: 'published_at' },
+  deletedAt: { name: 'deleted_at' },
+}
+
+vi.mock('@/lib/server/db', () => ({
+  db: {
+    query: {
+      changelogEntries: {
+        findFirst: (...args: unknown[]) => mockEntryFindFirst(...args),
+        findMany: (...args: unknown[]) => mockEntryFindMany(...args),
+      },
+      changelogEntryPosts: {
+        findMany: (...args: unknown[]) => mockLinkedPostsFindMany(...args),
+      },
+      postStatuses: {
+        findMany: (...args: unknown[]) => mockStatusesFindMany(...args),
+      },
+    },
+    update: () => ({
+      set: (values: unknown) => {
+        mockUpdateSet(values)
+        return {
+          where: (...args: unknown[]) => {
+            mockUpdateWhere(...args)
+            return { returning: () => mockUpdateReturning() }
+          },
+        }
+      },
+    }),
+  },
+  changelogEntries: changelogEntriesTable,
+  changelogEntryPosts: { changelogEntryId: 'changelog_entry_id' },
+  postStatuses: { id: 'id' },
+  eq: vi.fn((col, val) => ({ kind: 'eq', col, val })),
+  and: vi.fn((...args: unknown[]) => ({ kind: 'and', args })),
+  or: vi.fn((...args: unknown[]) => ({ kind: 'or', args })),
+  isNull: vi.fn((col) => ({ kind: 'isNull', col })),
+  isNotNull: vi.fn((col) => ({ kind: 'isNotNull', col })),
+  lt: vi.fn((col, val) => ({ kind: 'lt', col, val })),
+  lte: vi.fn((col, val) => ({ kind: 'lte', col, val })),
+  desc: vi.fn((col) => ({ kind: 'desc', col })),
+  inArray: vi.fn((col, vals) => ({ kind: 'inArray', col, vals })),
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockLinkedPostsFindMany.mockResolvedValue([])
+  mockStatusesFindMany.mockResolvedValue([])
+})
+
+describe('getPublicChangelogById', () => {
+  it('filters out soft-deleted entries (isNull deletedAt)', async () => {
+    const { getPublicChangelogById } = await import('../changelog.public')
+    const { isNull } = await import('@/lib/server/db')
+
+    mockEntryFindFirst.mockResolvedValueOnce({
+      id: 'cl_1' as ChangelogId,
+      title: 'Test',
+      content: '',
+      contentJson: null,
+      publishedAt: new Date('2026-01-01'),
+    })
+
+    await getPublicChangelogById('cl_1' as ChangelogId)
+
+    expect(isNull).toHaveBeenCalledWith(changelogEntriesTable.deletedAt)
+  })
+})
+
+describe('listPublicChangelogs', () => {
+  it('filters out soft-deleted entries (isNull deletedAt)', async () => {
+    const { listPublicChangelogs } = await import('../changelog.public')
+    const { isNull } = await import('@/lib/server/db')
+
+    mockEntryFindMany.mockResolvedValueOnce([])
+
+    await listPublicChangelogs({})
+
+    expect(isNull).toHaveBeenCalledWith(changelogEntriesTable.deletedAt)
+  })
+
+  it('filters the cursor lookup to exclude soft-deleted entries', async () => {
+    const { listPublicChangelogs } = await import('../changelog.public')
+    const { isNull } = await import('@/lib/server/db')
+
+    mockEntryFindFirst.mockResolvedValueOnce({
+      publishedAt: new Date('2026-01-01'),
+    })
+    mockEntryFindMany.mockResolvedValueOnce([])
+
+    await listPublicChangelogs({ cursor: 'cl_cursor' })
+
+    const deletedAtCalls = vi
+      .mocked(isNull)
+      .mock.calls.filter((args) => (args[0] as unknown) === changelogEntriesTable.deletedAt)
+    expect(deletedAtCalls.length).toBeGreaterThanOrEqual(2)
+  })
+})
+
+describe('deleteChangelog', () => {
+  it('clears publishedAt when soft-deleting (defense-in-depth)', async () => {
+    mockUpdateReturning.mockResolvedValueOnce([{ id: 'cl_1' }])
+
+    const { deleteChangelog } = await import('../changelog.service')
+    await deleteChangelog('cl_1' as ChangelogId)
+
+    expect(mockUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ deletedAt: expect.any(Date), publishedAt: null })
+    )
+  })
+})

--- a/apps/web/src/lib/server/domains/changelog/__tests__/changelog-soft-delete.test.ts
+++ b/apps/web/src/lib/server/domains/changelog/__tests__/changelog-soft-delete.test.ts
@@ -93,10 +93,12 @@ describe('listPublicChangelogs', () => {
     expect(isNull).toHaveBeenCalledWith(changelogEntriesTable.deletedAt)
   })
 
-  it('filters the cursor lookup to exclude soft-deleted entries', async () => {
+  it('keeps cursor pagination working when the anchor row was soft-deleted', async () => {
     const { listPublicChangelogs } = await import('../changelog.public')
-    const { isNull } = await import('@/lib/server/db')
+    const { eq, lt } = await import('@/lib/server/db')
 
+    // Cursor row still has its publishedAt because deleteChangelog
+    // preserves it precisely so pagination has an anchor.
     mockEntryFindFirst.mockResolvedValueOnce({
       publishedAt: new Date('2026-01-01'),
     })
@@ -104,22 +106,33 @@ describe('listPublicChangelogs', () => {
 
     await listPublicChangelogs({ cursor: 'cl_cursor' })
 
-    const deletedAtCalls = vi
-      .mocked(isNull)
-      .mock.calls.filter((args) => (args[0] as unknown) === changelogEntriesTable.deletedAt)
-    expect(deletedAtCalls.length).toBeGreaterThanOrEqual(2)
+    // The cursor lookup itself does NOT filter on deletedAt — it must
+    // find the row even if deleted, so we keep paginating past it.
+    const cursorEqCalls = vi
+      .mocked(eq)
+      .mock.calls.filter(
+        (args) => (args[0] as unknown) === changelogEntriesTable.id && args[1] === 'cl_cursor'
+      )
+    expect(cursorEqCalls.length).toBe(1)
+
+    // The pagination filter (lt publishedAt) was applied, so the user
+    // doesn't fall back to the first page.
+    const ltPublishedAtCalls = vi
+      .mocked(lt)
+      .mock.calls.filter((args) => (args[0] as unknown) === changelogEntriesTable.publishedAt)
+    expect(ltPublishedAtCalls.length).toBeGreaterThanOrEqual(1)
   })
 })
 
 describe('deleteChangelog', () => {
-  it('clears publishedAt when soft-deleting (defense-in-depth)', async () => {
+  it('sets deletedAt but preserves publishedAt so cursors stay valid', async () => {
     mockUpdateReturning.mockResolvedValueOnce([{ id: 'cl_1' }])
 
     const { deleteChangelog } = await import('../changelog.service')
     await deleteChangelog('cl_1' as ChangelogId)
 
-    expect(mockUpdateSet).toHaveBeenCalledWith(
-      expect.objectContaining({ deletedAt: expect.any(Date), publishedAt: null })
-    )
+    const setArgs = mockUpdateSet.mock.calls[0][0] as Record<string, unknown>
+    expect(setArgs.deletedAt).toBeInstanceOf(Date)
+    expect('publishedAt' in setArgs).toBe(false)
   })
 })

--- a/apps/web/src/lib/server/domains/changelog/changelog.public.ts
+++ b/apps/web/src/lib/server/domains/changelog/changelog.public.ts
@@ -124,13 +124,15 @@ export async function listPublicChangelogs(params: {
 
   const conditions = publicChangelogConditions(now)
 
-  // Cursor-based pagination
+  // Cursor-based pagination. The lookup does NOT filter on deletedAt:
+  // if an admin deleted the cursor row between page load and "Load
+  // more", we still want its prior publishedAt to anchor the next page
+  // so the user doesn't get duplicates / a stuck list. The main
+  // results query below applies the full visibility filter, so the
+  // deleted row itself stays out of the returned items.
   if (cursor) {
     const cursorEntry = await db.query.changelogEntries.findFirst({
-      where: and(
-        eq(changelogEntries.id, cursor as ChangelogId),
-        isNull(changelogEntries.deletedAt)
-      ),
+      where: eq(changelogEntries.id, cursor as ChangelogId),
       columns: { publishedAt: true },
     })
     if (cursorEntry?.publishedAt) {

--- a/apps/web/src/lib/server/domains/changelog/changelog.public.ts
+++ b/apps/web/src/lib/server/domains/changelog/changelog.public.ts
@@ -5,6 +5,7 @@ import {
   postStatuses,
   eq,
   and,
+  isNull,
   isNotNull,
   lt,
   lte,
@@ -18,6 +19,19 @@ import { computeStatus } from './changelog.service'
 import type { PublicChangelogEntry, PublicChangelogListResult } from './changelog.types'
 
 /**
+ * Predicates that make a changelog entry publicly visible: not soft-deleted
+ * and published at or before `now`. Shared by every public read path so the
+ * filter stays consistent.
+ */
+export function publicChangelogConditions(now: Date) {
+  return [
+    isNull(changelogEntries.deletedAt),
+    isNotNull(changelogEntries.publishedAt),
+    lte(changelogEntries.publishedAt, now),
+  ]
+}
+
+/**
  * Get a published changelog entry by ID for public view
  *
  * @param id - Changelog entry ID
@@ -27,11 +41,7 @@ export async function getPublicChangelogById(id: ChangelogId): Promise<PublicCha
   const now = new Date()
 
   const entry = await db.query.changelogEntries.findFirst({
-    where: and(
-      eq(changelogEntries.id, id),
-      isNotNull(changelogEntries.publishedAt),
-      lte(changelogEntries.publishedAt, now)
-    ),
+    where: and(eq(changelogEntries.id, id), ...publicChangelogConditions(now)),
   })
 
   if (!entry || !entry.publishedAt) {
@@ -112,16 +122,15 @@ export async function listPublicChangelogs(params: {
   const { cursor, limit = 20 } = params
   const now = new Date()
 
-  // Build where conditions - only published entries
-  const conditions = [
-    isNotNull(changelogEntries.publishedAt),
-    lte(changelogEntries.publishedAt, now),
-  ]
+  const conditions = publicChangelogConditions(now)
 
   // Cursor-based pagination
   if (cursor) {
     const cursorEntry = await db.query.changelogEntries.findFirst({
-      where: eq(changelogEntries.id, cursor as ChangelogId),
+      where: and(
+        eq(changelogEntries.id, cursor as ChangelogId),
+        isNull(changelogEntries.deletedAt)
+      ),
       columns: { publishedAt: true },
     })
     if (cursorEntry?.publishedAt) {

--- a/apps/web/src/lib/server/domains/changelog/changelog.service.ts
+++ b/apps/web/src/lib/server/domains/changelog/changelog.service.ts
@@ -229,15 +229,18 @@ export async function updateChangelog(
 // ============================================================================
 
 /**
- * Soft delete a changelog entry. Clears publishedAt so a public query that
- * forgets to filter on deletedAt still cannot serve the entry.
+ * Soft delete a changelog entry. publishedAt is preserved so cursor
+ * pagination in public read paths still has a valid anchor when the
+ * cursor row gets deleted mid-session. Visibility is enforced by the
+ * shared `publicChangelogConditions` helper, which every public read
+ * uses to filter out `deletedAt IS NOT NULL` rows.
  *
  * @param id - Changelog entry ID
  */
 export async function deleteChangelog(id: ChangelogId): Promise<void> {
   const result = await db
     .update(changelogEntries)
-    .set({ deletedAt: new Date(), publishedAt: null })
+    .set({ deletedAt: new Date() })
     .where(and(eq(changelogEntries.id, id), isNull(changelogEntries.deletedAt)))
     .returning()
 

--- a/apps/web/src/lib/server/domains/changelog/changelog.service.ts
+++ b/apps/web/src/lib/server/domains/changelog/changelog.service.ts
@@ -229,16 +229,15 @@ export async function updateChangelog(
 // ============================================================================
 
 /**
- * Soft delete a changelog entry
- *
- * Sets deletedAt timestamp instead of removing the row.
+ * Soft delete a changelog entry. Clears publishedAt so a public query that
+ * forgets to filter on deletedAt still cannot serve the entry.
  *
  * @param id - Changelog entry ID
  */
 export async function deleteChangelog(id: ChangelogId): Promise<void> {
   const result = await db
     .update(changelogEntries)
-    .set({ deletedAt: new Date() })
+    .set({ deletedAt: new Date(), publishedAt: null })
     .where(and(eq(changelogEntries.id, id), isNull(changelogEntries.deletedAt)))
     .returning()
 

--- a/apps/web/src/routes/changelog/feed.ts
+++ b/apps/web/src/routes/changelog/feed.ts
@@ -11,11 +11,13 @@ export const Route = createFileRoute('/changelog/feed')({
       GET: async () => {
         const [
           { config },
-          { db, changelogEntries, desc, isNotNull, lte },
+          { db, changelogEntries, and, desc },
+          { publicChangelogConditions },
           { getSettingsBrandingData },
         ] = await Promise.all([
           import('@/lib/server/config'),
           import('@/lib/server/db'),
+          import('@/lib/server/domains/changelog/changelog.public'),
           import('@/lib/server/settings-utils'),
         ])
 
@@ -25,10 +27,8 @@ export const Route = createFileRoute('/changelog/feed')({
         const branding = await getSettingsBrandingData()
         const siteName = branding?.name || 'Changelog'
 
-        // Fetch published changelog entries (limit to last 50)
         const entries = await db.query.changelogEntries.findMany({
-          where: (table, { and }) =>
-            and(isNotNull(table.publishedAt), lte(table.publishedAt, new Date())),
+          where: and(...publicChangelogConditions(new Date())),
           orderBy: [desc(changelogEntries.publishedAt)],
           limit: 50,
         })

--- a/apps/web/src/routes/sitemap[.]xml.ts
+++ b/apps/web/src/routes/sitemap[.]xml.ts
@@ -35,9 +35,15 @@ export const Route = createFileRoute('/sitemap.xml')({
 })
 
 async function collectUrls(baseUrl: string): Promise<SitemapUrl[]> {
-  const [{ db, changelogEntries, desc, eq, isNotNull, lte }, { toIsoDateOnly }] = await Promise.all(
-    [import('@/lib/server/db'), import('@/lib/shared/utils/date')]
-  )
+  const [
+    { db, changelogEntries, and, desc, eq },
+    { publicChangelogConditions },
+    { toIsoDateOnly },
+  ] = await Promise.all([
+    import('@/lib/server/db'),
+    import('@/lib/server/domains/changelog/changelog.public'),
+    import('@/lib/shared/utils/date'),
+  ])
 
   const urls: SitemapUrl[] = []
 
@@ -46,10 +52,8 @@ async function collectUrls(baseUrl: string): Promise<SitemapUrl[]> {
   urls.push({ loc: `${baseUrl}/roadmap` })
   urls.push({ loc: `${baseUrl}/changelog` })
 
-  // Published changelog entries
   const entries = await db.query.changelogEntries.findMany({
-    where: (table, { and }) =>
-      and(isNotNull(table.publishedAt), lte(table.publishedAt, new Date())),
+    where: and(...publicChangelogConditions(new Date())),
     orderBy: [desc(changelogEntries.publishedAt)],
     columns: { id: true, updatedAt: true },
   })


### PR DESCRIPTION
## Summary

Closes #163.

Public changelog reads filtered on `publishedAt` but not `deletedAt`, so admin deletes did not remove entries from the portal, RSS feed, or sitemap.

- Extract `publicChangelogConditions()` in `changelog.public.ts` and use it from `getPublicChangelogById`, `listPublicChangelogs` (including the cursor lookup), the RSS feed route, and the sitemap route — the three-predicate `deletedAt IS NULL AND publishedAt IS NOT NULL AND publishedAt <= now` filter now has a single source.
- `deleteChangelog` also clears `publishedAt` alongside `deletedAt` as defense-in-depth — if a future public query forgets the helper it still cannot serve the row.

## Notes

- The RSS feed and sitemap routes set `Cache-Control: public, max-age=3600`, so downstream caches (CDN, browser, feed readers) may serve a deleted entry for up to one hour after deletion. Direct portal URLs are uncached and update immediately. Considered acceptable for this fix; can be tightened separately if needed.

## Test plan

- [x] New vitest tests in `changelog-soft-delete.test.ts` assert the `isNull(deletedAt)` predicate is applied to `getPublicChangelogById`, `listPublicChangelogs`, and the cursor lookup, and that `deleteChangelog` clears `publishedAt`.
- [x] `bun run test apps/web/src/lib/server/domains/changelog apps/web/src/routes --run` — 163 / 163 pass
- [x] `bun run typecheck` — clean
- [x] `bun run lint` on touched files — clean
- [x] Manual: publish a changelog entry, hit the portal URL, the RSS feed (`/changelog/feed`), and `/sitemap.xml`, delete from admin, confirm all three stop serving it