### PR TITLE
chore(release): bump version to 0.12.0

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quackback/web",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "license": "AGPL-3.0",
   "type": "module",


### PR DESCRIPTION
Version bump for the 0.12.0 release. Highlights since 0.11.0:

- **Configurable AI models** — AI is off unless explicitly configured; models per role with per-feature overrides; any OpenAI-compatible endpoint via `OPENAI_BASE_URL` (#206, root cause of #180)
- **Managed-cloud platform-credential source** — `PLATFORM_CREDENTIALS_SOURCE=env` reads shared integration OAuth creds from env; self-host DB path unchanged (#209)
- i18n: full locale parity backfill + portal auth screen translations (#202, #203)
- Shortcut: resolve inbound workflow state from webhook references (#204)

Tag `v0.12.0` follows on the merge commit (docker workflow publishes the `0.12.0` image via semver tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)