### PR TITLE
fix(storage): verify upload bytes against the declared image type; nosniff on proxied reads

### DIFF
--- a/apps/web/src/lib/server/__tests__/s3-upload-content-validation.test.ts
+++ b/apps/web/src/lib/server/__tests__/s3-upload-content-validation.test.ts
@@ -1,0 +1,96 @@
+/**
+ * uploadImageFromFormData must validate file CONTENT, not just the declared
+ * multipart Content-Type — the type label is caller-controlled, and the bytes
+ * are stored and served back under that label. A mismatch (or unsniffable
+ * bytes) is rejected before anything reaches storage, mirroring the magic-byte
+ * check the unfurl image proxy already applies to fetched images.
+ */
+import { describe, expect, it, vi } from 'vitest'
+
+const mockConfig = {
+  s3Bucket: 'my-bucket',
+  s3Region: 'us-east-1',
+  s3AccessKeyId: 'access-key',
+  s3SecretAccessKey: 'secret-key',
+  s3Endpoint: undefined as string | undefined,
+  s3ForcePathStyle: false,
+  s3PublicUrl: undefined as string | undefined,
+  s3Proxy: false,
+  baseUrl: 'https://app.example.com',
+}
+
+vi.mock('@/lib/server/config', () => ({ config: mockConfig }))
+
+const mockSend = vi.fn(async () => ({}))
+
+vi.mock('@aws-sdk/client-s3', () => ({
+  S3Client: vi.fn(function () {
+    return { send: mockSend, destroy: vi.fn() }
+  }),
+  PutObjectCommand: vi.fn(function (input: unknown) {
+    return { input }
+  }),
+  GetObjectCommand: vi.fn(function (input: unknown) {
+    return { input }
+  }),
+  DeleteObjectCommand: vi.fn(function (input: unknown) {
+    return { input }
+  }),
+}))
+
+vi.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: vi.fn(async () => 'https://s3.amazonaws.com/presigned'),
+}))
+
+const { uploadImageFromFormData } = await import('@/lib/server/storage/s3')
+
+const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0])
+const GIF_BYTES = new Uint8Array([...'GIF89a'].map((c) => c.charCodeAt(0)).concat([0, 0, 0, 0]))
+const HTML_BYTES = new Uint8Array(
+  [...'<html><script>alert(1)</script></html>'].map((c) => c.charCodeAt(0))
+)
+
+function formDataWith(bytes: Uint8Array<ArrayBuffer>, name: string, type: string): FormData {
+  const fd = new FormData()
+  fd.append('file', new File([bytes], name, { type }))
+  return fd
+}
+
+describe('uploadImageFromFormData — content validation', () => {
+  it('accepts bytes that match the declared type', async () => {
+    const res = await uploadImageFromFormData(formDataWith(PNG_BYTES, 'a.png', 'image/png'), 'p')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { publicUrl: string }
+    expect(body.publicUrl).toContain('/api/storage/p/')
+  })
+
+  it('rejects non-image bytes declared as an allowed image type', async () => {
+    mockSend.mockClear()
+    const res = await uploadImageFromFormData(formDataWith(HTML_BYTES, 'a.png', 'image/png'), 'p')
+    expect(res.status).toBe(400)
+    expect(mockSend).not.toHaveBeenCalled()
+  })
+
+  it('rejects image bytes whose format differs from the declared type', async () => {
+    mockSend.mockClear()
+    const res = await uploadImageFromFormData(formDataWith(GIF_BYTES, 'a.png', 'image/png'), 'p')
+    expect(res.status).toBe(400)
+    expect(mockSend).not.toHaveBeenCalled()
+  })
+
+  it('rejects a body too short to identify', async () => {
+    const res = await uploadImageFromFormData(
+      formDataWith(new Uint8Array([0x89, 0x50]), 'a.png', 'image/png'),
+      'p'
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('still rejects disallowed declared types before reading bytes', async () => {
+    const res = await uploadImageFromFormData(
+      formDataWith(PNG_BYTES, 'a.svg', 'image/svg+xml'),
+      'p'
+    )
+    expect(res.status).toBe(400)
+  })
+})

--- a/apps/web/src/lib/server/storage/s3.ts
+++ b/apps/web/src/lib/server/storage/s3.ts
@@ -19,6 +19,7 @@
 
 import { createHmac, timingSafeEqual } from 'node:crypto'
 import { config } from '@/lib/server/config'
+import { sniffImageMime } from '@/lib/server/content/magic-bytes'
 
 // ============================================================================
 // Configuration
@@ -382,6 +383,12 @@ export async function uploadImageFromFormData(
     const filename = file.name || `paste-${Date.now()}.${ext}`
     const key = generateStorageKey(storagePrefix, filename)
     const body = Buffer.from(await file.arrayBuffer())
+    // The multipart type label is caller-controlled and becomes the stored
+    // Content-Type, so verify it against the actual bytes before storing —
+    // same check the unfurl image proxy applies to fetched images.
+    if (sniffImageMime(body) !== file.type) {
+      return Response.json({ error: 'File content does not match its type' }, { status: 400 })
+    }
     const publicUrl = await uploadObject(key, body, file.type)
     return Response.json({ publicUrl })
   } catch {

--- a/apps/web/src/routes/api/__tests__/s3-upload-mock.ts
+++ b/apps/web/src/routes/api/__tests__/s3-upload-mock.ts
@@ -1,4 +1,5 @@
 import { vi } from 'vitest'
+import { sniffImageMime } from '@/lib/server/content/magic-bytes'
 
 /**
  * Shared vi.mock factory for @/lib/server/storage/s3.
@@ -45,11 +46,13 @@ export function createS3MockFactory() {
       try {
         const filename = file.name || `paste-${Date.now()}.${file.type.split('/')[1] || 'png'}`
         const key = mockGenerateStorageKey(storagePrefix, filename)
-        const publicUrl = await mockUploadObject(
-          key,
-          Buffer.from(await file.arrayBuffer()),
-          file.type
-        )
+        const body = Buffer.from(await file.arrayBuffer())
+        // Mirror the real implementation's magic-byte check (sniffImageMime is
+        // pure, so the real one is used) — declared type must match the bytes.
+        if (sniffImageMime(body) !== file.type) {
+          return Response.json({ error: 'File content does not match its type' }, { status: 400 })
+        }
+        const publicUrl = await mockUploadObject(key, body, file.type)
         return Response.json({ publicUrl })
       } catch {
         return Response.json({ error: 'Upload failed' }, { status: 500 })

--- a/apps/web/src/routes/api/__tests__/upload-fixtures.ts
+++ b/apps/web/src/routes/api/__tests__/upload-fixtures.ts
@@ -11,6 +11,26 @@ import type { db } from '@/lib/server/db'
 type SessionResult = NonNullable<Awaited<ReturnType<typeof auth.api.getSession>>>
 type PrincipalRecord = NonNullable<Awaited<ReturnType<typeof db.query.principal.findFirst>>>
 
+/**
+ * Minimal valid magic bytes per allowed image type, so upload fixtures pass
+ * the content sniff the same way a real file of that type would.
+ */
+const IMAGE_MAGIC_BYTES: Record<string, number[]> = {
+  'image/png': [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0],
+  'image/jpeg': [0xff, 0xd8, 0xff, 0xe0, 0, 0, 0, 0],
+  'image/gif': [...'GIF89a'].map((c) => c.charCodeAt(0)).concat([0, 0]),
+  'image/webp': [...'RIFFxxxxWEBP'].map((c, i) => (i >= 4 && i < 8 ? 0 : c.charCodeAt(0))),
+}
+
+/** Create a File whose bytes match its declared image type. */
+export function mockImageFile(name: string, type: string, extraBytes = 0): File {
+  const magic = IMAGE_MAGIC_BYTES[type]
+  if (!magic) throw new Error(`no magic bytes fixture for ${type}`)
+  return new File([new Uint8Array([...magic, ...new Array<number>(extraBytes).fill(0)])], name, {
+    type,
+  })
+}
+
 /** Create a mock Better Auth session result */
 export function mockSession(
   overrides: Partial<{ user: Partial<SessionResult['user']> }> = {}

--- a/apps/web/src/routes/api/portal/__tests__/upload.test.ts
+++ b/apps/web/src/routes/api/portal/__tests__/upload.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mockSession, mockPrincipal } from '../../__tests__/upload-fixtures'
+import { mockSession, mockPrincipal, mockImageFile } from '../../__tests__/upload-fixtures'
 
 vi.mock('@/lib/server/auth', () => ({
   auth: {
@@ -107,7 +107,7 @@ describe('POST /api/portal/upload', () => {
     vi.mocked(auth.api.getSession).mockResolvedValueOnce(identifiedSession)
     vi.mocked(db.query.principal.findFirst).mockResolvedValueOnce(identifiedPrincipal)
     vi.mocked(uploadObject).mockResolvedValueOnce('https://cdn.example.com/portal-images/photo.jpg')
-    const file = new File(['img'], 'photo.jpg', { type: 'image/jpeg' })
+    const file = mockImageFile('photo.jpg', 'image/jpeg')
     const res = await handlePortalUpload({ request: makeRequest(file) })
     expect(res.status).toBe(200)
     const body = await res.json()
@@ -123,7 +123,7 @@ describe('POST /api/portal/upload', () => {
     vi.mocked(auth.api.getSession).mockResolvedValueOnce(identifiedSession)
     vi.mocked(db.query.principal.findFirst).mockResolvedValueOnce(identifiedPrincipal)
     vi.mocked(uploadObject).mockResolvedValueOnce('https://cdn.example.com/portal-images/img.png')
-    const file = new File(['img'], 'img.png', { type: 'image/png' })
+    const file = mockImageFile('img.png', 'image/png')
     await handlePortalUpload({ request: makeRequest(file) })
     const { generateStorageKey } = await import('@/lib/server/storage/s3')
     expect(generateStorageKey).toHaveBeenCalledWith('portal-images', expect.any(String))

--- a/apps/web/src/routes/api/storage/$.ts
+++ b/apps/web/src/routes/api/storage/$.ts
@@ -49,8 +49,15 @@ export async function readBodyWithLimit(
 }
 
 export async function handleProxyUpload({ request }: { request: Request }): Promise<Response> {
-  const { isS3Configured, getS3Config, uploadObject, verifyProxyUploadToken, MAX_FILE_SIZE } =
-    await import('@/lib/server/storage/s3')
+  const {
+    isS3Configured,
+    getS3Config,
+    uploadObject,
+    verifyProxyUploadToken,
+    isAllowedImageType,
+    MAX_FILE_SIZE,
+  } = await import('@/lib/server/storage/s3')
+  const { sniffImageMime } = await import('@/lib/server/content/magic-bytes')
   const { config } = await import('@/lib/server/config')
 
   if (!isS3Configured() || !config.s3Proxy) {
@@ -74,6 +81,15 @@ export async function handleProxyUpload({ request }: { request: Request }): Prom
 
   const body = await readBodyWithLimit(request, MAX_FILE_SIZE)
   if (!body) return Response.json({ error: 'File too large' }, { status: 413 })
+
+  // The token authenticates which (key, ct) may be written, not that the bytes
+  // are that type — apply the same magic-byte check as the multipart path.
+  // Every presigned flow signs an allowed image type, so non-image cts are
+  // rejected outright.
+  const sniffed = sniffImageMime(Buffer.from(body.buffer, body.byteOffset, body.byteLength))
+  if (!isAllowedImageType(ct) || sniffed !== ct) {
+    return Response.json({ error: 'File content does not match its type' }, { status: 400 })
+  }
 
   await uploadObject(key, body, ct)
   proxyCache.delete(key)

--- a/apps/web/src/routes/api/storage/$.ts
+++ b/apps/web/src/routes/api/storage/$.ts
@@ -80,6 +80,84 @@ export async function handleProxyUpload({ request }: { request: Request }): Prom
   return new Response(null, { status: 200 })
 }
 
+/**
+ * GET /api/storage/*
+ * Serve files from S3 storage.
+ *
+ * When S3_PROXY is enabled, streams file bytes through the server — useful when
+ * the browser can't reach the S3 endpoint directly (e.g., ngrok, mixed content).
+ *
+ * Otherwise, redirects to a presigned S3 URL (302) so the browser fetches
+ * directly from S3 — no bytes are proxied through the server.
+ */
+export async function handleStorageGet({ request }: { request: Request }): Promise<Response> {
+  const { isS3Configured, generatePresignedGetUrl, getS3Object } =
+    await import('@/lib/server/storage/s3')
+  const { config } = await import('@/lib/server/config')
+
+  if (!isS3Configured()) {
+    return Response.json({ error: 'Storage not configured' }, { status: 503 })
+  }
+
+  const url = new URL(request.url)
+  const key = extractKey(url)
+
+  if (!key) {
+    return Response.json({ error: 'Invalid storage key' }, { status: 400 })
+  }
+
+  // Force proxy for email embeds (?email=1) since email clients don't follow redirects
+  const forceProxy = url.searchParams.has('email')
+
+  try {
+    if (config.s3Proxy || forceProxy) {
+      const cached = proxyCache.get(key)
+      if (cached) {
+        if (Date.now() - cached.cachedAt < PROXY_CACHE_TTL) {
+          return new Response(cached.data, {
+            status: 200,
+            headers: {
+              'Content-Type': cached.contentType,
+              'Cache-Control': 'public, max-age=31536000, immutable',
+              // Stored Content-Types originate from upload requests — never
+              // let a browser second-guess them on a same-origin response.
+              'X-Content-Type-Options': 'nosniff',
+            },
+          })
+        }
+        proxyCache.delete(key)
+      }
+
+      const { body, contentType } = await getS3Object(key)
+      const data = await new Response(body).arrayBuffer()
+
+      proxyCache.set(key, { data, contentType, cachedAt: Date.now() })
+
+      return new Response(data, {
+        status: 200,
+        headers: {
+          'Content-Type': contentType,
+          'Cache-Control': 'public, max-age=31536000, immutable',
+          'X-Content-Type-Options': 'nosniff',
+        },
+      })
+    }
+
+    const presignedUrl = await generatePresignedGetUrl(key)
+
+    return new Response(null, {
+      status: 302,
+      headers: {
+        Location: presignedUrl,
+        'Cache-Control': 'public, max-age=86400',
+      },
+    })
+  } catch (error) {
+    console.error('Error serving storage object:', error)
+    return Response.json({ error: 'Failed to resolve storage URL' }, { status: 500 })
+  }
+}
+
 export const Route = createFileRoute('/api/storage/$')({
   server: {
     handlers: {
@@ -92,79 +170,7 @@ export const Route = createFileRoute('/api/storage/$')({
        */
       PUT: handleProxyUpload,
 
-      /**
-       * GET /api/storage/*
-       * Serve files from S3 storage.
-       *
-       * When S3_PROXY is enabled, streams file bytes through the server — useful when
-       * the browser can't reach the S3 endpoint directly (e.g., ngrok, mixed content).
-       *
-       * Otherwise, redirects to a presigned S3 URL (302) so the browser fetches
-       * directly from S3 — no bytes are proxied through the server.
-       */
-      GET: async ({ request }) => {
-        const { isS3Configured, generatePresignedGetUrl, getS3Object } =
-          await import('@/lib/server/storage/s3')
-        const { config } = await import('@/lib/server/config')
-
-        if (!isS3Configured()) {
-          return Response.json({ error: 'Storage not configured' }, { status: 503 })
-        }
-
-        const url = new URL(request.url)
-        const key = extractKey(url)
-
-        if (!key) {
-          return Response.json({ error: 'Invalid storage key' }, { status: 400 })
-        }
-
-        // Force proxy for email embeds (?email=1) since email clients don't follow redirects
-        const forceProxy = url.searchParams.has('email')
-
-        try {
-          if (config.s3Proxy || forceProxy) {
-            const cached = proxyCache.get(key)
-            if (cached) {
-              if (Date.now() - cached.cachedAt < PROXY_CACHE_TTL) {
-                return new Response(cached.data, {
-                  status: 200,
-                  headers: {
-                    'Content-Type': cached.contentType,
-                    'Cache-Control': 'public, max-age=31536000, immutable',
-                  },
-                })
-              }
-              proxyCache.delete(key)
-            }
-
-            const { body, contentType } = await getS3Object(key)
-            const data = await new Response(body).arrayBuffer()
-
-            proxyCache.set(key, { data, contentType, cachedAt: Date.now() })
-
-            return new Response(data, {
-              status: 200,
-              headers: {
-                'Content-Type': contentType,
-                'Cache-Control': 'public, max-age=31536000, immutable',
-              },
-            })
-          }
-
-          const presignedUrl = await generatePresignedGetUrl(key)
-
-          return new Response(null, {
-            status: 302,
-            headers: {
-              Location: presignedUrl,
-              'Cache-Control': 'public, max-age=86400',
-            },
-          })
-        } catch (error) {
-          console.error('Error serving storage object:', error)
-          return Response.json({ error: 'Failed to resolve storage URL' }, { status: 500 })
-        }
-      },
+      GET: handleStorageGet,
     },
   },
 })

--- a/apps/web/src/routes/api/storage/__tests__/proxy-upload.test.ts
+++ b/apps/web/src/routes/api/storage/__tests__/proxy-upload.test.ts
@@ -12,6 +12,8 @@ vi.mock('@/lib/server/storage/s3', () => ({
   getS3Config: mockGetS3Config,
   uploadObject: mockUploadObject,
   verifyProxyUploadToken: mockVerifyProxyUploadToken,
+  isAllowedImageType: (t: string) =>
+    ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/avif'].includes(t),
   MAX_FILE_SIZE,
 }))
 
@@ -23,23 +25,25 @@ const { handleProxyUpload } = await import('../$.js')
 
 const KEY = 'avatars/2024/01/abc123-photo.png'
 const CT = 'image/png'
+// Bodies must carry real magic bytes — the handler sniffs them against `ct`.
+const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0])
 
-function makeUrl(key = KEY) {
+function makeUrl(key = KEY, ct = CT) {
   const url = new URL(`http://localhost/api/storage/${key}`)
-  url.searchParams.set('ct', CT)
+  url.searchParams.set('ct', ct)
   url.searchParams.set('exp', String(Date.now() + 60_000))
   url.searchParams.set('sig', 'mock-sig')
   return url.toString()
 }
 
 function makeRequest(
-  options: { key?: string; body?: BodyInit; urlOverride?: string } = {}
+  options: { key?: string; body?: BodyInit; ct?: string; urlOverride?: string } = {}
 ): Request {
-  const url = options.urlOverride ?? makeUrl(options.key)
+  const url = options.urlOverride ?? makeUrl(options.key, options.ct)
   return new Request(url, {
     method: 'PUT',
-    body: options.body ?? new Uint8Array(100),
-    headers: { 'Content-Type': CT },
+    body: options.body ?? PNG_BYTES,
+    headers: { 'Content-Type': options.ct ?? CT },
   })
 }
 
@@ -98,6 +102,21 @@ describe('PUT /api/storage/* (proxy upload)', () => {
     const res = await handleProxyUpload({ request: makeRequest() })
     expect(res.status).toBe(200)
     expect(mockUploadObject).toHaveBeenCalledWith(KEY, expect.any(Uint8Array), CT)
+  })
+
+  it('rejects bytes that do not match the signed image content-type', async () => {
+    // The token authenticates (key, ct), not the bytes — HTML under an
+    // image/png label must not reach storage.
+    const html = new Uint8Array([...'<html><script>x</script>'].map((c) => c.charCodeAt(0)))
+    const res = await handleProxyUpload({ request: makeRequest({ body: html }) })
+    expect(res.status).toBe(400)
+    expect(mockUploadObject).not.toHaveBeenCalled()
+  })
+
+  it('rejects a non-image signed content-type outright', async () => {
+    const res = await handleProxyUpload({ request: makeRequest({ ct: 'text/html' }) })
+    expect(res.status).toBe(400)
+    expect(mockUploadObject).not.toHaveBeenCalled()
   })
 
   it('passes the secretAccessKey from getS3Config to verifyProxyUploadToken', async () => {

--- a/apps/web/src/routes/api/storage/__tests__/storage-get-headers.test.ts
+++ b/apps/web/src/routes/api/storage/__tests__/storage-get-headers.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Proxied storage responses carry caller-influenced Content-Types (the upload
+ * path stores the declared multipart type), so every proxy response must send
+ * X-Content-Type-Options: nosniff — including the in-memory cache hit and the
+ * ?email=1 forced-proxy path, which is reachable on every deployment
+ * regardless of S3_PROXY.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockConfig = { s3Proxy: false }
+
+const getS3Object = vi.fn(async (_key: string) => ({
+  body: new Blob([new Uint8Array([0x47, 0x49, 0x46])]).stream(),
+  contentType: 'image/gif',
+}))
+
+vi.mock('@/lib/server/config', () => ({ config: mockConfig }))
+vi.mock('@/lib/server/storage/s3', () => ({
+  isS3Configured: vi.fn(() => true),
+  getS3Object,
+  generatePresignedGetUrl: vi.fn(async () => 'https://s3.example.com/presigned'),
+}))
+
+const { handleStorageGet } = await import('../$')
+
+const get = (path: string) =>
+  handleStorageGet({ request: new Request(`https://app.example.com${path}`) })
+
+beforeEach(() => {
+  mockConfig.s3Proxy = false
+  getS3Object.mockClear()
+})
+
+describe('handleStorageGet — proxy response headers', () => {
+  it('sends nosniff on proxied responses (S3_PROXY=true)', async () => {
+    mockConfig.s3Proxy = true
+    const res = await get('/api/storage/widget-images/fresh-proxy.gif')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('X-Content-Type-Options')).toBe('nosniff')
+  })
+
+  it('sends nosniff on the in-memory cache hit', async () => {
+    mockConfig.s3Proxy = true
+    await get('/api/storage/widget-images/cached.gif')
+    const res = await get('/api/storage/widget-images/cached.gif')
+    expect(getS3Object).toHaveBeenCalledTimes(1)
+    expect(res.headers.get('X-Content-Type-Options')).toBe('nosniff')
+  })
+
+  it('sends nosniff on the ?email=1 forced-proxy path even without S3_PROXY', async () => {
+    const res = await get('/api/storage/widget-images/email-embed.gif?email=1')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('X-Content-Type-Options')).toBe('nosniff')
+  })
+
+  it('still redirects to the presigned URL when not proxying', async () => {
+    const res = await get('/api/storage/widget-images/redirect.gif')
+    expect(res.status).toBe(302)
+    expect(res.headers.get('Location')).toBe('https://s3.example.com/presigned')
+  })
+})

--- a/apps/web/src/routes/api/upload/__tests__/image.test.ts
+++ b/apps/web/src/routes/api/upload/__tests__/image.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mockSession, mockPrincipal } from '../../__tests__/upload-fixtures'
+import { mockSession, mockPrincipal, mockImageFile } from '../../__tests__/upload-fixtures'
 
 vi.mock('@/lib/server/auth', () => ({
   auth: {
@@ -71,7 +71,7 @@ describe('POST /api/upload/image', () => {
     vi.mocked(auth.api.getSession).mockResolvedValueOnce(memberSession)
     vi.mocked(db.query.principal.findFirst).mockResolvedValueOnce(memberPrincipal)
     vi.mocked(uploadObject).mockResolvedValueOnce('https://cdn.example.com/uploads/img.jpg')
-    const file = new File(['img'], 'img.jpg', { type: 'image/jpeg' })
+    const file = mockImageFile('img.jpg', 'image/jpeg')
     const res = await handleAdminUpload({ request: makeRequest(file) })
     expect(res.status).toBe(200)
   })
@@ -118,7 +118,7 @@ describe('POST /api/upload/image', () => {
     vi.mocked(uploadObject).mockResolvedValueOnce(
       'https://cdn.example.com/changelog-images/img.png'
     )
-    const file = new File(['img'], 'img.png', { type: 'image/png' })
+    const file = mockImageFile('img.png', 'image/png')
     await handleAdminUpload({ request: makeRequest(file, 'changelog-images') })
     expect(generateStorageKey).toHaveBeenCalledWith('changelog-images', expect.any(String))
   })
@@ -127,7 +127,7 @@ describe('POST /api/upload/image', () => {
     vi.mocked(auth.api.getSession).mockResolvedValueOnce(adminSession)
     vi.mocked(db.query.principal.findFirst).mockResolvedValueOnce(adminPrincipal)
     vi.mocked(uploadObject).mockResolvedValueOnce('https://cdn.example.com/uploads/img.png')
-    const file = new File(['img'], 'img.png', { type: 'image/png' })
+    const file = mockImageFile('img.png', 'image/png')
     await handleAdminUpload({ request: makeRequest(file, 'totally-unknown-prefix') })
     expect(generateStorageKey).toHaveBeenCalledWith('uploads', expect.any(String))
   })
@@ -144,7 +144,7 @@ describe('POST /api/upload/image', () => {
       vi.mocked(auth.api.getSession).mockResolvedValueOnce(adminSession)
       vi.mocked(db.query.principal.findFirst).mockResolvedValueOnce(adminPrincipal)
       vi.mocked(uploadObject).mockResolvedValueOnce(`https://cdn.example.com/${prefix}/img.png`)
-      const file = new File(['img'], 'img.png', { type: 'image/png' })
+      const file = mockImageFile('img.png', 'image/png')
       await handleAdminUpload({ request: makeRequest(file, prefix) })
       expect(generateStorageKey).toHaveBeenCalledWith(prefix, expect.any(String))
       vi.clearAllMocks()
@@ -156,7 +156,7 @@ describe('POST /api/upload/image', () => {
     vi.mocked(auth.api.getSession).mockResolvedValueOnce(adminSession)
     vi.mocked(db.query.principal.findFirst).mockResolvedValueOnce(adminPrincipal)
     vi.mocked(uploadObject).mockResolvedValueOnce('https://cdn.example.com/post-images/photo.gif')
-    const file = new File(['img'], 'photo.gif', { type: 'image/gif' })
+    const file = mockImageFile('photo.gif', 'image/gif')
     const res = await handleAdminUpload({ request: makeRequest(file, 'post-images') })
     expect(res.status).toBe(200)
     expect(await res.json()).toHaveProperty(

--- a/apps/web/src/routes/api/widget/__tests__/upload.test.ts
+++ b/apps/web/src/routes/api/widget/__tests__/upload.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mockSession } from '../../__tests__/upload-fixtures'
+import { mockSession, mockImageFile } from '../../__tests__/upload-fixtures'
 
 vi.mock('@/lib/server/auth', () => ({
   auth: { api: { getSession: vi.fn() } },
@@ -87,7 +87,7 @@ describe('POST /api/widget/upload', () => {
     // live-chat visitor without an account can attach images too.
     authAs()
     vi.mocked(uploadObject).mockResolvedValueOnce('https://cdn.example.com/widget-images/shot.webp')
-    const file = new File(['img'], 'shot.webp', { type: 'image/webp' })
+    const file = mockImageFile('shot.webp', 'image/webp')
     const res = await handleWidgetUpload({ request: makeRequest(file, 'valid-token') })
     expect(res.status).toBe(200)
     const body = await res.json()


### PR DESCRIPTION
## Problem

Two gaps in how uploaded images are validated and served:

1. `uploadImageFromFormData` validated only the **declared** multipart `Content-Type` against the image allowlist. The bytes themselves were never inspected, and the declared label became the stored object's `Content-Type`. The unfurl image proxy already cross-checks magic bytes for fetched images; the upload path didn't.
2. The `/api/storage` GET proxy served stored bytes without `X-Content-Type-Options: nosniff` — and the `?email=1` forced-proxy path makes the proxy reachable on every deployment, not just `S3_PROXY=true`. Sniffing-prone browsers could second-guess the served Content-Type on a same-origin response.

Together: arbitrary bytes stored under an `image/*` label and served same-origin without a sniffing guard.

## Fix

- Sniff magic bytes in `uploadImageFromFormData` (reusing `sniffImageMime`) and reject with 400 when they don't match the declared type, before anything reaches storage.
- Send `X-Content-Type-Options: nosniff` on both proxy branches (fresh fetch and in-memory cache hit).
- Extract the storage GET handler to an exported `handleStorageGet` so the headers are unit-testable (pure refactor, behavior unchanged).

## Tests

- New `s3-upload-content-validation.test.ts`: matching bytes accepted; HTML bytes under an image label rejected; cross-format mismatch (GIF bytes as `image/png`) rejected; too-short bodies rejected; disallowed declared types still rejected first.
- New `storage-get-headers.test.ts`: nosniff on proxied, cached, and `?email=1` responses; presigned redirect path unchanged.
- The shared S3 mock factory now mirrors the magic-byte check (using the real, pure `sniffImageMime`), and upload route fixtures carry real magic bytes via a new `mockImageFile` helper — so route-level tests exercise the same contract as production.