### PR TITLE
feat(ai): configurable models, off unless configured (root cause of #180)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,11 +80,32 @@ EMAIL_INBOUND_SIGNING_SECRET=
 # ============================================================================
 # Enable AI features like auto-categorization and summarization.
 
-# OpenAI API
+# AI (optional). All AI features are OFF unless configured below.
+# Quackback talks to any OpenAI-compatible endpoint. You must set BOTH a key
+# and an explicit base URL — there is no implicit provider default.
 OPENAI_API_KEY=
-# Optional: custom endpoint (e.g. Azure OpenAI, Cloudflare AI Gateway).
-# Leave empty to talk to api.openai.com directly.
+# Endpoint examples:
+#   Direct OpenAI:        https://api.openai.com/v1
+#   OpenRouter:           https://openrouter.ai/api/v1
+#   Cloudflare AI Gateway: https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/openai
 OPENAI_BASE_URL=
+
+# Models. A feature is enabled only when its model resolves to a value.
+# Two roles cover everything; per-feature overrides are optional.
+#   - Chat features: summary, sentiment, extraction, quality gate, interpretation, merge
+#   - Embedding features: duplicate detection, help-center semantic search
+# Use model ids your endpoint accepts (direct OpenAI: e.g. gpt-4o-mini,
+# text-embedding-3-small; a gateway: e.g. google/gemini-3.1-flash-lite-preview).
+AI_CHAT_MODEL=
+AI_EMBEDDING_MODEL=
+# Optional per-feature overrides of AI_CHAT_MODEL. Set to "off" to disable just
+# that feature while keeping the rest (e.g. AI_SUMMARY_MODEL=off).
+AI_SUMMARY_MODEL=
+AI_SENTIMENT_MODEL=
+AI_EXTRACTION_MODEL=
+AI_QUALITY_GATE_MODEL=
+AI_INTERPRETATION_MODEL=
+AI_MERGE_MODEL=
 
 # ============================================================================
 # File Storage (for image uploads)

--- a/apps/web/src/lib/server/config.ts
+++ b/apps/web/src/lib/server/config.ts
@@ -98,6 +98,14 @@ const configSchema = z.object({
   // AI (optional)
   openaiApiKey: z.string().optional(),
   openaiBaseUrl: z.string().optional(),
+  aiChatModel: z.string().optional(),
+  aiEmbeddingModel: z.string().optional(),
+  aiSummaryModel: z.string().optional(),
+  aiSentimentModel: z.string().optional(),
+  aiExtractionModel: z.string().optional(),
+  aiQualityGateModel: z.string().optional(),
+  aiInterpretationModel: z.string().optional(),
+  aiMergeModel: z.string().optional(),
 
   // Telemetry (optional)
   disableTelemetry: envBoolean,
@@ -150,6 +158,14 @@ function buildConfigFromEnv(): unknown {
     // AI
     openaiApiKey: env('OPENAI_API_KEY'),
     openaiBaseUrl: env('OPENAI_BASE_URL'),
+    aiChatModel: env('AI_CHAT_MODEL'),
+    aiEmbeddingModel: env('AI_EMBEDDING_MODEL'),
+    aiSummaryModel: env('AI_SUMMARY_MODEL'),
+    aiSentimentModel: env('AI_SENTIMENT_MODEL'),
+    aiExtractionModel: env('AI_EXTRACTION_MODEL'),
+    aiQualityGateModel: env('AI_QUALITY_GATE_MODEL'),
+    aiInterpretationModel: env('AI_INTERPRETATION_MODEL'),
+    aiMergeModel: env('AI_MERGE_MODEL'),
 
     // Telemetry
     disableTelemetry: env('DISABLE_TELEMETRY'),
@@ -278,6 +294,30 @@ export const config = {
   },
   get openaiBaseUrl() {
     return loadConfig().openaiBaseUrl
+  },
+  get aiChatModel() {
+    return loadConfig().aiChatModel
+  },
+  get aiEmbeddingModel() {
+    return loadConfig().aiEmbeddingModel
+  },
+  get aiSummaryModel() {
+    return loadConfig().aiSummaryModel
+  },
+  get aiSentimentModel() {
+    return loadConfig().aiSentimentModel
+  },
+  get aiExtractionModel() {
+    return loadConfig().aiExtractionModel
+  },
+  get aiQualityGateModel() {
+    return loadConfig().aiQualityGateModel
+  },
+  get aiInterpretationModel() {
+    return loadConfig().aiInterpretationModel
+  },
+  get aiMergeModel() {
+    return loadConfig().aiMergeModel
   },
 
   // Telemetry

--- a/apps/web/src/lib/server/domains/ai/__tests__/config-gate.test.ts
+++ b/apps/web/src/lib/server/domains/ai/__tests__/config-gate.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { isAiClientConfigured } from '../config'
+
+describe('isAiClientConfigured', () => {
+  it('is true only when both api key and base url are set', () => {
+    expect(isAiClientConfigured('sk-key', 'https://api.openai.com/v1')).toBe(true)
+  })
+
+  it('is false when base url is missing (no implicit api.openai.com)', () => {
+    expect(isAiClientConfigured('sk-key', undefined)).toBe(false)
+    expect(isAiClientConfigured('sk-key', '')).toBe(false)
+  })
+
+  it('is false when api key is missing', () => {
+    expect(isAiClientConfigured(undefined, 'https://gateway.example/v1')).toBe(false)
+  })
+})

--- a/apps/web/src/lib/server/domains/ai/__tests__/config-gate.test.ts
+++ b/apps/web/src/lib/server/domains/ai/__tests__/config-gate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { isAiClientConfigured } from '../config'
+import { isAiClientConfigured, collectAiConfigWarnings } from '../config'
 
 describe('isAiClientConfigured', () => {
   it('is true only when both api key and base url are set', () => {
@@ -13,5 +13,47 @@ describe('isAiClientConfigured', () => {
 
   it('is false when api key is missing', () => {
     expect(isAiClientConfigured(undefined, 'https://gateway.example/v1')).toBe(false)
+  })
+})
+
+describe('collectAiConfigWarnings', () => {
+  it('warns when api key is set but base url is missing', () => {
+    const w = collectAiConfigWarnings({
+      apiKey: 'sk',
+      baseUrl: undefined,
+      chatModel: undefined,
+      embeddingModel: undefined,
+    })
+    expect(w.some((m) => m.includes('OPENAI_BASE_URL'))).toBe(true)
+  })
+
+  it('warns when client is configured but no models are set', () => {
+    const w = collectAiConfigWarnings({
+      apiKey: 'sk',
+      baseUrl: 'https://x/v1',
+      chatModel: undefined,
+      embeddingModel: undefined,
+    })
+    expect(w.some((m) => m.includes('no models'))).toBe(true)
+  })
+
+  it('is silent when client and at least one model are configured', () => {
+    const w = collectAiConfigWarnings({
+      apiKey: 'sk',
+      baseUrl: 'https://x/v1',
+      chatModel: 'm',
+      embeddingModel: undefined,
+    })
+    expect(w).toEqual([])
+  })
+
+  it('is silent when AI is entirely unconfigured', () => {
+    const w = collectAiConfigWarnings({
+      apiKey: undefined,
+      baseUrl: undefined,
+      chatModel: undefined,
+      embeddingModel: undefined,
+    })
+    expect(w).toEqual([])
   })
 })

--- a/apps/web/src/lib/server/domains/ai/__tests__/models.test.ts
+++ b/apps/web/src/lib/server/domains/ai/__tests__/models.test.ts
@@ -30,4 +30,14 @@ describe('resolveModel', () => {
       'google/gemini-3.1-flash-lite-preview'
     )
   })
+
+  it('treats an off/none/false role default as disabled too', () => {
+    expect(resolveModel(undefined, 'off')).toBeNull()
+    expect(resolveModel(undefined, 'none')).toBeNull()
+    expect(resolveModel(undefined, 'false')).toBeNull()
+  })
+
+  it('trims a non-sentinel value', () => {
+    expect(resolveModel('  gpt-4o-mini  ', undefined)).toBe('gpt-4o-mini')
+  })
 })

--- a/apps/web/src/lib/server/domains/ai/__tests__/models.test.ts
+++ b/apps/web/src/lib/server/domains/ai/__tests__/models.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { resolveModel } from '../models'
+
+describe('resolveModel', () => {
+  it('returns the override when set', () => {
+    expect(resolveModel('gpt-4o-mini', 'role-default')).toBe('gpt-4o-mini')
+  })
+
+  it('falls back to the role default when override is unset', () => {
+    expect(resolveModel(undefined, 'role-default')).toBe('role-default')
+  })
+
+  it('returns null when neither override nor role default is set', () => {
+    expect(resolveModel(undefined, undefined)).toBeNull()
+  })
+
+  it('treats off/none/false override as disabled even when role default is set', () => {
+    expect(resolveModel('off', 'role-default')).toBeNull()
+    expect(resolveModel('none', 'role-default')).toBeNull()
+    expect(resolveModel('false', 'role-default')).toBeNull()
+  })
+
+  it('matches the disable sentinel case-insensitively and trimmed', () => {
+    expect(resolveModel('  OFF ', 'role-default')).toBeNull()
+    expect(resolveModel('None', 'role-default')).toBeNull()
+  })
+
+  it('does not treat a normal model id as disabled', () => {
+    expect(resolveModel('google/gemini-3.1-flash-lite-preview', undefined)).toBe(
+      'google/gemini-3.1-flash-lite-preview'
+    )
+  })
+})

--- a/apps/web/src/lib/server/domains/ai/config.ts
+++ b/apps/web/src/lib/server/domains/ai/config.ts
@@ -60,7 +60,9 @@ export function collectAiConfigWarnings(snap: AiConfigSnapshot): string[] {
       'AI disabled: OPENAI_API_KEY is set but OPENAI_BASE_URL is empty. Set OPENAI_BASE_URL to your provider or gateway endpoint.'
     )
   }
-  // Client configured but no models → every feature is off.
+  // Note: this checks role defaults only; a config that sets just a per-feature
+  // override (e.g. AI_SUMMARY_MODEL) without a role default will still log this,
+  // even though that one feature is enabled. Logs-only, so acceptable.
   if (snap.apiKey && snap.baseUrl && !snap.chatModel && !snap.embeddingModel) {
     warnings.push(
       'AI endpoint configured but no models set; all AI features are disabled. Set AI_CHAT_MODEL and/or AI_EMBEDDING_MODEL.'

--- a/apps/web/src/lib/server/domains/ai/config.ts
+++ b/apps/web/src/lib/server/domains/ai/config.ts
@@ -1,8 +1,10 @@
 /**
  * AI configuration and client management.
  *
- * Uses OpenAI for embeddings and sentiment analysis.
- * Routes through Cloudflare AI Gateway when OPENAI_BASE_URL is configured.
+ * Talks to any OpenAI-compatible endpoint (direct provider, a model gateway,
+ * or a local server) declared via OPENAI_BASE_URL. There is no implicit
+ * endpoint default: AI is off unless both the API key and base URL are set,
+ * and each feature additionally requires a configured model (see ./models).
  */
 
 import OpenAI from 'openai'
@@ -11,18 +13,28 @@ import { config } from '@/lib/server/config'
 let openai: OpenAI | null = null
 
 /**
- * Get the OpenAI client instance, or `null` when AI is not configured.
- *
- * This is the single guard for all AI functionality. Callers should handle
- * `null` by returning early, falling back to a non-AI path, or throwing
- * `UnrecoverableError` (BullMQ workers).
+ * Whether an AI client can be constructed. Requires BOTH an API key and an
+ * explicit base URL — there is no implicit provider default (see #180).
+ */
+export function isAiClientConfigured(
+  apiKey: string | undefined,
+  baseUrl: string | undefined
+): boolean {
+  return Boolean(apiKey) && Boolean(baseUrl)
+}
+
+/**
+ * Get the OpenAI-compatible client instance, or `null` when AI is not
+ * configured. This is the single client guard for all AI functionality.
+ * Callers handle `null` by returning early, falling back to a non-AI path,
+ * or throwing `UnrecoverableError` (BullMQ workers).
  */
 export function getOpenAI(): OpenAI | null {
-  if (!config.openaiApiKey) return null
+  if (!isAiClientConfigured(config.openaiApiKey, config.openaiBaseUrl)) return null
   if (!openai) {
     openai = new OpenAI({
       apiKey: config.openaiApiKey,
-      baseURL: config.openaiBaseUrl, // Cloudflare gateway or undefined for direct
+      baseURL: config.openaiBaseUrl,
     })
   }
   return openai

--- a/apps/web/src/lib/server/domains/ai/config.ts
+++ b/apps/web/src/lib/server/domains/ai/config.ts
@@ -40,6 +40,46 @@ export function getOpenAI(): OpenAI | null {
   return openai
 }
 
+interface AiConfigSnapshot {
+  apiKey: string | undefined
+  baseUrl: string | undefined
+  chatModel: string | undefined
+  embeddingModel: string | undefined
+}
+
+/**
+ * Pure check for half-configured AI: returns human-readable warnings.
+ * Silent when AI is fully off (nothing set) or correctly configured.
+ */
+export function collectAiConfigWarnings(snap: AiConfigSnapshot): string[] {
+  const warnings: string[] = []
+  // Key set but no endpoint → the client can't start; the old implicit
+  // provider default is gone (see #180).
+  if (snap.apiKey && !snap.baseUrl) {
+    warnings.push(
+      'AI disabled: OPENAI_API_KEY is set but OPENAI_BASE_URL is empty. Set OPENAI_BASE_URL to your provider or gateway endpoint.'
+    )
+  }
+  // Client configured but no models → every feature is off.
+  if (snap.apiKey && snap.baseUrl && !snap.chatModel && !snap.embeddingModel) {
+    warnings.push(
+      'AI endpoint configured but no models set; all AI features are disabled. Set AI_CHAT_MODEL and/or AI_EMBEDDING_MODEL.'
+    )
+  }
+  return warnings
+}
+
+/** Log AI config warnings once at boot. Never throws. */
+export function validateAiConfig(): void {
+  const warnings = collectAiConfigWarnings({
+    apiKey: config.openaiApiKey,
+    baseUrl: config.openaiBaseUrl,
+    chatModel: config.aiChatModel,
+    embeddingModel: config.aiEmbeddingModel,
+  })
+  for (const w of warnings) console.warn(`[AI] ${w}`)
+}
+
 /** Strip markdown code fences that some models wrap around JSON responses. */
 export function stripCodeFences(text: string): string {
   return text.replace(/^```(?:json)?\s*\n?/i, '').replace(/\n?```\s*$/i, '')

--- a/apps/web/src/lib/server/domains/ai/models.ts
+++ b/apps/web/src/lib/server/domains/ai/models.ts
@@ -28,10 +28,14 @@ export function resolveModel(
   override: string | undefined,
   roleDefault: string | undefined
 ): string | null {
-  if (override !== undefined) {
-    return DISABLED_VALUES.has(override.trim().toLowerCase()) ? null : override
-  }
-  return roleDefault ?? null
+  // Per-feature override wins over the role default. The disable sentinel and
+  // trimming apply to whichever value is effective — so AI_CHAT_MODEL=off (a
+  // role default) and AI_EMBEDDING_MODEL=off both disable, not just per-feature
+  // overrides.
+  const effective = override ?? roleDefault
+  if (effective === undefined) return null
+  const trimmed = effective.trim()
+  return DISABLED_VALUES.has(trimmed.toLowerCase()) ? null : trimmed
 }
 
 /** Effective chat model for a feature, or null when the feature is disabled. */

--- a/apps/web/src/lib/server/domains/ai/models.ts
+++ b/apps/web/src/lib/server/domains/ai/models.ts
@@ -1,0 +1,53 @@
+/**
+ * AI model resolution.
+ *
+ * Models are configured per-role (chat, embedding) with optional per-feature
+ * overrides. An override of "off" / "none" / "false" disables that feature
+ * even when the role default is set. An unset role default means that
+ * capability is off — there is no built-in default model and no implied
+ * provider. See #180 for why a missing/invalid default must mean "disabled".
+ */
+
+import { config } from '@/lib/server/config'
+
+const DISABLED_VALUES = new Set(['off', 'none', 'false'])
+
+export type ChatFeature =
+  | 'summary'
+  | 'sentiment'
+  | 'extraction'
+  | 'qualityGate'
+  | 'interpretation'
+  | 'merge'
+
+/**
+ * Resolve an effective model: per-feature override wins over the role default;
+ * a disable sentinel or a fully-unset config yields null (feature disabled).
+ */
+export function resolveModel(
+  override: string | undefined,
+  roleDefault: string | undefined
+): string | null {
+  if (override !== undefined) {
+    return DISABLED_VALUES.has(override.trim().toLowerCase()) ? null : override
+  }
+  return roleDefault ?? null
+}
+
+/** Effective chat model for a feature, or null when the feature is disabled. */
+export function getChatModel(feature: ChatFeature): string | null {
+  const overrides: Record<ChatFeature, string | undefined> = {
+    summary: config.aiSummaryModel,
+    sentiment: config.aiSentimentModel,
+    extraction: config.aiExtractionModel,
+    qualityGate: config.aiQualityGateModel,
+    interpretation: config.aiInterpretationModel,
+    merge: config.aiMergeModel,
+  }
+  return resolveModel(overrides[feature], config.aiChatModel)
+}
+
+/** Effective embedding model, or null when embeddings are disabled. */
+export function getEmbeddingModel(): string | null {
+  return resolveModel(undefined, config.aiEmbeddingModel)
+}

--- a/apps/web/src/lib/server/domains/embeddings/embedding.service.ts
+++ b/apps/web/src/lib/server/domains/embeddings/embedding.service.ts
@@ -1,17 +1,17 @@
 /**
  * Embedding service for semantic similarity search.
  *
- * Generates embeddings using OpenAI text-embedding-3-small.
+ * Generates embeddings using the configured embedding model.
  * Used for finding similar posts and duplicate detection.
  */
 
 import { db, posts, eq, and, isNull, sql, desc, ne } from '@/lib/server/db'
 import type { PostId, BoardId } from '@quackback/ids'
 import { getOpenAI } from '@/lib/server/domains/ai/config'
+import { getEmbeddingModel } from '@/lib/server/domains/ai/models'
 import { withRetry } from '@/lib/server/domains/ai/retry'
 import { withUsageLogging } from '@/lib/server/domains/ai/usage-log'
 
-export const EMBEDDING_MODEL = 'openai/text-embedding-3-small'
 const EMBEDDING_DIMENSIONS = 1536
 
 /**
@@ -28,9 +28,10 @@ export async function generateEmbedding(
   }
 ): Promise<number[] | null> {
   const openai = getOpenAI()
-  if (!openai) return null
+  const model = getEmbeddingModel()
+  if (!openai || !model) return null
 
-  // Truncate to avoid token limits (8191 tokens for text-embedding-3-small)
+  // Truncate to avoid token limits for the configured model
   const truncated = text.slice(0, 8000)
 
   try {
@@ -39,7 +40,7 @@ export async function generateEmbedding(
         {
           pipelineStep: logContext.pipelineStep,
           callType: 'embedding',
-          model: EMBEDDING_MODEL,
+          model,
           postId: logContext.postId,
           rawFeedbackItemId: logContext.rawFeedbackItemId,
           signalId: logContext.signalId,
@@ -47,7 +48,7 @@ export async function generateEmbedding(
         () =>
           withRetry(() =>
             openai.embeddings.create({
-              model: EMBEDDING_MODEL,
+              model,
               input: truncated,
               dimensions: EMBEDDING_DIMENSIONS,
             })
@@ -62,7 +63,7 @@ export async function generateEmbedding(
 
     const { result: response } = await withRetry(() =>
       openai.embeddings.create({
-        model: EMBEDDING_MODEL,
+        model,
         input: truncated,
         dimensions: EMBEDDING_DIMENSIONS,
       })
@@ -139,7 +140,7 @@ export async function savePostEmbedding(postId: PostId, embedding: number[]): Pr
     .update(posts)
     .set({
       embedding: sql<number[]>`${vectorStr}::vector`,
-      embeddingModel: EMBEDDING_MODEL,
+      embeddingModel: getEmbeddingModel() ?? 'unknown',
       embeddingUpdatedAt: new Date(),
       mergeCheckedAt: null,
     })

--- a/apps/web/src/lib/server/domains/feedback/pipeline/__tests__/embedding.service.test.ts
+++ b/apps/web/src/lib/server/domains/feedback/pipeline/__tests__/embedding.service.test.ts
@@ -53,7 +53,11 @@ const mockGenerateEmbedding = vi.fn()
 
 vi.mock('@/lib/server/domains/embeddings/embedding.service', () => ({
   generateEmbedding: (...args: unknown[]) => mockGenerateEmbedding(...args),
-  EMBEDDING_MODEL: 'openai/text-embedding-3-small',
+}))
+
+vi.mock('@/lib/server/domains/ai/models', () => ({
+  getChatModel: () => 'test-model',
+  getEmbeddingModel: () => 'test-embedding-model',
 }))
 
 describe('embedding.service', () => {

--- a/apps/web/src/lib/server/domains/feedback/pipeline/__tests__/extraction.service.test.ts
+++ b/apps/web/src/lib/server/domains/feedback/pipeline/__tests__/extraction.service.test.ts
@@ -84,6 +84,11 @@ vi.mock('@/lib/server/domains/ai/config', () => ({
   stripCodeFences: vi.fn((s: string) => s.replace(/^```[\s\S]*?\n/, '').replace(/\n```$/, '')),
 }))
 
+vi.mock('@/lib/server/domains/ai/models', () => ({
+  getChatModel: () => 'test-model',
+  getEmbeddingModel: () => 'test-embedding-model',
+}))
+
 vi.mock('@/lib/server/domains/ai/retry', () => ({
   withRetry: vi.fn((fn: () => Promise<unknown>) =>
     fn().then((result: unknown) => ({ result, retryCount: 0 }))

--- a/apps/web/src/lib/server/domains/feedback/pipeline/__tests__/extraction.service.test.ts
+++ b/apps/web/src/lib/server/domains/feedback/pipeline/__tests__/extraction.service.test.ts
@@ -85,8 +85,8 @@ vi.mock('@/lib/server/domains/ai/config', () => ({
 }))
 
 vi.mock('@/lib/server/domains/ai/models', () => ({
-  getChatModel: () => 'test-model',
-  getEmbeddingModel: () => 'test-embedding-model',
+  getChatModel: vi.fn(() => 'test-model'),
+  getEmbeddingModel: vi.fn(() => 'test-embedding-model'),
 }))
 
 vi.mock('@/lib/server/domains/ai/retry', () => ({
@@ -392,5 +392,16 @@ describe('extraction.service', () => {
 
     const { extractSignals } = await import('../extraction.service')
     await expect(extractSignals(rawItemId)).rejects.toThrow('not configured')
+  })
+
+  it('should throw UnrecoverableError when client is present but extraction model is null', async () => {
+    // Client is non-null (default mock returns mockOpenAI) but the model is
+    // disabled — e.g. AI_EXTRACTION_MODEL=off. The service must reject before
+    // touching the DB.
+    const { getChatModel } = await import('@/lib/server/domains/ai/models')
+    vi.mocked(getChatModel).mockReturnValueOnce(null)
+
+    const { extractSignals } = await import('../extraction.service')
+    await expect(extractSignals(rawItemId)).rejects.toThrow('Extraction model not configured')
   })
 })

--- a/apps/web/src/lib/server/domains/feedback/pipeline/__tests__/interpretation.service-state.test.ts
+++ b/apps/web/src/lib/server/domains/feedback/pipeline/__tests__/interpretation.service-state.test.ts
@@ -92,6 +92,11 @@ vi.mock('@/lib/server/domains/ai/config', () => ({
   stripCodeFences: vi.fn((s: string) => s.replace(/^```[\s\S]*?\n/, '').replace(/\n```$/, '')),
 }))
 
+vi.mock('@/lib/server/domains/ai/models', () => ({
+  getChatModel: () => 'test-model',
+  getEmbeddingModel: () => 'test-embedding-model',
+}))
+
 vi.mock('@/lib/server/domains/ai/retry', () => ({
   withRetry: vi.fn((fn: () => Promise<unknown>) =>
     fn().then((result: unknown) => ({ result, retryCount: 0 }))

--- a/apps/web/src/lib/server/domains/feedback/pipeline/__tests__/interpretation.service.test.ts
+++ b/apps/web/src/lib/server/domains/feedback/pipeline/__tests__/interpretation.service.test.ts
@@ -92,6 +92,11 @@ vi.mock('@/lib/server/domains/ai/config', () => ({
   stripCodeFences: vi.fn((s: string) => s.replace(/^```[\s\S]*?\n/, '').replace(/\n```$/, '')),
 }))
 
+vi.mock('@/lib/server/domains/ai/models', () => ({
+  getChatModel: () => 'test-model',
+  getEmbeddingModel: () => 'test-embedding-model',
+}))
+
 vi.mock('@/lib/server/domains/ai/retry', () => ({
   withRetry: vi.fn((fn: () => Promise<unknown>) =>
     fn().then((result: unknown) => ({ result, retryCount: 0 }))

--- a/apps/web/src/lib/server/domains/feedback/pipeline/__tests__/quality-gate.service.test.ts
+++ b/apps/web/src/lib/server/domains/feedback/pipeline/__tests__/quality-gate.service.test.ts
@@ -17,6 +17,11 @@ vi.mock('@/lib/server/domains/ai/config', () => ({
   stripCodeFences: vi.fn((s: string) => s.replace(/^```[\s\S]*?\n/, '').replace(/\n```$/, '')),
 }))
 
+vi.mock('@/lib/server/domains/ai/models', () => ({
+  getChatModel: () => 'test-model',
+  getEmbeddingModel: () => 'test-embedding-model',
+}))
+
 vi.mock('@/lib/server/domains/ai/retry', () => ({
   withRetry: vi.fn((fn: () => Promise<unknown>) =>
     fn().then((result: unknown) => ({ result, retryCount: 0 }))

--- a/apps/web/src/lib/server/domains/feedback/pipeline/embedding.service.ts
+++ b/apps/web/src/lib/server/domains/feedback/pipeline/embedding.service.ts
@@ -8,10 +8,8 @@
 import { UnrecoverableError } from 'bullmq'
 import { db, eq, feedbackSignals, sql } from '@/lib/server/db'
 import { getExecuteRows } from '@/lib/server/utils/execute-rows'
-import {
-  generateEmbedding,
-  EMBEDDING_MODEL,
-} from '@/lib/server/domains/embeddings/embedding.service'
+import { generateEmbedding } from '@/lib/server/domains/embeddings/embedding.service'
+import { getEmbeddingModel } from '@/lib/server/domains/ai/models'
 import { toUuid, type FeedbackSignalId } from '@quackback/ids'
 
 /**
@@ -56,7 +54,7 @@ export async function embedSignal(
     .update(feedbackSignals)
     .set({
       embedding: sql<number[]>`${vectorStr}::vector`,
-      embeddingModel: EMBEDDING_MODEL,
+      embeddingModel: getEmbeddingModel() ?? 'unknown',
       embeddingUpdatedAt: new Date(),
       updatedAt: new Date(),
     })

--- a/apps/web/src/lib/server/domains/feedback/pipeline/extraction.service.ts
+++ b/apps/web/src/lib/server/domains/feedback/pipeline/extraction.service.ts
@@ -8,6 +8,7 @@
 import { UnrecoverableError } from 'bullmq'
 import { db, eq, rawFeedbackItems, feedbackSignals, sql } from '@/lib/server/db'
 import { getOpenAI, stripCodeFences } from '@/lib/server/domains/ai/config'
+import { getChatModel } from '@/lib/server/domains/ai/models'
 import { withRetry } from '@/lib/server/domains/ai/retry'
 import { withUsageLogging } from '@/lib/server/domains/ai/usage-log'
 import { buildExtractionPrompt } from './prompts/extraction.prompt'
@@ -17,7 +18,6 @@ import { enqueueFeedbackAiJob } from '../queues/feedback-ai-queue'
 import type { ExtractionResult, RawFeedbackContent, RawFeedbackItemContextEnvelope } from '../types'
 import type { RawFeedbackItemId } from '@quackback/ids'
 
-const EXTRACTION_MODEL = 'google/gemini-3.1-flash-lite-preview'
 const EXTRACTION_PROMPT_VERSION = 'v1'
 
 /**
@@ -26,8 +26,9 @@ const EXTRACTION_PROMPT_VERSION = 'v1'
  */
 export async function extractSignals(rawItemId: RawFeedbackItemId): Promise<void> {
   const openai = getOpenAI()
-  if (!openai) {
-    throw new UnrecoverableError('OpenAI not configured')
+  const model = getChatModel('extraction')
+  if (!openai || !model) {
+    throw new UnrecoverableError('Extraction model not configured')
   }
 
   const item = await db.query.rawFeedbackItems.findFirst({
@@ -128,14 +129,14 @@ export async function extractSignals(rawItemId: RawFeedbackItemId): Promise<void
       {
         pipelineStep: 'extraction',
         callType: 'chat_completion',
-        model: EXTRACTION_MODEL,
+        model,
         rawFeedbackItemId: rawItemId,
         metadata: { promptVersion: EXTRACTION_PROMPT_VERSION },
       },
       () =>
         withRetry(() =>
           openai.chat.completions.create({
-            model: EXTRACTION_MODEL,
+            model,
             messages: [{ role: 'user', content: prompt }],
             response_format: { type: 'json_object' },
             temperature: 0.1,
@@ -200,7 +201,7 @@ export async function extractSignals(rawItemId: RawFeedbackItemId): Promise<void
                 ? Math.max(0, Math.min(1, s.confidence))
                 : 0.5,
             processingState: 'pending_interpretation' as const,
-            extractionModel: EXTRACTION_MODEL,
+            extractionModel: model,
             extractionPromptVersion: EXTRACTION_PROMPT_VERSION,
           }))
         )
@@ -218,7 +219,7 @@ export async function extractSignals(rawItemId: RawFeedbackItemId): Promise<void
         signalsCapped,
         signalTypes: allSignalTypes,
         confidences: allConfidences,
-        model: EXTRACTION_MODEL,
+        model,
         promptVersion: EXTRACTION_PROMPT_VERSION,
       },
     })

--- a/apps/web/src/lib/server/domains/feedback/pipeline/interpretation.service.ts
+++ b/apps/web/src/lib/server/domains/feedback/pipeline/interpretation.service.ts
@@ -13,6 +13,7 @@
 import { UnrecoverableError } from 'bullmq'
 import { db, eq, feedbackSignals, rawFeedbackItems } from '@/lib/server/db'
 import { getOpenAI, stripCodeFences } from '@/lib/server/domains/ai/config'
+import { getChatModel } from '@/lib/server/domains/ai/models'
 import { withRetry } from '@/lib/server/domains/ai/retry'
 import { withUsageLogging } from '@/lib/server/domains/ai/usage-log'
 import { embedSignal, findSimilarPosts, findSimilarPendingSuggestions } from './embedding.service'
@@ -21,8 +22,6 @@ import { logPipelineEvent } from './pipeline-log'
 import { buildSuggestionPrompt } from './prompts/suggestion.prompt'
 import type { SuggestionGenerationResult } from '../types'
 import type { FeedbackSignalId, RawFeedbackItemId, BoardId, PostId } from '@quackback/ids'
-
-const SUGGESTION_MODEL = 'google/gemini-3.1-flash-lite-preview'
 
 /** Above this threshold, the primary suggestion is vote_on_post. */
 const VOTE_SUGGESTION_THRESHOLD = 0.8
@@ -259,6 +258,7 @@ async function generateSuggestion(opts: {
   similarPosts?: Array<{ postId: string; title: string; similarity: number; voteCount: number }>
 }): Promise<void> {
   const openai = getOpenAI()
+  const model = getChatModel('interpretation')
 
   // Load boards for the prompt
   const { boards: _boards } = await import('@/lib/server/db')
@@ -277,7 +277,7 @@ async function generateSuggestion(opts: {
   let boardId = (validUserBoardId ?? allBoards[0]?.id) as BoardId | undefined
   let usedFallback = true
 
-  if (openai) {
+  if (openai && model) {
     const prompt = buildSuggestionPrompt({
       signal: opts.signal,
       sourceContent: opts.sourceContent,
@@ -289,7 +289,7 @@ async function generateSuggestion(opts: {
         {
           pipelineStep: 'suggestion',
           callType: 'chat_completion',
-          model: SUGGESTION_MODEL,
+          model,
           rawFeedbackItemId: opts.rawFeedbackItemId,
           signalId: opts.signalId,
           metadata: { suggestionType: opts.type },
@@ -297,7 +297,7 @@ async function generateSuggestion(opts: {
         () =>
           withRetry(() =>
             openai.chat.completions.create({
-              model: SUGGESTION_MODEL,
+              model,
               messages: [{ role: 'user', content: prompt }],
               response_format: { type: 'json_object' },
               temperature: 0.3,

--- a/apps/web/src/lib/server/domains/feedback/pipeline/quality-gate.service.ts
+++ b/apps/web/src/lib/server/domains/feedback/pipeline/quality-gate.service.ts
@@ -13,12 +13,11 @@
  */
 
 import { getOpenAI, stripCodeFences } from '@/lib/server/domains/ai/config'
+import { getChatModel } from '@/lib/server/domains/ai/models'
 import { withRetry } from '@/lib/server/domains/ai/retry'
 import { withUsageLogging } from '@/lib/server/domains/ai/usage-log'
 import { buildQualityGatePrompt } from './prompts/quality-gate.prompt'
 import type { RawFeedbackContent, RawFeedbackItemContextEnvelope } from '../types'
-
-const QUALITY_GATE_MODEL = 'google/gemini-3.1-flash-lite-preview'
 
 /** Sources where users intentionally submit feedback — high baseline intent. */
 const HIGH_INTENT_SOURCES = new Set(['api', 'quackback'])
@@ -73,7 +72,8 @@ export async function shouldExtract(item: {
 
   // Tier 3: LLM gate
   const openai = getOpenAI()
-  if (!openai) {
+  const model = getChatModel('qualityGate')
+  if (!openai || !model) {
     // AI not configured — fall back to permissive behavior
     return {
       extract: words >= 15,
@@ -91,7 +91,7 @@ export async function shouldExtract(item: {
       {
         pipelineStep: 'quality_gate',
         callType: 'chat_completion',
-        model: QUALITY_GATE_MODEL,
+        model,
         rawFeedbackItemId: item.rawFeedbackItemId,
         metadata: { promptVersion: 'v1', isChannelMonitor, temperature: 0 },
       },
@@ -99,7 +99,7 @@ export async function shouldExtract(item: {
         withRetry(
           () =>
             openai.chat.completions.create({
-              model: QUALITY_GATE_MODEL,
+              model,
               messages: [{ role: 'user', content: prompt }],
               response_format: { type: 'json_object' },
               temperature: 0,

--- a/apps/web/src/lib/server/domains/help-center/help-center-embedding.service.ts
+++ b/apps/web/src/lib/server/domains/help-center/help-center-embedding.service.ts
@@ -2,13 +2,13 @@
  * Help Center Embedding Service
  *
  * Generates embeddings for knowledge base articles using the same
- * OpenAI text-embedding-3-small model as the feedback pipeline.
+ * configured embedding model as the feedback pipeline.
  */
 
 import { db, helpCenterArticles, eq, sql } from '@/lib/server/db'
 import { getOpenAI } from '@/lib/server/domains/ai/config'
+import { getEmbeddingModel } from '@/lib/server/domains/ai/models'
 import { withRetry } from '@/lib/server/domains/ai/retry'
-import { EMBEDDING_MODEL } from '@/lib/server/domains/embeddings/embedding.service'
 import type { HelpCenterArticleId } from '@quackback/ids'
 
 const KB_EMBEDDING_DIMENSIONS = 1536
@@ -27,16 +27,17 @@ export function formatArticleText(title: string, content: string, categoryName?:
 }
 
 /**
- * Generate embedding for text using OpenAI text-embedding-3-small.
+ * Generate embedding for text using the configured embedding model.
  */
 export async function generateKbEmbedding(text: string): Promise<number[] | null> {
   const openai = getOpenAI()
-  if (!openai) return null
+  const model = getEmbeddingModel()
+  if (!openai || !model) return null
 
   try {
     const { result: response } = await withRetry(() =>
       openai.embeddings.create({
-        model: EMBEDDING_MODEL,
+        model,
         input: text,
         dimensions: KB_EMBEDDING_DIMENSIONS,
       })
@@ -66,7 +67,7 @@ export async function generateArticleEmbedding(
     .update(helpCenterArticles)
     .set({
       embedding: sql`${vectorStr}::vector`,
-      embeddingModel: EMBEDDING_MODEL,
+      embeddingModel: getEmbeddingModel() ?? 'unknown',
       embeddingUpdatedAt: new Date(),
     })
     .where(eq(helpCenterArticles.id, articleId as HelpCenterArticleId))

--- a/apps/web/src/lib/server/domains/merge-suggestions/__tests__/merge-assessment.service.test.ts
+++ b/apps/web/src/lib/server/domains/merge-suggestions/__tests__/merge-assessment.service.test.ts
@@ -17,11 +17,6 @@ vi.mock('@/lib/server/domains/ai/config', () => ({
   stripCodeFences: vi.fn((text: string) => text),
 }))
 
-vi.mock('@/lib/server/domains/ai/models', () => ({
-  getChatModel: () => 'test-model',
-  getEmbeddingModel: () => 'test-embedding-model',
-}))
-
 vi.mock('@/lib/server/domains/ai/retry', () => ({
   withRetry: vi.fn((fn: () => Promise<unknown>) =>
     fn().then((result: unknown) => ({ result, retryCount: 0 }))
@@ -112,7 +107,7 @@ describe('merge-assessment.service', () => {
       })
 
       const { assessMergeCandidates } = await import('../merge-assessment.service')
-      const results = await assessMergeCandidates(sourcePost, candidates)
+      const results = await assessMergeCandidates(sourcePost, candidates, 'test-model')
 
       expect(results).toHaveLength(1)
       expect(results[0].candidatePostId).toBe('post_cand1')
@@ -141,7 +136,7 @@ describe('merge-assessment.service', () => {
       })
 
       const { assessMergeCandidates } = await import('../merge-assessment.service')
-      const results = await assessMergeCandidates(sourcePost, candidates)
+      const results = await assessMergeCandidates(sourcePost, candidates, 'test-model')
 
       expect(results).toHaveLength(1)
       expect(results[0].candidatePostId).toBe('post_cand1')
@@ -166,7 +161,7 @@ describe('merge-assessment.service', () => {
       })
 
       const { assessMergeCandidates } = await import('../merge-assessment.service')
-      const results = await assessMergeCandidates(sourcePost, candidates)
+      const results = await assessMergeCandidates(sourcePost, candidates, 'test-model')
 
       expect(results).toHaveLength(0)
     })
@@ -190,14 +185,14 @@ describe('merge-assessment.service', () => {
       })
 
       const { assessMergeCandidates } = await import('../merge-assessment.service')
-      const results = await assessMergeCandidates(sourcePost, candidates)
+      const results = await assessMergeCandidates(sourcePost, candidates, 'test-model')
 
       expect(results).toHaveLength(0)
     })
 
     it('should return empty for empty candidates', async () => {
       const { assessMergeCandidates } = await import('../merge-assessment.service')
-      const results = await assessMergeCandidates(sourcePost, [])
+      const results = await assessMergeCandidates(sourcePost, [], 'test-model')
 
       expect(results).toHaveLength(0)
       expect(mockCreate).not.toHaveBeenCalled()
@@ -209,7 +204,7 @@ describe('merge-assessment.service', () => {
       })
 
       const { assessMergeCandidates } = await import('../merge-assessment.service')
-      const results = await assessMergeCandidates(sourcePost, candidates)
+      const results = await assessMergeCandidates(sourcePost, candidates, 'test-model')
 
       expect(results).toHaveLength(0)
     })
@@ -220,7 +215,7 @@ describe('merge-assessment.service', () => {
       })
 
       const { assessMergeCandidates } = await import('../merge-assessment.service')
-      const results = await assessMergeCandidates(sourcePost, candidates)
+      const results = await assessMergeCandidates(sourcePost, candidates, 'test-model')
 
       expect(results).toHaveLength(0)
     })

--- a/apps/web/src/lib/server/domains/merge-suggestions/__tests__/merge-assessment.service.test.ts
+++ b/apps/web/src/lib/server/domains/merge-suggestions/__tests__/merge-assessment.service.test.ts
@@ -17,6 +17,11 @@ vi.mock('@/lib/server/domains/ai/config', () => ({
   stripCodeFences: vi.fn((text: string) => text),
 }))
 
+vi.mock('@/lib/server/domains/ai/models', () => ({
+  getChatModel: () => 'test-model',
+  getEmbeddingModel: () => 'test-embedding-model',
+}))
+
 vi.mock('@/lib/server/domains/ai/retry', () => ({
   withRetry: vi.fn((fn: () => Promise<unknown>) =>
     fn().then((result: unknown) => ({ result, retryCount: 0 }))

--- a/apps/web/src/lib/server/domains/merge-suggestions/__tests__/merge-check-sweep.test.ts
+++ b/apps/web/src/lib/server/domains/merge-suggestions/__tests__/merge-check-sweep.test.ts
@@ -72,6 +72,10 @@ vi.mock('@/lib/server/domains/ai/config', () => ({
   getOpenAI: vi.fn(() => ({})),
 }))
 
+vi.mock('@/lib/server/domains/ai/models', () => ({
+  getChatModel: () => 'test-model',
+}))
+
 function makeStalePost(id: string): { id: PostId } {
   return { id: id as PostId }
 }

--- a/apps/web/src/lib/server/domains/merge-suggestions/__tests__/merge-check-sweep.test.ts
+++ b/apps/web/src/lib/server/domains/merge-suggestions/__tests__/merge-check-sweep.test.ts
@@ -73,7 +73,7 @@ vi.mock('@/lib/server/domains/ai/config', () => ({
 }))
 
 vi.mock('@/lib/server/domains/ai/models', () => ({
-  getChatModel: () => 'test-model',
+  getChatModel: vi.fn(() => 'test-model'),
 }))
 
 function makeStalePost(id: string): { id: PostId } {
@@ -120,6 +120,19 @@ describe('sweepMergeSuggestions — circuit breaker (#180)', () => {
         hybridScore: 0.92,
       },
     ])
+  })
+
+  it('no-ops when the merge model is null (client present, model disabled)', async () => {
+    // Simulate: embeddings on, chat model off — getOpenAI() is non-null but
+    // getChatModel('merge') returns null. The sweep must return before querying
+    // for stale posts, so mockLimit is never called.
+    const { getChatModel } = await import('@/lib/server/domains/ai/models')
+    vi.mocked(getChatModel).mockReturnValueOnce(null)
+
+    const { sweepMergeSuggestions } = await import('../merge-check.service')
+    await sweepMergeSuggestions()
+
+    expect(mockLimit).not.toHaveBeenCalled()
   })
 
   it('terminates instead of looping forever when every assessment fails', async () => {

--- a/apps/web/src/lib/server/domains/merge-suggestions/__tests__/merge-check.service.test.ts
+++ b/apps/web/src/lib/server/domains/merge-suggestions/__tests__/merge-check.service.test.ts
@@ -83,7 +83,6 @@ vi.mock('@/lib/server/domains/ai/config', () => ({
 
 vi.mock('@/lib/server/domains/ai/models', () => ({
   getChatModel: () => 'test-model',
-  getEmbeddingModel: () => 'test-embedding-model',
 }))
 
 describe('merge-check.service', () => {

--- a/apps/web/src/lib/server/domains/merge-suggestions/__tests__/merge-check.service.test.ts
+++ b/apps/web/src/lib/server/domains/merge-suggestions/__tests__/merge-check.service.test.ts
@@ -81,6 +81,11 @@ vi.mock('@/lib/server/domains/ai/config', () => ({
   getOpenAI: vi.fn(() => ({})),
 }))
 
+vi.mock('@/lib/server/domains/ai/models', () => ({
+  getChatModel: () => 'test-model',
+  getEmbeddingModel: () => 'test-embedding-model',
+}))
+
 describe('merge-check.service', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -219,7 +224,7 @@ describe('merge-check.service', () => {
           hybridScore: 0.93,
           llmConfidence: 0.9,
           llmReasoning: 'Both about dark mode',
-          llmModel: 'google/gemini-3.1-flash-lite-preview',
+          llmModel: 'test-model',
         })
       )
     })

--- a/apps/web/src/lib/server/domains/merge-suggestions/__tests__/merge-suggestion.service.test.ts
+++ b/apps/web/src/lib/server/domains/merge-suggestions/__tests__/merge-suggestion.service.test.ts
@@ -102,6 +102,11 @@ vi.mock('@/lib/server/domains/posts/post.merge', () => ({
   mergePost: (...args: unknown[]) => mockMergePost(...args),
 }))
 
+vi.mock('@/lib/server/domains/ai/models', () => ({
+  getChatModel: () => 'test-model',
+  getEmbeddingModel: () => 'test-embedding-model',
+}))
+
 describe('merge-suggestion.service', () => {
   beforeEach(() => {
     insertValuesCalls.length = 0
@@ -126,7 +131,7 @@ describe('merge-suggestion.service', () => {
         hybridScore: 0.93,
         llmConfidence: 0.9,
         llmReasoning: 'Both request dark mode',
-        llmModel: 'google/gemini-3.1-flash-lite-preview',
+        llmModel: 'test-model',
       })
 
       expect(insertValuesCalls).toHaveLength(1)

--- a/apps/web/src/lib/server/domains/merge-suggestions/__tests__/merge-suggestion.service.test.ts
+++ b/apps/web/src/lib/server/domains/merge-suggestions/__tests__/merge-suggestion.service.test.ts
@@ -104,7 +104,6 @@ vi.mock('@/lib/server/domains/posts/post.merge', () => ({
 
 vi.mock('@/lib/server/domains/ai/models', () => ({
   getChatModel: () => 'test-model',
-  getEmbeddingModel: () => 'test-embedding-model',
 }))
 
 describe('merge-suggestion.service', () => {

--- a/apps/web/src/lib/server/domains/merge-suggestions/__tests__/merge-tier-gate.test.ts
+++ b/apps/web/src/lib/server/domains/merge-suggestions/__tests__/merge-tier-gate.test.ts
@@ -29,11 +29,13 @@ describe('assessMergeCandidates — token budget gate', () => {
   it('throws TierLimitError when budget exceeded', async () => {
     vi.mocked(getTierLimits).mockResolvedValue({ ...OSS_TIER_LIMITS, aiTokensPerMonth: 0 })
     vi.mocked(aiTokensThisMonth).mockResolvedValue(0)
-    await expect(assessMergeCandidates(sourcePost, [])).rejects.toBeInstanceOf(TierLimitError)
+    await expect(assessMergeCandidates(sourcePost, [], 'test-model')).rejects.toBeInstanceOf(
+      TierLimitError
+    )
   })
 
   it('does not throw when below budget', async () => {
     vi.mocked(getTierLimits).mockResolvedValue(OSS_TIER_LIMITS)
-    await expect(assessMergeCandidates(sourcePost, [])).resolves.toEqual([])
+    await expect(assessMergeCandidates(sourcePost, [], 'test-model')).resolves.toEqual([])
   })
 })

--- a/apps/web/src/lib/server/domains/merge-suggestions/merge-assessment.service.ts
+++ b/apps/web/src/lib/server/domains/merge-suggestions/merge-assessment.service.ts
@@ -5,13 +5,12 @@
  */
 
 import { getOpenAI, stripCodeFences } from '@/lib/server/domains/ai/config'
+import { getChatModel } from '@/lib/server/domains/ai/models'
 import { withRetry } from '@/lib/server/domains/ai/retry'
 import { enforceAiTokenBudget } from '@/lib/server/domains/settings/tier-enforce'
 import type { PostId } from '@quackback/ids'
 import { truncate } from '@/lib/shared/utils/string'
 import type { MergeCandidate } from './merge-search.service'
-
-const ASSESSMENT_MODEL = 'google/gemini-3.1-flash-lite-preview'
 
 const SYSTEM_PROMPT = `You are a duplicate-detection assistant for a customer feedback platform used by product managers.
 You will be given a reference post and one or more posts to compare. For each comparison post, determine whether it is truly a DUPLICATE of the reference — meaning they request the exact same thing, just worded differently.
@@ -59,13 +58,14 @@ export async function assessMergeCandidates(
   await enforceAiTokenBudget()
 
   const openai = getOpenAI()
-  if (!openai || candidates.length === 0) return []
+  const model = getChatModel('merge')
+  if (!openai || !model || candidates.length === 0) return []
 
   const userPrompt = buildPrompt(sourcePost, candidates)
 
   const { result: completion } = await withRetry(() =>
     openai.chat.completions.create({
-      model: ASSESSMENT_MODEL,
+      model,
       messages: [
         { role: 'system', content: SYSTEM_PROMPT },
         { role: 'user', content: userPrompt },

--- a/apps/web/src/lib/server/domains/merge-suggestions/merge-assessment.service.ts
+++ b/apps/web/src/lib/server/domains/merge-suggestions/merge-assessment.service.ts
@@ -5,7 +5,6 @@
  */
 
 import { getOpenAI, stripCodeFences } from '@/lib/server/domains/ai/config'
-import { getChatModel } from '@/lib/server/domains/ai/models'
 import { withRetry } from '@/lib/server/domains/ai/retry'
 import { enforceAiTokenBudget } from '@/lib/server/domains/settings/tier-enforce'
 import type { PostId } from '@quackback/ids'
@@ -53,13 +52,13 @@ const CONFIDENCE_THRESHOLD = 0.75
  */
 export async function assessMergeCandidates(
   sourcePost: PostInfo,
-  candidates: MergeCandidate[]
+  candidates: MergeCandidate[],
+  model: string
 ): Promise<MergeAssessment[]> {
   await enforceAiTokenBudget()
 
   const openai = getOpenAI()
-  const model = getChatModel('merge')
-  if (!openai || !model || candidates.length === 0) return []
+  if (!openai || candidates.length === 0) return []
 
   const userPrompt = buildPrompt(sourcePost, candidates)
 

--- a/apps/web/src/lib/server/domains/merge-suggestions/merge-check.service.ts
+++ b/apps/web/src/lib/server/domains/merge-suggestions/merge-check.service.ts
@@ -6,6 +6,7 @@
 
 import { db, posts, and, isNull, isNotNull, desc, eq, notInArray } from '@/lib/server/db'
 import { getOpenAI } from '@/lib/server/domains/ai/config'
+import { getChatModel } from '@/lib/server/domains/ai/models'
 import { findMergeCandidates } from './merge-search.service'
 import { assessMergeCandidates, determineDirection } from './merge-assessment.service'
 import { createMergeSuggestion, expireStaleMergeSuggestions } from './merge-suggestion.service'
@@ -96,7 +97,7 @@ export async function checkPostForMergeCandidates(postId: PostId): Promise<void>
       hybridScore: bestCandidate.hybridScore,
       llmConfidence: bestAssessment.confidence,
       llmReasoning: bestAssessment.reasoning,
-      llmModel: 'google/gemini-3.1-flash-lite-preview',
+      llmModel: getChatModel('merge') ?? 'unknown',
     })
   }
 

--- a/apps/web/src/lib/server/domains/merge-suggestions/merge-check.service.ts
+++ b/apps/web/src/lib/server/domains/merge-suggestions/merge-check.service.ts
@@ -116,7 +116,7 @@ let _sweepInProgress = false
  * Mirrors the refreshStaleSummaries pattern from summary.service.ts.
  */
 export async function sweepMergeSuggestions(): Promise<void> {
-  if (!getOpenAI()) return
+  if (!getOpenAI() || !getChatModel('merge')) return
   if (_sweepInProgress) return
   _sweepInProgress = true
 

--- a/apps/web/src/lib/server/domains/merge-suggestions/merge-check.service.ts
+++ b/apps/web/src/lib/server/domains/merge-suggestions/merge-check.service.ts
@@ -42,6 +42,10 @@ export async function checkPostForMergeCandidates(postId: PostId): Promise<void>
     return
   }
 
+  // Bail early if AI is not configured — skip the candidate search entirely
+  const model = getChatModel('merge')
+  if (!getOpenAI() || !model) return
+
   // Step 1: Hybrid search (pass already-fetched post to avoid redundant DB query)
   const candidates = await findMergeCandidates(postId, {
     sourcePost: { title: post.title, embedding: post.embedding },
@@ -56,7 +60,8 @@ export async function checkPostForMergeCandidates(postId: PostId): Promise<void>
   // Step 2: LLM verification
   const assessments = await assessMergeCandidates(
     { id: post.id, title: post.title, content: post.content },
-    candidates
+    candidates,
+    model
   )
 
   console.log(`[MergeSuggestion] LLM confirmed ${assessments.length} duplicates for post ${postId}`)
@@ -97,7 +102,7 @@ export async function checkPostForMergeCandidates(postId: PostId): Promise<void>
       hybridScore: bestCandidate.hybridScore,
       llmConfidence: bestAssessment.confidence,
       llmReasoning: bestAssessment.reasoning,
-      llmModel: getChatModel('merge') ?? 'unknown',
+      llmModel: model,
     })
   }
 

--- a/apps/web/src/lib/server/domains/sentiment/__tests__/sentiment-tier-gate.test.ts
+++ b/apps/web/src/lib/server/domains/sentiment/__tests__/sentiment-tier-gate.test.ts
@@ -14,6 +14,11 @@ vi.mock('@/lib/server/domains/ai/config', () => ({
   stripCodeFences: vi.fn((s: string) => s),
 }))
 
+vi.mock('@/lib/server/domains/ai/models', () => ({
+  getChatModel: () => 'test-model',
+  getEmbeddingModel: () => 'test-embedding-model',
+}))
+
 vi.mock('@/lib/server/db', () => ({
   db: { query: { posts: { findFirst: vi.fn() } } },
   posts: { id: 'p' },

--- a/apps/web/src/lib/server/domains/sentiment/sentiment.service.ts
+++ b/apps/web/src/lib/server/domains/sentiment/sentiment.service.ts
@@ -58,7 +58,7 @@ function isValidSentiment(value: unknown): value is Sentiment {
 }
 
 /**
- * Analyze sentiment using OpenAI google/gemini-3.1-flash-lite-preview.
+ * Analyze sentiment using the configured chat model.
  */
 export async function analyzeSentiment(
   title: string,

--- a/apps/web/src/lib/server/domains/sentiment/sentiment.service.ts
+++ b/apps/web/src/lib/server/domains/sentiment/sentiment.service.ts
@@ -2,17 +2,16 @@
  * Sentiment analysis service.
  *
  * Analyzes customer feedback to classify sentiment as positive, neutral, or negative.
- * Uses OpenAI google/gemini-3.1-flash-lite-preview via Cloudflare AI Gateway.
+ * Uses the configured chat model via the configured provider or gateway endpoint.
  */
 
 import { db, postSentiment, posts, eq, and, gte, lte, sql, count, isNull } from '@/lib/server/db'
 import { createId, type PostId } from '@quackback/ids'
 import { getOpenAI } from '@/lib/server/domains/ai/config'
+import { getChatModel } from '@/lib/server/domains/ai/models'
 import { withRetry } from '@/lib/server/domains/ai/retry'
 import { withUsageLogging } from '@/lib/server/domains/ai/usage-log'
 import { enforceAiTokenBudget } from '@/lib/server/domains/settings/tier-enforce'
-
-const SENTIMENT_MODEL = 'google/gemini-3.1-flash-lite-preview'
 
 export type Sentiment = 'positive' | 'neutral' | 'negative'
 
@@ -69,7 +68,8 @@ export async function analyzeSentiment(
   await enforceAiTokenBudget()
 
   const openai = getOpenAI()
-  if (!openai) return null
+  const model = getChatModel('sentiment')
+  if (!openai || !model) return null
 
   const truncatedContent = (content || '(no content)').slice(0, MAX_CONTENT_LENGTH)
   const text = `Title: ${title}\n\nContent: ${truncatedContent}`
@@ -79,13 +79,13 @@ export async function analyzeSentiment(
       {
         pipelineStep: 'sentiment',
         callType: 'chat_completion',
-        model: SENTIMENT_MODEL,
+        model,
         postId,
       },
       () =>
         withRetry(() =>
           openai.chat.completions.create({
-            model: SENTIMENT_MODEL,
+            model,
             max_completion_tokens: 1000,
             messages: [
               { role: 'system', content: SENTIMENT_PROMPT },
@@ -110,7 +110,7 @@ export async function analyzeSentiment(
     return {
       sentiment: parsed.sentiment,
       confidence: parsed.confidence,
-      model: SENTIMENT_MODEL,
+      model,
       inputTokens: response.usage?.prompt_tokens,
       outputTokens: response.usage?.completion_tokens,
     }

--- a/apps/web/src/lib/server/domains/summary/__tests__/summary-tier-gate.test.ts
+++ b/apps/web/src/lib/server/domains/summary/__tests__/summary-tier-gate.test.ts
@@ -18,6 +18,11 @@ vi.mock('@/lib/server/domains/ai/config', () => ({
   stripCodeFences: vi.fn((s: string) => s),
 }))
 
+vi.mock('@/lib/server/domains/ai/models', () => ({
+  getChatModel: () => 'test-model',
+  getEmbeddingModel: () => 'test-embedding-model',
+}))
+
 vi.mock('@/lib/server/db', () => ({
   db: {
     query: { posts: { findFirst: (...a: unknown[]) => hoisted.mockedFindFirst(...a) } },

--- a/apps/web/src/lib/server/domains/summary/summary.service.ts
+++ b/apps/web/src/lib/server/domains/summary/summary.service.ts
@@ -189,7 +189,10 @@ let _sweepInProgress = false
  * the sweep needs an attempted-set, circuit breaker, and reentrancy guard.
  */
 export async function refreshStaleSummaries(): Promise<void> {
-  if (!getOpenAI()) return
+  // Fast-path skip when AI is off OR the summary model is unset/disabled —
+  // otherwise the sweep would query a batch and per-post no-op until the
+  // circuit breaker trips.
+  if (!getOpenAI() || !getChatModel('summary')) return
   if (_sweepInProgress) return
   _sweepInProgress = true
   try {

--- a/apps/web/src/lib/server/domains/summary/summary.service.ts
+++ b/apps/web/src/lib/server/domains/summary/summary.service.ts
@@ -19,11 +19,10 @@ import {
   notInArray,
 } from '@/lib/server/db'
 import { getOpenAI, stripCodeFences } from '@/lib/server/domains/ai/config'
+import { getChatModel } from '@/lib/server/domains/ai/models'
 import { withRetry } from '@/lib/server/domains/ai/retry'
 import { enforceAiTokenBudget } from '@/lib/server/domains/settings/tier-enforce'
 import type { PostId } from '@quackback/ids'
-
-const SUMMARY_MODEL = 'google/gemini-3.1-flash-lite-preview'
 
 const SYSTEM_PROMPT = `You are a product feedback analyst writing post briefs for a PM's triage queue.
 Your job is to surface what matters for prioritization, not restate the obvious.
@@ -69,7 +68,8 @@ export async function generateAndSavePostSummary(postId: PostId): Promise<void> 
   await enforceAiTokenBudget()
 
   const openai = getOpenAI()
-  if (!openai) return
+  const model = getChatModel('summary')
+  if (!openai || !model) return
 
   // Fetch post (include existing summary for continuity on updates)
   const post = await db.query.posts.findFirst({
@@ -121,7 +121,7 @@ export async function generateAndSavePostSummary(postId: PostId): Promise<void> 
 
   const { result: completion } = await withRetry(() =>
     openai.chat.completions.create({
-      model: SUMMARY_MODEL,
+      model,
       messages: [
         { role: 'system', content: systemPrompt },
         { role: 'user', content: input },
@@ -166,7 +166,7 @@ export async function generateAndSavePostSummary(postId: PostId): Promise<void> 
     .update(posts)
     .set({
       summaryJson,
-      summaryModel: SUMMARY_MODEL,
+      summaryModel: model,
       summaryUpdatedAt: new Date(),
       summaryCommentCount: postComments.length,
     })

--- a/apps/web/src/lib/server/startup.ts
+++ b/apps/web/src/lib/server/startup.ts
@@ -103,6 +103,11 @@ export function logStartupBanner(): void {
 
   console.log(lines.join('\n'))
 
+  // Surface half-configured AI loudly instead of failing silently (see #180).
+  import('@/lib/server/domains/ai/config')
+    .then(({ validateAiConfig }) => validateAiConfig())
+    .catch((err) => console.error('[Startup] AI config validation failed:', err))
+
   // Wire SIGTERM/SIGINT once — the rest of this function spawns
   // long-lived workers + sweepers, so register the drain handler before
   // any of them start so a fast Ctrl-C in dev still gets a clean exit.


### PR DESCRIPTION
## Summary

Makes AI model selection configurable the way the endpoint and key already are, and removes the mismatched default that caused #180. AI is now off unless explicitly configured.

- Every AI feature previously hardcoded a provider-prefixed model slug (e.g. `google/gemini-3.1-flash-lite-preview`, `openai/text-embedding-3-small`) while the client silently defaulted to `api.openai.com`. A self-hoster who set only `OPENAI_API_KEY` got a `400 invalid model` on **every** AI call, not just summaries.
- New config: `AI_CHAT_MODEL` and `AI_EMBEDDING_MODEL` role defaults, plus optional per-feature overrides (`AI_SUMMARY_MODEL`, `AI_SENTIMENT_MODEL`, `AI_EXTRACTION_MODEL`, `AI_QUALITY_GATE_MODEL`, `AI_INTERPRETATION_MODEL`, `AI_MERGE_MODEL`). Resolution is `override -> role -> off`; a value of `off`/`none`/`false` disables just that feature.
- `getOpenAI()` now requires **both** `OPENAI_API_KEY` and `OPENAI_BASE_URL` (no implicit endpoint). Any OpenAI-compatible endpoint works (direct, a gateway, a local server); declare it explicitly.
- Each feature treats an unset model exactly like an absent client: soft no-op for most, `UnrecoverableError` for the extraction worker so the queue does not retry-storm. The summary and merge sweeps fast-path skip when their model is unset.
- Boot-time `validateAiConfig()` logs a loud warning when half-configured instead of failing silently.
- The 7 hardcoded model constants and one hidden inline slug (in the merge-check writer) are gone.

The existing #180 safeguards (4xx non-retryable in `retry.ts`, the summary/merge sweep circuit breakers) are untouched and remain as defense in depth. The per-feature `off` switch generalizes the `SUMMARY_DISABLED` request from the issue.

## Breaking change

`OPENAI_BASE_URL` is now required to enable AI. Deployments relying on the implicit `api.openai.com` default were already failing on every AI call, so no working config regresses. To use OpenAI directly: set `OPENAI_BASE_URL=https://api.openai.com/v1` plus the model vars. `.env.example` documents this with endpoint examples.

## Test plan

- [x] `bun run typecheck` clean
- [x] Full suite: 404 files, 4568 passed, 2 skipped
- [x] Unit tests for resolver precedence + disable sentinel (incl. role-default `=off`), the base-URL client gate, startup warnings
- [x] Disabled-model paths pinned: merge sweep no-ops when merge model unset; extraction throws `UnrecoverableError` when model unset but client present

Addresses #180.