### PR TITLE
feat(ui): redesign link preview card with favicon, left accent bar, and OG image at bottom

### DIFF
--- a/apps/web/src/components/shared/link-preview-card.tsx
+++ b/apps/web/src/components/shared/link-preview-card.tsx
@@ -53,6 +53,7 @@ export function LinkPreviewCard({ url, getAuthHeaders }: LinkPreviewCardProps) {
                 <img
                   src={preview.faviconUrl}
                   alt=""
+                  loading="lazy"
                   className="h-4 w-4 shrink-0 rounded-sm object-contain"
                 />
               )}

--- a/apps/web/src/components/shared/link-preview-card.tsx
+++ b/apps/web/src/components/shared/link-preview-card.tsx
@@ -75,7 +75,12 @@ export function LinkPreviewCard({ url, getAuthHeaders }: LinkPreviewCardProps) {
       </div>
       {/* OG image at bottom, full-width */}
       {preview.imageUrl && (
-        <img src={preview.imageUrl} alt="" className="block w-full" loading="lazy" />
+        <img
+          src={preview.imageUrl}
+          alt=""
+          className="block w-full max-h-48 object-contain"
+          loading="lazy"
+        />
       )}
     </a>
   )

--- a/apps/web/src/components/shared/link-preview-card.tsx
+++ b/apps/web/src/components/shared/link-preview-card.tsx
@@ -43,24 +43,45 @@ export function LinkPreviewCard({ url, getAuthHeaders }: LinkPreviewCardProps) {
       rel="noopener noreferrer nofollow"
       className="mt-1 block overflow-hidden rounded-lg border border-border bg-card no-underline transition-colors hover:bg-muted/40"
     >
-      {preview.imageUrl && (
-        <img src={preview.imageUrl} alt="" className="h-32 w-full object-cover" loading="lazy" />
-      )}
-      <div className="p-2.5">
-        {preview.siteName && (
-          <p className="mb-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground/70">
-            {preview.siteName}
-          </p>
-        )}
-        {preview.title && (
-          <p className="line-clamp-2 text-xs font-semibold text-foreground">{preview.title}</p>
-        )}
-        {preview.description && (
-          <p className="mt-0.5 line-clamp-2 text-[11px] text-muted-foreground">
-            {preview.description}
-          </p>
-        )}
+      {/* Text section with left accent bar */}
+      <div className="flex">
+        <div className="w-[3px] shrink-0 self-stretch bg-primary/80" />
+        <div className="min-w-0 flex-1 p-2.5">
+          {(preview.faviconUrl || preview.siteName) && (
+            <div className="mb-1 flex items-center gap-1.5">
+              {preview.faviconUrl && (
+                <img
+                  src={preview.faviconUrl}
+                  alt=""
+                  className="h-4 w-4 shrink-0 rounded-sm object-contain"
+                />
+              )}
+              {preview.siteName && (
+                <span className="truncate text-[11px] font-medium text-muted-foreground">
+                  {preview.siteName}
+                </span>
+              )}
+            </div>
+          )}
+          {preview.title && (
+            <p className="line-clamp-2 text-xs font-semibold text-primary">{preview.title}</p>
+          )}
+          {preview.description && (
+            <p className="mt-0.5 line-clamp-2 text-[11px] text-muted-foreground">
+              {preview.description}
+            </p>
+          )}
+        </div>
       </div>
+      {/* OG image at bottom, full-width */}
+      {preview.imageUrl && (
+        <img
+          src={preview.imageUrl}
+          alt=""
+          className="block w-full max-h-48 object-cover"
+          loading="lazy"
+        />
+      )}
     </a>
   )
 }

--- a/apps/web/src/components/shared/link-preview-card.tsx
+++ b/apps/web/src/components/shared/link-preview-card.tsx
@@ -41,7 +41,7 @@ export function LinkPreviewCard({ url, getAuthHeaders }: LinkPreviewCardProps) {
       href={preview.url}
       target="_blank"
       rel="noopener noreferrer nofollow"
-      className="mt-1 block overflow-hidden rounded-lg border border-border bg-card no-underline transition-colors hover:bg-muted/40"
+      className="mt-1 block max-w-sm overflow-hidden rounded-lg border border-border bg-card no-underline transition-colors hover:bg-muted/40"
     >
       {/* Text section with left accent bar */}
       <div className="flex">
@@ -75,12 +75,7 @@ export function LinkPreviewCard({ url, getAuthHeaders }: LinkPreviewCardProps) {
       </div>
       {/* OG image at bottom, full-width */}
       {preview.imageUrl && (
-        <img
-          src={preview.imageUrl}
-          alt=""
-          className="block w-full max-h-48 object-cover"
-          loading="lazy"
-        />
+        <img src={preview.imageUrl} alt="" className="block w-full" loading="lazy" />
       )}
     </a>
   )

--- a/apps/web/src/lib/server/__tests__/s3-upload-content-validation.test.ts
+++ b/apps/web/src/lib/server/__tests__/s3-upload-content-validation.test.ts
@@ -42,7 +42,7 @@ vi.mock('@aws-sdk/s3-request-presigner', () => ({
   getSignedUrl: vi.fn(async () => 'https://s3.amazonaws.com/presigned'),
 }))
 
-const { uploadImageFromFormData } = await import('@/lib/server/storage/s3')
+const { uploadImageFromFormData, uploadImageBuffer } = await import('@/lib/server/storage/s3')
 
 const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0])
 const GIF_BYTES = new Uint8Array([...'GIF89a'].map((c) => c.charCodeAt(0)).concat([0, 0, 0, 0]))
@@ -92,5 +92,25 @@ describe('uploadImageFromFormData — content validation', () => {
       'p'
     )
     expect(res.status).toBe(400)
+  })
+})
+
+describe('uploadImageBuffer — content-addressed keys', () => {
+  const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3, 4])
+  const keyOf = (i: number) =>
+    ((mockSend.mock.calls[i] as unknown[])[0] as { input: { Key: string } }).input.Key
+
+  it('derives one stable key from identical bytes so duplicates collapse', async () => {
+    mockSend.mockClear()
+    await uploadImageBuffer(PNG, 'image/png', 'link-previews', { contentAddressed: true })
+    await uploadImageBuffer(PNG, 'image/png', 'link-previews', { contentAddressed: true })
+    expect(keyOf(0)).toBe(keyOf(1))
+    expect(keyOf(0)).toMatch(/^link-previews\/[0-9a-f]{64}\.png$/)
+  })
+
+  it('uses a timestamped key by default', async () => {
+    mockSend.mockClear()
+    await uploadImageBuffer(PNG, 'image/png', 'link-previews')
+    expect(keyOf(0)).toMatch(/rehost-\d+\.png$/)
   })
 })

--- a/apps/web/src/lib/server/content/__tests__/magic-bytes.test.ts
+++ b/apps/web/src/lib/server/content/__tests__/magic-bytes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { sniffImageMime, ALLOWED_REHOST_MIMES } from '../magic-bytes'
+import { sniffImageMime, ALLOWED_REHOST_MIMES, canonicalizeImageMime } from '../magic-bytes'
 
 const bytes = (...values: number[]) => Buffer.from(values)
 
@@ -71,5 +71,18 @@ describe('ALLOWED_REHOST_MIMES', () => {
     expect(ALLOWED_REHOST_MIMES).toEqual(
       new Set(['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/avif', 'image/x-icon'])
     )
+  })
+})
+
+describe('canonicalizeImageMime', () => {
+  it('maps ICO aliases to image/x-icon', () => {
+    expect(canonicalizeImageMime('image/vnd.microsoft.icon')).toBe('image/x-icon')
+    expect(canonicalizeImageMime('image/icon')).toBe('image/x-icon')
+    expect(canonicalizeImageMime('image/ico')).toBe('image/x-icon')
+  })
+
+  it('leaves non-alias MIMEs untouched', () => {
+    expect(canonicalizeImageMime('image/png')).toBe('image/png')
+    expect(canonicalizeImageMime('image/x-icon')).toBe('image/x-icon')
   })
 })

--- a/apps/web/src/lib/server/content/__tests__/magic-bytes.test.ts
+++ b/apps/web/src/lib/server/content/__tests__/magic-bytes.test.ts
@@ -59,12 +59,17 @@ describe('sniffImageMime', () => {
     const svg = Buffer.from('<?xml version="1.0"?><svg xmlns="..."></svg>')
     expect(sniffImageMime(svg)).toBeNull()
   })
+
+  it('detects ICO from magic bytes', () => {
+    const buf = Buffer.concat([bytes(0x00, 0x00, 0x01, 0x00), Buffer.alloc(32)])
+    expect(sniffImageMime(buf)).toBe('image/x-icon')
+  })
 })
 
 describe('ALLOWED_REHOST_MIMES', () => {
-  it('contains the five image formats we rehost', () => {
+  it('contains the six image formats we rehost', () => {
     expect(ALLOWED_REHOST_MIMES).toEqual(
-      new Set(['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/avif'])
+      new Set(['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/avif', 'image/x-icon'])
     )
   })
 })

--- a/apps/web/src/lib/server/content/__tests__/og-parse.test.ts
+++ b/apps/web/src/lib/server/content/__tests__/og-parse.test.ts
@@ -167,4 +167,17 @@ describe('faviconUrl parsing', () => {
     const html = `<html><head><link rel="icon" href="ftp://bad.example/icon.ico" /></head></html>`
     expect(parseOpenGraph(html, BASE).faviconUrl).toBe('https://example.com/favicon.ico')
   })
+
+  it('treats apple-touch-icon-precomposed as an apple icon', () => {
+    const html = `<html><head>
+      <link rel="apple-touch-icon-precomposed" href="/touch.png" />
+      <link rel="icon" href="/favicon.png" />
+    </head></html>`
+    expect(parseOpenGraph(html, BASE).faviconUrl).toBe('https://example.com/touch.png')
+  })
+
+  it('matches rel tokens regardless of order (e.g. rel="icon shortcut")', () => {
+    const html = `<html><head><link rel="icon shortcut" href="/fav.ico" /></head></html>`
+    expect(parseOpenGraph(html, BASE).faviconUrl).toBe('https://example.com/fav.ico')
+  })
 })

--- a/apps/web/src/lib/server/content/__tests__/og-parse.test.ts
+++ b/apps/web/src/lib/server/content/__tests__/og-parse.test.ts
@@ -16,6 +16,7 @@ describe('parseOpenGraph', () => {
       description: 'My Desc',
       siteName: 'My Site',
       imageUrl: 'https://example.com/img.jpg',
+      faviconUrl: 'https://example.com/favicon.ico',
     })
   })
 
@@ -100,6 +101,7 @@ describe('parseOpenGraph', () => {
       description: null,
       siteName: null,
       imageUrl: null,
+      faviconUrl: 'https://example.com/favicon.ico',
     })
   })
 
@@ -121,5 +123,48 @@ describe('parseOpenGraph', () => {
   it('never throws on malformed html', () => {
     expect(() => parseOpenGraph('not html at all << >>', 'not-a-url')).not.toThrow()
     expect(() => parseOpenGraph('', '')).not.toThrow()
+  })
+})
+
+describe('faviconUrl parsing', () => {
+  it('extracts apple-touch-icon with highest priority', () => {
+    const html = `<html><head>
+      <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+      <link rel="icon" href="/favicon.png" />
+    </head></html>`
+    expect(parseOpenGraph(html, BASE).faviconUrl).toBe('https://example.com/apple-touch-icon.png')
+  })
+
+  it('falls back to rel="icon" when no apple-touch-icon', () => {
+    const html = `<html><head>
+      <link rel="icon" href="https://cdn.example.com/icon.png" />
+    </head></html>`
+    expect(parseOpenGraph(html, BASE).faviconUrl).toBe('https://cdn.example.com/icon.png')
+  })
+
+  it('falls back to rel="shortcut icon"', () => {
+    const html = `<html><head>
+      <link rel="shortcut icon" href="/fav.ico" />
+    </head></html>`
+    expect(parseOpenGraph(html, BASE).faviconUrl).toBe('https://example.com/fav.ico')
+  })
+
+  it('falls back to /favicon.ico when no link tags present', () => {
+    const html = `<html><head><title>No Icons</title></head></html>`
+    expect(parseOpenGraph(html, 'https://site.example/page').faviconUrl).toBe(
+      'https://site.example/favicon.ico'
+    )
+  })
+
+  it('resolves relative favicon href against baseUrl', () => {
+    const html = `<html><head><link rel="icon" href="/static/icon.png" /></head></html>`
+    expect(parseOpenGraph(html, 'https://app.example/page').faviconUrl).toBe(
+      'https://app.example/static/icon.png'
+    )
+  })
+
+  it('skips non-http favicon href and falls back to /favicon.ico', () => {
+    const html = `<html><head><link rel="icon" href="ftp://bad.example/icon.ico" /></head></html>`
+    expect(parseOpenGraph(html, BASE).faviconUrl).toBe('https://example.com/favicon.ico')
   })
 })

--- a/apps/web/src/lib/server/content/__tests__/unfurl.test.ts
+++ b/apps/web/src/lib/server/content/__tests__/unfurl.test.ts
@@ -20,6 +20,7 @@ vi.mock('../magic-bytes', () => ({
     'image/jpeg',
     'image/gif',
     'image/webp',
+    'image/avif',
     'image/x-icon',
   ]),
 }))

--- a/apps/web/src/lib/server/content/__tests__/unfurl.test.ts
+++ b/apps/web/src/lib/server/content/__tests__/unfurl.test.ts
@@ -150,7 +150,7 @@ describe('unfurlExternalUrl', () => {
             new Response(icoBytes, { status: 200, headers: { 'content-type': 'image/x-icon' } })
           )
         }
-        return Promise.resolve(undefined as unknown as Response)
+        return Promise.resolve(new Response(null, { status: 404 }))
       })
     sniffImageMime.mockReturnValue('image/x-icon')
     uploadImageBuffer.mockResolvedValue({ url: '/api/storage/link-previews/fav.ico' })
@@ -178,7 +178,7 @@ describe('unfurlExternalUrl', () => {
             })
           )
         }
-        return Promise.resolve(undefined as unknown as Response)
+        return Promise.resolve(new Response(null, { status: 404 }))
       })
     sniffImageMime.mockReturnValue('image/x-icon')
     uploadImageBuffer.mockResolvedValue({ url: '/api/storage/link-previews/fav.ico' })

--- a/apps/web/src/lib/server/content/__tests__/unfurl.test.ts
+++ b/apps/web/src/lib/server/content/__tests__/unfurl.test.ts
@@ -15,7 +15,13 @@ vi.mock('../ssrf-guard', () => ({
 }))
 vi.mock('../magic-bytes', () => ({
   sniffImageMime,
-  ALLOWED_REHOST_MIMES: new Set(['image/png', 'image/jpeg', 'image/gif', 'image/webp']),
+  ALLOWED_REHOST_MIMES: new Set([
+    'image/png',
+    'image/jpeg',
+    'image/gif',
+    'image/webp',
+    'image/x-icon',
+  ]),
 }))
 vi.mock('@/lib/server/storage/s3', () => ({ uploadImageBuffer }))
 
@@ -40,6 +46,7 @@ describe('unfurlExternalUrl', () => {
     safeFetch
       .mockResolvedValueOnce(redirect('https://final.example/page'))
       .mockResolvedValueOnce(htmlRes(page('<meta property="og:title" content="Hello">')))
+      .mockResolvedValue(new Response(null, { status: 404 }))
 
     const res = await unfurlExternalUrl('https://start.example/')
 
@@ -81,6 +88,7 @@ describe('unfurlExternalUrl', () => {
       .mockResolvedValueOnce(
         new Response('<svg/>', { status: 200, headers: { 'content-type': 'image/svg+xml' } })
       )
+      .mockResolvedValue(new Response(null, { status: 404 }))
 
     const res = await unfurlExternalUrl('https://site.example/')
     expect(res?.title).toBe('T')
@@ -99,6 +107,7 @@ describe('unfurlExternalUrl', () => {
         )
       )
       .mockResolvedValueOnce(imageRes([1, 2, 3], 'image/png'))
+      .mockResolvedValue(new Response(null, { status: 404 }))
     sniffImageMime.mockReturnValue('image/gif') // mismatch with declared image/png
 
     const res = await unfurlExternalUrl('https://site.example/')
@@ -116,11 +125,81 @@ describe('unfurlExternalUrl', () => {
         )
       )
       .mockResolvedValueOnce(imageRes([0x89, 0x50, 0x4e, 0x47], 'image/png'))
+      .mockResolvedValue(new Response(null, { status: 404 }))
     sniffImageMime.mockReturnValue('image/png')
     uploadImageBuffer.mockResolvedValue({ url: '/api/storage/link-previews/abc.png' })
 
     const res = await unfurlExternalUrl('https://site.example/')
     expect(res?.imageUrl).toBe('/api/storage/link-previews/abc.png')
     expect(uploadImageBuffer).toHaveBeenCalledWith(expect.any(Buffer), 'image/png', 'link-previews')
+  })
+
+  it('proxies a favicon ICO and returns faviconUrl', async () => {
+    const icoBytes = Buffer.from([0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x10, 0x10])
+    safeFetch
+      .mockResolvedValueOnce(
+        htmlRes(
+          page(
+            '<meta property="og:title" content="T"><link rel="icon" href="https://site.example/favicon.ico" />'
+          )
+        )
+      )
+      .mockImplementation((url: string) => {
+        if (url === 'https://site.example/favicon.ico') {
+          return Promise.resolve(
+            new Response(icoBytes, { status: 200, headers: { 'content-type': 'image/x-icon' } })
+          )
+        }
+        return Promise.resolve(undefined as unknown as Response)
+      })
+    sniffImageMime.mockReturnValue('image/x-icon')
+    uploadImageBuffer.mockResolvedValue({ url: '/api/storage/link-previews/fav.ico' })
+
+    const res = await unfurlExternalUrl('https://site.example/')
+    expect(res?.faviconUrl).toBe('/api/storage/link-previews/fav.ico')
+  })
+
+  it('normalises image/vnd.microsoft.icon to image/x-icon before the MIME check', async () => {
+    const icoBytes = Buffer.from([0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x10, 0x10])
+    safeFetch
+      .mockResolvedValueOnce(
+        htmlRes(
+          page(
+            '<meta property="og:title" content="T"><link rel="icon" href="https://site.example/fav.ico" />'
+          )
+        )
+      )
+      .mockImplementation((url: string) => {
+        if (url === 'https://site.example/fav.ico') {
+          return Promise.resolve(
+            new Response(icoBytes, {
+              status: 200,
+              headers: { 'content-type': 'image/vnd.microsoft.icon' },
+            })
+          )
+        }
+        return Promise.resolve(undefined as unknown as Response)
+      })
+    sniffImageMime.mockReturnValue('image/x-icon')
+    uploadImageBuffer.mockResolvedValue({ url: '/api/storage/link-previews/fav.ico' })
+
+    const res = await unfurlExternalUrl('https://site.example/')
+    expect(res?.faviconUrl).toBe('/api/storage/link-previews/fav.ico')
+  })
+
+  it('sets faviconUrl to null when favicon fetch returns 404', async () => {
+    safeFetch
+      .mockResolvedValueOnce(
+        htmlRes(
+          page(
+            '<meta property="og:title" content="T"><link rel="icon" href="https://site.example/fav.ico" />'
+          )
+        )
+      )
+      .mockImplementation(() => Promise.resolve(new Response(null, { status: 404 })))
+
+    const res = await unfurlExternalUrl('https://site.example/')
+    expect(res?.title).toBe('T')
+    expect(res?.faviconUrl).toBeNull()
   })
 })

--- a/apps/web/src/lib/server/content/__tests__/unfurl.test.ts
+++ b/apps/web/src/lib/server/content/__tests__/unfurl.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 // Mocks must exist before the module factories run — vi.hoisted lifts them.
-const { safeFetch, uploadImageBuffer, sniffImageMime } = vi.hoisted(() => ({
+const { safeFetch, uploadImageBuffer, sniffImageMime, cacheGet, cacheSet } = vi.hoisted(() => ({
   safeFetch: vi.fn(),
   uploadImageBuffer: vi.fn(),
   sniffImageMime: vi.fn(),
+  cacheGet: vi.fn(),
+  cacheSet: vi.fn(),
 }))
 
 vi.mock('../ssrf-guard', () => ({
@@ -13,18 +15,14 @@ vi.mock('../ssrf-guard', () => ({
   TimeoutError: class TimeoutError extends Error {},
   ResponseTooLargeError: class ResponseTooLargeError extends Error {},
 }))
-vi.mock('../magic-bytes', () => ({
+vi.mock('../magic-bytes', async (importActual) => ({
+  // sniffImageMime is mocked (we drive it per-test); the rest is real — the
+  // allow-list and the pure MIME canonicalizer don't need stubbing.
+  ...(await importActual<typeof import('../magic-bytes')>()),
   sniffImageMime,
-  ALLOWED_REHOST_MIMES: new Set([
-    'image/png',
-    'image/jpeg',
-    'image/gif',
-    'image/webp',
-    'image/avif',
-    'image/x-icon',
-  ]),
 }))
 vi.mock('@/lib/server/storage/s3', () => ({ uploadImageBuffer }))
+vi.mock('@/lib/server/redis', () => ({ cacheGet, cacheSet }))
 
 import { unfurlExternalUrl } from '../unfurl'
 
@@ -40,6 +38,9 @@ beforeEach(() => {
   safeFetch.mockReset()
   uploadImageBuffer.mockReset()
   sniffImageMime.mockReset()
+  // Favicon dedup cache: default to a miss + a no-op set.
+  cacheGet.mockReset().mockResolvedValue(null)
+  cacheSet.mockReset().mockResolvedValue(undefined)
 })
 
 describe('unfurlExternalUrl', () => {
@@ -132,7 +133,14 @@ describe('unfurlExternalUrl', () => {
 
     const res = await unfurlExternalUrl('https://site.example/')
     expect(res?.imageUrl).toBe('/api/storage/link-previews/abc.png')
-    expect(uploadImageBuffer).toHaveBeenCalledWith(expect.any(Buffer), 'image/png', 'link-previews')
+    expect(uploadImageBuffer).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      'image/png',
+      'link-previews',
+      {
+        contentAddressed: true,
+      }
+    )
   })
 
   it('proxies a favicon ICO and returns faviconUrl', async () => {
@@ -186,6 +194,110 @@ describe('unfurlExternalUrl', () => {
 
     const res = await unfurlExternalUrl('https://site.example/')
     expect(res?.faviconUrl).toBe('/api/storage/link-previews/fav.ico')
+  })
+
+  it('normalises image/ico to image/x-icon before the MIME check', async () => {
+    const icoBytes = Buffer.from([0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x10, 0x10])
+    safeFetch
+      .mockResolvedValueOnce(
+        htmlRes(
+          page(
+            '<meta property="og:title" content="T"><link rel="icon" href="https://site.example/fav.ico" />'
+          )
+        )
+      )
+      .mockImplementation((url: string) => {
+        if (url === 'https://site.example/fav.ico') {
+          return Promise.resolve(
+            new Response(icoBytes, { status: 200, headers: { 'content-type': 'image/ico' } })
+          )
+        }
+        return Promise.resolve(new Response(null, { status: 404 }))
+      })
+    sniffImageMime.mockReturnValue('image/x-icon')
+    uploadImageBuffer.mockResolvedValue({ url: '/api/storage/link-previews/fav.ico' })
+
+    const res = await unfurlExternalUrl('https://site.example/')
+    expect(res?.faviconUrl).toBe('/api/storage/link-previews/fav.ico')
+  })
+
+  it('uploads favicons with a content-addressed key so duplicates collapse', async () => {
+    const icoBytes = Buffer.from([0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x10, 0x10])
+    safeFetch
+      .mockResolvedValueOnce(
+        htmlRes(
+          page(
+            '<meta property="og:title" content="T"><link rel="icon" href="https://site.example/fav.ico" />'
+          )
+        )
+      )
+      .mockImplementation((url: string) =>
+        url === 'https://site.example/fav.ico'
+          ? Promise.resolve(
+              new Response(icoBytes, { status: 200, headers: { 'content-type': 'image/x-icon' } })
+            )
+          : Promise.resolve(new Response(null, { status: 404 }))
+      )
+    sniffImageMime.mockReturnValue('image/x-icon')
+    uploadImageBuffer.mockResolvedValue({ url: '/api/storage/link-previews/fav.ico' })
+
+    await unfurlExternalUrl('https://site.example/')
+    expect(uploadImageBuffer).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      'image/x-icon',
+      'link-previews',
+      {
+        contentAddressed: true,
+      }
+    )
+  })
+
+  it('reuses a cached proxied favicon without re-fetching or re-uploading', async () => {
+    cacheGet.mockResolvedValue('/api/storage/link-previews/cached-fav.ico')
+    safeFetch.mockResolvedValueOnce(htmlRes(page('<meta property="og:title" content="T">')))
+
+    const res = await unfurlExternalUrl('https://site.example/')
+    expect(res?.faviconUrl).toBe('/api/storage/link-previews/cached-fav.ico')
+    // Page fetched once; favicon served from cache (no second fetch, no upload).
+    expect(safeFetch).toHaveBeenCalledTimes(1)
+    expect(uploadImageBuffer).not.toHaveBeenCalled()
+  })
+
+  it('honors a negative favicon cache entry without re-fetching', async () => {
+    cacheGet.mockResolvedValue('__none')
+    safeFetch.mockResolvedValueOnce(htmlRes(page('<meta property="og:title" content="T">')))
+
+    const res = await unfurlExternalUrl('https://site.example/')
+    expect(res?.faviconUrl).toBeNull()
+    expect(safeFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('caches the proxied favicon URL keyed by the favicon URL on a miss', async () => {
+    const icoBytes = Buffer.from([0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x10, 0x10])
+    safeFetch
+      .mockResolvedValueOnce(
+        htmlRes(
+          page(
+            '<meta property="og:title" content="T"><link rel="icon" href="https://site.example/fav.ico" />'
+          )
+        )
+      )
+      .mockImplementation((url: string) =>
+        url === 'https://site.example/fav.ico'
+          ? Promise.resolve(
+              new Response(icoBytes, { status: 200, headers: { 'content-type': 'image/x-icon' } })
+            )
+          : Promise.resolve(new Response(null, { status: 404 }))
+      )
+    sniffImageMime.mockReturnValue('image/x-icon')
+    uploadImageBuffer.mockResolvedValue({ url: '/api/storage/link-previews/fav.ico' })
+
+    await unfurlExternalUrl('https://site.example/')
+    expect(cacheSet).toHaveBeenCalledWith(
+      expect.stringContaining('favicon'),
+      '/api/storage/link-previews/fav.ico',
+      expect.any(Number)
+    )
   })
 
   it('sets faviconUrl to null when favicon fetch returns 404', async () => {

--- a/apps/web/src/lib/server/content/magic-bytes.ts
+++ b/apps/web/src/lib/server/content/magic-bytes.ts
@@ -19,6 +19,18 @@ export const ALLOWED_REHOST_MIMES = new Set([
   'image/x-icon',
 ])
 
+/**
+ * Map equivalent MIME spellings to the canonical form `sniffImageMime` returns,
+ * so a header cross-check accepts e.g. `image/vnd.microsoft.icon` as `image/x-icon`.
+ * Owns the alias vocabulary alongside the canonical set above.
+ */
+export function canonicalizeImageMime(mime: string): string {
+  if (mime === 'image/vnd.microsoft.icon' || mime === 'image/icon' || mime === 'image/ico') {
+    return 'image/x-icon'
+  }
+  return mime
+}
+
 function startsWithAt(buf: Buffer, offset: number, pattern: number[]): boolean {
   if (buf.length < offset + pattern.length) return false
   for (let i = 0; i < pattern.length; i++) {

--- a/apps/web/src/lib/server/content/magic-bytes.ts
+++ b/apps/web/src/lib/server/content/magic-bytes.ts
@@ -16,6 +16,7 @@ export const ALLOWED_REHOST_MIMES = new Set([
   'image/gif',
   'image/webp',
   'image/avif',
+  'image/x-icon',
 ])
 
 function startsWithAt(buf: Buffer, offset: number, pattern: number[]): boolean {
@@ -56,6 +57,10 @@ export function sniffImageMime(buf: Buffer): string | null {
   if (buf.length >= 12 && buf.slice(4, 8).toString('ascii') === 'ftyp') {
     const brand = buf.slice(8, 12).toString('ascii')
     if (brand === 'avif' || brand === 'avis') return 'image/avif'
+  }
+  // ICO: 00 00 01 00
+  if (startsWithAt(buf, 0, [0x00, 0x00, 0x01, 0x00])) {
+    return 'image/x-icon'
   }
   return null
 }

--- a/apps/web/src/lib/server/content/og-parse.ts
+++ b/apps/web/src/lib/server/content/og-parse.ts
@@ -55,6 +55,7 @@ export interface OpenGraphData {
   description: string | null
   siteName: string | null
   imageUrl: string | null
+  faviconUrl: string | null
 }
 
 /**
@@ -114,6 +115,51 @@ export function parseOpenGraph(html: string, baseUrl: string): OpenGraphData {
     const rawSiteName = ogSiteName
     const rawImage = ogImage ?? twitterImage
 
+    // Parse favicon links — priority: apple-touch-icon > icon > shortcut icon
+    const iconHrefs: Partial<Record<'apple-touch-icon' | 'icon' | 'shortcut icon', string>> = {}
+    const linkTagRe = /<link\s[^>]+>/gi
+    let lm: RegExpExecArray | null
+    while ((lm = linkTagRe.exec(head)) !== null) {
+      const tag = lm[0]
+      const rel = extractAttr(tag, 'rel')?.trim().toLowerCase()
+      const href = extractAttr(tag, 'href')
+      if (!rel || !href) continue
+      if (rel === 'apple-touch-icon' && !iconHrefs['apple-touch-icon']) {
+        iconHrefs['apple-touch-icon'] = href
+      } else if (rel === 'icon' && !iconHrefs['icon']) {
+        iconHrefs['icon'] = href
+      } else if (rel === 'shortcut icon' && !iconHrefs['shortcut icon']) {
+        iconHrefs['shortcut icon'] = href
+      }
+    }
+    const rawFavicon =
+      iconHrefs['apple-touch-icon'] ?? iconHrefs['icon'] ?? iconHrefs['shortcut icon'] ?? null
+
+    let faviconUrl: string | null = null
+    if (rawFavicon) {
+      try {
+        const resolved = new URL(rawFavicon, baseUrl)
+        if (
+          (resolved.protocol === 'http:' || resolved.protocol === 'https:') &&
+          resolved.href.length <= 2048
+        ) {
+          faviconUrl = resolved.href
+        }
+      } catch {
+        // malformed URL — fall through to /favicon.ico
+      }
+    }
+    if (!faviconUrl) {
+      try {
+        const fallback = new URL('/favicon.ico', baseUrl)
+        if (fallback.protocol === 'http:' || fallback.protocol === 'https:') {
+          faviconUrl = fallback.href
+        }
+      } catch {
+        // malformed baseUrl
+      }
+    }
+
     // Resolve and validate image URL
     let imageUrl: string | null = null
     if (rawImage) {
@@ -132,8 +178,9 @@ export function parseOpenGraph(html: string, baseUrl: string): OpenGraphData {
       description: cap(rawDescription, 500),
       siteName: cap(rawSiteName, 100),
       imageUrl,
+      faviconUrl,
     }
   } catch {
-    return { title: null, description: null, siteName: null, imageUrl: null }
+    return { title: null, description: null, siteName: null, imageUrl: null, faviconUrl: null }
   }
 }

--- a/apps/web/src/lib/server/content/og-parse.ts
+++ b/apps/web/src/lib/server/content/og-parse.ts
@@ -50,6 +50,23 @@ function extractAttr(tag: string, attr: string): string | null {
   return m[1] ?? m[2] ?? m[3] ?? null
 }
 
+/**
+ * Resolve an href against baseUrl and return it only if it's an http(s) URL
+ * within maxLen. Returns null on a malformed URL or a disallowed scheme, so the
+ * caller can fall through to a default.
+ */
+function resolveHttpUrl(href: string, baseUrl: string, maxLen = Infinity): string | null {
+  try {
+    const u = new URL(href, baseUrl)
+    if ((u.protocol === 'http:' || u.protocol === 'https:') && u.href.length <= maxLen) {
+      return u.href
+    }
+  } catch {
+    // malformed URL — caller falls back
+  }
+  return null
+}
+
 export interface OpenGraphData {
   title: string | null
   description: string | null
@@ -115,63 +132,37 @@ export function parseOpenGraph(html: string, baseUrl: string): OpenGraphData {
     const rawSiteName = ogSiteName
     const rawImage = ogImage ?? twitterImage
 
-    // Parse favicon links — priority: apple-touch-icon > icon > shortcut icon
-    const iconHrefs: Partial<Record<'apple-touch-icon' | 'icon' | 'shortcut icon', string>> = {}
+    // Parse favicon links — priority: apple-touch-icon > icon. The rel attribute
+    // is a space-separated token set, so `shortcut icon` and `icon shortcut` are
+    // the same thing; tokenize rather than string-match the whole value.
+    let appleIconHref: string | null = null
+    let iconHref: string | null = null
     const linkTagRe = /<link\s[^>]+>/gi
     let lm: RegExpExecArray | null
     while ((lm = linkTagRe.exec(head)) !== null) {
       const tag = lm[0]
-      const rel = extractAttr(tag, 'rel')?.trim().toLowerCase()
+      const rel = extractAttr(tag, 'rel')
       const href = extractAttr(tag, 'href')
       if (!rel || !href) continue
-      if (rel === 'apple-touch-icon' && !iconHrefs['apple-touch-icon']) {
-        iconHrefs['apple-touch-icon'] = href
-      } else if (rel === 'icon' && !iconHrefs['icon']) {
-        iconHrefs['icon'] = href
-      } else if (rel === 'shortcut icon' && !iconHrefs['shortcut icon']) {
-        iconHrefs['shortcut icon'] = href
+      const tokens = rel.trim().toLowerCase().split(/\s+/)
+      if (
+        (tokens.includes('apple-touch-icon') || tokens.includes('apple-touch-icon-precomposed')) &&
+        !appleIconHref
+      ) {
+        appleIconHref = href
+      } else if (tokens.includes('icon') && !iconHref) {
+        iconHref = href
       }
     }
-    const rawFavicon =
-      iconHrefs['apple-touch-icon'] ?? iconHrefs['icon'] ?? iconHrefs['shortcut icon'] ?? null
+    const rawFavicon = appleIconHref ?? iconHref
 
-    let faviconUrl: string | null = null
-    if (rawFavicon) {
-      try {
-        const resolved = new URL(rawFavicon, baseUrl)
-        if (
-          (resolved.protocol === 'http:' || resolved.protocol === 'https:') &&
-          resolved.href.length <= 2048
-        ) {
-          faviconUrl = resolved.href
-        }
-      } catch {
-        // malformed URL — fall through to /favicon.ico
-      }
-    }
-    if (!faviconUrl) {
-      try {
-        const fallback = new URL('/favicon.ico', baseUrl)
-        if (fallback.protocol === 'http:' || fallback.protocol === 'https:') {
-          faviconUrl = fallback.href
-        }
-      } catch {
-        // malformed baseUrl
-      }
-    }
+    // Use the declared favicon if it resolves to a sane http(s) URL; otherwise
+    // assume the conventional /favicon.ico at the site root.
+    const faviconUrl =
+      (rawFavicon ? resolveHttpUrl(rawFavicon, baseUrl, 2048) : null) ??
+      resolveHttpUrl('/favicon.ico', baseUrl)
 
-    // Resolve and validate image URL
-    let imageUrl: string | null = null
-    if (rawImage) {
-      try {
-        const resolved = new URL(rawImage, baseUrl)
-        if (resolved.protocol === 'http:' || resolved.protocol === 'https:') {
-          imageUrl = resolved.href
-        }
-      } catch {
-        // Malformed URL — leave null
-      }
-    }
+    const imageUrl = rawImage ? resolveHttpUrl(rawImage, baseUrl) : null
 
     return {
       title: cap(rawTitle, 200),

--- a/apps/web/src/lib/server/content/unfurl.ts
+++ b/apps/web/src/lib/server/content/unfurl.ts
@@ -161,7 +161,7 @@ async function proxyFavicon(rawFaviconUrl: string): Promise<string | null> {
   if (sniffed === null || sniffed !== headerMime) return null
 
   try {
-    const { url } = await uploadImageBuffer(buffer, headerMime, 'link-previews')
+    const { url } = await uploadImageBuffer(buffer, sniffed, 'link-previews')
     return url
   } catch {
     return null

--- a/apps/web/src/lib/server/content/unfurl.ts
+++ b/apps/web/src/lib/server/content/unfurl.ts
@@ -18,6 +18,7 @@ export interface LinkPreview {
   description: string | null
   siteName: string | null
   imageUrl: string | null
+  faviconUrl: string | null
 }
 
 const MAX_REDIRECTS = 3
@@ -25,6 +26,8 @@ const PAGE_TIMEOUT_MS = 5_000
 const PAGE_MAX_BYTES = 512 * 1024
 const IMAGE_TIMEOUT_MS = 10_000
 const IMAGE_MAX_BYTES = 5 * 1024 * 1024
+const FAVICON_TIMEOUT_MS = 5_000
+const FAVICON_MAX_BYTES = 64 * 1024
 
 /**
  * Fetch a URL with SSRF protection and a redirect-following loop (max 3 hops).
@@ -116,6 +119,55 @@ async function proxyImage(rawImageUrl: string): Promise<string | null> {
   }
 }
 
+/** Normalize ICO MIME aliases to the canonical form before the sniff cross-check. */
+function normalizeIconMime(mime: string): string {
+  if (mime === 'image/vnd.microsoft.icon' || mime === 'image/icon') return 'image/x-icon'
+  return mime
+}
+
+/**
+ * Fetch a favicon URL, magic-byte verify it, and upload to our storage.
+ * Handles ICO MIME aliases; rejects SVG. 64KB max.
+ * Returns the proxied URL on success, null on any failure.
+ */
+async function proxyFavicon(rawFaviconUrl: string): Promise<string | null> {
+  let response: Response
+  try {
+    response = await safeFetch(rawFaviconUrl, {
+      method: 'GET',
+      timeoutMs: FAVICON_TIMEOUT_MS,
+      maxResponseBytes: FAVICON_MAX_BYTES,
+      onOverflow: 'error',
+    })
+  } catch {
+    return null
+  }
+
+  if (response.status >= 300 || !response.ok) return null
+
+  const rawMime = (response.headers.get('content-type') ?? '').split(';')[0].trim().toLowerCase()
+  const headerMime = normalizeIconMime(rawMime)
+  if (headerMime === 'image/svg+xml') return null
+  if (!ALLOWED_REHOST_MIMES.has(headerMime)) return null
+
+  let buffer: Buffer
+  try {
+    buffer = Buffer.from(await response.arrayBuffer())
+  } catch {
+    return null
+  }
+
+  const sniffed = sniffImageMime(buffer)
+  if (sniffed === null || sniffed !== headerMime) return null
+
+  try {
+    const { url } = await uploadImageBuffer(buffer, headerMime, 'link-previews')
+    return url
+  } catch {
+    return null
+  }
+}
+
 /**
  * Unfurl an external URL: fetch HTML, parse OG tags, proxy the image.
  * Returns null if the URL is unsafe, non-HTML, or yields nothing worth showing.
@@ -149,11 +201,11 @@ export async function unfurlExternalUrl(rawUrl: string): Promise<LinkPreview | n
 
     const og = parseOpenGraph(html, finalUrl)
 
-    // Proxy the OG image
-    let proxiedImage: string | null = null
-    if (og.imageUrl) {
-      proxiedImage = await proxyImage(og.imageUrl)
-    }
+    // Proxy OG image and favicon in parallel
+    const [proxiedImage, proxiedFavicon] = await Promise.all([
+      og.imageUrl ? proxyImage(og.imageUrl) : Promise.resolve(null),
+      og.faviconUrl ? proxyFavicon(og.faviconUrl) : Promise.resolve(null),
+    ])
 
     const preview: LinkPreview = {
       url: finalUrl,
@@ -161,6 +213,7 @@ export async function unfurlExternalUrl(rawUrl: string): Promise<LinkPreview | n
       description: og.description,
       siteName: og.siteName,
       imageUrl: proxiedImage,
+      faviconUrl: proxiedFavicon,
     }
 
     // Nothing worth showing

--- a/apps/web/src/lib/server/content/unfurl.ts
+++ b/apps/web/src/lib/server/content/unfurl.ts
@@ -7,9 +7,11 @@
  * hotlinked. Never throws; degrades to null on any failure.
  */
 
+import { createHash } from 'node:crypto'
 import { safeFetch, SsrfError, TimeoutError } from './ssrf-guard'
-import { sniffImageMime, ALLOWED_REHOST_MIMES } from './magic-bytes'
+import { sniffImageMime, ALLOWED_REHOST_MIMES, canonicalizeImageMime } from './magic-bytes'
 import { uploadImageBuffer } from '@/lib/server/storage/s3'
+import { cacheGet, cacheSet } from '@/lib/server/redis'
 import { parseOpenGraph } from './og-parse'
 
 export interface LinkPreview {
@@ -28,6 +30,14 @@ const IMAGE_TIMEOUT_MS = 10_000
 const IMAGE_MAX_BYTES = 5 * 1024 * 1024
 const FAVICON_TIMEOUT_MS = 5_000
 const FAVICON_MAX_BYTES = 64 * 1024
+// One favicon URL is shared across every page of a site, so cache the proxied
+// result by favicon URL to skip the fetch + upload on subsequent unfurls. Long
+// TTL for hits (favicons rarely change); short TTL for misses so a transient
+// failure doesn't suppress the icon for long.
+const FAVICON_CACHE_TTL_S = 7 * 24 * 60 * 60
+const FAVICON_CACHE_NEG_TTL_S = 60 * 60
+/** Negative-cache sentinel — distinguishable from any real proxied URL. */
+const FAVICON_NONE = '__none'
 
 /**
  * Fetch a URL with SSRF protection and a redirect-following loop (max 3 hops).
@@ -79,25 +89,32 @@ async function fetchFollowingRedirects(
 }
 
 /**
- * Fetch an image URL, magic-byte verify it, and upload to our storage.
- * Returns the proxied URL on success, null on any failure.
+ * Fetch an image/favicon URL, magic-byte verify it against its declared
+ * Content-Type, and upload to our storage. Rejects SVG. Returns the proxied URL
+ * on success, null on any failure. Uploads are content-addressed so the same
+ * bytes (a favicon shared across a site, a repeated OG image) collapse to one
+ * stored object instead of accumulating a copy per unfurl.
  */
-async function proxyImage(rawImageUrl: string): Promise<string | null> {
+async function proxyRehostedImage(
+  rawUrl: string,
+  opts: { timeoutMs: number; maxBytes: number }
+): Promise<string | null> {
   let response: Response
   try {
-    response = await safeFetch(rawImageUrl, {
+    response = await safeFetch(rawUrl, {
       method: 'GET',
-      timeoutMs: IMAGE_TIMEOUT_MS,
-      maxResponseBytes: IMAGE_MAX_BYTES,
+      timeoutMs: opts.timeoutMs,
+      maxResponseBytes: opts.maxBytes,
       onOverflow: 'error',
     })
   } catch {
     return null
   }
 
-  if (response.status >= 300 || !response.ok) return null
+  if (!response.ok) return null
 
-  const headerMime = (response.headers.get('content-type') ?? '').split(';')[0].trim().toLowerCase()
+  const rawMime = (response.headers.get('content-type') ?? '').split(';')[0].trim().toLowerCase()
+  const headerMime = canonicalizeImageMime(rawMime)
   if (headerMime === 'image/svg+xml') return null
   if (!ALLOWED_REHOST_MIMES.has(headerMime)) return null
 
@@ -112,60 +129,43 @@ async function proxyImage(rawImageUrl: string): Promise<string | null> {
   if (sniffed === null || sniffed !== headerMime) return null
 
   try {
-    const { url } = await uploadImageBuffer(buffer, sniffed, 'link-previews')
+    const { url } = await uploadImageBuffer(buffer, sniffed, 'link-previews', {
+      contentAddressed: true,
+    })
     return url
   } catch {
     return null
   }
 }
 
-/** Normalize ICO MIME aliases to the canonical form before the sniff cross-check. */
-function normalizeIconMime(mime: string): string {
-  if (mime === 'image/vnd.microsoft.icon' || mime === 'image/icon') return 'image/x-icon'
-  return mime
+const proxyImage = (rawImageUrl: string) =>
+  proxyRehostedImage(rawImageUrl, { timeoutMs: IMAGE_TIMEOUT_MS, maxBytes: IMAGE_MAX_BYTES })
+
+const proxyFavicon = (rawFaviconUrl: string) =>
+  proxyRehostedImage(rawFaviconUrl, { timeoutMs: FAVICON_TIMEOUT_MS, maxBytes: FAVICON_MAX_BYTES })
+
+/** Cache key for a proxied favicon, derived from its source URL. */
+function faviconCacheKey(rawFaviconUrl: string): string {
+  return `linkpreview:favicon:v1:${createHash('sha256').update(rawFaviconUrl).digest('hex')}`
 }
 
 /**
- * Fetch a favicon URL, magic-byte verify it, and upload to our storage.
- * Handles ICO MIME aliases; rejects SVG. 64KB max.
- * Returns the proxied URL on success, null on any failure.
+ * Proxy a favicon, memoized by its source URL in Redis so every page of a site
+ * reuses the first page's proxied favicon instead of re-fetching + re-uploading.
+ * Caching is best-effort: a Redis miss/error just falls through to proxyFavicon.
  */
-async function proxyFavicon(rawFaviconUrl: string): Promise<string | null> {
-  let response: Response
-  try {
-    response = await safeFetch(rawFaviconUrl, {
-      method: 'GET',
-      timeoutMs: FAVICON_TIMEOUT_MS,
-      maxResponseBytes: FAVICON_MAX_BYTES,
-      onOverflow: 'error',
-    })
-  } catch {
-    return null
-  }
+async function proxyFaviconCached(rawFaviconUrl: string): Promise<string | null> {
+  const key = faviconCacheKey(rawFaviconUrl)
+  const cached = await cacheGet<string>(key)
+  if (cached !== null) return cached === FAVICON_NONE ? null : cached
 
-  if (response.status >= 300 || !response.ok) return null
-
-  const rawMime = (response.headers.get('content-type') ?? '').split(';')[0].trim().toLowerCase()
-  const headerMime = normalizeIconMime(rawMime)
-  if (headerMime === 'image/svg+xml') return null
-  if (!ALLOWED_REHOST_MIMES.has(headerMime)) return null
-
-  let buffer: Buffer
-  try {
-    buffer = Buffer.from(await response.arrayBuffer())
-  } catch {
-    return null
-  }
-
-  const sniffed = sniffImageMime(buffer)
-  if (sniffed === null || sniffed !== headerMime) return null
-
-  try {
-    const { url } = await uploadImageBuffer(buffer, sniffed, 'link-previews')
-    return url
-  } catch {
-    return null
-  }
+  const proxied = await proxyFavicon(rawFaviconUrl)
+  await cacheSet(
+    key,
+    proxied ?? FAVICON_NONE,
+    proxied ? FAVICON_CACHE_TTL_S : FAVICON_CACHE_NEG_TTL_S
+  )
+  return proxied
 }
 
 /**
@@ -209,7 +209,7 @@ export async function unfurlExternalUrl(rawUrl: string): Promise<LinkPreview | n
     // Proxy OG image and favicon in parallel
     const [proxiedImage, proxiedFavicon] = await Promise.all([
       og.imageUrl ? proxyImage(og.imageUrl) : Promise.resolve(null),
-      og.faviconUrl ? proxyFavicon(og.faviconUrl) : Promise.resolve(null),
+      og.faviconUrl ? proxyFaviconCached(og.faviconUrl) : Promise.resolve(null),
     ])
 
     const preview: LinkPreview = {

--- a/apps/web/src/lib/server/content/unfurl.ts
+++ b/apps/web/src/lib/server/content/unfurl.ts
@@ -201,6 +201,11 @@ export async function unfurlExternalUrl(rawUrl: string): Promise<LinkPreview | n
 
     const og = parseOpenGraph(html, finalUrl)
 
+    // Short-circuit before any proxy work if there is nothing worth showing.
+    // og.faviconUrl is always set (fallback to /favicon.ico), so without this
+    // guard every dead page would cause an external fetch + orphaned S3 upload.
+    if (!og.title && !og.description && !og.imageUrl) return null
+
     // Proxy OG image and favicon in parallel
     const [proxiedImage, proxiedFavicon] = await Promise.all([
       og.imageUrl ? proxyImage(og.imageUrl) : Promise.resolve(null),

--- a/apps/web/src/lib/server/storage/s3.ts
+++ b/apps/web/src/lib/server/storage/s3.ts
@@ -17,7 +17,7 @@
  * typed with no `any`.
  */
 
-import { createHmac, timingSafeEqual } from 'node:crypto'
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto'
 import { config } from '@/lib/server/config'
 import { sniffImageMime } from '@/lib/server/content/magic-bytes'
 
@@ -407,13 +407,18 @@ export async function uploadImageFromFormData(
  * @param buffer - Image bytes
  * @param mimeType - Must be one of the allowed image types (see isAllowedImageType)
  * @param storagePrefix - Bucket prefix, e.g. "post-images" | "changelog-images" | "help-center"
+ * @param opts.contentAddressed - Derive the key from a hash of the bytes instead
+ *   of a timestamp, so re-uploading identical content overwrites one object
+ *   rather than accumulating duplicates. Used for highly repetitive assets like
+ *   favicons that the same source serves across many pages.
  * @returns Public URL to the uploaded object
  * @throws Error if the mime type is not allowed, the buffer is empty, or the upload fails
  */
 export async function uploadImageBuffer(
   buffer: Buffer,
   mimeType: string,
-  storagePrefix: string
+  storagePrefix: string,
+  opts?: { contentAddressed?: boolean }
 ): Promise<{ url: string }> {
   if (!isAllowedImageType(mimeType)) {
     throw new Error(`Invalid mime type for rehost: ${mimeType}`)
@@ -422,8 +427,9 @@ export async function uploadImageBuffer(
     throw new Error('Cannot upload empty buffer')
   }
   const ext = mimeType.split('/')[1] ?? 'bin'
-  const filename = `rehost-${Date.now()}.${ext}`
-  const key = generateStorageKey(storagePrefix, filename)
+  const key = opts?.contentAddressed
+    ? `${storagePrefix}/${createHash('sha256').update(buffer).digest('hex')}.${ext}`
+    : generateStorageKey(storagePrefix, `rehost-${Date.now()}.${ext}`)
   const url = await uploadObject(key, buffer, mimeType)
   return { url }
 }

--- a/apps/web/src/lib/server/storage/s3.ts
+++ b/apps/web/src/lib/server/storage/s3.ts
@@ -340,6 +340,7 @@ const ALLOWED_IMAGE_TYPES = new Set([
   'image/gif',
   'image/webp',
   'image/avif',
+  'image/x-icon',
 ])
 
 /**


### PR DESCRIPTION
## Summary

- **Backend**: ICO magic-byte detection added to the image sniffer; favicon URL extracted from `<link rel="icon/apple-touch-icon/shortcut icon">` tags (with `/favicon.ico` fallback); `proxyFavicon` runs in parallel with `proxyImage` and proxies favicons through our S3 pipeline with ICO MIME alias normalisation
- **Frontend**: Link preview card redesigned — 3px primary left accent bar, proxied favicon + site name row, title in `text-primary`, description, full OG image at bottom; capped at `max-w-sm` (384px) with `max-h-48 object-contain` on the image (full image visible, no crop, height-bounded)
- **Test**: `ALLOWED_REHOST_MIMES` mock in `unfurl.test.ts` synced with the real set (was missing `image/avif`)

## Test plan

- [x] All 4839 unit tests pass
- [x] Typecheck clean
- [x] Send a GitHub URL in the admin inbox — card shows favicon, blue title, description, OG image at bottom, width ≤ 384px
- [x] Send a YouTube URL in the widget — card height stays within viewport, full image visible