### PR TITLE
publish custom postgres image

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -21,8 +21,12 @@ BASE_URL=https://feedback.example.com
 # Generate with: openssl rand -base64 32
 SECRET_KEY=
 
-# Published image tag to run. Pin to a release (e.g. 0.10.6) in production.
+# Published app image tag to run. Pin to a release (e.g. 0.10.6) in production.
 QUACKBACK_TAG=latest
+
+# Bundled Postgres image tag. This image changes less often than the app; keep
+# latest unless you want to pin database infrastructure separately.
+QUACKBACK_POSTGRES_TAG=latest
 
 # Host port to publish the app on (the container always listens on 3000).
 APP_PORT=3000

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  POSTGRES_IMAGE_NAME: ${{ github.repository }}-postgres
 
 jobs:
   # Build each architecture on its OWN native runner — free arm64 hosted
@@ -129,9 +130,17 @@ jobs:
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create \
-            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf "${IMAGE}@sha256:%s " *)
+          tag_args=()
+          while IFS= read -r tag; do
+            tag_args+=("-t" "$tag")
+          done < <(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+
+          image_args=()
+          for digest in *; do
+            image_args+=("${IMAGE}@sha256:${digest}")
+          done
+
+          docker buildx imagetools create "${tag_args[@]}" "${image_args[@]}"
 
       - name: Capture image index digest
         id: index
@@ -150,6 +159,132 @@ jobs:
       # AND each per-arch child manifest, so policy can verify either the index
       # or a resolved per-arch digest.
       - name: Sign image index (keyless)
+        env:
+          IMAGE_DIGEST: ${{ steps.index.outputs.digest }}
+        run: cosign sign --yes --recursive "${IMAGE}@${IMAGE_DIGEST}"
+
+  build-postgres:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Prepare platform pair
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: echo "PLATFORM_PAIR=${PLATFORM//\//-}" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.sha || github.ref }}
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Resolve lowercase Postgres image ref
+        run: echo "IMAGE=${REGISTRY}/$(printf '%s' "$POSTGRES_IMAGE_NAME" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Postgres by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: ./docker/postgres
+          file: ./docker/postgres/Dockerfile
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=postgres-${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=postgres-${{ env.PLATFORM_PAIR }}
+
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: postgres-digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-postgres:
+    runs-on: ubuntu-latest
+    needs: [build-postgres]
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: postgres-digests-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Resolve lowercase Postgres image ref
+        run: echo "IMAGE=${REGISTRY}/$(printf '%s' "$POSTGRES_IMAGE_NAME" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v6
+        id: meta
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=ref,event=branch,enable=${{ github.event_name != 'workflow_dispatch' }}
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=${{ github.event.inputs.image_tag }},enable=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.image_tag != '' }}
+            type=sha,enable=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.image_tag == '' }}
+
+      - name: Create Postgres manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          tag_args=()
+          while IFS= read -r tag; do
+            tag_args+=("-t" "$tag")
+          done < <(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+
+          image_args=()
+          for digest in *; do
+            image_args+=("${IMAGE}@sha256:${digest}")
+          done
+
+          docker buildx imagetools create "${tag_args[@]}" "${image_args[@]}"
+
+      - name: Capture Postgres image index digest
+        id: index
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          DIGEST=$(docker buildx imagetools inspect "${IMAGE}:${VERSION}" --format '{{json .Manifest.Digest}}' | tr -d '"')
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Postgres image index (keyless)
         env:
           IMAGE_DIGEST: ${{ steps.index.outputs.digest }}
         run: cosign sign --yes --recursive "${IMAGE}@${IMAGE_DIGEST}"

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -37,7 +37,7 @@ cp .env.prod.example .env
 docker compose -f docker-compose.prod.yml up -d
 ```
 
-> The root `docker-compose.yml` is for **local development only** (datastores, no app service). Use `docker-compose.prod.yml` to self-host — it bundles the app plus Postgres, Dragonfly, and MinIO with hardened defaults.
+> The root `docker-compose.yml` is for **local development only** (datastores, no app service). Use `docker-compose.prod.yml` to self-host — it bundles the app plus Postgres, Dragonfly, and MinIO with hardened defaults. The matching published Postgres image is `ghcr.io/quackbackio/quackback-postgres`.
 
 See the [Self-Hosted Guide](./self-hosted/README.md) for complete documentation.
 

--- a/deploy/self-hosted/README.md
+++ b/deploy/self-hosted/README.md
@@ -78,6 +78,12 @@ docker pull ghcr.io/quackbackio/quackback:v1.0.0
 docker pull ghcr.io/quackbackio/quackback:latest-enterprise
 ```
 
+The Docker workflow also publishes `ghcr.io/quackbackio/quackback-postgres`
+with the same branch, release, and manual tags as the app image. It is built
+from `docker/postgres/Dockerfile` and includes PostgreSQL 18 with `pg_cron` and
+`pgvector`. `docker-compose.prod.yml` uses `QUACKBACK_POSTGRES_TAG` so the
+database image can be pinned independently from `QUACKBACK_TAG`.
+
 ---
 
 ## Environment Variables
@@ -122,7 +128,15 @@ docker pull ghcr.io/quackbackio/quackback:latest-enterprise
 
 ## Database Setup
 
-Quackback requires PostgreSQL 13+.
+Quackback requires PostgreSQL 13+. The bundled Docker Postgres image includes
+`pgvector` for vector columns and `pg_cron` for scheduled jobs.
+
+For an external database, make sure `pgvector` is available before running
+migrations:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
+```
 
 ### Create Database
 
@@ -294,7 +308,8 @@ Contact sales@quackback.io for enterprise licensing information.
 docker compose -f docker-compose.prod.yml exec postgres \
   pg_dump -Fc -U "$POSTGRES_USER" "$POSTGRES_DB" > backup-$(date +%Y%m%d).dump
 
-# 2. Pull the latest source + image (bump QUACKBACK_TAG in .env to pin a version)
+# 2. Pull the latest source + images
+#    Bump QUACKBACK_TAG and/or QUACKBACK_POSTGRES_TAG in .env to pin versions.
 git pull
 docker compose -f docker-compose.prod.yml pull
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -72,9 +72,7 @@ services:
       start_period: 40s
 
   postgres:
-    build:
-      context: ./docker/postgres
-      dockerfile: Dockerfile
+    image: ghcr.io/quackbackio/quackback-postgres:${QUACKBACK_POSTGRES_TAG:-latest}
     container_name: quackback-db
     restart: unless-stopped
     environment:
@@ -84,7 +82,6 @@ services:
     # No host port — Postgres is reachable only on the internal network.
     volumes:
       - postgres_data:/var/lib/postgresql
-      - ./docker/postgres/init-pgcron.sql:/docker-entrypoint-initdb.d/init-pgcron.sql
     # pg_cron is required for scheduled analytics/materialized-view refreshes.
     command: postgres -c shared_preload_libraries=pg_cron -c cron.database_name=${POSTGRES_DB:-quackback} -c max_connections=200
     healthcheck:

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -9,3 +9,5 @@ RUN apt-get update \
 
 # Add pg_cron to shared_preload_libraries
 RUN echo "shared_preload_libraries = 'pg_cron'" >> /usr/share/postgresql/postgresql.conf.sample
+
+COPY init-pgcron.sql /docker-entrypoint-initdb.d/init-pgcron.sql


### PR DESCRIPTION
This PR publishes the custom Postgres image with the extensions needed for this repo.

## Summary
- publish the bundled Postgres image as `ghcr.io/quackbackio/quackback-postgres`
- use the published Postgres image from production compose with `QUACKBACK_POSTGRES_TAG`
- bake the extension init SQL into the Postgres image and document the self-hosted image/extension requirements

## Verification
- `docker compose -f docker-compose.prod.yml config --no-interpolate`
- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest .github/workflows/docker.yml`
- smoke-tested the workflow end to end in a temporary non-fork repo
- verified app and Postgres test images published as multi-arch OCI indexes for `linux/amd64` and `linux/arm64`