### PR TITLE
fix(shortcut): inbound status-sync no-op + surface webhook signing secret

### DIFF
--- a/apps/web/src/components/admin/settings/integrations/__tests__/status-sync-config.test.tsx
+++ b/apps/web/src/components/admin/settings/integrations/__tests__/status-sync-config.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment happy-dom
+/**
+ * <StatusSyncConfig> — webhook secret surfacing for manual integrations.
+ *
+ * Manual-webhook platforms (Shortcut, Azure DevOps) can't auto-register their
+ * webhook, so the admin must paste both the URL *and* the signing secret into
+ * the external platform. The secret must therefore be visible in the UI.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { StatusSyncConfig } from '../status-sync-config'
+
+vi.mock('@tanstack/react-query', () => ({
+  useSuspenseQuery: () => ({ data: [] }),
+}))
+
+const idleMutation = { mutate: vi.fn(), isPending: false, isError: false, error: null }
+vi.mock('@/lib/client/mutations', () => ({
+  useEnableStatusSync: () => idleMutation,
+  useDisableStatusSync: () => idleMutation,
+  useUpdateStatusMappings: () => idleMutation,
+}))
+
+vi.mock('@/lib/client/queries/admin', () => ({
+  adminQueries: { statuses: () => ({ queryKey: ['statuses'], queryFn: async () => [] }) },
+}))
+
+afterEach(cleanup)
+
+const SECRET = 'whsec_test_secret_123'
+
+function renderConfig(overrides: Record<string, unknown> = {}) {
+  return render(
+    <StatusSyncConfig
+      integrationId="int_1"
+      integrationType="shortcut"
+      config={{ statusSyncEnabled: true, webhookSecret: SECRET }}
+      enabled
+      externalStatuses={[]}
+      isManual
+      {...overrides}
+    />
+  )
+}
+
+describe('StatusSyncConfig — manual webhook secret', () => {
+  it('renders the webhook signing secret for a manual integration', () => {
+    renderConfig()
+    expect(screen.getByText(SECRET)).toBeTruthy()
+  })
+
+  it('does not render the secret for an auto-registered integration', () => {
+    renderConfig({ isManual: false })
+    expect(screen.queryByText(SECRET)).toBeNull()
+  })
+})

--- a/apps/web/src/components/admin/settings/integrations/status-sync-config.tsx
+++ b/apps/web/src/components/admin/settings/integrations/status-sync-config.tsx
@@ -2,10 +2,10 @@
 
 import { useState } from 'react'
 import { useSuspenseQuery } from '@tanstack/react-query'
-import { ArrowPathIcon, ClipboardDocumentIcon, CheckIcon } from '@heroicons/react/24/solid'
+import { ArrowPathIcon } from '@heroicons/react/24/solid'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
-import { Button } from '@/components/ui/button'
+import { CopyButton } from '@/components/shared/copy-button'
 import {
   Select,
   SelectContent,
@@ -52,7 +52,6 @@ export function StatusSyncConfig({
   const webhookSecret = config.webhookSecret as string | undefined
 
   const [mappings, setMappings] = useState<Record<string, string | null>>(existingMappings)
-  const [copied, setCopied] = useState(false)
 
   const statusesQuery = useSuspenseQuery(adminQueries.statuses())
   const quackbackStatuses = statusesQuery.data
@@ -82,14 +81,6 @@ export function StatusSyncConfig({
     ? `${window.location.origin}/api/integrations/${integrationType}/webhook`
     : null
 
-  const handleCopyUrl = () => {
-    if (webhookUrl) {
-      navigator.clipboard.writeText(webhookUrl)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    }
-  }
-
   return (
     <div className="space-y-6 border-t border-border/50 pt-6">
       <div className="flex items-center justify-between">
@@ -111,23 +102,23 @@ export function StatusSyncConfig({
       </div>
 
       {statusSyncEnabled && isManual && webhookUrl && (
-        <div className="rounded-lg border border-border/50 bg-muted/30 p-4 space-y-2">
-          <p className="text-sm font-medium">Webhook URL</p>
-          <p className="text-xs text-muted-foreground">
-            Copy this URL into your {integrationType.replace('_', ' ')} webhook settings.
-          </p>
-          <div className="flex items-center gap-2">
-            <code className="flex-1 rounded bg-muted px-3 py-2 text-xs font-mono break-all">
-              {webhookUrl}
-            </code>
-            <Button variant="outline" size="sm" onClick={handleCopyUrl} className="shrink-0">
-              {copied ? (
-                <CheckIcon className="h-4 w-4" />
-              ) : (
-                <ClipboardDocumentIcon className="h-4 w-4" />
-              )}
-            </Button>
+        <div className="rounded-lg border border-border/50 bg-muted/30 p-4 space-y-4">
+          <div className="space-y-2">
+            <p className="text-sm font-medium">Webhook URL</p>
+            <p className="text-xs text-muted-foreground">
+              Copy this URL into your {integrationType.replace('_', ' ')} webhook settings.
+            </p>
+            <CopyableValue value={webhookUrl} />
           </div>
+          {webhookSecret && (
+            <div className="space-y-2">
+              <p className="text-sm font-medium">Signing secret</p>
+              <p className="text-xs text-muted-foreground">
+                Paste this as the webhook payload secret so status updates can be verified.
+              </p>
+              <CopyableValue value={webhookSecret} />
+            </div>
+          )}
         </div>
       )}
 
@@ -187,6 +178,16 @@ export function StatusSyncConfig({
             'Failed to save changes'}
         </div>
       )}
+    </div>
+  )
+}
+
+/** A read-only value shown in a code block with a copy-to-clipboard button. */
+function CopyableValue({ value }: { value: string }) {
+  return (
+    <div className="flex items-center gap-2">
+      <code className="flex-1 rounded bg-muted px-3 py-2 text-xs font-mono break-all">{value}</code>
+      <CopyButton value={value} variant="outline" size="sm" />
     </div>
   )
 }

--- a/apps/web/src/lib/server/integrations/shortcut/__tests__/inbound.test.ts
+++ b/apps/web/src/lib/server/integrations/shortcut/__tests__/inbound.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for Shortcut inbound webhook handler.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createHmac } from 'crypto'
+import { shortcutInboundHandler } from '../inbound'
+
+function sign(body: string, secret: string): string {
+  return createHmac('sha256', secret).update(body).digest('hex')
+}
+
+function makeRequest(headers: Record<string, string> = {}): Request {
+  return new Request('https://example.com/webhook', { headers })
+}
+
+// The handler only reads the body; config/secrets are required by the
+// InboundWebhookHandler interface signature but ignored here.
+const parse = (payload: unknown) =>
+  shortcutInboundHandler.parseStatusChange(JSON.stringify(payload), {}, {})
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * A realistic Shortcut `story-update` webhook payload. The `changes` carry the
+ * numeric workflow_state_id, and the top-level `references` array maps those
+ * numeric IDs to human-readable state names (Shortcut's own self-describing
+ * format — see https://developer.shortcut.com/api/webhook/v1).
+ */
+function storyStateChangePayload(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'webhook-event-id',
+    changed_at: '2026-06-06T00:00:00Z',
+    primary_id: 16,
+    version: 'v1',
+    actions: [
+      {
+        id: 16,
+        entity_type: 'story',
+        action: 'update',
+        name: 'My story',
+        changes: {
+          workflow_state_id: { new: 1495, old: 1493 },
+        },
+      },
+    ],
+    references: [
+      { id: 1495, entity_type: 'workflow-state', name: 'Ready for Deploy' },
+      { id: 1493, entity_type: 'workflow-state', name: 'Ready for Dev' },
+    ],
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Status change parsing
+// ---------------------------------------------------------------------------
+
+describe('shortcutInboundHandler.parseStatusChange', () => {
+  it('resolves the new workflow state name from the payload references', async () => {
+    const payload = storyStateChangePayload()
+    const result = await parse(payload)
+
+    expect(result).toEqual({
+      externalId: '16',
+      externalStatus: 'Ready for Deploy',
+      eventType: 'story.workflow_state_changed',
+    })
+  })
+
+  it('returns null when no reference matches the new state ID', async () => {
+    const payload = storyStateChangePayload({
+      references: [{ id: 9999, entity_type: 'workflow-state', name: 'Unrelated' }],
+    })
+    const result = await parse(payload)
+    expect(result).toBeNull()
+  })
+
+  it('ignores a matching ID whose reference is not a workflow-state', async () => {
+    const payload = storyStateChangePayload({
+      references: [{ id: 1495, entity_type: 'story', name: 'Decoy' }],
+    })
+    const result = await parse(payload)
+    expect(result).toBeNull()
+  })
+
+  it('returns null when the payload has no references array', async () => {
+    const payload = storyStateChangePayload({ references: undefined })
+    const result = await parse(payload)
+    expect(result).toBeNull()
+  })
+
+  it('returns null for non-story entity types', async () => {
+    const payload = storyStateChangePayload()
+    ;(payload.actions[0] as Record<string, unknown>).entity_type = 'epic'
+    const result = await parse(payload)
+    expect(result).toBeNull()
+  })
+
+  it('returns null for non-update actions', async () => {
+    const payload = storyStateChangePayload()
+    ;(payload.actions[0] as Record<string, unknown>).action = 'create'
+    const result = await parse(payload)
+    expect(result).toBeNull()
+  })
+
+  it('returns null when the action has no workflow_state_id change', async () => {
+    const payload = storyStateChangePayload()
+    ;(payload.actions[0] as Record<string, unknown>).changes = { name: { new: 'x', old: 'y' } }
+    const result = await parse(payload)
+    expect(result).toBeNull()
+  })
+
+  it('returns null when the payload has no actions array', async () => {
+    const result = await parse({})
+    expect(result).toBeNull()
+  })
+})
+
+describe('shortcutInboundHandler.verifySignature', () => {
+  const secret = 'webhook-secret'
+  const body = '{"test": true}'
+
+  it('returns true for a valid signature', async () => {
+    const req = makeRequest({ 'Payload-Signature': sign(body, secret) })
+    const result = await shortcutInboundHandler.verifySignature(req, body, secret)
+    expect(result).toBe(true)
+  })
+
+  it('returns 401 when the signature header is missing', async () => {
+    const result = await shortcutInboundHandler.verifySignature(makeRequest(), body, secret)
+    expect(result).not.toBe(true)
+    expect((result as Response).status).toBe(401)
+  })
+
+  it('returns 401 for an invalid signature', async () => {
+    const req = makeRequest({ 'Payload-Signature': 'bad-sig' })
+    const result = await shortcutInboundHandler.verifySignature(req, body, secret)
+    expect(result).not.toBe(true)
+    expect((result as Response).status).toBe(401)
+  })
+
+  it('returns 401 for a same-length but incorrect signature', async () => {
+    // 64 hex chars matches the SHA-256 digest length, so this exercises the
+    // constant-time compare rather than short-circuiting on the length guard.
+    const req = makeRequest({ 'Payload-Signature': '0'.repeat(64) })
+    const result = await shortcutInboundHandler.verifySignature(req, body, secret)
+    expect(result).not.toBe(true)
+    expect((result as Response).status).toBe(401)
+  })
+})

--- a/apps/web/src/lib/server/integrations/shortcut/inbound.ts
+++ b/apps/web/src/lib/server/integrations/shortcut/inbound.ts
@@ -3,8 +3,9 @@
  *
  * Receives webhook events from Shortcut and extracts status changes.
  * Signature: HMAC-SHA256 hex in `Payload-Signature` header.
- * Status field: `changes.workflow_state_id.new` — this is an ID, not a name.
- * Must map workflow state IDs to names using config.workflowStates.
+ * Status field: `changes.workflow_state_id.new` — this is a numeric ID, not a
+ * name. The name is resolved from the payload's own `references` array, which
+ * Shortcut populates with the workflow states involved in the change.
  */
 
 import { timingSafeEqual, createHmac } from 'crypto'
@@ -29,10 +30,7 @@ export const shortcutInboundHandler: InboundWebhookHandler = {
     return true
   },
 
-  async parseStatusChange(
-    body: string,
-    config: Record<string, unknown>
-  ): Promise<InboundWebhookResult | null> {
+  async parseStatusChange(body: string): Promise<InboundWebhookResult | null> {
     const payload = JSON.parse(body)
     const actions = payload.actions
     if (!Array.isArray(actions)) return null
@@ -48,12 +46,18 @@ export const shortcutInboundHandler: InboundWebhookHandler = {
     const newStateId = (stateChange.changes.workflow_state_id as { new?: number })?.new
     if (!storyId || !newStateId) return null
 
-    // Map workflow state ID to name using cached config
-    const workflowStates = config.workflowStates as Record<string, string> | undefined
-    const stateName = workflowStates?.[String(newStateId)]
+    // Resolve the numeric state ID to its name via the payload's `references`
+    // array — Shortcut includes the workflow states involved in the change, so
+    // no separately-cached ID→name map is needed.
+    const references = payload.references as
+      | Array<{ id?: number; entity_type?: string; name?: string }>
+      | undefined
+    const stateName = references?.find(
+      (ref) => ref.entity_type === 'workflow-state' && ref.id === newStateId
+    )?.name
     if (!stateName) {
       console.log(
-        `[Shortcut Inbound] Unknown workflow state ID: ${newStateId}. Configure workflowStates mapping.`
+        `[Shortcut Inbound] No workflow-state reference for ID ${newStateId} in webhook payload.`
       )
       return null
     }


### PR DESCRIPTION
Fixes #201.

Shortcut's inbound status sync (Shortcut story state to Quackback post status) was a silent no-op, and the webhook signing secret needed to complete a manual webhook was never shown in the UI.

## Issue 1: inbound status sync never fired (primary)

`parseStatusChange` translated Shortcut's numeric `workflow_state_id` to a state name via `config.workflowStates`, but no code path ever wrote that key. Every story-update webhook resolved to `undefined`, returned `null`, and the linked post status was never updated. A correctly linked story with a valid signature still produced no status change, with only a `console.log` as evidence.

**Fix:** resolve the state name from the webhook payload's own `references` array, which Shortcut populates with the workflow states involved in the change. This removes the unpopulated config dependency entirely and stays correct if workflow states are later renamed or added. It also brings Shortcut in line with the other inbound handlers, which all read the status name straight from their payload rather than a separately cached map.

## Issue 2: webhook signing secret was hidden (secondary)

For manual-webhook integrations (Shortcut, Azure DevOps) the admin must create the webhook themselves and paste in the signing secret. The settings UI showed the webhook URL but never the secret, so the inbound webhook could not be completed from the product (the secret only lived in the database).

**Fix:** surface the generated signing secret with a copy-to-clipboard control next to the URL (admin-only settings; reuses the shared `CopyButton`). Azure DevOps benefits automatically since the block is gated on `isManual`.

## Tests

- New unit tests for `shortcutInboundHandler`: references-based resolution, the `workflow-state` / matching-id discriminator branches, absent `references`, and signature verification including a same-length-but-wrong signature that exercises the constant-time compare.
- New component test: the secret is shown for manual integrations and hidden for auto-registered ones.
- `bun run typecheck`, eslint, and the integration + component suites pass.

## Not included

The catalog advertises "link existing Shortcut stories to feedback posts", but there is no admin-UI affordance for it (only the `POST /api/v1/apps/link` API). Out of scope here; flagged as a follow-up.

## Verification

Confirmed against Shortcut's current webhook docs: numeric `workflow_state_id`, a `references` array with `entity_type: "workflow-state"` mapping ids to names, and `Payload-Signature` HMAC-SHA256 with a user-supplied secret.
