### PR TITLE
feat(admin): operator-set plan notice banner

### DIFF
--- a/apps/web/src/components/admin/plan-notice-banner.tsx
+++ b/apps/web/src/components/admin/plan-notice-banner.tsx
@@ -1,0 +1,60 @@
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/solid'
+import type { PlanNotice } from '@/lib/server/domains/settings/tier-limits.types'
+import { presentPlanNotice } from '@/lib/shared/plan-notice'
+
+interface PlanNoticeBannerProps {
+  notice: PlanNotice | null
+}
+
+/**
+ * Operator-set notice strip (e.g. "Free trial — 9 days left"). Driven
+ * entirely by settings.tier_limits.notice; renders nothing when unset.
+ * Not dismissible: it represents workspace state, and clearing the
+ * notice (by whoever set it) is what removes it.
+ */
+export function PlanNoticeBanner({ notice }: PlanNoticeBannerProps) {
+  const view = presentPlanNotice(notice)
+  if (!view) return null
+
+  const tone = view.urgent
+    ? 'bg-amber-500/10 border-amber-500/20'
+    : 'bg-primary/5 border-primary/10'
+
+  return (
+    <div className={`flex items-center justify-between gap-3 px-4 py-2.5 text-sm border-b ${tone}`}>
+      <div className="flex items-center gap-2 min-w-0">
+        <span className="font-medium text-foreground shrink-0">{view.label}</span>
+        {view.daysLeft !== null && (
+          <>
+            <span className="text-muted-foreground">—</span>
+            <span
+              className={
+                view.urgent
+                  ? 'text-amber-600 dark:text-amber-400 font-medium'
+                  : 'text-muted-foreground'
+              }
+            >
+              {view.daysLeft === 0
+                ? 'ends today'
+                : `${view.daysLeft} day${view.daysLeft === 1 ? '' : 's'} left`}
+            </span>
+          </>
+        )}
+        {view.message && (
+          <span className="text-muted-foreground hidden sm:inline truncate">{view.message}</span>
+        )}
+      </div>
+      {view.actionUrl && (
+        <a
+          href={view.actionUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="shrink-0 inline-flex items-center gap-1 text-primary font-medium hover:underline"
+        >
+          {view.actionLabel ?? 'Manage'}
+          <ArrowTopRightOnSquareIcon className="h-3 w-3" />
+        </a>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/lib/server/config-file/__tests__/schema.test.ts
+++ b/apps/web/src/lib/server/config-file/__tests__/schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { parseQuackbackConfig } from '../schema'
+import { parseQuackbackConfig, quackbackConfigSchema } from '../schema'
 
 describe('parseQuackbackConfig', () => {
   it('accepts a fully-populated valid config', () => {
@@ -148,5 +148,54 @@ describe('parseQuackbackConfig', () => {
       },
     })
     expect(result.success).toBe(false)
+  })
+})
+
+const baseConfig = {
+  apiVersion: 'quackback.io/v1' as const,
+  kind: 'QuackbackConfig' as const,
+  spec: {},
+}
+
+describe('tierLimits.notice', () => {
+  it('accepts a full notice', () => {
+    const r = quackbackConfigSchema.safeParse({
+      ...baseConfig,
+      spec: {
+        tierLimits: {
+          maxBoards: null,
+          notice: {
+            label: 'Free trial',
+            expiresAt: '2026-06-24T00:00:00.000Z',
+            actionUrl: 'https://billing.example.com/plan',
+            actionLabel: 'Choose your plan',
+          },
+        },
+      },
+    })
+    expect(r.success).toBe(true)
+  })
+
+  it('accepts a label-only notice', () => {
+    const r = quackbackConfigSchema.safeParse({
+      ...baseConfig,
+      spec: { tierLimits: { notice: { label: 'Maintenance window' } } },
+    })
+    expect(r.success).toBe(true)
+  })
+
+  it('still rejects unknown keys inside tierLimits and notice', () => {
+    expect(
+      quackbackConfigSchema.safeParse({
+        ...baseConfig,
+        spec: { tierLimits: { notice: { label: 'x', bogus: true } } },
+      }).success
+    ).toBe(false)
+    expect(
+      quackbackConfigSchema.safeParse({
+        ...baseConfig,
+        spec: { tierLimits: { bogus: true } },
+      }).success
+    ).toBe(false)
   })
 })

--- a/apps/web/src/lib/server/config-file/schema.ts
+++ b/apps/web/src/lib/server/config-file/schema.ts
@@ -42,6 +42,19 @@ const workspaceSchema = z
 // (the reconciler merges into the existing tierLimits row, so the
 // file only needs to declare the fields it wants to lock).
 const tierLimitNumberSchema = z.number().int().nonnegative().nullable()
+
+// Optional operator-set admin banner. Delivered alongside tier limits;
+// see PlanNotice in domains/settings/tier-limits.types.ts.
+const planNoticeSchema = z
+  .object({
+    label: z.string().min(1),
+    message: z.string().optional(),
+    expiresAt: z.string().optional(),
+    actionUrl: httpsUrl.optional(),
+    actionLabel: z.string().optional(),
+  })
+  .strict()
+
 const tierFeatureFlagsSchema = z
   .object({
     customDomain: z.boolean().optional(),
@@ -65,6 +78,7 @@ const tierLimitsSchema = z
     apiRequestsPerMonth: tierLimitNumberSchema.optional(),
     apiRequestsPerMinute: tierLimitNumberSchema.optional(),
     features: tierFeatureFlagsSchema,
+    notice: planNoticeSchema.optional(),
   })
   .strict()
 

--- a/apps/web/src/lib/server/domains/settings/__tests__/tier-limits.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/tier-limits.test.ts
@@ -59,3 +59,29 @@ describe('mergeTierLimits', () => {
     expect(result.maxBoards).toBeNull()
   })
 })
+
+describe('plan notice passthrough', () => {
+  it('carries a stored notice through the merge', () => {
+    const merged = mergeTierLimits({
+      maxBoards: 5,
+      notice: {
+        label: 'Free trial',
+        expiresAt: '2026-06-24T00:00:00.000Z',
+        actionUrl: 'https://example.com/billing',
+        actionLabel: 'Choose your plan',
+      },
+    })
+    expect(merged.notice).toEqual({
+      label: 'Free trial',
+      expiresAt: '2026-06-24T00:00:00.000Z',
+      actionUrl: 'https://example.com/billing',
+      actionLabel: 'Choose your plan',
+    })
+    expect(merged.maxBoards).toBe(5)
+  })
+
+  it('returns no notice when absent from stored limits', () => {
+    expect(mergeTierLimits({ maxBoards: 1 }).notice).toBeUndefined()
+    expect(mergeTierLimits(null).notice).toBeUndefined()
+  })
+})

--- a/apps/web/src/lib/server/domains/settings/tier-limits.types.ts
+++ b/apps/web/src/lib/server/domains/settings/tier-limits.types.ts
@@ -25,6 +25,25 @@ export interface TierFeatureFlags {
   integrations: boolean
 }
 
+/**
+ * Optional operator-set notice rendered as a banner in the admin UI.
+ * Written through the same channel as the limits themselves (the
+ * declarative config file / internal writer). Self-hosters can use it
+ * for license or maintenance notices; absent (the default) renders
+ * nothing.
+ */
+export interface PlanNotice {
+  /** Short badge text, e.g. "Free trial". */
+  label: string
+  /** Optional supporting copy. */
+  message?: string
+  /** ISO timestamp; when set the banner renders a countdown. */
+  expiresAt?: string
+  /** When set the banner renders an action button linking here. */
+  actionUrl?: string
+  actionLabel?: string
+}
+
 export interface TierLimits {
   maxBoards: TierLimit<number>
   maxPosts: TierLimit<number>
@@ -42,6 +61,8 @@ export interface TierLimits {
   apiRequestsPerMinute: TierLimit<number>
 
   features: TierFeatureFlags
+  /** See PlanNotice. Absent on OSS defaults. */
+  notice?: PlanNotice
 }
 
 export const OSS_TIER_LIMITS: TierLimits = {

--- a/apps/web/src/lib/server/functions/__tests__/plan-notice-auth.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/plan-notice-auth.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Regression: `getPlanNotice` shipped with zero auth check — any
+ * unauthenticated RPC call to the server-fn endpoint could read
+ * whatever the operator put in tierLimits.notice (label/message/
+ * actionUrl), e.g. billing or maintenance details. The admin route
+ * gates the UI path on admin/member, but the handler itself must
+ * enforce the same boundary.
+ *
+ * This pins the contract at the handler boundary: requireAuth({roles:
+ * ['admin', 'member']}) is invoked before tier limits are read.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const hoisted = vi.hoisted(() => ({
+  mockRequireAuth: vi.fn(),
+  mockGetTierLimits: vi.fn(),
+}))
+
+vi.mock('@/lib/server/functions/auth-helpers', () => ({
+  requireAuth: hoisted.mockRequireAuth,
+}))
+
+vi.mock('@/lib/server/domains/settings/tier-limits.service', () => ({
+  getTierLimits: hoisted.mockGetTierLimits,
+}))
+
+type AnyHandler = () => Promise<unknown>
+
+const handlers: AnyHandler[] = []
+vi.mock('@tanstack/react-start', () => ({
+  createServerFn: () => {
+    const chain = {
+      inputValidator() {
+        return chain
+      },
+      handler(fn: AnyHandler) {
+        handlers.push(fn)
+        return chain
+      },
+    }
+    return chain
+  },
+}))
+
+let getPlanNoticeHandler: AnyHandler
+
+beforeEach(async () => {
+  vi.clearAllMocks()
+  hoisted.mockGetTierLimits.mockResolvedValue({})
+  if (handlers.length === 0) await import('../plan-notice')
+  getPlanNoticeHandler = handlers[0]
+})
+
+describe('getPlanNotice — team-member gate', () => {
+  it('rejects an unauthenticated caller without reading tier limits', async () => {
+    hoisted.mockRequireAuth.mockRejectedValueOnce(new Error('Authentication required'))
+
+    await expect(getPlanNoticeHandler()).rejects.toThrow(/auth/i)
+
+    expect(hoisted.mockRequireAuth).toHaveBeenCalledWith(
+      expect.objectContaining({ roles: expect.arrayContaining(['admin', 'member']) })
+    )
+    expect(hoisted.mockGetTierLimits).not.toHaveBeenCalled()
+  })
+
+  it('refuses a portal-user caller', async () => {
+    hoisted.mockRequireAuth.mockRejectedValueOnce(
+      new Error('Access denied: Requires [admin, member], got user')
+    )
+
+    await expect(getPlanNoticeHandler()).rejects.toThrow(/denied/i)
+
+    expect(hoisted.mockGetTierLimits).not.toHaveBeenCalled()
+  })
+
+  it('returns the notice for a team member', async () => {
+    hoisted.mockRequireAuth.mockResolvedValueOnce({
+      user: { id: 'usr_member' },
+      principal: { id: 'prn_member', role: 'member' },
+    })
+    const notice = {
+      label: 'Pro',
+      message: 'Renewal due',
+      actionUrl: 'https://example.com/billing',
+    }
+    hoisted.mockGetTierLimits.mockResolvedValueOnce({ notice })
+
+    await expect(getPlanNoticeHandler()).resolves.toEqual(notice)
+  })
+})

--- a/apps/web/src/lib/server/functions/plan-notice.ts
+++ b/apps/web/src/lib/server/functions/plan-notice.ts
@@ -1,10 +1,14 @@
 import { createServerFn } from '@tanstack/react-start'
 import type { PlanNotice } from '@/lib/server/domains/settings/tier-limits.types'
+import { requireAuth } from './auth-helpers'
 
 /** The operator-set plan notice, or null. Read by the admin layout to
- *  render the notice banner. */
+ *  render the notice banner. Team-only: the notice can carry billing or
+ *  maintenance details, so the RPC endpoint must not leak it to portal
+ *  users or anonymous callers. */
 export const getPlanNotice = createServerFn({ method: 'GET' }).handler(
   async (): Promise<PlanNotice | null> => {
+    await requireAuth({ roles: ['admin', 'member'] })
     const { getTierLimits } = await import('@/lib/server/domains/settings/tier-limits.service')
     const limits = await getTierLimits()
     return limits.notice ?? null

--- a/apps/web/src/lib/server/functions/plan-notice.ts
+++ b/apps/web/src/lib/server/functions/plan-notice.ts
@@ -1,0 +1,12 @@
+import { createServerFn } from '@tanstack/react-start'
+import type { PlanNotice } from '@/lib/server/domains/settings/tier-limits.types'
+
+/** The operator-set plan notice, or null. Read by the admin layout to
+ *  render the notice banner. */
+export const getPlanNotice = createServerFn({ method: 'GET' }).handler(
+  async (): Promise<PlanNotice | null> => {
+    const { getTierLimits } = await import('@/lib/server/domains/settings/tier-limits.service')
+    const limits = await getTierLimits()
+    return limits.notice ?? null
+  }
+)

--- a/apps/web/src/lib/shared/__tests__/plan-notice.test.ts
+++ b/apps/web/src/lib/shared/__tests__/plan-notice.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { presentPlanNotice } from '../plan-notice'
+
+const NOW = new Date('2026-06-15T12:00:00.000Z')
+
+describe('presentPlanNotice', () => {
+  it('returns null for no notice', () => {
+    expect(presentPlanNotice(undefined, NOW)).toBeNull()
+    expect(presentPlanNotice(null, NOW)).toBeNull()
+  })
+
+  it('renders a countdown with day granularity, not urgent when > 3 days out', () => {
+    const v = presentPlanNotice({ label: 'Free trial', expiresAt: '2026-06-24T00:00:00.000Z' }, NOW)
+    expect(v).toMatchObject({ label: 'Free trial', daysLeft: 9, urgent: false })
+  })
+
+  it('marks urgent at 3 days or fewer', () => {
+    const v = presentPlanNotice({ label: 'Free trial', expiresAt: '2026-06-17T12:00:00.000Z' }, NOW)
+    expect(v).toMatchObject({ daysLeft: 2, urgent: true })
+  })
+
+  it('clamps an already-expired notice to 0 days, urgent', () => {
+    const v = presentPlanNotice({ label: 'Free trial', expiresAt: '2026-06-01T00:00:00.000Z' }, NOW)
+    expect(v).toMatchObject({ daysLeft: 0, urgent: true })
+  })
+
+  it('passes through label-only notices with no countdown', () => {
+    const v = presentPlanNotice({ label: 'Maintenance window' }, NOW)
+    expect(v).toMatchObject({ label: 'Maintenance window', daysLeft: null, urgent: false })
+  })
+
+  it('ignores an unparseable expiresAt', () => {
+    const v = presentPlanNotice({ label: 'x', expiresAt: 'not-a-date' }, NOW)
+    expect(v).toMatchObject({ daysLeft: null })
+  })
+
+  it('carries action fields through', () => {
+    const v = presentPlanNotice(
+      { label: 'x', actionUrl: 'https://e.com', actionLabel: 'Manage' },
+      NOW
+    )
+    expect(v).toMatchObject({ actionUrl: 'https://e.com', actionLabel: 'Manage' })
+  })
+})

--- a/apps/web/src/lib/shared/plan-notice.ts
+++ b/apps/web/src/lib/shared/plan-notice.ts
@@ -1,0 +1,40 @@
+// Canonical type lives in lib/server/domains/settings/tier-limits.types.ts.
+// import type is safe here — type-only imports are erased at runtime and
+// cannot pull server modules into the client bundle.
+import type { PlanNotice } from '@/lib/server/domains/settings/tier-limits.types'
+
+export interface PlanNoticeView {
+  label: string
+  message?: string
+  /** Whole days until expiry (ceil), clamped to >= 0. Null when the
+   *  notice has no (valid) expiresAt. */
+  daysLeft: number | null
+  /** True at 3 days or fewer remaining — banner shifts to amber. */
+  urgent: boolean
+  actionUrl?: string
+  actionLabel?: string
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+export function presentPlanNotice(
+  notice: PlanNotice | null | undefined,
+  now: Date = new Date()
+): PlanNoticeView | null {
+  if (!notice) return null
+  let daysLeft: number | null = null
+  if (notice.expiresAt) {
+    const expires = Date.parse(notice.expiresAt)
+    if (!Number.isNaN(expires)) {
+      daysLeft = Math.max(0, Math.ceil((expires - now.getTime()) / DAY_MS))
+    }
+  }
+  return {
+    label: notice.label,
+    message: notice.message,
+    daysLeft,
+    urgent: daysLeft !== null && daysLeft <= 3,
+    actionUrl: notice.actionUrl,
+    actionLabel: notice.actionLabel,
+  }
+}

--- a/apps/web/src/routes/admin.tsx
+++ b/apps/web/src/routes/admin.tsx
@@ -9,6 +9,8 @@ import { AdminSidebar } from '@/components/admin/admin-sidebar'
 import { PostModal } from '@/components/admin/feedback/post-modal'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { UpdateBanner } from '@/components/admin/update-banner'
+import { PlanNoticeBanner } from '@/components/admin/plan-notice-banner'
+import { getPlanNotice } from '@/lib/server/functions/plan-notice'
 
 export const Route = createFileRoute('/admin')({
   beforeLoad: async ({ location }) => {
@@ -35,7 +37,13 @@ export const Route = createFileRoute('/admin')({
     // Skip for public admin routes (login, signup) - they have their own layouts
     const publicPaths = ['/admin/login', '/admin/signup']
     if (publicPaths.includes(location.pathname)) {
-      return { user: null, initialUserData: null, latestVersion: null, currentUser: null }
+      return {
+        user: null,
+        initialUserData: null,
+        latestVersion: null,
+        currentUser: null,
+        planNotice: null,
+      }
     }
 
     // Auth is already validated in beforeLoad - user and principal are guaranteed here
@@ -44,11 +52,12 @@ export const Route = createFileRoute('/admin')({
       principal: NonNullable<typeof context.principal>
     }
 
-    const [avatarData, latestRelease] = await Promise.all([
+    const [avatarData, latestRelease, planNotice] = await Promise.all([
       fetchUserAvatar({
         data: { userId: user.id, fallbackImageUrl: user.image },
       }),
       getLatestVersion(),
+      getPlanNotice(),
     ])
 
     const latestVersion =
@@ -65,6 +74,7 @@ export const Route = createFileRoute('/admin')({
       user,
       initialUserData,
       latestVersion,
+      planNotice,
       currentUser: {
         name: user.name,
         email: user.email,
@@ -85,7 +95,7 @@ function usePostIdFromUrl(): string | undefined {
 }
 
 function AdminLayout() {
-  const { initialUserData, latestVersion, currentUser } = Route.useLoaderData()
+  const { initialUserData, latestVersion, planNotice, currentUser } = Route.useLoaderData()
   const postId = usePostIdFromUrl()
 
   // Mark team members online for chat routing across the whole admin (not just
@@ -108,6 +118,7 @@ function AdminLayout() {
           <main className="flex-1 min-w-0 overflow-hidden sm:h-screen sm:py-2 sm:pr-2 sm:pl-1 p-0">
             {/* Mobile: Add padding for fixed header */}
             <div className="h-full sm:pt-0 pt-14 sm:rounded-lg sm:border sm:border-border overflow-hidden flex flex-col">
+              <PlanNoticeBanner notice={planNotice} />
               <UpdateBanner latestVersion={latestVersion} />
               <div className="flex-1 min-h-0 overflow-hidden">
                 <Outlet />


### PR DESCRIPTION
Adds an optional `notice` object to tier limits (label, expiry countdown, action link) that the admin UI renders as a banner above the content area.

Operators or management tooling can set it via the declarative config file (`spec.tierLimits.notice`) or the tier-limits writer; useful for license, maintenance, or plan notices. Absent by default — nothing renders, so existing deployments are unaffected.

- `PlanNotice` type on `TierLimits` + merge passthrough
- Strict config-file schema field (`tierLimits.notice`)
- Pure presenter (`presentPlanNotice`) with day-granularity countdown, amber at <= 3 days
- Non-dismissible `PlanNoticeBanner` mounted in the admin layout

Tests: presenter unit tests, schema accept/reject cases, merge passthrough.