### PR TITLE
Add contentJson field to portal comment mapping

### DIFF
--- a/apps/web/src/components/admin/feedback/detail/post-utils.ts
+++ b/apps/web/src/components/admin/feedback/detail/post-utils.ts
@@ -14,6 +14,7 @@ export function toPortalComments(post: PostDetails): PublicCommentView[] {
   const mapComment = (c: PostDetails['comments'][0]): PublicCommentView => ({
     id: c.id as CommentId,
     content: c.content,
+    contentJson: c.contentJson ?? null,
     authorName: c.authorName,
     principalId: c.principalId,
     createdAt: c.createdAt,


### PR DESCRIPTION
## Summary
Adds the `contentJson` field to the `PublicCommentView` mapping in the feedback detail post utilities, enabling structured content representation for portal comments.

## Changes
- Map `contentJson` from `PostDetails` comments to `PublicCommentView`, defaulting to `null` if not present

## Details
This change ensures that when comments are transformed for portal display, the structured JSON content representation is preserved alongside the plain text content. The optional chaining (`??`) provides a safe fallback to `null` for comments that may not have this field populated.

https://claude.ai/code/session_01Kx8g8bPMPYN1FWgzcQfGVA