### PR TITLE
fix(chat): verify inbound email senders; scope the SSE backfill cursor

### DIFF
--- a/apps/web/src/lib/server/domains/chat/__tests__/chat-backfill-cursor.test.ts
+++ b/apps/web/src/lib/server/domains/chat/__tests__/chat-backfill-cursor.test.ts
@@ -1,0 +1,78 @@
+/**
+ * findBackfillCursor resolves the (createdAt, id) keyset anchor for SSE
+ * reconnect backfill. The lookup must be scoped to the conversation the
+ * caller is authorized for: a Last-Event-ID naming a message from another
+ * conversation must resolve to no cursor, not shift the backfill window.
+ * Same rule listMessages applies to its `before` cursor.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import type { ConversationId } from '@quackback/ids'
+
+// Rows the fake db serves; the where-predicate built from the mocked eq/and is
+// evaluated against them so the test exercises filtering behavior, not just
+// query shape.
+const rows = [
+  { id: 'msg_a', conversationId: 'conversation_A', createdAt: new Date('2026-06-01T10:00:00Z') },
+  { id: 'msg_b', conversationId: 'conversation_B', createdAt: new Date('2026-06-01T11:00:00Z') },
+]
+
+type Cond = { col?: string; val?: unknown; all?: Cond[] }
+const evalCond = (c: Cond, row: Record<string, unknown>): boolean =>
+  c.all ? c.all.every((x) => evalCond(x, row)) : row[c.col!] === c.val
+
+vi.mock('@/lib/server/db', () => {
+  function makeChain() {
+    let cond: Cond | null = null
+    const chain: Record<string, unknown> = {}
+    chain.select = () => chain
+    chain.from = () => chain
+    chain.where = (c: Cond) => {
+      cond = c
+      return chain
+    }
+    chain.limit = () => chain
+    chain.then = (resolve: (r: unknown[]) => unknown) =>
+      resolve(rows.filter((r) => (cond ? evalCond(cond, r) : true)))
+    return chain
+  }
+  return {
+    db: { select: () => makeChain() },
+    eq: (col: string, val: unknown) => ({ col, val }),
+    and: (...all: Cond[]) => ({ all: all.filter(Boolean) }),
+    or: (...c: unknown[]) => ({ or: c }),
+    lt: () => ({}),
+    gt: () => ({}),
+    desc: () => ({}),
+    asc: () => ({}),
+    isNull: () => ({}),
+    inArray: () => ({}),
+    sql: Object.assign(() => ({}), { raw: () => ({}) }),
+    chatMessages: { id: 'id', conversationId: 'conversationId', createdAt: 'createdAt' },
+    conversations: { id: 'id' },
+    principal: { id: 'id' },
+    user: { id: 'id' },
+    chatMessageReactions: {},
+    chatMessageMentions: {},
+    conversationTags: {},
+    tags: {},
+  }
+})
+
+const { findBackfillCursor } = await import('../chat.query')
+
+describe('findBackfillCursor', () => {
+  it('returns the keyset anchor for a message in the conversation', async () => {
+    const cursor = await findBackfillCursor('conversation_A' as ConversationId, 'msg_a')
+    expect(cursor).toMatchObject({ id: 'msg_a' })
+  })
+
+  it('refuses a cursor message that belongs to another conversation', async () => {
+    const cursor = await findBackfillCursor('conversation_A' as ConversationId, 'msg_b')
+    expect(cursor).toBeNull()
+  })
+
+  it('returns null for an unknown message id', async () => {
+    const cursor = await findBackfillCursor('conversation_A' as ConversationId, 'msg_nope')
+    expect(cursor).toBeNull()
+  })
+})

--- a/apps/web/src/lib/server/domains/chat/__tests__/chat-email-inbound.test.ts
+++ b/apps/web/src/lib/server/domains/chat/__tests__/chat-email-inbound.test.ts
@@ -4,7 +4,7 @@
  * message is just what the visitor actually wrote.
  */
 import { describe, it, expect } from 'vitest'
-import { parseInboundEmail, extractReplyText } from '../chat.email-inbound'
+import { parseInboundEmail, extractReplyText, extractEmailAddress } from '../chat.email-inbound'
 
 describe('parseInboundEmail', () => {
   it('normalizes an array `to`, reads `from`/`subject`/`text`, and the Message-ID header', () => {
@@ -99,5 +99,31 @@ describe('extractReplyText', () => {
 
   it('still returns empty for a reply that is entirely quoted history', () => {
     expect(extractReplyText('On Mon wrote:\n> only quoted text\n> more quoted')).toBe('')
+  })
+})
+
+describe('extractEmailAddress', () => {
+  it('returns a bare address lowercased and trimmed', () => {
+    expect(extractEmailAddress(' Jane@Example.COM ')).toBe('jane@example.com')
+  })
+
+  it('extracts the addr-spec from a name-addr From header', () => {
+    expect(extractEmailAddress('Jane Visitor <Jane@Example.com>')).toBe('jane@example.com')
+  })
+
+  it('handles a quoted display name containing a comma', () => {
+    expect(extractEmailAddress('"Doe, Jane" <jane@example.com>')).toBe('jane@example.com')
+  })
+
+  it('returns null for null, empty, or address-less input', () => {
+    expect(extractEmailAddress(null)).toBeNull()
+    expect(extractEmailAddress('')).toBeNull()
+    expect(extractEmailAddress('not an address')).toBeNull()
+  })
+
+  it('returns null for malformed addr-specs', () => {
+    expect(extractEmailAddress('Jane <@example.com>')).toBeNull()
+    expect(extractEmailAddress('Jane <jane@>')).toBeNull()
+    expect(extractEmailAddress('a@b@c')).toBeNull()
   })
 })

--- a/apps/web/src/lib/server/domains/chat/__tests__/chat-email-ingest.test.ts
+++ b/apps/web/src/lib/server/domains/chat/__tests__/chat-email-ingest.test.ts
@@ -17,6 +17,7 @@ const sendVisitorMessage = vi.fn()
 const assertChatSendRate = vi.fn()
 let conversationRow: Record<string, unknown> | undefined
 let principalRow: Record<string, unknown> | undefined
+let userRow: Record<string, unknown> | undefined
 let dupeRows: Array<Record<string, unknown>> = []
 
 vi.mock('../chat.service', () => ({
@@ -42,6 +43,7 @@ vi.mock('@/lib/server/db', () => {
       query: {
         conversations: { findFirst: async () => conversationRow },
         principal: { findFirst: async () => principalRow },
+        user: { findFirst: async () => userRow },
       },
       select: () => selectChain,
     },
@@ -50,6 +52,7 @@ vi.mock('@/lib/server/db', () => {
     chatMessages: { metadata: 'metadata' },
     conversations: { id: 'id' },
     principal: { id: 'id' },
+    user: { id: 'id' },
   }
 })
 
@@ -69,7 +72,16 @@ const baseEvent = {
 beforeEach(() => {
   vi.clearAllMocks()
   conversationRow = { id: 'conversation_abc', visitorPrincipalId: 'principal_v', status: 'closed' }
-  principalRow = { id: 'principal_v', type: 'anonymous', displayName: 'Jane' }
+  // contactEmail matches baseEvent's From — sender verification must hold for
+  // the happy-path tests.
+  principalRow = {
+    id: 'principal_v',
+    type: 'anonymous',
+    displayName: 'Jane',
+    contactEmail: 'jane@example.com',
+    userId: null,
+  }
+  userRow = undefined
   dupeRows = []
   sendVisitorMessage.mockResolvedValue({ created: false })
   assertChatSendRate.mockResolvedValue(undefined)
@@ -144,6 +156,86 @@ describe('ingestInboundEmail', () => {
     })
 
     expect(result).toEqual({ status: 'no_conversation' })
+    expect(sendVisitorMessage).not.toHaveBeenCalled()
+  })
+
+  it('drops a reply whose From matches no known address for the visitor', async () => {
+    const result = await ingestInboundEmail({
+      ...baseEvent,
+      data: { ...baseEvent.data, from: 'attacker@evil.example' },
+    })
+
+    expect(result).toEqual({ status: 'from_mismatch' })
+    expect(sendVisitorMessage).not.toHaveBeenCalled()
+  })
+
+  it('drops a payload with no From at all', async () => {
+    const data: Record<string, unknown> = { ...baseEvent.data }
+    delete data.from
+    const result = await ingestInboundEmail({ ...baseEvent, data })
+
+    expect(result).toEqual({ status: 'from_mismatch' })
+    expect(sendVisitorMessage).not.toHaveBeenCalled()
+  })
+
+  it('accepts a name-addr From matching the contact email case-insensitively', async () => {
+    const result = await ingestInboundEmail({
+      ...baseEvent,
+      data: { ...baseEvent.data, from: 'Jane Visitor <JANE@Example.com>' },
+    })
+
+    expect(result).toEqual({ status: 'ingested', conversationId: 'conversation_abc' })
+  })
+
+  it('matches the linked account email for an identified visitor', async () => {
+    principalRow = {
+      id: 'principal_v',
+      type: 'user',
+      displayName: 'Jane',
+      contactEmail: null,
+      userId: 'user_1',
+    }
+    userRow = { id: 'user_1', email: 'jane@corp.example' }
+
+    const result = await ingestInboundEmail({
+      ...baseEvent,
+      data: { ...baseEvent.data, from: 'jane@corp.example' },
+    })
+
+    expect(result).toEqual({ status: 'ingested', conversationId: 'conversation_abc' })
+  })
+
+  it('matches the captured pre-chat email on the conversation', async () => {
+    principalRow = { ...principalRow!, contactEmail: null }
+    conversationRow = { ...conversationRow!, visitorEmail: 'prechat@example.com' }
+
+    const result = await ingestInboundEmail({
+      ...baseEvent,
+      data: { ...baseEvent.data, from: 'prechat@example.com' },
+    })
+
+    expect(result).toEqual({ status: 'ingested', conversationId: 'conversation_abc' })
+  })
+
+  it('never matches a synthetic anonymous placeholder address', async () => {
+    principalRow = { ...principalRow!, contactEmail: null }
+    conversationRow = { ...conversationRow!, visitorEmail: 'temp-abc@anon.quackback.io' }
+
+    const result = await ingestInboundEmail({
+      ...baseEvent,
+      data: { ...baseEvent.data, from: 'temp-abc@anon.quackback.io' },
+    })
+
+    expect(result).toEqual({ status: 'from_mismatch' })
+    expect(sendVisitorMessage).not.toHaveBeenCalled()
+  })
+
+  it('drops every sender when the visitor has no address on file', async () => {
+    principalRow = { ...principalRow!, contactEmail: null }
+
+    const result = await ingestInboundEmail(baseEvent)
+
+    expect(result).toEqual({ status: 'from_mismatch' })
     expect(sendVisitorMessage).not.toHaveBeenCalled()
   })
 

--- a/apps/web/src/lib/server/domains/chat/chat.email-inbound.service.ts
+++ b/apps/web/src/lib/server/domains/chat/chat.email-inbound.service.ts
@@ -10,11 +10,12 @@
  * the route maps to a 200 (so the provider stops retrying a message we can't
  * place) and logs the reason.
  */
-import { db, eq, sql, chatMessages, conversations, principal } from '@/lib/server/db'
+import { db, eq, sql, chatMessages, conversations, principal, user } from '@/lib/server/db'
 import type { ConversationId, PrincipalId } from '@quackback/ids'
 import type { Actor } from '@/lib/server/policy/types'
 import { normalizePrincipalType } from '@/lib/server/functions/auth-helpers'
-import { parseInboundEmail, extractReplyText } from './chat.email-inbound'
+import { realEmail } from '@/lib/shared/anonymous-email'
+import { parseInboundEmail, extractReplyText, extractEmailAddress } from './chat.email-inbound'
 import { conversationIdFromInboundAddress } from './chat.email-channel'
 import { assertChatSendRate, ChatRateLimitError } from './chat.ratelimit'
 import { sendVisitorMessage } from './chat.service'
@@ -24,6 +25,7 @@ export type IngestInboundResult =
   | { status: 'duplicate' }
   | { status: 'no_conversation' }
   | { status: 'empty' }
+  | { status: 'from_mismatch' }
   | { status: 'rate_limited' }
 
 /** Find the conversation id carried by any recipient plus-address. */
@@ -69,6 +71,25 @@ export async function ingestInboundEmail(event: unknown): Promise<IngestInboundR
     where: eq(principal.id, visitorPrincipalId),
   })
   if (!visitor) return { status: 'no_conversation' }
+
+  // The Svix signature authenticates the delivery provider, not the sender:
+  // the reply+ address is visible to anyone on the email thread (CC, forward),
+  // so without this check any third party could inject messages attributed to
+  // the visitor. The From must match an address we know for this visitor —
+  // linked account email, principal contact email, or the captured pre-chat
+  // email. realEmail() keeps synthetic anonymous placeholders out of the set;
+  // an empty set means we never emailed this visitor, so nothing can match.
+  const linkedUser = visitor.userId
+    ? await db.query.user.findFirst({ where: eq(user.id, visitor.userId) })
+    : null
+  const knownAddresses = new Set(
+    [linkedUser?.email, visitor.contactEmail, conversation.visitorEmail]
+      .map((e) => realEmail(e))
+      .filter((e): e is string => e !== null)
+      .map((e) => e.toLowerCase())
+  )
+  const sender = extractEmailAddress(parsed.from)
+  if (!sender || !knownAddresses.has(sender)) return { status: 'from_mismatch' }
 
   // Same per-visitor throttle the widget send path enforces — the inbound email
   // channel must not be an unbounded back door for the offline-notification

--- a/apps/web/src/lib/server/domains/chat/chat.email-inbound.ts
+++ b/apps/web/src/lib/server/domains/chat/chat.email-inbound.ts
@@ -43,6 +43,22 @@ function readHeader(headers: unknown, name: string): string | null {
   return null
 }
 
+/**
+ * Pull the addr-spec out of a From header value (`Jane <jane@x>` or a bare
+ * address), normalized to lower case. Returns null when no plausible single
+ * address is present — callers treat that as "sender unknown", never as a
+ * wildcard match.
+ */
+export function extractEmailAddress(raw: string | null): string | null {
+  if (!raw) return null
+  const angled = raw.match(/<([^<>]+)>\s*$/)
+  const candidate = (angled ? angled[1] : raw).trim().toLowerCase()
+  if (!candidate || /[\s<>,;"]/.test(candidate)) return null
+  const at = candidate.indexOf('@')
+  if (at <= 0 || at !== candidate.lastIndexOf('@') || at === candidate.length - 1) return null
+  return candidate
+}
+
 export function parseInboundEmail(data: unknown): ParsedInboundEmail {
   const d = (data && typeof data === 'object' ? data : {}) as Record<string, unknown>
   const rawTo = d.to

--- a/apps/web/src/lib/server/domains/chat/chat.query.ts
+++ b/apps/web/src/lib/server/domains/chat/chat.query.ts
@@ -575,6 +575,29 @@ export interface MessagePage {
 }
 
 /**
+ * Resolve a message-id cursor to its (created_at, id) keyset anchor, scoped to
+ * the conversation: a cursor from another conversation must not be honored —
+ * it could truncate a page or shift a reconnect-backfill window. Shared by
+ * listMessages (`before`) and the SSE stream's Last-Event-ID backfill.
+ */
+export async function findBackfillCursor(
+  conversationId: ConversationId,
+  messageId: string
+): Promise<{ createdAt: Date; id: ChatMessage['id'] } | null> {
+  const [row] = await db
+    .select({ createdAt: chatMessages.createdAt, id: chatMessages.id })
+    .from(chatMessages)
+    .where(
+      and(
+        eq(chatMessages.id, messageId as ChatMessage['id']),
+        eq(chatMessages.conversationId, conversationId)
+      )
+    )
+    .limit(1)
+  return row ?? null
+}
+
+/**
  * List messages in a conversation, newest-first internally for keyset
  * pagination, returned oldest-first for rendering. `before` is a message id
  * cursor (fetch messages older than it).
@@ -588,22 +611,7 @@ export async function listMessages(
   // Composite keyset cursor on (created_at, id): two messages can share a
   // microsecond timestamp (e.g. same-transaction or concurrent sends), so a
   // strict created_at comparison would silently skip same-timestamp siblings.
-  let cursor: { createdAt: Date; id: ChatMessage['id'] } | null = null
-  if (opts?.before) {
-    // Scope the cursor lookup to this conversation: a cursor from another
-    // conversation must not be honored (it could truncate the page).
-    const [cursorRow] = await db
-      .select({ createdAt: chatMessages.createdAt, id: chatMessages.id })
-      .from(chatMessages)
-      .where(
-        and(
-          eq(chatMessages.id, opts.before as ChatMessage['id']),
-          eq(chatMessages.conversationId, conversationId)
-        )
-      )
-      .limit(1)
-    cursor = cursorRow ?? null
-  }
+  const cursor = opts?.before ? await findBackfillCursor(conversationId, opts.before) : null
 
   const rows = await db
     .select()

--- a/apps/web/src/lib/server/domains/chat/email-webhook-handler.ts
+++ b/apps/web/src/lib/server/domains/chat/email-webhook-handler.ts
@@ -55,6 +55,7 @@ export async function handleInboundEmailWebhook(request: Request): Promise<Respo
     if (
       result.status === 'no_conversation' ||
       result.status === 'empty' ||
+      result.status === 'from_mismatch' ||
       result.status === 'rate_limited'
     ) {
       console.warn(`[chat:email-inbound] dropped event (${result.status})`)

--- a/apps/web/src/routes/api/chat/stream.ts
+++ b/apps/web/src/routes/api/chat/stream.ts
@@ -22,7 +22,12 @@ import { subscribe } from '@/lib/server/realtime/pubsub'
 import { markPresent, refreshPresence, clearPresence } from '@/lib/server/realtime/presence'
 import { canViewConversation } from '@/lib/server/policy/chat'
 import { isTeamMember } from '@/lib/shared/roles'
-import { loadAuthors, toMessageDTO, fallbackAuthor } from '@/lib/server/domains/chat/chat.query'
+import {
+  loadAuthors,
+  toMessageDTO,
+  fallbackAuthor,
+  findBackfillCursor,
+} from '@/lib/server/domains/chat/chat.query'
 import { normalizePrincipalType } from '@/lib/server/functions/auth-helpers'
 import type { Actor } from '@/lib/server/policy/types'
 
@@ -288,9 +293,9 @@ export const Route = createFileRoute('/api/chat/stream')({
               // stream, so it's isolated in its own try/catch.
               if (backfillConversationId && lastEventId) {
                 try {
-                  const cursor = await db.query.chatMessages.findFirst({
-                    where: eq(chatMessages.id, lastEventId as never),
-                  })
+                  // Scoped to the authorized conversation — a Last-Event-ID
+                  // from elsewhere must not shift the backfill window.
+                  const cursor = await findBackfillCursor(backfillConversationId, lastEventId)
                   if (cursor) {
                     const missed = await db
                       .select()


### PR DESCRIPTION
## Problem

**Inbound email sender verification.** The inbound email webhook correctly verifies the provider signature, but that signature authenticates the *delivery provider*, not the *sender*. After verification, the message was attributed to the conversation's stored visitor with no check on the From address. The `reply+<id>@` address is visible to anyone on the email thread (CC'd recipients, forwarded mail), so any third party who had seen it could send mail to it from any address and have it ingested as a visitor reply — reopening conversations, faking acknowledgements, steering agents.

**SSE backfill cursor.** Separately (second commit), the stream's reconnect backfill resolved its `Last-Event-ID` anchor by message id alone. Results were already filtered to the authorized conversation, so nothing leaked — but an id from another conversation could shift the backfill window. `listMessages` already guards its `before` cursor against exactly this.

## Fix

- New `extractEmailAddress()` normalizes the From header (`Jane <jane@x>` or bare addr-spec) to a lowercase address; anything ambiguous resolves to null, which never matches.
- `ingestInboundEmail` now requires the sender to match one of the visitor's known addresses — linked account email, principal contact email, or the captured pre-chat email — before attributing the message. `realEmail()` keeps synthetic anonymous placeholders out of the set, and a visitor with no address on file (who was therefore never emailed the reply+ address) matches nothing.
- Mismatches return a new `from_mismatch` status: logged, acked 200 like other unroutable payloads so the provider stops retrying.
- The backfill cursor lookup is extracted into `findBackfillCursor()` (scoped by conversation), shared by `listMessages` and the SSE stream.

## Notes

A visitor replying from a different address than the one we emailed will now be dropped (logged with status `from_mismatch`). That's the intended trade-off: accepting unverified senders is what made the channel spoofable. The known-address set spans all three sources, which covers the common alias case where the account and contact addresses differ.

## Tests

- `extractEmailAddress`: bare/name-addr/quoted-display-name forms, malformed addr-specs.
- Ingestion: mismatched sender dropped, missing From dropped, case-insensitive name-addr match, linked-account match, pre-chat-email match, synthetic placeholder never matches, empty known-set drops everything.
- `findBackfillCursor`: anchor resolved in-conversation, foreign-conversation id refused, unknown id null.