### PR TITLE
fix(sso): send PKCE (S256) on the authorization-code flow (OAuth 2.1 IdP support)

### DIFF
--- a/apps/web/src/lib/server/auth/__tests__/sso-test-handshake.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/sso-test-handshake.test.ts
@@ -20,6 +20,7 @@ const baseInput: HandshakeInput = {
   clientId: 'cid',
   clientSecret: 'csecret',
   redirectUri: 'https://qb/api/auth/oauth2/callback/sso',
+  codeVerifier: 'test-code-verifier',
   expectedNonce: 'nonce789',
   expectedState: 'state123',
 }

--- a/apps/web/src/lib/server/auth/index.ts
+++ b/apps/web/src/lib/server/auth/index.ts
@@ -108,6 +108,7 @@ async function createAuth() {
     clientSecret: string
     disableSignUp?: boolean
     discoveryUrl?: string
+    pkce?: boolean
     authorizationUrl?: string
     tokenUrl?: string
     scopes?: string[]
@@ -185,6 +186,14 @@ async function createAuth() {
         clientSecret,
         discoveryUrl: cfg.discoveryUrl,
         scopes: ['openid', 'email', 'profile'],
+        // PKCE on the authorization-code grant. OAuth 2.1 IdPs (e.g.
+        // Supabase Auth's OAuth server) REQUIRE code_challenge on every
+        // authorize request and reject without it; RFC 7636 §5 makes the
+        // params backwards-compatible — IdPs that don't support PKCE
+        // simply ignore them (Okta, Auth0, Entra, Keycloak all accept
+        // it). Better-Auth threads code_verifier through the token
+        // exchange when this flag is set.
+        pkce: true,
         // Force the IdP to show the account-picker. Without this, an
         // admin typing demo@example.com at the login form gets
         // silently signed in as whoever the IdP already has a
@@ -257,6 +266,11 @@ async function createAuth() {
         ...(creds.authorizationUrl && { authorizationUrl: creds.authorizationUrl }),
         ...(creds.tokenUrl && { tokenUrl: creds.tokenUrl }),
         scopes: scopeStr.split(/\s+/).filter(Boolean),
+        // PKCE on every generic-oauth provider too (portal Custom OIDC).
+        // Same rationale as the 'sso' provider above: OAuth 2.1 IdPs
+        // require code_challenge; RFC 7636 params are ignored by IdPs
+        // without PKCE support, so it is safe to send unconditionally.
+        pkce: true,
         mapProfileToUser: mapProfileLocale,
       })
       trustedProviders.push(provider.id)

--- a/apps/web/src/lib/server/auth/sso-test-callback.ts
+++ b/apps/web/src/lib/server/auth/sso-test-callback.ts
@@ -71,6 +71,7 @@ export async function handleSsoTestCallback(
     clientId: session.clientId,
     clientSecret: session.clientSecret,
     redirectUri: session.redirectUri,
+    codeVerifier: session.codeVerifier,
   })
 
   // Strip the failure-branch `raw` debug field before persisting:

--- a/apps/web/src/lib/server/auth/sso-test-handshake.ts
+++ b/apps/web/src/lib/server/auth/sso-test-handshake.ts
@@ -33,6 +33,8 @@ export interface HandshakeInput {
   clientId: string
   clientSecret: string
   redirectUri: string
+  /** PKCE verifier minted at authorize time (S256 challenge). */
+  codeVerifier: string
   /** IdP-returned `error` query parameter, if the authorize step failed. */
   idpError?: string | null
   idpErrorDescription?: string | null
@@ -164,6 +166,7 @@ export async function runHandshake(input: HandshakeInput): Promise<HandshakeResu
   // and produce false positives.
   const tokenBody = new URLSearchParams({
     grant_type: 'authorization_code',
+    code_verifier: input.codeVerifier,
     code: input.code,
     redirect_uri: input.redirectUri,
     client_id: input.clientId,

--- a/apps/web/src/lib/server/functions/__tests__/sso-test.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/sso-test.test.ts
@@ -149,7 +149,11 @@ describe('startSsoTestFn', () => {
     expect(result.authorizeUrl).toMatch(
       /redirect_uri=https%3A%2F%2Fqb\.test%2Fapi%2Fauth%2Foauth2%2Fcallback%2Fsso/
     )
-    expect(result.authorizeUrl).not.toMatch(/code_challenge/)
+    // PKCE is mandatory for OAuth 2.1 IdPs (e.g. Supabase Auth) and
+    // ignored by IdPs that don't support it — the authorize URL must
+    // carry an S256 challenge pair, mirroring production (pkce: true).
+    expect(result.authorizeUrl).toMatch(/code_challenge=[A-Za-z0-9_-]{43}/)
+    expect(result.authorizeUrl).toMatch(/code_challenge_method=S256/)
     expect(hoisted.cacheSet).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/src/lib/server/functions/sso-test.ts
+++ b/apps/web/src/lib/server/functions/sso-test.ts
@@ -19,7 +19,7 @@
  *    payload or null if not ready.
  */
 
-import { randomBytes } from 'node:crypto'
+import { createHash, randomBytes } from 'node:crypto'
 import { createServerFn } from '@tanstack/react-start'
 import { z } from 'zod'
 import { requireAuth } from './auth-helpers'
@@ -47,6 +47,7 @@ type TestSession = {
   redirectUri: string
   adminUserId: string
   startedAt: number
+  codeVerifier: string
 }
 
 export type StartSsoTestResult =
@@ -96,6 +97,11 @@ export const startSsoTestFn = createServerFn({ method: 'POST' })
     const testId = `ssotest_${randomBytes(15).toString('base64url')}`
     const state = randomBytes(32).toString('base64url')
     const nonce = randomBytes(32).toString('base64url')
+    // PKCE (RFC 7636, S256) — mirrors production now that genericOAuth
+    // runs with pkce: true. OAuth 2.1 IdPs reject authorize requests
+    // without a code_challenge; IdPs without PKCE support ignore it.
+    const codeVerifier = randomBytes(32).toString('base64url')
+    const codeChallenge = createHash('sha256').update(codeVerifier).digest('base64url')
 
     const session: TestSession = {
       testId,
@@ -110,6 +116,7 @@ export const startSsoTestFn = createServerFn({ method: 'POST' })
       clientId: sso.clientId,
       clientSecret,
       redirectUri,
+      codeVerifier,
       adminUserId: user.id,
       startedAt: Date.now(),
     }
@@ -117,8 +124,8 @@ export const startSsoTestFn = createServerFn({ method: 'POST' })
     const { cacheSet } = await import('@/lib/server/redis')
     await cacheSet(ssoTestSessionKey(state), session, TTL_SECONDS)
 
-    // Mirror production: no PKCE on the authorize request because
-    // genericOAuth doesn't send code_verifier on the token request.
+    // Mirror production: genericOAuth runs with pkce: true, so the
+    // test handshake sends the same S256 code_challenge pair.
     const params = new URLSearchParams({
       response_type: 'code',
       client_id: sso.clientId,
@@ -127,6 +134,8 @@ export const startSsoTestFn = createServerFn({ method: 'POST' })
       state,
       nonce,
       prompt: 'login',
+      code_challenge: codeChallenge,
+      code_challenge_method: 'S256',
     })
     return {
       testId,


### PR DESCRIPTION
## Problem

The SSO / generic-OAuth sign-in flow does not send PKCE (`code_challenge`) on the authorization request. Identity providers that implement **OAuth 2.1 reject the flow outright** — PKCE is mandatory there, not optional. Concretely, connecting Quackback SSO to a Supabase Auth OAuth-2.1 server fails at:

- **authorize** → `400 invalid_request: "PKCE flow requires both code_challenge and code_challenge_method"`, and even past that,
- **token exchange** → `400`, because no `code_verifier` is sent.

The SSO **Test sign-in** surfaces this as `Stopped at: idp-authorize` / `token-exchange`.

## Fix

Enable PKCE (S256) on the authorization-code flow, in both code paths that build genericOAuth providers:

1. The team **`sso`** provider — `pkce: true` (Better Auth threads `code_verifier` through the token exchange automatically).
2. Every **portal generic-oauth** provider, including **Custom OIDC** — same `pkce: true`.

The built-in **SSO Test handshake** is updated to mirror production: it now mints an S256 verifier/challenge pair, sends `code_challenge`/`code_challenge_method` on the authorize URL, persists the verifier in the test session, and includes `code_verifier` at the token exchange — so the diagnostic keeps matching real sign-in behavior.

## Why this is safe for existing IdPs

PKCE is **backwards-compatible by design (RFC 7636 §5)**: IdPs that don't support it ignore the extra parameters. Okta, Auth0, Microsoft Entra, Google Workspace, and Keycloak all accept PKCE on the auth-code grant, so enabling it unconditionally doesn't regress any current provider — it only *adds* OAuth 2.1 compatibility.

## Tests

- Updated the test that asserted the authorize URL contained **no** `code_challenge` to assert it now carries the S256 pair; added the `codeVerifier` to the handshake input/fixture.
- All SSO suites green: `sso-test`, `sso-test-handshake`, `sso-test-callback`, `oidc-error-explain` (53 tests).
- `tsc` clean in the touched files; eslint/prettier hooks pass.

## Verification

Field-verified end to end against a Supabase Auth OAuth-2.1 server (self-hosted Quackback): Test sign-in now passes every step — state, discovery, token exchange, ID-token ES256 decode, JWKS signature, nonce, email claim, userinfo.
