### PR TITLE
fix(storage): match S3 public URL on a path-segment boundary in trusted-attachment check

### DIFF
--- a/apps/web/src/lib/server/storage/__tests__/trusted-url.test.ts
+++ b/apps/web/src/lib/server/storage/__tests__/trusted-url.test.ts
@@ -1,0 +1,70 @@
+/**
+ * isTrustedAttachmentUrl gates which URLs may appear as chat attachments and
+ * inline chatImage srcs — anything else becomes a third-party fetch fired from
+ * an agent's browser. The path-boundary cases matter most: on a path-style
+ * object store, `/bucket` must not admit `/bucket-evil/...` (a sibling bucket
+ * on the same host is attacker-creatable).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockConfig = {
+  baseUrl: 'https://app.example.com',
+  s3PublicUrl: undefined as string | undefined,
+}
+
+vi.mock('@/lib/server/config', () => ({ config: mockConfig }))
+
+const { isTrustedAttachmentUrl } = await import('@/lib/server/storage/trusted-url')
+
+beforeEach(() => {
+  mockConfig.baseUrl = 'https://app.example.com'
+  mockConfig.s3PublicUrl = undefined
+})
+
+describe('isTrustedAttachmentUrl — app storage route', () => {
+  it('accepts own-app /api/storage/ URLs (absolute and relative)', () => {
+    expect(isTrustedAttachmentUrl('https://app.example.com/api/storage/x/y.png')).toBe(true)
+    expect(isTrustedAttachmentUrl('/api/storage/x/y.png')).toBe(true)
+  })
+
+  it('rejects other hosts and non-http(s) schemes', () => {
+    expect(isTrustedAttachmentUrl('https://evil.example.com/api/storage/x.png')).toBe(false)
+    expect(isTrustedAttachmentUrl("javascript:'/api/storage/'")).toBe(false)
+  })
+
+  it('rejects dot-segment escapes out of the storage prefix', () => {
+    expect(isTrustedAttachmentUrl('https://app.example.com/api/storage/../x.png')).toBe(false)
+  })
+})
+
+describe('isTrustedAttachmentUrl — S3_PUBLIC_URL path boundary', () => {
+  it('accepts objects under a path-style public URL', () => {
+    mockConfig.s3PublicUrl = 'https://minio.example.com/app-bucket'
+    expect(isTrustedAttachmentUrl('https://minio.example.com/app-bucket/2026/x.png')).toBe(true)
+  })
+
+  it('accepts objects when the public URL has a trailing slash', () => {
+    mockConfig.s3PublicUrl = 'https://minio.example.com/app-bucket/'
+    expect(isTrustedAttachmentUrl('https://minio.example.com/app-bucket/2026/x.png')).toBe(true)
+  })
+
+  it('rejects a sibling bucket whose name extends the configured one', () => {
+    mockConfig.s3PublicUrl = 'https://minio.example.com/app-bucket'
+    expect(isTrustedAttachmentUrl('https://minio.example.com/app-bucket-evil/x.png')).toBe(false)
+  })
+
+  it('rejects a sibling bucket when the public URL has a trailing slash', () => {
+    mockConfig.s3PublicUrl = 'https://minio.example.com/app-bucket/'
+    expect(isTrustedAttachmentUrl('https://minio.example.com/app-bucket-evil/x.png')).toBe(false)
+  })
+
+  it('accepts any path on a host-only public URL (virtual-hosted bucket)', () => {
+    mockConfig.s3PublicUrl = 'https://cdn.example.com'
+    expect(isTrustedAttachmentUrl('https://cdn.example.com/anything/x.png')).toBe(true)
+  })
+
+  it('still rejects other hosts when a public URL is configured', () => {
+    mockConfig.s3PublicUrl = 'https://minio.example.com/app-bucket'
+    expect(isTrustedAttachmentUrl('https://evil.example.com/app-bucket/x.png')).toBe(false)
+  })
+})

--- a/apps/web/src/lib/server/storage/trusted-url.ts
+++ b/apps/web/src/lib/server/storage/trusted-url.ts
@@ -19,7 +19,12 @@ export function isTrustedAttachmentUrl(url: string): boolean {
     if (u.protocol !== 'https:' && u.protocol !== 'http:') return false
     if (config.s3PublicUrl) {
       const base = new URL(config.s3PublicUrl)
-      if (u.hostname === base.hostname && u.pathname.startsWith(base.pathname)) return true
+      // Match on a path-segment boundary: a bare prefix check would admit a
+      // sibling bucket on the same host (`/bucket` matching `/bucket-evil/x`).
+      const basePath = base.pathname.replace(/\/$/, '')
+      const pathOk =
+        basePath === '' || u.pathname === basePath || u.pathname.startsWith(`${basePath}/`)
+      if (u.hostname === base.hostname && pathOk) return true
     }
     return u.hostname === appBase.hostname && u.pathname.startsWith('/api/storage/')
   } catch {


### PR DESCRIPTION
## Problem

`isTrustedAttachmentUrl` validated S3-hosted attachment URLs with a bare `pathname.startsWith(base.pathname)`. When `S3_PUBLIC_URL` is path-style without a trailing slash (e.g. `https://minio.example.com/app-bucket`, common with MinIO/Ceph), any path that merely extends the prefix also passed — `https://minio.example.com/app-bucket-evil/x.png` was treated as our own storage.

On a shared object-store host this lets content outside our bucket be referenced as a chat attachment or inline `chatImage` src, which is exactly the third-party-fetch-from-an-agent's-browser vector this check exists to block.

## Fix

Match on a path-segment boundary: strip the trailing slash from the configured path, then require the candidate path to equal it or continue with `/`. This mirrors `isSameOrigin` in `rehost-images.ts`, which already handles this case.

## Tests

New `trusted-url.test.ts` covering the app-storage route, dot-segment escapes, scheme/host rejection, and the path-boundary matrix (with and without trailing slash, sibling-bucket rejection, host-only public URL).