### PR TITLE
fix(dragonfly): enable snapshot persistence so sessions & jobs survive restarts

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -98,7 +98,8 @@ services:
     container_name: quackback-dragonfly
     restart: unless-stopped
     # BullMQ requires cluster_mode=emulated + lock_on_hashtags for Lua script compatibility.
-    command: dragonfly --cluster_mode=emulated --lock_on_hashtags
+    # Persist to the dragonfly_data volume so OAuth sessions + BullMQ jobs survive restarts.
+    command: dragonfly --cluster_mode=emulated --lock_on_hashtags --dir /data --dbfilename dump --snapshot_cron "*/5 * * * *"
     # No host port — reachable only on the internal network.
     volumes:
       - dragonfly_data:/data


### PR DESCRIPTION
## Problem

The `dragonfly` service in `docker-compose.prod.yml` mounts a `dragonfly_data:/data` volume, but the launch `command` never enables Dragonfly's snapshot persistence:

```yaml
command: dragonfly --cluster_mode=emulated --lock_on_hashtags
volumes:
  - dragonfly_data:/data   # mounted, but nothing is ever written to it
```

As a result Dragonfly runs **in-memory only** and the volume stays empty. On every container restart or redeploy, all keys are lost.

Because the app uses Dragonfly for both:
- **OAuth sessions / refresh tokens** (`REDIS_URL: redis://dragonfly:6379`), and
- the **BullMQ** job queue,

a restart causes:
- **`session not found` → clients are forced to re-authenticate** (notably the MCP/OAuth integration loops on `invalid_grant: session not found` after any redeploy), and
- **queued / in-flight background jobs are silently dropped.**

This is easy to miss on a box that's deployed once and left running, but bites reliably in any environment that redeploys.

## Fix

Enable Dragonfly persistence into the already-present volume:

```yaml
command: dragonfly --cluster_mode=emulated --lock_on_hashtags --dir /data --dbfilename dump --snapshot_cron "*/5 * * * *"
```

- `--dir /data` — write snapshots into the existing `dragonfly_data` volume
- `--dbfilename dump` — load on startup; save on graceful shutdown
- `--snapshot_cron "*/5 * * * *"` — periodic snapshots so a hard crash loses at most ~5 minutes

`--cluster_mode=emulated --lock_on_hashtags` are preserved (still required for BullMQ Lua compatibility).

## Testing

Deployed to a live Coolify instance. After the change:
- Dragonfly writes `dump*.dfs` snapshots to `/data`.
- OAuth sessions and BullMQ jobs survive container restarts / redeploys.
- The MCP re-authentication loop is gone.