### PR TITLE
fix(docker): self-host deploy fixes and multi-arch image

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,28 +3,35 @@
 # ============================================================================
 # Copy this file to .env and fill in your values.
 # For self-hosted deployments, only the "Required" section needs configuration.
+#
+# IMPORTANT — do NOT wrap values in quotes, and do not put inline comments on a
+# value line. Docker's `--env-file` / Compose `env_file` reads the entire text
+# after `=` literally: it does NOT strip quotes or trailing `# comments`. So a
+# quoted DATABASE_URL="postgresql://..." is passed with the quotes attached and
+# fails with `ERR_INVALID_URL`. Plain `KEY=value` works everywhere (Docker
+# --env-file, Compose, and Bun's dotenv loader).
 
 # ============================================================================
 # Required
 # ============================================================================
 
 # PostgreSQL connection string
-DATABASE_URL="postgresql://postgres:password@localhost:5432/quackback"
+DATABASE_URL=postgresql://postgres:password@localhost:5432/quackback
 
 # Public URL for your Quackback instance (used for auth, emails, OAuth callbacks)
-BASE_URL="http://localhost:3000"
+BASE_URL=http://localhost:3000
 
 # Port for the application server
-PORT="3000"
+PORT=3000
 
 # Secret key for authentication and encryption - MUST be at least 32 characters
 # This single key is used for session signing and deriving encryption keys.
 # Generate with: openssl rand -base64 32
-SECRET_KEY=""
+SECRET_KEY=
 
 # Redis/Dragonfly connection for background job queue (BullMQ)
 # Dragonfly is included in docker-compose and started by `bun run setup`.
-REDIS_URL="redis://localhost:6379"
+REDIS_URL=redis://localhost:6379
 
 # ============================================================================
 # Email (optional)
@@ -38,20 +45,21 @@ REDIS_URL="redis://localhost:6379"
 #   - Mailgun: smtp.mailgun.org
 #   - SendGrid: smtp.sendgrid.net
 
-EMAIL_SMTP_HOST=""
-EMAIL_SMTP_PORT="587"
-EMAIL_SMTP_USER=""
-EMAIL_SMTP_PASS=""
-# EMAIL_SMTP_SECURE="true"  # Uncomment for port 465 (implicit TLS)
+EMAIL_SMTP_HOST=
+EMAIL_SMTP_PORT=587
+EMAIL_SMTP_USER=
+EMAIL_SMTP_PASS=
+# Uncomment for port 465 (implicit TLS):
+# EMAIL_SMTP_SECURE=true
 
 # Option 2: Resend API (simpler setup, requires Resend account)
 # Get your API key at: https://resend.com/api-keys
 
-EMAIL_RESEND_API_KEY=""
+EMAIL_RESEND_API_KEY=
 
 # Sender address (REQUIRED when using SMTP or Resend)
-# Format: "Your App <noreply@yourdomain.com>"
-EMAIL_FROM=""
+# Format (no quotes): Your App <noreply@yourdomain.com>
+EMAIL_FROM=
 
 # ============================================================================
 # Inbound email (optional) — live-chat email channel
@@ -64,8 +72,8 @@ EMAIL_FROM=""
 #   - EMAIL_INBOUND_SIGNING_SECRET: the provider's webhook signing secret
 #     (Svix "whsec_..."). Point the provider's inbound webhook at
 #     <BASE_URL>/api/chat/email/inbound.
-EMAIL_INBOUND_DOMAIN=""
-EMAIL_INBOUND_SIGNING_SECRET=""
+EMAIL_INBOUND_DOMAIN=
+EMAIL_INBOUND_SIGNING_SECRET=
 
 # ============================================================================
 # AI (optional)
@@ -73,8 +81,10 @@ EMAIL_INBOUND_SIGNING_SECRET=""
 # Enable AI features like auto-categorization and summarization.
 
 # OpenAI API
-OPENAI_API_KEY=""
-OPENAI_BASE_URL=""  # Optional: custom endpoint (e.g., Azure OpenAI, Cloudflare AI Gateway)
+OPENAI_API_KEY=
+# Optional: custom endpoint (e.g. Azure OpenAI, Cloudflare AI Gateway).
+# Leave empty to talk to api.openai.com directly.
+OPENAI_BASE_URL=
 
 # ============================================================================
 # File Storage (for image uploads)
@@ -91,52 +101,59 @@ OPENAI_BASE_URL=""  # Optional: custom endpoint (e.g., Azure OpenAI, Cloudflare 
 # Run `bun run setup` or `docker compose up -d minio` to start it.
 
 # MinIO (local development - enabled by default)
-S3_ENDPOINT="http://localhost:9000"
-S3_BUCKET="quackback"
-S3_REGION="us-east-1"
-S3_ACCESS_KEY_ID="minioadmin"
-S3_SECRET_ACCESS_KEY="minioadmin"
-S3_FORCE_PATH_STYLE="true"
-S3_PUBLIC_URL=""
-# S3_PROXY="false"  # Proxy all S3 traffic (uploads and downloads) through the server.
-                     # Enable when the browser can't reach S3 directly (e.g., self-hosted Docker, ngrok).
+S3_ENDPOINT=http://localhost:9000
+S3_BUCKET=quackback
+S3_REGION=us-east-1
+S3_ACCESS_KEY_ID=minioadmin
+S3_SECRET_ACCESS_KEY=minioadmin
+S3_FORCE_PATH_STYLE=true
+S3_PUBLIC_URL=
+# Proxy all S3 traffic (uploads and downloads) through the server. Enable when
+# the browser can't reach S3 directly (e.g. self-hosted Docker, ngrok):
+# S3_PROXY=false
 
+# Using an external S3 provider instead of the bundled MinIO?
+#   - The local `minio` and `minio-init` services in docker-compose.yml are
+#     then unused — stop/remove them (e.g. `docker compose stop minio minio-init`)
+#     so you aren't running a container you don't need.
+#   - Fill in the provider values below.
+#
 # For production, replace with your preferred S3-compatible provider:
 #
 # AWS S3 (public bucket):
-#   S3_ENDPOINT=""  # Leave empty for AWS S3
-#   S3_BUCKET="your-bucket-name"
-#   S3_REGION="us-east-1"
-#   S3_ACCESS_KEY_ID="your-access-key"
-#   S3_SECRET_ACCESS_KEY="your-secret-key"
-#   S3_FORCE_PATH_STYLE="false"
-#   S3_PUBLIC_URL="https://your-bucket-name.s3.us-east-1.amazonaws.com"
+#   S3_ENDPOINT=          # Leave empty for AWS S3
+#   S3_BUCKET=your-bucket-name
+#   S3_REGION=us-east-1
+#   S3_ACCESS_KEY_ID=your-access-key
+#   S3_SECRET_ACCESS_KEY=your-secret-key
+#   S3_FORCE_PATH_STYLE=false
+#   S3_PUBLIC_URL=https://your-bucket-name.s3.us-east-1.amazonaws.com
 #
 # AWS S3 (private bucket via presigned redirect):
-#   S3_ENDPOINT=""
-#   S3_BUCKET="your-bucket-name"
-#   S3_REGION="us-east-1"
-#   S3_ACCESS_KEY_ID="your-access-key"
-#   S3_SECRET_ACCESS_KEY="your-secret-key"
-#   S3_FORCE_PATH_STYLE="false"
-#   S3_PUBLIC_URL="https://your-app.example.com/api/storage"
+#   S3_ENDPOINT=
+#   S3_BUCKET=your-bucket-name
+#   S3_REGION=us-east-1
+#   S3_ACCESS_KEY_ID=your-access-key
+#   S3_SECRET_ACCESS_KEY=your-secret-key
+#   S3_FORCE_PATH_STYLE=false
+#   S3_PUBLIC_URL=https://your-app.example.com/api/storage
 #
 # Cloudflare R2:
-#   S3_ENDPOINT="https://<account-id>.r2.cloudflarestorage.com"
-#   S3_BUCKET="your-bucket-name"
-#   S3_REGION="auto"
-#   S3_ACCESS_KEY_ID="your-access-key"
-#   S3_SECRET_ACCESS_KEY="your-secret-key"
-#   S3_FORCE_PATH_STYLE="true"
-#   S3_PUBLIC_URL="https://your-custom-domain.com"
+#   S3_ENDPOINT=https://<account-id>.r2.cloudflarestorage.com
+#   S3_BUCKET=your-bucket-name
+#   S3_REGION=auto
+#   S3_ACCESS_KEY_ID=your-access-key
+#   S3_SECRET_ACCESS_KEY=your-secret-key
+#   S3_FORCE_PATH_STYLE=true
+#   S3_PUBLIC_URL=https://your-custom-domain.com
 #
 # Railway Buckets (private — served via presigned URL redirects automatically):
-#   S3_ENDPOINT="https://your-bucket-endpoint.storageapi.dev"
-#   S3_BUCKET="your-bucket-name"
-#   S3_REGION="us-east-1"
-#   S3_ACCESS_KEY_ID="your-access-key"
-#   S3_SECRET_ACCESS_KEY="your-secret-key"
-#   S3_FORCE_PATH_STYLE="true"
+#   S3_ENDPOINT=https://your-bucket-endpoint.storageapi.dev
+#   S3_BUCKET=your-bucket-name
+#   S3_REGION=us-east-1
+#   S3_ACCESS_KEY_ID=your-access-key
+#   S3_SECRET_ACCESS_KEY=your-secret-key
+#   S3_FORCE_PATH_STYLE=true
 #   # No S3_PUBLIC_URL needed — files served via BASE_URL/api/storage automatically
 
 # ============================================================================
@@ -145,4 +162,4 @@ S3_PUBLIC_URL=""
 # Anonymous usage statistics are enabled by default to help improve Quackback.
 # Uncomment to disable.
 
-# DISABLE_TELEMETRY="true"
+# DISABLE_TELEMETRY=true

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,61 @@
+# ============================================================================
+# Quackback production environment — for docker-compose.prod.yml
+# ============================================================================
+# Copy to .env (in the repo root, next to docker-compose.prod.yml), fill in
+# EVERY value below, then:
+#   docker compose -f docker-compose.prod.yml up -d
+#
+# Rules (Docker reads these literally):
+#   - no quotes around values
+#   - no inline "# comments" on a value line
+#
+# You do NOT set DATABASE_URL / REDIS_URL / S3_ENDPOINT / S3 keys here — the
+# prod compose builds those from the secrets below and wires them to the
+# internal services automatically.
+
+# --- Application ---------------------------------------------------------
+# Public URL of your instance (auth, emails and OAuth callbacks depend on it).
+BASE_URL=https://feedback.example.com
+
+# Session signing + encryption key. MUST be >= 32 chars.
+# Generate with: openssl rand -base64 32
+SECRET_KEY=
+
+# Published image tag to run. Pin to a release (e.g. 0.10.6) in production.
+QUACKBACK_TAG=latest
+
+# Host port to publish the app on (the container always listens on 3000).
+APP_PORT=3000
+
+# --- PostgreSQL (internal `postgres` service) ----------------------------
+POSTGRES_USER=quackback
+# Generate with: openssl rand -base64 24
+POSTGRES_PASSWORD=
+POSTGRES_DB=quackback
+
+# --- Object storage (internal `minio` service) ---------------------------
+# These double as the S3 access key / secret the app uses.
+MINIO_ROOT_USER=quackback
+# Generate with: openssl rand -base64 24
+MINIO_ROOT_PASSWORD=
+S3_BUCKET=quackback
+S3_REGION=us-east-1
+
+# Bundled MinIO image tags (pin to a specific RELEASE.* / version in prod).
+# MINIO_IMAGE_TAG=latest
+# MC_IMAGE_TAG=latest
+
+# --- Email (required for invites, magic links, notifications) ------------
+# SMTP (works with any provider). Leave blank to log emails to the console.
+EMAIL_SMTP_HOST=
+EMAIL_SMTP_PORT=587
+EMAIL_SMTP_USER=
+EMAIL_SMTP_PASS=
+EMAIL_FROM=Quackback <noreply@example.com>
+# Or use Resend instead of SMTP:
+# EMAIL_RESEND_API_KEY=
+
+# --- AI (optional) -------------------------------------------------------
+# Enables summaries, duplicate detection, feedback extraction, etc.
+# OPENAI_API_KEY=
+# OPENAI_BASE_URL=

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,14 +14,35 @@ on:
         required: false
         default: ''
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
+  # Build each architecture on its OWN native runner — free arm64 hosted
+  # runners (ubuntu-24.04-arm) are GA for public repos — in parallel, pushing
+  # each as an untagged per-arch image BY DIGEST. Native beats QEMU here: the
+  # image runs `bun install` plus two Vite/TanStack production builds, which are
+  # far too slow under arm64 emulation (and risk job timeouts).
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
-      id-token: write # keyless cosign signing via GitHub OIDC
     steps:
+      - name: Prepare platform pair
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: echo "PLATFORM_PAIR=${PLATFORM//\//-}" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v6
         with:
           # On workflow_dispatch, build the requested sha/ref (re-release of an
@@ -30,16 +51,74 @@ jobs:
 
       - uses: docker/setup-buildx-action@v4
 
+      - name: Resolve lowercase image ref
+        run: echo "IMAGE=${REGISTRY}/$(printf '%s' "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
       - uses: docker/login-action@v4
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./apps/web/Dockerfile
+          platforms: ${{ matrix.platform }}
+          # No tags here — the manifest list (and its tags) is assembled in the
+          # merge job; each leg pushes an untagged per-arch image by digest.
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          # Per-arch cache scope so the two runners don't clobber each other.
+          cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}
+
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Assemble the multi-arch manifest list (OCI image index) from the per-arch
+  # digests, apply the real tags, then keyless-sign the index digest.
+  merge:
+    runs-on: ubuntu-latest
+    needs: [build]
+    permissions:
+      contents: read
+      packages: write
+      id-token: write # keyless cosign signing via GitHub OIDC
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Resolve lowercase image ref
+        run: echo "IMAGE=${REGISTRY}/$(printf '%s' "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: docker/metadata-action@v6
         id: meta
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ${{ env.IMAGE }}
           tags: |
             type=ref,event=branch,enable=${{ github.event_name != 'workflow_dispatch' }}
             type=semver,pattern={{version}}
@@ -47,28 +126,30 @@ jobs:
             type=raw,value=${{ github.event.inputs.image_tag }},enable=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.image_tag != '' }}
             type=sha,enable=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.image_tag == '' }}
 
-      - uses: docker/build-push-action@v7
-        id: build
-        with:
-          context: .
-          file: ./apps/web/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf "${IMAGE}@sha256:%s " *)
 
-      # Keyless cosign signature over the pushed digest, required by the
-      # cluster's Kyverno verify-images ClusterPolicy (keyless, GitHub OIDC
-      # issuer + QuackbackIO workflow subject). github.repository is a
-      # trusted GitHub-set slug; lowercased because OCI refs must be lower.
+      - name: Capture image index digest
+        id: index
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          DIGEST=$(docker buildx imagetools inspect "${IMAGE}:${VERSION}" --format '{{json .Manifest.Digest}}' | tr -d '"')
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
 
-      - name: Sign image (keyless)
+      # Keyless cosign signature over the pushed index digest, required by the
+      # cluster's Kyverno verify-images ClusterPolicy (keyless, GitHub OIDC
+      # issuer + QuackbackIO workflow subject). --recursive signs the OCI index
+      # AND each per-arch child manifest, so policy can verify either the index
+      # or a resolved per-arch digest.
+      - name: Sign image index (keyless)
         env:
-          DIGEST: ${{ steps.build.outputs.digest }}
-          REPO: ${{ github.repository }}
-        run: |
-          IMAGE="ghcr.io/$(printf '%s' "$REPO" | tr '[:upper:]' '[:lower:]')"
-          cosign sign --yes "${IMAGE}@${DIGEST}"
+          IMAGE_DIGEST: ${{ steps.index.outputs.digest }}
+        run: cosign sign --yes --recursive "${IMAGE}@${IMAGE_DIGEST}"

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -24,18 +24,20 @@ docker run -d \
   -e DATABASE_URL="postgresql://user:pass@host:5432/quackback" \
   -e SECRET_KEY="your-secret-32-chars-minimum" \
   -e BASE_URL="https://your-domain.com" \
-  ghcr.io/quackbackhq/quackback:latest
+  ghcr.io/quackbackio/quackback:latest
 ```
 
 ### With Docker Compose
 
 ```bash
-git clone https://github.com/quackbackhq/quackback.git
+git clone https://github.com/quackbackio/quackback.git
 cd quackback
-cp .env.example .env
-# Edit .env with your settings
-docker compose up -d
+cp .env.prod.example .env
+# Edit .env with your settings (generate secrets with: openssl rand -base64 32)
+docker compose -f docker-compose.prod.yml up -d
 ```
+
+> The root `docker-compose.yml` is for **local development only** (datastores, no app service). Use `docker-compose.prod.yml` to self-host — it bundles the app plus Postgres, Dragonfly, and MinIO with hardened defaults.
 
 See the [Self-Hosted Guide](./self-hosted/README.md) for complete documentation.
 

--- a/deploy/self-hosted/README.md
+++ b/deploy/self-hosted/README.md
@@ -22,21 +22,23 @@ Deploy Quackback on your own infrastructure with full control over your data.
 
 ```bash
 # Clone the repository
-git clone https://github.com/quackbackhq/quackback.git
+git clone https://github.com/quackbackio/quackback.git
 cd quackback
 
 # Copy and configure environment
-cp .env.example .env
-# Edit .env with your settings (see Environment Variables below)
+cp .env.prod.example .env
+# Edit .env — fill in every value (generate secrets with: openssl rand -base64 32)
 
-# Start the application
-docker compose up -d
+# Start the application (app + Postgres + Dragonfly + MinIO)
+docker compose -f docker-compose.prod.yml up -d
 
 # View logs
-docker compose logs -f
+docker compose -f docker-compose.prod.yml logs -f
 ```
 
 Open http://localhost:3000 to access Quackback.
+
+> The root `docker-compose.yml` is **development infrastructure only** (no app service, insecure defaults, world-readable bucket). Always use `docker-compose.prod.yml` for self-hosting.
 
 ### Using Docker Run
 
@@ -47,7 +49,7 @@ docker run -d \
   -e DATABASE_URL="postgresql://user:pass@host:5432/quackback" \
   -e SECRET_KEY="your-secret-key-at-least-32-chars" \
   -e BASE_URL="https://your-domain.com" \
-  ghcr.io/quackbackhq/quackback:latest
+  ghcr.io/quackbackio/quackback:latest
 ```
 
 ---
@@ -67,13 +69,13 @@ Images are published to GitHub Container Registry:
 
 ```bash
 # Pull latest community edition
-docker pull ghcr.io/quackbackhq/quackback:latest
+docker pull ghcr.io/quackbackio/quackback:latest
 
 # Pull specific version
-docker pull ghcr.io/quackbackhq/quackback:v1.0.0
+docker pull ghcr.io/quackbackio/quackback:v1.0.0
 
 # Pull enterprise edition
-docker pull ghcr.io/quackbackhq/quackback:latest-enterprise
+docker pull ghcr.io/quackbackio/quackback:latest-enterprise
 ```
 
 ---
@@ -90,12 +92,12 @@ docker pull ghcr.io/quackbackhq/quackback:latest-enterprise
 
 ### Optional
 
-| Variable         | Description             | Default      |
-| ---------------- | ----------------------- | ------------ |
-| `PORT`           | Server port             | `3000`       |
-| `NODE_ENV`       | Environment             | `production` |
-| `RESEND_API_KEY` | Email service (Resend)  | -            |
-| `EMAIL_FROM`     | From address for emails | -            |
+| Variable               | Description             | Default      |
+| ---------------------- | ----------------------- | ------------ |
+| `PORT`                 | Server port             | `3000`       |
+| `NODE_ENV`             | Environment             | `production` |
+| `EMAIL_RESEND_API_KEY` | Email service (Resend)  | -            |
+| `EMAIL_FROM`           | From address for emails | -            |
 
 ### Integrations (Optional)
 
@@ -168,7 +170,7 @@ pg_restore -d quackback quackback_backup.dump
 
 ```bash
 # Clone repository
-git clone https://github.com/quackbackhq/quackback.git
+git clone https://github.com/quackbackio/quackback.git
 cd quackback
 
 # Install dependencies
@@ -248,7 +250,7 @@ feedback.yourcompany.com {
 # docker-compose.yml with Traefik labels
 services:
   quackback:
-    image: ghcr.io/quackbackhq/quackback:latest
+    image: ghcr.io/quackbackio/quackback:latest
     labels:
       - 'traefik.enable=true'
       - 'traefik.http.routers.quackback.rule=Host(`feedback.yourcompany.com`)'
@@ -274,7 +276,7 @@ docker run -d \
   -e DATABASE_URL="postgresql://..." \
   -e SECRET_KEY="..." \
   -e QUACKBACK_LICENSE_KEY="your-license-key" \
-  ghcr.io/quackbackhq/quackback:latest-enterprise
+  ghcr.io/quackbackio/quackback:latest-enterprise
 ```
 
 ### Obtaining a License
@@ -288,13 +290,16 @@ Contact sales@quackback.io for enterprise licensing information.
 ### Docker Compose
 
 ```bash
-# Pull latest image
-docker compose pull
+# 1. Back up your database first
+docker compose -f docker-compose.prod.yml exec postgres \
+  pg_dump -Fc -U "$POSTGRES_USER" "$POSTGRES_DB" > backup-$(date +%Y%m%d).dump
 
-# Restart with new image
-docker compose up -d
+# 2. Pull the latest source + image (bump QUACKBACK_TAG in .env to pin a version)
+git pull
+docker compose -f docker-compose.prod.yml pull
 
-# Migrations run automatically on startup
+# 3. Restart — migrations run automatically on startup
+docker compose -f docker-compose.prod.yml up -d
 ```
 
 ### Docker Run
@@ -305,7 +310,7 @@ docker stop quackback
 docker rm quackback
 
 # Pull new image
-docker pull ghcr.io/quackbackhq/quackback:latest
+docker pull ghcr.io/quackbackio/quackback:latest
 
 # Start new container (same run command as before)
 docker run -d --name quackback ...
@@ -418,5 +423,5 @@ Coming soon:
 ## Support
 
 - **Documentation**: https://docs.quackback.io
-- **GitHub Issues**: https://github.com/quackbackhq/quackback/issues
+- **GitHub Issues**: https://github.com/quackbackio/quackback/issues
 - **Discord**: https://discord.gg/quackback

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,153 @@
+# ============================================================================
+# Quackback — production stack (self-hosting)
+# ============================================================================
+# A self-contained, single-host deployment: the Quackback app plus its
+# datastores (PostgreSQL + Dragonfly + MinIO). Unlike the dev docker-compose.yml,
+# this file is safe to run on a server:
+#   - the app is the ONLY service with a published host port
+#   - datastores are reachable only on the internal compose network
+#   - every secret is required via ${VAR:?...} — the stack refuses to start
+#     half-configured instead of falling back to insecure defaults
+#   - the upload bucket is PRIVATE (served through the app at /api/storage)
+#
+# Quick start:
+#   git clone https://github.com/QuackbackIO/quackback.git && cd quackback
+#   cp .env.prod.example .env      # then fill in every value
+#   docker compose -f docker-compose.prod.yml up -d
+#
+# Migrations run automatically on app startup. Upgrade with:
+#   git pull && docker compose -f docker-compose.prod.yml pull && \
+#     docker compose -f docker-compose.prod.yml up -d
+# (back up your database first — see the self-hosting docs).
+#
+# For an external Postgres / Redis / S3 instead of the bundled datastores,
+# point the URLs at your managed services and remove the services you no longer
+# need. To scale beyond one host, use managed datastores + the `docker run`
+# path; this compose is single-node by design.
+# ============================================================================
+
+services:
+  app:
+    image: ghcr.io/quackbackio/quackback:${QUACKBACK_TAG:-latest}
+    container_name: quackback-app
+    restart: unless-stopped
+    init: true
+    # Carries BASE_URL, SECRET_KEY, email settings, S3_BUCKET/S3_REGION, etc.
+    env_file: .env
+    # Internal wiring is fixed here (derived from the secrets in .env) so a
+    # self-hoster can't point these at the wrong host — these override env_file.
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:?set POSTGRES_USER in .env}:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}@postgres:5432/${POSTGRES_DB:-quackback}
+      REDIS_URL: redis://dragonfly:6379
+      S3_ENDPOINT: http://minio:9000
+      S3_BUCKET: ${S3_BUCKET:-quackback}
+      S3_ACCESS_KEY_ID: ${MINIO_ROOT_USER:?set MINIO_ROOT_USER in .env}
+      S3_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:?set MINIO_ROOT_PASSWORD in .env}
+      S3_FORCE_PATH_STYLE: 'true'
+      # MinIO has no public port, so the browser can't reach it directly:
+      # serve uploads through the app's /api/storage proxy.
+      S3_PROXY: 'true'
+    ports:
+      - '${APP_PORT:-3000}:3000'
+    depends_on:
+      postgres:
+        condition: service_healthy
+      dragonfly:
+        condition: service_healthy
+      minio-init:
+        condition: service_completed_successfully
+    healthcheck:
+      # Use Bun (always in the image) so we don't depend on curl/wget. The
+      # container listens on 3000 regardless of the published APP_PORT.
+      test:
+        [
+          'CMD',
+          'bun',
+          '-e',
+          "fetch('http://localhost:3000/api/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+        ]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 40s
+
+  postgres:
+    build:
+      context: ./docker/postgres
+      dockerfile: Dockerfile
+    container_name: quackback-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:?set POSTGRES_USER in .env}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}
+      POSTGRES_DB: ${POSTGRES_DB:-quackback}
+    # No host port — Postgres is reachable only on the internal network.
+    volumes:
+      - postgres_data:/var/lib/postgresql
+      - ./docker/postgres/init-pgcron.sql:/docker-entrypoint-initdb.d/init-pgcron.sql
+    # pg_cron is required for scheduled analytics/materialized-view refreshes.
+    command: postgres -c shared_preload_libraries=pg_cron -c cron.database_name=${POSTGRES_DB:-quackback} -c max_connections=200
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U "$${POSTGRES_USER}" -d "$${POSTGRES_DB}"']
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  dragonfly:
+    image: docker.dragonflydb.io/dragonflydb/dragonfly:v1.27.1
+    container_name: quackback-dragonfly
+    restart: unless-stopped
+    # BullMQ requires cluster_mode=emulated + lock_on_hashtags for Lua script compatibility.
+    command: dragonfly --cluster_mode=emulated --lock_on_hashtags
+    # No host port — reachable only on the internal network.
+    volumes:
+      - dragonfly_data:/data
+    ulimits:
+      memlock: -1
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  minio:
+    image: minio/minio:${MINIO_IMAGE_TAG:-latest}
+    container_name: quackback-minio
+    restart: unless-stopped
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?set MINIO_ROOT_USER in .env}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?set MINIO_ROOT_PASSWORD in .env}
+    # No host port — object storage is internal; uploads are served via the app.
+    command: server /data
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ['CMD', 'mc', 'ready', 'local']
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  # Creates the upload bucket on first start. Unlike the dev stack it does NOT
+  # set a public download policy — the bucket stays private and is served
+  # through the app's /api/storage proxy (S3_PROXY=true above).
+  minio-init:
+    image: minio/mc:${MC_IMAGE_TAG:-latest}
+    container_name: quackback-minio-init
+    depends_on:
+      minio:
+        condition: service_healthy
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?set MINIO_ROOT_USER in .env}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?set MINIO_ROOT_PASSWORD in .env}
+      S3_BUCKET: ${S3_BUCKET:-quackback}
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 \"$$MINIO_ROOT_USER\" \"$$MINIO_ROOT_PASSWORD\" &&
+      mc mb --ignore-existing local/\"$$S3_BUCKET\"
+      "
+    restart: 'no'
+
+volumes:
+  postgres_data:
+  minio_data:
+  dragonfly_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,16 @@
+# ============================================================================
+# DEVELOPMENT infrastructure only — Postgres, MinIO, Dragonfly, Mailpit.
+# Started by `bun run setup` / `bun run dev`; the app itself runs on the host
+# via `bun run dev`, so there is NO app service here.
+#
+# This file uses insecure defaults (postgres/password, minioadmin), publishes
+# datastore ports on localhost, and makes the upload bucket world-readable —
+# all fine for local development, NOT safe on an internet-facing host.
+#
+# To self-host Quackback, use docker-compose.prod.yml instead (app included,
+# hardened defaults). See the self-hosting docs.
+# ============================================================================
+
 services:
   postgres:
     build:


### PR DESCRIPTION
## What

Fixes the Docker self-hosting experience and ships a multi-arch image.

### App-included production compose (`docker-compose.prod.yml`)
The docs promised `docker compose up -d` would start Quackback, but the only compose file was dev infrastructure with no `app` service. This adds a hardened, self-contained stack:

- app (from `ghcr.io/quackbackio/quackback`) + Postgres + Dragonfly + MinIO
- the app is the only service with a published host port; datastores stay on the internal network
- fail-fast `${VAR:?}` secrets (refuses to boot half-configured instead of using insecure defaults)
- healthcheck-gated startup
- private upload bucket (no `mc anonymous set download`), served through the app via `S3_PROXY`

The root `docker-compose.yml` is now clearly marked development-only. Adds `.env.prod.example`.

### Multi-arch image (`linux/amd64` + `linux/arm64`)
Rebuilt the Docker workflow to use a native runner matrix (`ubuntu-latest` + `ubuntu-24.04-arm`, free for public repos), pushing each arch by digest, merging into one manifest list, then signing the index with `cosign --recursive`. Native runners avoid the slow QEMU emulation of the `bun install` + double Vite build.

### `.env.example` is now `--env-file` safe
Removed quotes from all values and moved inline comments off value lines. Docker's `--env-file` reads them literally, so a quoted `DATABASE_URL` caused `ERR_INVALID_URL`. Documented removing MinIO when using an external S3 provider.

### Docs
Updated `deploy/README.md` and `deploy/self-hosted/README.md` (prod-compose quick start, backup-first upgrades, `quackbackhq` -> `quackbackio` org slug, `EMAIL_RESEND_API_KEY`). Companion docs-site changes are in a separate `quackback-docs` PR.

## Testing
- `docker compose -f docker-compose.prod.yml config` fails fast on missing secrets and validates with a filled `.env`; derived `DATABASE_URL`/`REDIS_URL`/`S3_*` resolve to the internal services.
- Root dev compose still validates.
- Workflow is valid YAML and follows Docker's documented multi-platform pattern (first real run happens on merge to `main`).

Closes #189
Closes #190
