### PR TITLE
fix(chat): unbreak link previews and stop typing-indicator self-echo

### DIFF
--- a/apps/web/src/lib/server/domains/chat/__tests__/chat-mark-unread.test.ts
+++ b/apps/web/src/lib/server/domains/chat/__tests__/chat-mark-unread.test.ts
@@ -19,7 +19,7 @@ vi.mock('@/lib/server/realtime/chat-channels', () => ({
   publishChatEvent: (...a: unknown[]) => publishChatEvent(...a),
   publishAgentChatEvent: (...a: unknown[]) => publishAgentChatEvent(...a),
   publishConversationUpdate: vi.fn(),
-  publishAgentTyping: vi.fn(),
+  publishTyping: vi.fn(),
 }))
 
 vi.mock('@/lib/server/config', () => ({

--- a/apps/web/src/lib/server/domains/chat/__tests__/chat-typing-read-side.test.ts
+++ b/apps/web/src/lib/server/domains/chat/__tests__/chat-typing-read-side.test.ts
@@ -13,7 +13,7 @@ const publish = vi.hoisted(() => ({
   publishChatEvent: vi.fn(),
   publishAgentChatEvent: vi.fn(),
   publishConversationUpdate: vi.fn(),
-  publishAgentTyping: vi.fn(),
+  publishTyping: vi.fn(),
 }))
 vi.mock('@/lib/server/realtime/chat-channels', () => publish)
 
@@ -137,24 +137,31 @@ beforeEach(() => {
 describe('signalTyping side derivation', () => {
   it('a team member typing in SOMEONE ELSE’s conversation signals the agent side', async () => {
     await signalTyping(conversationId, teamActor('principal_agent'))
-    expect(publish.publishAgentTyping).toHaveBeenCalledTimes(1)
-    expect(publish.publishChatEvent).not.toHaveBeenCalled()
-  })
-
-  it('a team member typing in THEIR OWN conversation signals the visitor side', async () => {
-    await signalTyping(conversationId, teamActor('principal_owner'))
-    expect(publish.publishAgentTyping).not.toHaveBeenCalled()
-    expect(publish.publishChatEvent).toHaveBeenCalledWith(
+    expect(publish.publishTyping).toHaveBeenCalledWith(
       conversationId,
-      expect.objectContaining({ kind: 'typing', side: 'visitor' })
+      'agent',
+      expect.any(String),
+      'principal_agent'
     )
   })
 
-  it('a portal user typing in their own conversation signals the visitor side', async () => {
-    await signalTyping(conversationId, userActor)
-    expect(publish.publishChatEvent).toHaveBeenCalledWith(
+  it('a team member typing in THEIR OWN conversation signals the visitor side with their id', async () => {
+    await signalTyping(conversationId, teamActor('principal_owner'))
+    expect(publish.publishTyping).toHaveBeenCalledWith(
       conversationId,
-      expect.objectContaining({ kind: 'typing', side: 'visitor' })
+      'visitor',
+      expect.any(String),
+      'principal_owner'
+    )
+  })
+
+  it('a portal user typing in their own conversation signals the visitor side with their id', async () => {
+    await signalTyping(conversationId, userActor)
+    expect(publish.publishTyping).toHaveBeenCalledWith(
+      conversationId,
+      'visitor',
+      expect.any(String),
+      'principal_owner'
     )
   })
 })

--- a/apps/web/src/lib/server/domains/chat/chat.service.ts
+++ b/apps/web/src/lib/server/domains/chat/chat.service.ts
@@ -37,11 +37,11 @@ import type { Actor } from '@/lib/server/policy/types'
 import {
   MAX_CHAT_MESSAGE_LENGTH,
   MAX_CHAT_ATTACHMENTS,
-  type ChatSenderType,
   type ConversationStatus,
   type ConversationPriority,
   type ConversationEndReason,
   type ConversationDTO,
+  type ConversationSide,
 } from '@/lib/shared/chat/types'
 import {
   applyVisitorReopenStatus,
@@ -54,7 +54,7 @@ import {
   publishChatEvent,
   publishAgentChatEvent,
   publishConversationUpdate,
-  publishAgentTyping,
+  publishTyping,
 } from '@/lib/server/realtime/chat-channels'
 import { truncate } from '@/lib/shared/utils/string'
 import { notifyVisitorMessage, notifyAgentReply, notifyConversationStarted } from './chat.notify'
@@ -1076,7 +1076,7 @@ export async function recordCsat(
  * is the visitor there — deriving from role alone would echo their typing back
  * to them as "agent is typing" and stamp the wrong read watermark.
  */
-function conversationSideFor(conversation: Conversation, actor: Actor): ChatSenderType {
+function conversationSideFor(conversation: Conversation, actor: Actor): ConversationSide {
   return isTeamMember(actor.role) && conversation.visitorPrincipalId !== actor.principalId
     ? 'agent'
     : 'visitor'
@@ -1088,14 +1088,8 @@ export async function signalTyping(conversationId: ConversationId, actor: Actor)
   // conversation the actor can't see.
   const conversation = await assertConversationViewable(conversationId, actor)
   const side = conversationSideFor(conversation, actor)
-  const at = new Date().toISOString()
-  // Agent typing carries the agent id on the inbox channel only (collision
-  // detection) — never to the visitor. Visitor typing fans out as before.
-  if (side === 'agent' && actor.principalId) {
-    publishAgentTyping(conversationId, at, actor.principalId)
-  } else {
-    publishChatEvent(conversationId, { kind: 'typing', conversationId, side, at })
-  }
+  // The typist id rides along so the stream layer can drop the typist's own echo.
+  publishTyping(conversationId, side, new Date().toISOString(), actor.principalId)
 }
 
 /** Mark a conversation read up to now for the actor's side of it. */

--- a/apps/web/src/lib/server/functions/__tests__/link-preview-flag-gate.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/link-preview-flag-gate.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Regression: `unfurlLinkFn` read the feature flag off the raw settings
+ * row, where `featureFlags` is an unparsed JSON *string* (text column).
+ * `(string).linkPreviews` is always undefined, so the gate returned null
+ * for every URL and link previews never rendered, flag on or off.
+ *
+ * This pins the gate's behavior at the handler boundary: with the
+ * tenant flag enabled the handler unfurls; with it disabled it returns
+ * null without fetching.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const hoisted = vi.hoisted(() => ({
+  mockRequireAuth: vi.fn(),
+  mockGetSettings: vi.fn(),
+  mockIsFeatureEnabled: vi.fn(),
+  mockUnfurlExternalUrl: vi.fn(),
+  mockCacheGet: vi.fn(),
+  mockCacheSet: vi.fn(),
+  mockGetRedis: vi.fn(),
+  mockGetClientIp: vi.fn(),
+}))
+
+vi.mock('@/lib/server/functions/auth-helpers', () => ({
+  requireAuth: hoisted.mockRequireAuth,
+}))
+
+// Raw row shape: featureFlags is a JSON string, exactly as the text column
+// comes back from the DB. A gate reading it as an object silently fails.
+vi.mock('@/lib/server/functions/workspace', () => ({
+  getSettings: hoisted.mockGetSettings,
+}))
+
+vi.mock('@/lib/server/domains/settings/settings.service', () => ({
+  isFeatureEnabled: hoisted.mockIsFeatureEnabled,
+}))
+
+vi.mock('@/lib/server/content/unfurl', () => ({
+  unfurlExternalUrl: hoisted.mockUnfurlExternalUrl,
+}))
+
+vi.mock('@/lib/server/redis', () => ({
+  cacheGet: hoisted.mockCacheGet,
+  cacheSet: hoisted.mockCacheSet,
+  getRedis: hoisted.mockGetRedis,
+}))
+
+vi.mock('@/lib/server/domains/api/rate-limit', () => ({
+  getClientIp: hoisted.mockGetClientIp,
+}))
+
+vi.mock('@tanstack/react-start/server', () => ({
+  getRequestHeaders: () => ({}),
+}))
+
+type AnyHandler = (args: { data: Record<string, unknown> }) => Promise<unknown>
+
+const handlers: AnyHandler[] = []
+vi.mock('@tanstack/react-start', () => ({
+  createServerFn: () => {
+    const chain = {
+      inputValidator() {
+        return chain
+      },
+      handler(fn: AnyHandler) {
+        handlers.push(fn)
+        return chain
+      },
+    }
+    return chain
+  },
+}))
+
+let unfurlLinkHandler: AnyHandler
+
+const rawSettingsRow = (flags: Record<string, boolean>) => ({
+  id: 'settings_1',
+  name: 'Acme',
+  featureFlags: JSON.stringify(flags),
+})
+
+beforeEach(async () => {
+  vi.clearAllMocks()
+  hoisted.mockRequireAuth.mockResolvedValue({
+    user: { id: 'usr_1' },
+    principal: { id: 'prn_1', role: 'admin' },
+  })
+  hoisted.mockGetClientIp.mockReturnValue('203.0.113.7')
+  hoisted.mockGetRedis.mockReturnValue({
+    incr: vi.fn().mockResolvedValue(1),
+    expire: vi.fn().mockResolvedValue(1),
+  })
+  hoisted.mockCacheGet.mockResolvedValue(null)
+  hoisted.mockCacheSet.mockResolvedValue(undefined)
+  if (handlers.length === 0) await import('../link-preview')
+  unfurlLinkHandler = handlers[0]
+})
+
+describe('unfurlLinkFn — feature flag gate', () => {
+  it('unfurls when the linkPreviews flag is enabled', async () => {
+    hoisted.mockGetSettings.mockResolvedValue(rawSettingsRow({ linkPreviews: true }))
+    hoisted.mockIsFeatureEnabled.mockResolvedValue(true)
+    const preview = {
+      url: 'https://news.example/post',
+      title: 'A headline',
+      description: null,
+      siteName: null,
+      imageUrl: null,
+    }
+    hoisted.mockUnfurlExternalUrl.mockResolvedValue(preview)
+
+    const result = await unfurlLinkHandler({ data: { url: 'https://news.example/post' } })
+
+    expect(result).toEqual(preview)
+    expect(hoisted.mockIsFeatureEnabled).toHaveBeenCalledWith('linkPreviews')
+    expect(hoisted.mockUnfurlExternalUrl).toHaveBeenCalledWith('https://news.example/post')
+  })
+
+  it('returns null without fetching when the flag is disabled', async () => {
+    hoisted.mockGetSettings.mockResolvedValue(rawSettingsRow({ linkPreviews: false }))
+    hoisted.mockIsFeatureEnabled.mockResolvedValue(false)
+
+    const result = await unfurlLinkHandler({ data: { url: 'https://news.example/post' } })
+
+    expect(result).toBeNull()
+    expect(hoisted.mockUnfurlExternalUrl).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/lib/server/functions/link-preview.ts
+++ b/apps/web/src/lib/server/functions/link-preview.ts
@@ -54,11 +54,12 @@ export const unfurlLinkFn = createServerFn({ method: 'GET' })
         if (!access.granted) return null
       }
 
-      // 3. Feature flag
-      const { getSettings } = await import('./workspace')
-      const settings = await getSettings()
-      const flags = settings?.featureFlags as { linkPreviews?: boolean } | undefined
-      if (!flags?.linkPreviews) return null
+      // 3. Feature flag — read via the domain service, which parses the
+      //    featureFlags text column and merges defaults. The raw settings row
+      //    holds the unparsed JSON string, so reading the flag off it directly
+      //    always fails.
+      const { isFeatureEnabled } = await import('@/lib/server/domains/settings/settings.service')
+      if (!(await isFeatureEnabled('linkPreviews'))) return null
 
       // 4. Exclude internal Quackback URLs
       if (parseEmbedUrl(data.url) !== null) return null

--- a/apps/web/src/lib/server/functions/workspace.ts
+++ b/apps/web/src/lib/server/functions/workspace.ts
@@ -8,6 +8,11 @@ import { getSession } from '@/lib/server/auth/session'
 
 /**
  * Get the app settings.
+ *
+ * Returns the RAW settings row: JSON config columns (featureFlags, authConfig,
+ * portalConfig, ...) come back as unparsed text. For parsed, default-merged
+ * reads use the settings domain service (getTenantSettings / isFeatureEnabled)
+ * instead of casting a column off this row.
  */
 export const getSettings = createServerFn({ method: 'GET' }).handler(async () => {
   try {

--- a/apps/web/src/lib/server/realtime/__tests__/chat-channels.test.ts
+++ b/apps/web/src/lib/server/realtime/__tests__/chat-channels.test.ts
@@ -16,8 +16,9 @@ import {
   publishChatEvent,
   publishAgentChatEvent,
   publishConversationUpdate,
-  publishAgentTyping,
-  shouldSuppressOwnAgentTyping,
+  publishTyping,
+  parseChatFrame,
+  isOwnTyping,
 } from '../chat-channels'
 
 const conversationId = 'conversation_1' as ConversationId
@@ -86,48 +87,65 @@ describe('publishConversationUpdate', () => {
   })
 })
 
-describe('publishAgentTyping', () => {
-  it('sends the agent id only to the inbox, never to the visitor channel', () => {
-    publishAgentTyping(conversationId, '2026-01-01T00:00:00.000Z', 'principal_agent' as never)
+describe('publishTyping', () => {
+  it('agent side: sends the typist id only to the inbox, never to the visitor channel', () => {
+    publishTyping(conversationId, 'agent', '2026-01-01T00:00:00.000Z', 'principal_agent' as never)
 
     const inbox = publish.mock.calls.find((c) => c[0] === CHAT_INBOX_CHANNEL)
     const visitor = publish.mock.calls.find((c) => c[0] === conversationChannel(conversationId))
 
-    // Inbox carries the agent id (so other agents can detect a collision)...
+    // Inbox carries the typist id (collision detection + self-suppression)...
     expect(inbox![1]).toMatchObject({
       kind: 'typing',
       side: 'agent',
-      agentPrincipalId: 'principal_agent',
+      typistPrincipalId: 'principal_agent',
     })
     // ...the visitor only sees an anonymous "agent is typing" — no id leak.
     expect(visitor![1]).toMatchObject({ kind: 'typing', side: 'agent' })
-    expect((visitor![1] as { agentPrincipalId?: string }).agentPrincipalId).toBeUndefined()
+    expect((visitor![1] as { typistPrincipalId?: string }).typistPrincipalId).toBeUndefined()
+  })
+
+  it('visitor side: carries the typist id on BOTH channels so every stream can drop the echo', () => {
+    publishTyping(conversationId, 'visitor', '2026-01-01T00:00:00.000Z', 'principal_owner' as never)
+
+    const inbox = publish.mock.calls.find((c) => c[0] === CHAT_INBOX_CHANNEL)
+    const visitor = publish.mock.calls.find((c) => c[0] === conversationChannel(conversationId))
+
+    // Inbox: a team member typing in a conversation they OWN signals the
+    // visitor side — without the id their own inbox stream would echo it back.
+    expect(inbox![1]).toMatchObject({
+      kind: 'typing',
+      side: 'visitor',
+      typistPrincipalId: 'principal_owner',
+    })
+    // Conversation channel: the id is the owner's own (no agent leak) and lets
+    // the owner's streams drop their own echo server-side.
+    expect(visitor![1]).toMatchObject({
+      kind: 'typing',
+      side: 'visitor',
+      typistPrincipalId: 'principal_owner',
+    })
   })
 })
 
-describe('shouldSuppressOwnAgentTyping', () => {
-  const frame = (e: unknown) => JSON.stringify(e)
+describe('isOwnTyping', () => {
+  const frame = (e: unknown) => parseChatFrame(JSON.stringify(e))
 
-  it('suppresses an agent typing frame from the same principal', () => {
+  it('suppresses a typing frame from the same principal, on either side', () => {
     expect(
-      shouldSuppressOwnAgentTyping(
-        frame({ kind: 'typing', side: 'agent', agentPrincipalId: 'p1' }),
-        'p1'
-      )
+      isOwnTyping(frame({ kind: 'typing', side: 'agent', typistPrincipalId: 'p1' }), 'p1')
+    ).toBe(true)
+    expect(
+      isOwnTyping(frame({ kind: 'typing', side: 'visitor', typistPrincipalId: 'p1' }), 'p1')
     ).toBe(true)
   })
 
-  it('does not suppress another agent, a visitor, a non-typing event, or junk', () => {
+  it('does not suppress another typist, an anonymous frame, a non-typing event, or junk', () => {
     expect(
-      shouldSuppressOwnAgentTyping(
-        frame({ kind: 'typing', side: 'agent', agentPrincipalId: 'p2' }),
-        'p1'
-      )
+      isOwnTyping(frame({ kind: 'typing', side: 'agent', typistPrincipalId: 'p2' }), 'p1')
     ).toBe(false)
-    expect(shouldSuppressOwnAgentTyping(frame({ kind: 'typing', side: 'visitor' }), 'p1')).toBe(
-      false
-    )
-    expect(shouldSuppressOwnAgentTyping(frame({ kind: 'message' }), 'p1')).toBe(false)
-    expect(shouldSuppressOwnAgentTyping('not json{', 'p1')).toBe(false)
+    expect(isOwnTyping(frame({ kind: 'typing', side: 'visitor' }), 'p1')).toBe(false)
+    expect(isOwnTyping(frame({ kind: 'message', typistPrincipalId: 'p1' }), 'p1')).toBe(false)
+    expect(isOwnTyping(parseChatFrame('not json{'), 'p1')).toBe(false)
   })
 })

--- a/apps/web/src/lib/server/realtime/chat-channels.ts
+++ b/apps/web/src/lib/server/realtime/chat-channels.ts
@@ -9,7 +9,7 @@
  * agent's inbox update at once. Clients dedupe by message id.
  */
 import type { ConversationId, PrincipalId } from '@quackback/ids'
-import type { ChatStreamEvent, ConversationDTO } from '@/lib/shared/chat/types'
+import type { ChatStreamEvent, ConversationDTO, ConversationSide } from '@/lib/shared/chat/types'
 import { publish } from './pubsub'
 
 export function conversationChannel(conversationId: ConversationId): string {
@@ -26,49 +26,51 @@ export function publishChatEvent(conversationId: ConversationId, event: ChatStre
 }
 
 /**
- * Publish an agent typing signal. The visitor's channel gets an anonymous
- * "agent is typing" (NO principal id — never leak who is on the team side); the
- * inbox channel gets the id so other agents can detect a collision. The
- * originating agent's own echo is suppressed at the stream layer
- * (shouldSuppressOwnAgentTyping).
+ * Publish a typing signal, tagging each copy with the typist where it's safe:
+ * the inbox channel always gets the id (self-suppression + agent collision
+ * detection); the conversation channel gets it only for visitor-side typing —
+ * there the id is the owner's own, while agent identities must never reach the
+ * visitor. The typist's own echo is dropped at the stream layer on every
+ * surface (isOwnTyping).
  */
-export function publishAgentTyping(
+export function publishTyping(
   conversationId: ConversationId,
+  side: ConversationSide,
   at: string,
-  agentPrincipalId: PrincipalId
+  // null (no principal to attribute) publishes untagged — delivered to all, suppressed for none.
+  typistPrincipalId: PrincipalId | null
 ): void {
-  publish(conversationChannel(conversationId), {
-    kind: 'typing',
-    conversationId,
-    side: 'agent',
-    at,
-  })
-  publish(CHAT_INBOX_CHANNEL, {
-    kind: 'typing',
-    conversationId,
-    side: 'agent',
-    at,
-    agentPrincipalId,
-  })
+  const base = { kind: 'typing' as const, conversationId, side, at }
+  const tagged = typistPrincipalId ? { ...base, typistPrincipalId } : base
+  // Agent identities never reach the visitor channel; a visitor-side id is the
+  // owner's own, so it can ride along there.
+  publish(conversationChannel(conversationId), side === 'agent' ? base : tagged)
+  publish(CHAT_INBOX_CHANNEL, tagged)
+}
+
+/** A pub/sub frame parsed for routing decisions; null when unparseable. */
+export type ParsedChatFrame = {
+  kind?: string
+  typistPrincipalId?: string
+  message?: { id?: string }
+} | null
+
+export function parseChatFrame(message: string): ParsedChatFrame {
+  try {
+    return JSON.parse(message) as ParsedChatFrame
+  } catch {
+    return null
+  }
 }
 
 /**
- * True when a raw pub/sub frame is an agent-typing event from `selfPrincipalId`
- * — used by the inbox stream to drop an agent's own typing echo so the client
- * can treat any agent-typing it receives as "another agent". Unparseable or
+ * True when a parsed frame is a typing event from `selfPrincipalId` — used by
+ * every stream to drop the subscriber's own typing echo, so clients can treat
+ * any typing they receive as someone else's. Unparseable, anonymous, or
  * non-matching frames are never suppressed.
  */
-export function shouldSuppressOwnAgentTyping(message: string, selfPrincipalId: string): boolean {
-  try {
-    const e = JSON.parse(message) as {
-      kind?: string
-      side?: string
-      agentPrincipalId?: string
-    }
-    return e.kind === 'typing' && e.side === 'agent' && e.agentPrincipalId === selfPrincipalId
-  } catch {
-    return false
-  }
+export function isOwnTyping(frame: ParsedChatFrame, selfPrincipalId: string): boolean {
+  return frame?.kind === 'typing' && frame.typistPrincipalId === selfPrincipalId
 }
 
 /**

--- a/apps/web/src/lib/shared/chat/types.ts
+++ b/apps/web/src/lib/shared/chat/types.ts
@@ -21,6 +21,8 @@ export type ConversationPriority = 'none' | 'low' | 'medium' | 'high' | 'urgent'
 // 'system' = a status event (e.g. assignment) shown to both sides, rendered as
 // a centered notice rather than a chat bubble.
 export type ChatSenderType = 'visitor' | 'agent' | 'system'
+/** A human side of a conversation — who acts (types, reads); 'system' is neither. */
+export type ConversationSide = Exclude<ChatSenderType, 'system'>
 /** How a conversation arrived — mirrors the conversations.channel column enum. */
 export type Channel = 'live_chat' | 'email' | 'web_form'
 
@@ -203,10 +205,12 @@ export type ChatStreamEvent =
       conversationId: ConversationId
       side: ChatSenderType
       at: string
-      /** For agent typing: which agent (inbox channel only — never sent to the
-       *  visitor). Lets other agents detect a collision; the originating agent's
-       *  own echo is filtered server-side. */
-      agentPrincipalId?: PrincipalId
+      /** Who is typing. Set everywhere EXCEPT the conversation-channel copy of
+       *  agent typing (never leak team identities to the visitor). The stream
+       *  layer drops any typing event whose typist matches the subscriber, so
+       *  no surface ever sees its own echo; agents also use it to tell another
+       *  agent's typing from their own collisions. */
+      typistPrincipalId?: PrincipalId
     }
   | { kind: 'message_deleted'; conversationId: ConversationId; messageId: ChatMessageId }
   // An existing message changed in an agent-only way (reaction or flag toggled).

--- a/apps/web/src/routes/api/chat/stream.ts
+++ b/apps/web/src/routes/api/chat/stream.ts
@@ -16,7 +16,9 @@ import { verifyStreamToken } from '@/lib/server/realtime/stream-token'
 import {
   conversationChannel,
   CHAT_INBOX_CHANNEL,
-  shouldSuppressOwnAgentTyping,
+  parseChatFrame,
+  isOwnTyping,
+  type ParsedChatFrame,
 } from '@/lib/server/realtime/chat-channels'
 import { subscribe } from '@/lib/server/realtime/pubsub'
 import { markPresent, refreshPresence, clearPresence } from '@/lib/server/realtime/presence'
@@ -77,18 +79,13 @@ function sse(event: string, data: unknown, id?: string): string {
 }
 
 /** Frame a raw pub/sub payload as a named SSE event (id carried for message
- *  events so reconnect backfill can resume). Pure — hoisted so it isn't
+ *  events so reconnect backfill can resume). Takes the already-parsed frame so
+ *  the subscribe callback parses each payload once; an unparseable (null)
+ *  frame passes through as a generic message. Pure — hoisted so it isn't
  *  re-created per connection. */
-function formatFrame(message: string): { id?: string; frame: string } {
-  let id: string | undefined
-  let eventName = 'message'
-  try {
-    const parsed = JSON.parse(message) as { kind?: string; message?: { id?: string } }
-    eventName = parsed.kind ?? 'message'
-    if (parsed.kind === 'message') id = parsed.message?.id
-  } catch {
-    // pass through as-is if unparseable
-  }
+function formatFrame(message: string, parsed: ParsedChatFrame): { id?: string; frame: string } {
+  const eventName = parsed?.kind ?? 'message'
+  const id = parsed?.kind === 'message' ? parsed.message?.id : undefined
   return {
     id,
     frame: `${id ? `id: ${id}\n` : ''}event: ${eventName}\ndata: ${message}\n\n`,
@@ -264,12 +261,14 @@ export const Route = createFileRoute('/api/chat/stream')({
               const liveBuffer: Array<{ id?: string; frame: string }> = []
 
               const unsub = await subscribe(channels, (_channel, message) => {
-                // Don't echo an agent's own typing back to them — so the client
-                // can treat any agent-typing it receives as "another agent".
-                if (isAgentStream && shouldSuppressOwnAgentTyping(message, me.principalId)) {
+                const event = parseChatFrame(message)
+                // Never echo a subscriber's own typing back to them, on any
+                // surface — clients can treat every typing event they receive
+                // as someone else's.
+                if (isOwnTyping(event, me.principalId)) {
                   return
                 }
-                const { id, frame } = formatFrame(message)
+                const { id, frame } = formatFrame(message, event)
                 if (backfilling) {
                   liveBuffer.push({ id, frame })
                   return


### PR DESCRIPTION
## Link previews never unfurled

`unfurlLinkFn` gated on `settings.featureFlags.linkPreviews` read off the raw settings row, where `featureFlags` is an unparsed JSON text column. Reading a property off a string is always `undefined`, so the gate returned null for every URL and link previews never rendered, flag on or off (broken since the feature landed in 2fa5af80).

The gate now uses `isFeatureEnabled('linkPreviews')` from the settings domain service (cached, parsed, default-merged). `getSettings` documents the raw-row shape so the next caller doesn't repeat the cast. A handler-boundary regression test pins both gate outcomes; its workspace mock keeps the realistic string-flags row so a revert to the raw-row read fails the test.

Verified live end to end: composer preview card renders (title/description/site name), the OG image is fetched, magic-byte verified and rehosted, results cache in Redis (24h positive / 10min negative), SSRF probes (`169.254.169.254`, the app's own localhost) return null and negative-cache, pages without OG tags fall back to a title-only card, and the 3-URL cap holds.

## Typing indicators echoed back to the typist

Typing events from the conversation-owner side were published with no identity, so a team member typing in a conversation they own saw their own typing echoed back in the inbox ("X is typing..."). Visitor surfaces only avoided the echo by a client-side filter convention.

Every typing event now carries `typistPrincipalId` -- except the visitor-bound copy of agent typing, which stays anonymous so team identities never reach visitors -- and the SSE stream layer drops a subscriber's own typing on every scope. No surface can see its own echo, and clients may treat any typing they receive as someone else's. The `publishAgentTyping`/`publishChatEvent` fork collapses into one `publishTyping`, and the subscribe callback now parses each pub/sub frame once, shared between suppression and SSE framing.

Verified against a live stream: a frame tagged with the subscriber's own principal is dropped by the server; a different typist's frame and anonymous agent typing are delivered. Channel payloads and suppression behavior are pinned by unit tests.

## Test plan

- `bun run typecheck` clean, `bun run lint` 0 errors
- `bun run test`: 429 files, 4824 passed
- Manual: admin inbox composer + message-bubble previews, SSRF/edge probes, own-typing suppression on inbox and conversation streams