### PR TITLE
ci: restrict GITHUB_TOKEN to contents:read in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   DATABASE_URL: postgresql://postgres:password@localhost:5432/quackback_test
   BETTER_AUTH_SECRET: test-secret-for-ci-only-must-be-at-least-32-characters


### PR DESCRIPTION
## Summary

Fixes CodeQL alerts #1 and #2 (`actions/missing-workflow-permissions`, medium) in `.github/workflows/ci.yml`.

The CI workflow had no `permissions` block, so its `GITHUB_TOKEN` got the repository default permissions. Both jobs (`check` and `test`) only check out code and run build/lint/typecheck/tests — they never write to the repo or call the API — so a workflow-level `contents: read` is all they need. This limits the blast radius if a dependency or build script in CI is ever compromised.

The other three workflows (`docker.yml`, `publish-widget.yml`, `release-openapi.yml`) already declare explicit permissions; `ci.yml` was the only one missing a block, which matches the two alerts.

## Testing

- YAML validated
- CI running on this PR exercises the change directly — both jobs should pass with the reduced token scope