### PR TITLE
feat(tier-limits): aiFeedbackExtraction entitlement gates the extraction pipeline

### DIFF
--- a/apps/web/src/lib/server/config-file/schema.ts
+++ b/apps/web/src/lib/server/config-file/schema.ts
@@ -66,6 +66,7 @@ const tierFeatureFlagsSchema = z
     customColors: z.boolean().optional(),
     customCss: z.boolean().optional(),
     integrations: z.boolean().optional(),
+    aiFeedbackExtraction: z.boolean().optional(),
   })
   .strict()
   .optional()

--- a/apps/web/src/lib/server/domains/feedback/ingestion/feedback-ingest.service.ts
+++ b/apps/web/src/lib/server/domains/feedback/ingestion/feedback-ingest.service.ts
@@ -132,8 +132,12 @@ export async function enrichAndAdvance(rawItemId: string): Promise<void> {
     })
     .where(eq(rawFeedbackItems.id, rawItemId as RawFeedbackItemId))
 
-  // If AI is enabled, enqueue extraction; otherwise mark completed
-  if (getOpenAI()) {
+  // If AI is enabled and the plan includes extraction, enqueue it;
+  // otherwise mark completed. The tier check runs here (not just at the
+  // Labs toggle) so sources enabled before a downgrade stop extracting.
+  const { getTierLimits } = await import('@/lib/server/domains/settings/tier-limits.service')
+  const tierAllowsExtraction = (await getTierLimits()).features.aiFeedbackExtraction
+  if (getOpenAI() && tierAllowsExtraction) {
     await enqueueFeedbackAiJob({ type: 'extract-signals', rawItemId })
   } else {
     await db

--- a/apps/web/src/lib/server/domains/feedback/pipeline/__tests__/extraction.service.test.ts
+++ b/apps/web/src/lib/server/domains/feedback/pipeline/__tests__/extraction.service.test.ts
@@ -424,7 +424,10 @@ describe('extraction.service', () => {
     )
   })
 
-  it('should throw when AI not configured', async () => {
+  it('should throw when AI not configured (for an entitled, ready item)', async () => {
+    // The model check now runs AFTER the item/state/entitlement gates, so an
+    // entitled, ready item reaches it and throws when the client is missing.
+    mockFindFirst.mockResolvedValueOnce({ ...mockItem })
     const { getOpenAI } = await import('@/lib/server/domains/ai/config')
     vi.mocked(getOpenAI).mockReturnValueOnce(null)
 
@@ -434,12 +437,15 @@ describe('extraction.service', () => {
 
   it('should throw UnrecoverableError when client is present but extraction model is null', async () => {
     // Client is non-null (default mock returns mockOpenAI) but the model is
-    // disabled — e.g. AI_EXTRACTION_MODEL=off. The service must reject before
-    // touching the DB.
+    // disabled — e.g. AI_EXTRACTION_MODEL=off. Rejects before transitioning
+    // the item to `extracting` (no state write / attempt-count bump).
+    mockFindFirst.mockResolvedValueOnce({ ...mockItem })
     const { getChatModel } = await import('@/lib/server/domains/ai/models')
     vi.mocked(getChatModel).mockReturnValueOnce(null)
 
     const { extractSignals } = await import('../extraction.service')
     await expect(extractSignals(rawItemId)).rejects.toThrow('Extraction model not configured')
+    const states = updateSetCalls.map((c) => (c[0] as { processingState?: string }).processingState)
+    expect(states).not.toContain('extracting')
   })
 })

--- a/apps/web/src/lib/server/domains/feedback/pipeline/__tests__/extraction.service.test.ts
+++ b/apps/web/src/lib/server/domains/feedback/pipeline/__tests__/extraction.service.test.ts
@@ -119,12 +119,19 @@ vi.mock('../../queues/feedback-ai-queue', () => ({
   enqueueFeedbackAiJob: (...args: unknown[]) => mockEnqueue(...args),
 }))
 
+const mockGetTierLimits = vi.fn()
+vi.mock('@/lib/server/domains/settings/tier-limits.service', () => ({
+  getTierLimits: (...args: unknown[]) => mockGetTierLimits(...args),
+}))
+
 describe('extraction.service', () => {
   beforeEach(() => {
     updateSetCalls.length = 0
     insertValuesCalls.length = 0
     deleteWhereCalls.length = 0
     vi.clearAllMocks()
+    // Default: plan allows extraction. Disabled-path tests override per-case.
+    mockGetTierLimits.mockResolvedValue({ features: { aiFeedbackExtraction: true } })
   })
 
   const rawItemId = 'raw_item_123' as RawFeedbackItemId
@@ -260,6 +267,37 @@ describe('extraction.service', () => {
 
     // Should not update state
     expect(updateSetCalls.length).toBe(0)
+  })
+
+  it('skips the LLM and completes the item when the plan disallows extraction', async () => {
+    // Execution-time tier gate: a job queued before a downgrade (or
+    // re-enqueued by stuck-recovery / manual retry) must not run the LLM.
+    mockFindFirst.mockResolvedValueOnce({ ...mockItem })
+    mockGetTierLimits.mockResolvedValueOnce({ features: { aiFeedbackExtraction: false } })
+
+    const { extractSignals } = await import('../extraction.service')
+    await extractSignals(rawItemId)
+
+    expect(mockOpenAI.chat.completions.create).not.toHaveBeenCalled()
+    expect(mockShouldExtract).not.toHaveBeenCalled()
+    const states = updateSetCalls.map((c) => (c[0] as { processingState?: string }).processingState)
+    expect(states).toEqual(['completed'])
+    expect(states).not.toContain('extracting')
+  })
+
+  it('dismisses channel-monitored items when the plan disallows extraction', async () => {
+    mockFindFirst.mockResolvedValueOnce({
+      ...mockItem,
+      contextEnvelope: { metadata: { ingestionMode: 'channel_monitor' } },
+    })
+    mockGetTierLimits.mockResolvedValueOnce({ features: { aiFeedbackExtraction: false } })
+
+    const { extractSignals } = await import('../extraction.service')
+    await extractSignals(rawItemId)
+
+    expect(mockOpenAI.chat.completions.create).not.toHaveBeenCalled()
+    const states = updateSetCalls.map((c) => (c[0] as { processingState?: string }).processingState)
+    expect(states).toEqual(['dismissed'])
   })
 
   it('should filter low-confidence signals and log filter counts', async () => {

--- a/apps/web/src/lib/server/domains/feedback/pipeline/extraction.service.ts
+++ b/apps/web/src/lib/server/domains/feedback/pipeline/extraction.service.ts
@@ -25,12 +25,6 @@ const EXTRACTION_PROMPT_VERSION = 'v1'
  * Called by the {feedback-ai} queue worker.
  */
 export async function extractSignals(rawItemId: RawFeedbackItemId): Promise<void> {
-  const openai = getOpenAI()
-  const model = getChatModel('extraction')
-  if (!openai || !model) {
-    throw new UnrecoverableError('Extraction model not configured')
-  }
-
   const item = await db.query.rawFeedbackItems.findFirst({
     where: eq(rawFeedbackItems.id, rawItemId),
   })
@@ -48,8 +42,10 @@ export async function extractSignals(rawItemId: RawFeedbackItemId): Promise<void
   // plan entitlement. Enforced HERE, at the single execution chokepoint —
   // not only at enqueue — so a job that was already queued when the tenant
   // downgraded (or re-enqueued by stuck-recovery or a manual retry) does not
-  // run the LLM after the plan disallows it. Terminal no-op mirrors the
-  // quality-gate path so the item isn't re-picked by recoverStuckItems.
+  // run the LLM after the plan disallows it. Runs BEFORE the model lookup so a
+  // disallowed item still terminates cleanly when the extraction model is also
+  // unconfigured (otherwise it would throw and churn via stuck-recovery).
+  // Terminal no-op mirrors the quality-gate path so it isn't re-picked.
   const { getTierLimits } = await import('@/lib/server/domains/settings/tier-limits.service')
   if (!(await getTierLimits()).features.aiFeedbackExtraction) {
     const context = (item.contextEnvelope ?? {}) as RawFeedbackItemContextEnvelope
@@ -72,6 +68,12 @@ export async function extractSignals(rawItemId: RawFeedbackItemId): Promise<void
       })
       .where(eq(rawFeedbackItems.id, rawItemId))
     return
+  }
+
+  const openai = getOpenAI()
+  const model = getChatModel('extraction')
+  if (!openai || !model) {
+    throw new UnrecoverableError('Extraction model not configured')
   }
 
   await db

--- a/apps/web/src/lib/server/domains/feedback/pipeline/extraction.service.ts
+++ b/apps/web/src/lib/server/domains/feedback/pipeline/extraction.service.ts
@@ -44,6 +44,36 @@ export async function extractSignals(rawItemId: RawFeedbackItemId): Promise<void
     return
   }
 
+  // Tier gate (execution-time). Auto-capture / AI feedback extraction is a
+  // plan entitlement. Enforced HERE, at the single execution chokepoint —
+  // not only at enqueue — so a job that was already queued when the tenant
+  // downgraded (or re-enqueued by stuck-recovery or a manual retry) does not
+  // run the LLM after the plan disallows it. Terminal no-op mirrors the
+  // quality-gate path so the item isn't re-picked by recoverStuckItems.
+  const { getTierLimits } = await import('@/lib/server/domains/settings/tier-limits.service')
+  if (!(await getTierLimits()).features.aiFeedbackExtraction) {
+    const context = (item.contextEnvelope ?? {}) as RawFeedbackItemContextEnvelope
+    const isChannelMonitor =
+      (context.metadata as Record<string, unknown> | undefined)?.ingestionMode === 'channel_monitor'
+    const finalState = isChannelMonitor ? 'dismissed' : 'completed'
+    console.log(`[Extraction] Plan disallows extraction, ${rawItemId} -> ${finalState}`)
+    await logPipelineEvent({
+      eventType: 'extraction.skipped_no_entitlement',
+      rawFeedbackItemId: rawItemId,
+      detail: { finalState, sourceType: item.sourceType },
+    })
+    await db
+      .update(rawFeedbackItems)
+      .set({
+        processingState: finalState,
+        stateChangedAt: new Date(),
+        processedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(rawFeedbackItems.id, rawItemId))
+    return
+  }
+
   await db
     .update(rawFeedbackItems)
     .set({

--- a/apps/web/src/lib/server/domains/settings/__tests__/managed-guard-feature-flags.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/managed-guard-feature-flags.test.ts
@@ -44,7 +44,15 @@ vi.mock('@/lib/server/config-file/managed-guard', () => ({
   assertNotManaged: hoisted.mockAssertNotManaged,
 }))
 
+// updateFeatureFlags dynamically imports tier-enforce when enabling
+// aiFeedbackExtraction; stub it here and exercise it in the tier-gate
+// tests below.
+vi.mock('@/lib/server/domains/settings/tier-enforce', () => ({
+  assertTierFeature: vi.fn().mockResolvedValue(undefined),
+}))
+
 import { updateFeatureFlags } from '../settings.service'
+import { assertTierFeature } from '../tier-enforce'
 
 describe('updateFeatureFlags — per-key managed-paths gate', () => {
   beforeEach(() => {
@@ -77,5 +85,22 @@ describe('updateFeatureFlags — per-key managed-paths gate', () => {
     hoisted.mockAssertNotManaged.mockResolvedValue(undefined)
     const result = await updateFeatureFlags({ aiFeedbackExtraction: true })
     expect(result.aiFeedbackExtraction).toBe(true)
+  })
+
+  it('tier-gates enabling aiFeedbackExtraction, before any DB write', async () => {
+    hoisted.mockAssertNotManaged.mockResolvedValue(undefined)
+    vi.mocked(assertTierFeature).mockRejectedValueOnce(
+      new Error('AI feedback extraction is not available on your plan.')
+    )
+    await expect(updateFeatureFlags({ aiFeedbackExtraction: true })).rejects.toThrow(
+      'not available on your plan'
+    )
+    expect(hoisted.mockDbUpdate).not.toHaveBeenCalled()
+  })
+
+  it('does not tier-gate disabling aiFeedbackExtraction', async () => {
+    hoisted.mockAssertNotManaged.mockResolvedValue(undefined)
+    await updateFeatureFlags({ aiFeedbackExtraction: false })
+    expect(vi.mocked(assertTierFeature)).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/lib/server/domains/settings/__tests__/tier-limits.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/tier-limits.test.ts
@@ -20,6 +20,7 @@ describe('OSS_TIER_LIMITS', () => {
     expect(features.webhooks).toBe(true)
     expect(features.mcpServer).toBe(true)
     expect(features.analyticsExports).toBe(true)
+    expect(features.aiFeedbackExtraction).toBe(true)
   })
 
   it('matches the TierLimits shape (compile-time check)', () => {
@@ -33,8 +34,21 @@ describe('mergeTierLimits', () => {
     expect(mergeTierLimits(null)).toEqual(OSS_TIER_LIMITS)
   })
 
-  it('returns OSS defaults when stored is empty object', () => {
-    expect(mergeTierLimits({})).toEqual(OSS_TIER_LIMITS)
+  it('fails closed on the paid extraction flag for a stored row, even an empty one', () => {
+    // A stored row signals a managed/cloud (or config-managed) tenant. The
+    // paid auto-capture flag must NOT inherit the generous OSS default there,
+    // or pre-existing rows would grant Scale-only extraction to everyone until
+    // re-seeded. Every other flag still falls back to the OSS default.
+    expect(mergeTierLimits({})).toEqual({
+      ...OSS_TIER_LIMITS,
+      features: { ...OSS_TIER_LIMITS.features, aiFeedbackExtraction: false },
+    })
+  })
+
+  it('honours an explicit aiFeedbackExtraction grant in a stored row (Scale)', () => {
+    expect(
+      mergeTierLimits({ features: { aiFeedbackExtraction: true } }).features.aiFeedbackExtraction
+    ).toBe(true)
   })
 
   it('overrides numeric limits from stored partial', () => {

--- a/apps/web/src/lib/server/domains/settings/settings.service.ts
+++ b/apps/web/src/lib/server/domains/settings/settings.service.ts
@@ -918,6 +918,12 @@ export async function updateFeatureFlags(input: Partial<FeatureFlags>): Promise<
   for (const key of Object.keys(input)) {
     await assertNotManaged(`features.${key}`)
   }
+  // Tier gate: enabling AI feedback extraction is plan-entitled (Scale on
+  // cloud). Checked only on enable so a downgrade can still switch it off.
+  if (input.aiFeedbackExtraction === true) {
+    const { assertTierFeature } = await import('@/lib/server/domains/settings/tier-enforce')
+    await assertTierFeature('aiFeedbackExtraction', 'AI feedback extraction')
+  }
   const org = await requireSettings()
   const current: FeatureFlags = {
     ...DEFAULT_FEATURE_FLAGS,

--- a/apps/web/src/lib/server/domains/settings/tier-limits.service.ts
+++ b/apps/web/src/lib/server/domains/settings/tier-limits.service.ts
@@ -13,6 +13,15 @@ export function mergeTierLimits(stored: StoredTierLimits | null): TierLimits {
     features: {
       ...OSS_TIER_LIMITS.features,
       ...(stored.features ?? {}),
+      // Fail closed for the paid auto-capture entitlement on ANY stored row.
+      // A managed/cloud row (or a config-managed self-host row) created before
+      // this key existed would otherwise inherit the generous OSS default
+      // (true) and grant Scale-only AI feedback extraction to every tenant —
+      // including non-Scale plans — until the control plane re-seeds each row
+      // with an explicit value. Only a tenant with NO stored row at all (bare
+      // self-host) keeps the OSS default, via the early return above. An
+      // explicit value in stored.features (what the CP writes per plan) wins.
+      aiFeedbackExtraction: stored.features?.aiFeedbackExtraction ?? false,
     },
   }
 }

--- a/apps/web/src/lib/server/domains/settings/tier-limits.types.ts
+++ b/apps/web/src/lib/server/domains/settings/tier-limits.types.ts
@@ -23,6 +23,10 @@ export interface TierFeatureFlags {
   /** Connecting external tools (GitHub, Slack, Linear, Jira, etc.).
    *  Pro and Scale on cloud; always on for self-hosters. */
   integrations: boolean
+  /** AI auto-capture: the feedback-extraction pipeline that turns
+   *  conversations from connected sources into structured feedback.
+   *  Scale-only on cloud; always on for self-hosters. */
+  aiFeedbackExtraction: boolean
 }
 
 /**
@@ -85,5 +89,6 @@ export const OSS_TIER_LIMITS: TierLimits = {
     customColors: true,
     customCss: true,
     integrations: true,
+    aiFeedbackExtraction: true,
   },
 }


### PR DESCRIPTION
## What

Quackback Cloud markets AI auto-capture (pulling feedback out of Slack, Intercom, Zendesk, etc.) as a **Scale-only** feature, but the only plan gate was the `integrations` flag (Pro+). This adds a dedicated `aiFeedbackExtraction` entitlement.

## Changes

- **`TierFeatureFlags`**: new `aiFeedbackExtraction` flag, default **on** for self-hosters (`OSS_TIER_LIMITS`).
- **config-file schema**: accept the new key — the features schema is `.strict()`, so it must allow the field that managed deployments set in a tier-limits payload.
- **Labs toggle gate** (`updateFeatureFlags`): enabling the flag tier-checks and refuses on unentitled plans. Downgrades can still toggle it *off* (no gate on disable).
- **Pipeline gates**: gated both at enqueue (`enrichAndAdvance`) and at execution (`extractSignals` — the single chokepoint every enqueue path funnels through). A job queued before a downgrade, or re-enqueued by stuck-recovery / manual retry, terminates cleanly without calling the LLM. The execution gate runs before the model lookup so a disallowed item terminates even on an instance with no extraction model.
- **Fail closed**: a stored tier row missing the key resolves to `false` (only a bare self-host with no stored row keeps the OSS default), so a row written before this key existed can't grant the paid feature by default.

## Test plan

- [x] Touched-area suites green locally (settings, feedback, config-file)
- [x] Full OSS suite green locally
- [x] CI on this PR