### PR TITLE
fix(content): decode OG meta entities in a single pass

### DIFF
--- a/apps/web/src/lib/server/content/__tests__/og-parse.test.ts
+++ b/apps/web/src/lib/server/content/__tests__/og-parse.test.ts
@@ -72,6 +72,15 @@ describe('parseOpenGraph', () => {
     expect(parseOpenGraph(html, BASE).title).toBe('Tom & Jerry \'s "Show"')
   })
 
+  it('does not double-decode entities', () => {
+    // "&amp;lt;" is an escaped ampersand followed by literal "lt;" — it must
+    // decode to "&lt;" (text), never cascade to "<".
+    const html = `<html><head>
+      <meta property="og:title" content="&amp;lt;script&amp;gt; and &amp;amp; and &amp;#60;" />
+    </head></html>`
+    expect(parseOpenGraph(html, BASE).title).toBe('&lt;script&gt; and &amp; and &#60;')
+  })
+
   it('caps title at 200 chars, description at 500, siteName at 100', () => {
     const long = 'x'.repeat(600)
     const html = `<html><head>

--- a/apps/web/src/lib/server/content/og-parse.ts
+++ b/apps/web/src/lib/server/content/og-parse.ts
@@ -13,16 +13,16 @@ function fromCodePointSafe(n: number): string {
   return Number.isInteger(n) && n >= 0 && n <= 0x10ffff ? String.fromCodePoint(n) : ''
 }
 
-/** Decode the five named HTML entities plus decimal and hex character references. */
+const NAMED_ENTITIES: Record<string, string> = { amp: '&', lt: '<', gt: '>', quot: '"' }
+
+/** Decode the named HTML entities plus decimal and hex character references.
+ *  Single pass so produced characters are never re-interpreted as entities
+ *  ("&amp;lt;" decodes to "&lt;", not "<"). */
 function decodeEntities(s: string): string {
-  return s
-    .replace(/&amp;/gi, '&')
-    .replace(/&lt;/gi, '<')
-    .replace(/&gt;/gi, '>')
-    .replace(/&quot;/gi, '"')
-    .replace(/&#39;/gi, "'")
-    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => fromCodePointSafe(parseInt(hex, 16)))
-    .replace(/&#(\d+);/gi, (_, dec) => fromCodePointSafe(Number(dec)))
+  return s.replace(/&(?:(amp|lt|gt|quot)|#x([0-9a-f]+)|#(\d+));/gi, (_, name, hex, dec) => {
+    if (name) return NAMED_ENTITIES[name.toLowerCase()]
+    return fromCodePointSafe(hex ? parseInt(hex, 16) : Number(dec))
+  })
 }
 
 /** Strip ASCII control characters (U+0000-U+001F, U+007F). */


### PR DESCRIPTION
## Summary

Fixes CodeQL alert #7 (`js/double-escaping`, high) in `og-parse.ts`.

`decodeEntities()` decoded `&amp;` before the other entities, so double-escaped input was unescaped twice: `&amp;lt;` (the text `&lt;`) cascaded to a literal `<`. A page whose OG title contained escaped markup would have its preview text mangled into real angle brackets.

This isn't currently exploitable — link-preview data is rendered through React text nodes (`link-preview-card.tsx`), which escape on output — but it's a real correctness bug and a latent injection hazard if a future consumer renders previews differently.

## Fix

Decode all supported entities (named + decimal/hex character references) in a single `replace` pass, so characters produced by decoding are never re-interpreted as entities. `&amp;lt;` now decodes to `&lt;` as text.

## Testing

- New regression test: double-escaped entities decode exactly one level
- Existing og-parse tests unchanged and passing (13/13)
- Full unit suite passing (4817 tests), typecheck clean