### PR TITLE
Block public SSR portal reads for a suspended workspace

### DIFF
--- a/apps/web/src/lib/server/functions/__tests__/resolve-portal-access.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/resolve-portal-access.test.ts
@@ -98,6 +98,18 @@ vi.mock('@/lib/server/domains/segments/segment-membership.service', () => ({
   segmentIdsForPrincipal: (...args: unknown[]) => mockSegmentIdsForPrincipal(...args),
 }))
 
+// --- Mock: suspension guard (the resolver denies portal data when suspended) ---
+
+class SuspendedError extends Error {}
+class DeletingError extends Error {}
+const mockEnsureNotSuspended = vi.fn()
+
+vi.mock('@/lib/server/middleware/suspension-guard', () => ({
+  ensureNotSuspended: () => mockEnsureNotSuspended(),
+  SuspendedError,
+  DeletingError,
+}))
+
 import { resolvePortalAccessForRequest } from '../portal-access'
 import { NotFoundError } from '@/lib/shared/errors'
 
@@ -111,6 +123,40 @@ beforeEach(() => {
   mockGetWidgetConfig.mockResolvedValue({ identifyVerification: false })
   // Default: no segment memberships.
   mockSegmentIdsForPrincipal.mockResolvedValue(new Set())
+  // Default: workspace active (guard resolves without throwing).
+  mockEnsureNotSuspended.mockResolvedValue(undefined)
+})
+
+describe('resolvePortalAccessForRequest — suspension', () => {
+  it('denies (granted:false, reason:suspended) when the workspace is suspended', async () => {
+    mockGetSession.mockResolvedValue(null)
+    mockGetPortalConfig.mockResolvedValue({ access: { visibility: 'public' } })
+    mockEnsureNotSuspended.mockRejectedValue(new SuspendedError())
+
+    const result = await resolvePortalAccessForRequest()
+
+    expect(result).toEqual({ granted: false, reason: 'suspended' })
+  })
+
+  it('denies when the workspace is deleting', async () => {
+    mockGetSession.mockResolvedValue(null)
+    mockEnsureNotSuspended.mockRejectedValue(new DeletingError())
+
+    const result = await resolvePortalAccessForRequest()
+
+    expect(result).toEqual({ granted: false, reason: 'suspended' })
+  })
+
+  it('fails OPEN (proceeds to normal eval) when the suspension state read errors', async () => {
+    // A settings-read blip must not block a healthy public workspace.
+    mockGetSession.mockResolvedValue(null)
+    mockGetPortalConfig.mockResolvedValue({ access: { visibility: 'public' } })
+    mockEnsureNotSuspended.mockRejectedValue(new Error('db blip'))
+
+    const result = await resolvePortalAccessForRequest()
+
+    expect(result).toEqual({ granted: true, reason: 'public' })
+  })
 })
 
 describe('resolvePortalAccessForRequest — config-throw contract', () => {

--- a/apps/web/src/lib/server/functions/portal-access.ts
+++ b/apps/web/src/lib/server/functions/portal-access.ts
@@ -30,7 +30,7 @@ export type PortalAccessDecision =
     }
   | {
       granted: false
-      reason: 'unauthenticated' | 'unauthorized'
+      reason: 'unauthenticated' | 'unauthorized' | 'suspended'
     }
 
 /**
@@ -57,6 +57,28 @@ export type PortalAccessDecision =
  */
 export const resolvePortalAccessForRequest = createServerOnlyFn(
   async (): Promise<PortalAccessDecision> => {
+    // Billing suspension: a suspended/deleting workspace serves NO portal data.
+    // This is the shared chokepoint every public read funnels through, so
+    // gating here (rather than at each loader) keeps a suspended workspace's
+    // content out of the SSR payload entirely — not just hidden behind the
+    // root SuspendedView overlay. Reuse ensureNotSuspended (the same guard the
+    // write/API paths use — single source of truth for the state) but honour
+    // this resolver's never-throw contract by converting its throw into a
+    // denial. Any OTHER error (e.g. a settings-read blip) falls through to the
+    // normal access eval — fail OPEN so a transient read can't suspend a
+    // healthy workspace, matching the resolver's existing config-unreadable
+    // philosophy.
+    try {
+      const { ensureNotSuspended } = await import('@/lib/server/middleware/suspension-guard')
+      await ensureNotSuspended()
+    } catch (e) {
+      const { SuspendedError, DeletingError } =
+        await import('@/lib/server/middleware/suspension-guard')
+      if (e instanceof SuspendedError || e instanceof DeletingError) {
+        return { granted: false, reason: 'suspended' }
+      }
+    }
+
     const { auth } = await import('@/lib/server/auth/index')
     const { db, principal, eq } = await import('@/lib/server/db')
     const { getRequestHeaders } = await import('@tanstack/react-start/server')

--- a/apps/web/src/routes/__tests__/_portal.test.ts
+++ b/apps/web/src/routes/__tests__/_portal.test.ts
@@ -180,4 +180,17 @@ describe('_portal beforeLoad — portal.access.denied audit', () => {
     await new Promise((r) => setTimeout(r, 0))
     expect(mockRecordPortalAccessDeniedFn).not.toHaveBeenCalled()
   })
+
+  it('skips the access-gate (no throw, no audit) for a suspended workspace', async () => {
+    // A suspended workspace is surfaced by the root SuspendedView overlay, not
+    // the portal access-gate — so beforeLoad must NOT throw the gate error here,
+    // and it isn't an access-denial worth auditing.
+    mockEvaluateMyPortalAccessFn.mockResolvedValueOnce({ granted: false, reason: 'suspended' })
+
+    const context = makeContext({ id: 'user_1', email: 'admin@y.com', principalType: 'user' })
+    await expect(runBeforeLoad(context)).resolves.toBeUndefined()
+
+    await new Promise((r) => setTimeout(r, 0))
+    expect(mockRecordPortalAccessDeniedFn).not.toHaveBeenCalled()
+  })
 })

--- a/apps/web/src/routes/_portal.tsx
+++ b/apps/web/src/routes/_portal.tsx
@@ -39,6 +39,13 @@ export const Route = createFileRoute('/_portal')({
     const accessResult = await evaluateMyPortalAccessFn()
 
     if (!accessResult.granted) {
+      // A suspended/deleting workspace is surfaced by the root SuspendedView
+      // overlay (__root.tsx), not the portal access-gate. Skip the gate here —
+      // the public read fns already return empty for a suspended workspace
+      // (resolvePortalAccessForRequest denies), so nothing is dehydrated. This
+      // also narrows `reason` to the auth-denial literals for the rest below.
+      if (accessResult.reason === 'suspended') return
+
       // OWASP authz_fail — emit only for authenticated denials (anonymous denials
       // are too noisy and lower-signal). Best-effort, never blocks the gate throw.
       const session = context.session


### PR DESCRIPTION
## What
Closes the last enforcement-completeness gap from the go-live review: a billing-**suspended** workspace still served its public portal on the **SSR read path** (loaders fetched + dehydrated content), even though the write/API paths return 402 and the root renders a `SuspendedView` overlay. Enforcement was visual-only on reads and inconsistent with the API path.

Not a private-data leak — per-board authz still ran — but a suspended (non-paying) workspace shouldn't serve its public portal at all.

## How
- `resolvePortalAccessForRequest` (the shared chokepoint every public read funnels through) now **denies** for a suspended/deleting workspace: `{ granted: false, reason: 'suspended' }`. It reuses `ensureNotSuspended` (single source of truth for the state — same guard the write/API paths use) and converts its throw into a decision, honouring the resolver's never-throw contract. All ~14 read consumers already `return empty` on `!granted`, so the content never enters the SSR payload — one place, no per-loader special-casing.
- Fails **open** on any non-suspension error (e.g. a settings-read blip) so a transient read can't suspend a healthy workspace — matches the resolver's existing config-unreadable philosophy.
- `_portal.tsx` beforeLoad short-circuits `reason:'suspended'` so the root `SuspendedView` owns the UI, not the access-gate overlay.

## Tests
Resolver: denies on suspended + deleting, fails open on read error. `_portal`: skips the gate (no throw, no audit) when suspended. `tsc` clean; 520 server-fn tests + the `_portal` route test pass.

## Deploy
This is the per-tenant OSS image — ships via the normal release → `cp_version_releases` bump → `release-promote` (tenant rollout). Merge before the next release. Low urgency (0 tenants currently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)