### PR TITLE
chore(release): bump version to 0.11.0

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quackback/web",
-  "version": "0.10.5",
+  "version": "0.11.0",
   "private": true,
   "license": "AGPL-3.0",
   "type": "module",


### PR DESCRIPTION
Bumps `apps/web/package.json` to 0.11.0 (the source of truth for `__APP_VERSION__`) ahead of tagging `v0.11.0`.

Release contents are summarized in the GitHub Release notes to follow.