### PR TITLE
fix(settings): invalidate query cache after settings saves so toggles persist

### DIFF
--- a/apps/web/src/components/admin/settings/branding/use-branding-state.ts
+++ b/apps/web/src/components/admin/settings/branding/use-branding-state.ts
@@ -12,7 +12,7 @@ import {
   type ThemeMode,
   type ParsedCssVariables,
 } from '@/lib/shared/theme'
-import { updateThemeFn, updateCustomCssFn } from '@/lib/server/functions/settings'
+import { useSaveBrandingTheme } from '@/lib/client/mutations/settings'
 
 export const FONT_OPTIONS = [
   {
@@ -201,6 +201,7 @@ function buildInitialCss(initialCustomCss: string, initialThemeConfig: ThemeConf
 
 export function useBrandingState(options: UseBrandingStateOptions): BrandingState {
   const { initialLogoUrl, initialThemeConfig, initialCustomCss } = options
+  const { mutateAsync: saveBrandingTheme } = useSaveBrandingTheme()
 
   // ============================================
   // Primary state: CSS text is the source of truth
@@ -313,12 +314,13 @@ export function useBrandingState(options: UseBrandingStateOptions): BrandingStat
         dark: { ...darkMinimal, fontSans: font, radius: `${radius}rem` },
       }
 
-      await Promise.all([
-        updateThemeFn({
-          data: { brandingConfig: themeConfig as unknown as Record<string, unknown> },
-        }),
-        updateCustomCssFn({ data: { customCss: cssText } }),
-      ])
+      // The mutation hook invalidates the branding + customCss queries on success,
+      // so the next visit reflects the save instead of re-seeding the editor from
+      // the stale pre-save cache.
+      await saveBrandingTheme({
+        brandingConfig: themeConfig as unknown as Record<string, unknown>,
+        customCss: cssText,
+      })
 
       setSaveSuccess(true)
       setTimeout(() => setSaveSuccess(false), 2000)
@@ -327,7 +329,7 @@ export function useBrandingState(options: UseBrandingStateOptions): BrandingStat
     } finally {
       setIsSaving(false)
     }
-  }, [cssText, themeMode, font, radius, defaultLightMinimal, defaultDarkMinimal])
+  }, [cssText, themeMode, font, radius, defaultLightMinimal, defaultDarkMinimal, saveBrandingTheme])
 
   return {
     logoUrl,

--- a/apps/web/src/lib/client/mutations/__tests__/settings.test.ts
+++ b/apps/web/src/lib/client/mutations/__tests__/settings.test.ts
@@ -15,60 +15,70 @@ vi.mock('@tanstack/react-query', async () => {
 describe('settings config mutations cache invalidation', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // invalidateQueries returns a promise; onSuccess must return it so the
+    // mutation stays pending until the refetch settles (otherwise a fast
+    // navigate-away/back can re-read the still-stale cache via ensureQueryData).
+    invalidateQueries.mockResolvedValue(undefined)
   })
 
-  it('useUpdatePortalConfig.onSuccess invalidates the portalConfig query', async () => {
+  it('useUpdatePortalConfig.onSuccess awaits invalidation of the portalConfig query', async () => {
     const { useUpdatePortalConfig } = await import('../settings')
-    const mutation = useUpdatePortalConfig() as { onSuccess?: () => void }
+    const mutation = useUpdatePortalConfig() as { onSuccess?: () => unknown }
 
-    mutation.onSuccess?.()
+    const result = mutation.onSuccess?.()
 
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['settings', 'portalConfig'] })
+    expect(result).toBeInstanceOf(Promise)
   })
 
-  it('useUpdateModerationDefault.onSuccess invalidates the portalConfig query', async () => {
+  it('useUpdateModerationDefault.onSuccess awaits invalidation of the portalConfig query', async () => {
     const { useUpdateModerationDefault } = await import('../settings')
-    const mutation = useUpdateModerationDefault() as { onSuccess?: () => void }
+    const mutation = useUpdateModerationDefault() as { onSuccess?: () => unknown }
 
-    mutation.onSuccess?.()
+    const result = mutation.onSuccess?.()
 
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['settings', 'portalConfig'] })
+    expect(result).toBeInstanceOf(Promise)
   })
 
-  it('useUpdateWidgetConfig.onSuccess invalidates the widgetConfig query', async () => {
+  it('useUpdateWidgetConfig.onSuccess awaits invalidation of the widgetConfig query', async () => {
     const { useUpdateWidgetConfig } = await import('../settings')
-    const mutation = useUpdateWidgetConfig() as { onSuccess?: () => void }
+    const mutation = useUpdateWidgetConfig() as { onSuccess?: () => unknown }
 
-    mutation.onSuccess?.()
+    const result = mutation.onSuccess?.()
 
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['settings', 'widgetConfig'] })
+    expect(result).toBeInstanceOf(Promise)
   })
 
-  it('useRegenerateWidgetSecret.onSuccess invalidates the widgetSecret query', async () => {
+  it('useRegenerateWidgetSecret.onSuccess awaits invalidation of the widgetSecret query', async () => {
     const { useRegenerateWidgetSecret } = await import('../settings')
-    const mutation = useRegenerateWidgetSecret() as { onSuccess?: () => void }
+    const mutation = useRegenerateWidgetSecret() as { onSuccess?: () => unknown }
 
-    mutation.onSuccess?.()
+    const result = mutation.onSuccess?.()
 
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['settings', 'widgetSecret'] })
+    expect(result).toBeInstanceOf(Promise)
   })
 
-  it('useUpdateHelpCenterConfig.onSuccess invalidates the helpCenterConfig query', async () => {
+  it('useUpdateHelpCenterConfig.onSuccess awaits invalidation of the helpCenterConfig query', async () => {
     const { useUpdateHelpCenterConfig } = await import('../settings')
-    const mutation = useUpdateHelpCenterConfig() as { onSuccess?: () => void }
+    const mutation = useUpdateHelpCenterConfig() as { onSuccess?: () => unknown }
 
-    mutation.onSuccess?.()
+    const result = mutation.onSuccess?.()
 
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['settings', 'helpCenterConfig'] })
+    expect(result).toBeInstanceOf(Promise)
   })
 
-  it('useSaveBrandingTheme.onSuccess invalidates both branding and customCss queries', async () => {
+  it('useSaveBrandingTheme.onSuccess awaits invalidation of branding and customCss queries', async () => {
     const { useSaveBrandingTheme } = await import('../settings')
-    const mutation = useSaveBrandingTheme() as { onSuccess?: () => void }
+    const mutation = useSaveBrandingTheme() as { onSuccess?: () => unknown }
 
-    mutation.onSuccess?.()
+    const result = mutation.onSuccess?.()
 
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['settings', 'branding'] })
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['settings', 'customCss'] })
+    expect(result).toBeInstanceOf(Promise)
   })
 })

--- a/apps/web/src/lib/client/mutations/__tests__/settings.test.ts
+++ b/apps/web/src/lib/client/mutations/__tests__/settings.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const invalidateQueries = vi.fn()
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual =
+    await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query')
+  return {
+    ...actual,
+    useMutation: vi.fn((options: unknown) => options),
+    useQueryClient: vi.fn(() => ({ invalidateQueries })),
+  }
+})
+
+describe('settings config mutations cache invalidation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('useUpdatePortalConfig.onSuccess invalidates the portalConfig query', async () => {
+    const { useUpdatePortalConfig } = await import('../settings')
+    const mutation = useUpdatePortalConfig() as { onSuccess?: () => void }
+
+    mutation.onSuccess?.()
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['settings', 'portalConfig'] })
+  })
+
+  it('useUpdateModerationDefault.onSuccess invalidates the portalConfig query', async () => {
+    const { useUpdateModerationDefault } = await import('../settings')
+    const mutation = useUpdateModerationDefault() as { onSuccess?: () => void }
+
+    mutation.onSuccess?.()
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['settings', 'portalConfig'] })
+  })
+
+  it('useUpdateWidgetConfig.onSuccess invalidates the widgetConfig query', async () => {
+    const { useUpdateWidgetConfig } = await import('../settings')
+    const mutation = useUpdateWidgetConfig() as { onSuccess?: () => void }
+
+    mutation.onSuccess?.()
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['settings', 'widgetConfig'] })
+  })
+
+  it('useRegenerateWidgetSecret.onSuccess invalidates the widgetSecret query', async () => {
+    const { useRegenerateWidgetSecret } = await import('../settings')
+    const mutation = useRegenerateWidgetSecret() as { onSuccess?: () => void }
+
+    mutation.onSuccess?.()
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['settings', 'widgetSecret'] })
+  })
+
+  it('useUpdateHelpCenterConfig.onSuccess invalidates the helpCenterConfig query', async () => {
+    const { useUpdateHelpCenterConfig } = await import('../settings')
+    const mutation = useUpdateHelpCenterConfig() as { onSuccess?: () => void }
+
+    mutation.onSuccess?.()
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['settings', 'helpCenterConfig'] })
+  })
+
+  it('useSaveBrandingTheme.onSuccess invalidates both branding and customCss queries', async () => {
+    const { useSaveBrandingTheme } = await import('../settings')
+    const mutation = useSaveBrandingTheme() as { onSuccess?: () => void }
+
+    mutation.onSuccess?.()
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['settings', 'branding'] })
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['settings', 'customCss'] })
+  })
+})

--- a/apps/web/src/lib/client/mutations/settings.ts
+++ b/apps/web/src/lib/client/mutations/settings.ts
@@ -13,7 +13,14 @@ import {
   updateHeaderDisplayNameFn,
   saveLogoKeyFn,
   saveHeaderLogoKeyFn,
+  updatePortalConfigFn,
+  updateModerationDefaultFn,
+  updateWidgetConfigFn,
+  regenerateWidgetSecretFn,
+  updateThemeFn,
+  updateCustomCssFn,
 } from '@/lib/server/functions/settings'
+import { updateHelpCenterConfigFn } from '@/lib/server/functions/help-center-settings'
 import { getLogoUploadUrlFn, getHeaderLogoUploadUrlFn } from '@/lib/server/functions/uploads'
 import { settingsQueries } from '@/lib/client/queries/settings'
 
@@ -138,6 +145,92 @@ export function useUpdateHeaderDisplayName() {
     mutationFn: (name: string | null) => updateHeaderDisplayNameFn({ data: { name } }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: settingsQueries.headerLogo().queryKey })
+    },
+  })
+}
+
+// ============================================================================
+// Portal / widget / help-center config mutation hooks
+//
+// These configs are read via `settingsQueries.*` with a long staleTime, and the
+// route loaders warm them with `ensureQueryData` (which returns the cached value
+// without refetching a stale entry). So a write must invalidate its query, or the
+// loader-warmed cache keeps serving the pre-save value and settings pages that
+// seed `useState` from it revert on the next visit until a hard reload.
+// `router.invalidate()` alone does NOT fix this — it re-runs the same cached loader.
+// ============================================================================
+
+export function useUpdatePortalConfig() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: Parameters<typeof updatePortalConfigFn>[0]['data']) =>
+      updatePortalConfigFn({ data }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: settingsQueries.portalConfig().queryKey })
+    },
+  })
+}
+
+export function useUpdateModerationDefault() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: NonNullable<Parameters<typeof updateModerationDefaultFn>[0]>['data']) =>
+      updateModerationDefaultFn({ data }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: settingsQueries.portalConfig().queryKey })
+    },
+  })
+}
+
+export function useUpdateWidgetConfig() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: Parameters<typeof updateWidgetConfigFn>[0]['data']) =>
+      updateWidgetConfigFn({ data }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: settingsQueries.widgetConfig().queryKey })
+    },
+  })
+}
+
+export function useRegenerateWidgetSecret() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: () => regenerateWidgetSecretFn(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: settingsQueries.widgetSecret().queryKey })
+    },
+  })
+}
+
+export function useUpdateHelpCenterConfig() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: Parameters<typeof updateHelpCenterConfigFn>[0]['data']) =>
+      updateHelpCenterConfigFn({ data }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: settingsQueries.helpCenterConfig().queryKey })
+    },
+  })
+}
+
+export function useSaveBrandingTheme() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (input: { brandingConfig: Record<string, unknown>; customCss: string }) =>
+      Promise.all([
+        updateThemeFn({ data: { brandingConfig: input.brandingConfig } }),
+        updateCustomCssFn({ data: { customCss: input.customCss } }),
+      ]),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: settingsQueries.branding().queryKey })
+      queryClient.invalidateQueries({ queryKey: settingsQueries.customCss().queryKey })
     },
   })
 }

--- a/apps/web/src/lib/client/mutations/settings.ts
+++ b/apps/web/src/lib/client/mutations/settings.ts
@@ -158,6 +158,10 @@ export function useUpdateHeaderDisplayName() {
 // loader-warmed cache keeps serving the pre-save value and settings pages that
 // seed `useState` from it revert on the next visit until a hard reload.
 // `router.invalidate()` alone does NOT fix this — it re-runs the same cached loader.
+//
+// Each onSuccess RETURNS the invalidate promise so the mutation stays pending
+// until the refetch settles. Otherwise a fast navigate-away/back during the
+// in-flight refetch would re-read the still-stale cache via `ensureQueryData`.
 // ============================================================================
 
 export function useUpdatePortalConfig() {
@@ -166,9 +170,8 @@ export function useUpdatePortalConfig() {
   return useMutation({
     mutationFn: (data: Parameters<typeof updatePortalConfigFn>[0]['data']) =>
       updatePortalConfigFn({ data }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: settingsQueries.portalConfig().queryKey })
-    },
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: settingsQueries.portalConfig().queryKey }),
   })
 }
 
@@ -178,9 +181,8 @@ export function useUpdateModerationDefault() {
   return useMutation({
     mutationFn: (data: NonNullable<Parameters<typeof updateModerationDefaultFn>[0]>['data']) =>
       updateModerationDefaultFn({ data }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: settingsQueries.portalConfig().queryKey })
-    },
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: settingsQueries.portalConfig().queryKey }),
   })
 }
 
@@ -190,9 +192,8 @@ export function useUpdateWidgetConfig() {
   return useMutation({
     mutationFn: (data: Parameters<typeof updateWidgetConfigFn>[0]['data']) =>
       updateWidgetConfigFn({ data }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: settingsQueries.widgetConfig().queryKey })
-    },
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: settingsQueries.widgetConfig().queryKey }),
   })
 }
 
@@ -201,9 +202,8 @@ export function useRegenerateWidgetSecret() {
 
   return useMutation({
     mutationFn: () => regenerateWidgetSecretFn(),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: settingsQueries.widgetSecret().queryKey })
-    },
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: settingsQueries.widgetSecret().queryKey }),
   })
 }
 
@@ -213,9 +213,8 @@ export function useUpdateHelpCenterConfig() {
   return useMutation({
     mutationFn: (data: Parameters<typeof updateHelpCenterConfigFn>[0]['data']) =>
       updateHelpCenterConfigFn({ data }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: settingsQueries.helpCenterConfig().queryKey })
-    },
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: settingsQueries.helpCenterConfig().queryKey }),
   })
 }
 
@@ -228,9 +227,10 @@ export function useSaveBrandingTheme() {
         updateThemeFn({ data: { brandingConfig: input.brandingConfig } }),
         updateCustomCssFn({ data: { customCss: input.customCss } }),
       ]),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: settingsQueries.branding().queryKey })
-      queryClient.invalidateQueries({ queryKey: settingsQueries.customCss().queryKey })
-    },
+    onSuccess: () =>
+      Promise.all([
+        queryClient.invalidateQueries({ queryKey: settingsQueries.branding().queryKey }),
+        queryClient.invalidateQueries({ queryKey: settingsQueries.customCss().queryKey }),
+      ]),
   })
 }

--- a/apps/web/src/routes/admin/settings.conversations.tsx
+++ b/apps/web/src/routes/admin/settings.conversations.tsx
@@ -9,11 +9,8 @@ import type { OfficeHoursConfig } from '@/lib/shared/chat/types'
 import type { FeatureFlags } from '@/lib/shared/types/settings'
 import { useQuery } from '@tanstack/react-query'
 import { settingsQueries } from '@/lib/client/queries/settings'
-import {
-  getEmailChannelStatusFn,
-  updatePortalConfigFn,
-  updateWidgetConfigFn,
-} from '@/lib/server/functions/settings'
+import { useUpdatePortalConfig, useUpdateWidgetConfig } from '@/lib/client/mutations/settings'
+import { getEmailChannelStatusFn } from '@/lib/server/functions/settings'
 import { BackLink } from '@/components/ui/back-link'
 import { PageHeader } from '@/components/shared/page-header'
 import { SettingsCard } from '@/components/admin/settings/settings-card'
@@ -55,6 +52,8 @@ function ConversationsSettingsRoute() {
 
 function ConversationsSettingsPage() {
   const router = useRouter()
+  const updateWidgetConfig = useUpdateWidgetConfig()
+  const updatePortalConfig = useUpdatePortalConfig()
   const widgetConfigQuery = useSuspenseQuery(settingsQueries.widgetConfig())
   const portalConfigQuery = useSuspenseQuery(settingsQueries.portalConfig())
   const config = widgetConfigQuery.data
@@ -106,12 +105,12 @@ function ConversationsSettingsPage() {
 
   async function persist(
     field: string,
-    data: Parameters<typeof updateWidgetConfigFn>[0]['data'],
+    data: Parameters<typeof updateWidgetConfig.mutateAsync>[0],
     revert?: () => void
   ) {
     setSavingField(field)
     try {
-      await updateWidgetConfigFn({ data })
+      await updateWidgetConfig.mutateAsync(data)
       startTransition(() => router.invalidate())
     } catch {
       revert?.()
@@ -132,7 +131,7 @@ function ConversationsSettingsPage() {
     setPortalSupportEnabled(checked)
     setSavingField('portalSupport')
     try {
-      await updatePortalConfigFn({ data: { support: { enabled: checked } } })
+      await updatePortalConfig.mutateAsync({ support: { enabled: checked } })
       startTransition(() => router.invalidate())
     } catch {
       setPortalSupportEnabled(!checked)

--- a/apps/web/src/routes/admin/settings.help-center.tsx
+++ b/apps/web/src/routes/admin/settings.help-center.tsx
@@ -10,7 +10,7 @@ import { Switch } from '@/components/ui/switch'
 import { Label } from '@/components/ui/label'
 import { Input } from '@/components/ui/input'
 import { settingsQueries } from '@/lib/client/queries/settings'
-import { updateHelpCenterConfigFn } from '@/lib/server/functions/help-center-settings'
+import { useUpdateHelpCenterConfig } from '@/lib/client/mutations/settings'
 import type { HelpCenterConfig } from '@/lib/shared/types/settings'
 
 export const Route = createFileRoute('/admin/settings/help-center')({
@@ -27,6 +27,7 @@ export const Route = createFileRoute('/admin/settings/help-center')({
 
 function HelpCenterSettingsPage() {
   const router = useRouter()
+  const updateHelpCenterConfig = useUpdateHelpCenterConfig()
   const helpCenterConfigQuery = useSuspenseQuery(settingsQueries.helpCenterConfig())
   const config = helpCenterConfigQuery.data as HelpCenterConfig
 
@@ -51,9 +52,9 @@ function HelpCenterSettingsPage() {
   async function saveField(data: Record<string, unknown>) {
     setSaving(true)
     try {
-      await updateHelpCenterConfigFn({
-        data: data as Parameters<typeof updateHelpCenterConfigFn>[0]['data'],
-      })
+      await updateHelpCenterConfig.mutateAsync(
+        data as Parameters<typeof updateHelpCenterConfig.mutateAsync>[0]
+      )
       startTransition(() => router.invalidate())
     } finally {
       setSaving(false)

--- a/apps/web/src/routes/admin/settings.moderation.tsx
+++ b/apps/web/src/routes/admin/settings.moderation.tsx
@@ -2,12 +2,12 @@ import { useState, useTransition } from 'react'
 import { createFileRoute, useRouter } from '@tanstack/react-router'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { settingsQueries } from '@/lib/client/queries/settings'
+import { useUpdatePortalConfig, useUpdateModerationDefault } from '@/lib/client/mutations/settings'
 import { ShieldCheckIcon, ArrowPathIcon } from '@heroicons/react/24/solid'
 import { BackLink } from '@/components/ui/back-link'
 import { PageHeader } from '@/components/shared/page-header'
 import { SettingsCard } from '@/components/admin/settings/settings-card'
 import { Switch } from '@/components/ui/switch'
-import { updatePortalConfigFn, updateModerationDefaultFn } from '@/lib/server/functions/settings'
 import {
   requireApprovalToToggles,
   togglesToRequireApproval,
@@ -63,6 +63,8 @@ function PermissionToggle({
 
 function ModerationPage() {
   const router = useRouter()
+  const updatePortalConfig = useUpdatePortalConfig()
+  const updateModerationDefault = useUpdateModerationDefault()
   const portalConfigQuery = useSuspenseQuery(settingsQueries.portalConfig())
   const [isPending, startTransition] = useTransition()
 
@@ -84,7 +86,7 @@ function ModerationPage() {
   async function updateFeature(key: string, value: boolean, revert: () => void) {
     setSavingField(key)
     try {
-      await updatePortalConfigFn({ data: { features: { [key]: value } } })
+      await updatePortalConfig.mutateAsync({ features: { [key]: value } })
       startTransition(() => {
         router.invalidate()
       })
@@ -101,8 +103,8 @@ function ModerationPage() {
     setModerationToggles(next)
     setSavingField(`moderation-${key}`)
     try {
-      await updateModerationDefaultFn({
-        data: { requireApproval: togglesToRequireApproval(next) },
+      await updateModerationDefault.mutateAsync({
+        requireApproval: togglesToRequireApproval(next),
       })
       startTransition(() => router.invalidate())
     } catch {

--- a/apps/web/src/routes/admin/settings.portal.tsx
+++ b/apps/web/src/routes/admin/settings.portal.tsx
@@ -14,7 +14,7 @@ import { Button } from '@/components/ui/button'
 import { RichTextEditor } from '@/components/ui/rich-text-editor'
 import { PortalWelcomeCard } from '@/components/public/feedback/portal-welcome-card'
 import { settingsQueries } from '@/lib/client/queries/settings'
-import { updatePortalConfigFn } from '@/lib/server/functions/settings'
+import { useUpdatePortalConfig } from '@/lib/client/mutations/settings'
 import { useImageUpload } from '@/lib/client/hooks/use-image-upload'
 import { DEFAULT_PORTAL_CONFIG, PORTAL_WELCOME_CARD_TITLE_MAX } from '@/lib/shared/types/settings'
 import type {
@@ -38,13 +38,14 @@ export const Route = createFileRoute('/admin/settings/portal')({
 
 function PortalSettingsPage() {
   const router = useRouter()
+  const updatePortalConfig = useUpdatePortalConfig()
   const portalConfigQuery = useSuspenseQuery(settingsQueries.portalConfig())
   const config = portalConfigQuery.data as PortalConfig
 
   // Initialise once from the loader-warmed query and treat local state as
-  // authoritative until the user explicitly clicks Save. router.invalidate
-  // after a successful save refreshes the cache for the next visit, but the
-  // live form fields never get re-synced from it.
+  // authoritative until the user explicitly clicks Save. The mutation hook
+  // invalidates the portalConfig query so the cache reflects the saved value
+  // on the next visit; the live form fields are intentionally not re-synced.
   const [enabled, setEnabled] = useState(config.welcomeCard?.enabled ?? false)
   const [title, setTitle] = useState(
     config.welcomeCard?.title ?? DEFAULT_PORTAL_CONFIG.welcomeCard!.title
@@ -61,9 +62,7 @@ function PortalSettingsPage() {
   async function handleSave() {
     setSaving(true)
     try {
-      await updatePortalConfigFn({
-        data: { welcomeCard: { enabled, title, body } },
-      })
+      await updatePortalConfig.mutateAsync({ welcomeCard: { enabled, title, body } })
       startTransition(() => router.invalidate())
     } finally {
       setSaving(false)

--- a/apps/web/src/routes/admin/settings.widget.tsx
+++ b/apps/web/src/routes/admin/settings.widget.tsx
@@ -37,7 +37,7 @@ import {
 } from '@/components/ui/select'
 import { settingsQueries } from '@/lib/client/queries/settings'
 import { adminQueries } from '@/lib/client/queries/admin'
-import { updateWidgetConfigFn, regenerateWidgetSecretFn } from '@/lib/server/functions/settings'
+import { useUpdateWidgetConfig, useRegenerateWidgetSecret } from '@/lib/client/mutations/settings'
 import type { FeatureFlags } from '@/lib/shared/types/settings'
 
 export const Route = createFileRoute('/admin/settings/widget')({
@@ -119,6 +119,7 @@ function WidgetSettingsPage() {
 
 function WidgetToggle({ initialEnabled }: { initialEnabled: boolean }) {
   const router = useRouter()
+  const updateWidgetConfig = useUpdateWidgetConfig()
   const [isPending, startTransition] = useTransition()
   const [saving, setSaving] = useState(false)
   const [enabled, setEnabled] = useState(initialEnabled)
@@ -127,7 +128,7 @@ function WidgetToggle({ initialEnabled }: { initialEnabled: boolean }) {
     setEnabled(checked)
     setSaving(true)
     try {
-      await updateWidgetConfigFn({ data: { enabled: checked } })
+      await updateWidgetConfig.mutateAsync({ enabled: checked })
       startTransition(() => router.invalidate())
     } finally {
       setSaving(false)
@@ -184,6 +185,7 @@ function WidgetAppearanceControls({
   helpCenterFlagEnabled: boolean
 }) {
   const router = useRouter()
+  const updateWidgetConfig = useUpdateWidgetConfig()
   const [isPending, startTransition] = useTransition()
   const [saving, setSaving] = useState(false)
   const [defaultBoard, setDefaultBoard] = useState(config.defaultBoard ?? '')
@@ -196,10 +198,10 @@ function WidgetAppearanceControls({
 
   const showHelpTabToggle = helpCenterFlagEnabled && helpCenterEnabled
 
-  async function save(updates: Record<string, unknown>) {
+  async function save(updates: Parameters<typeof updateWidgetConfig.mutateAsync>[0]) {
     setSaving(true)
     try {
-      await updateWidgetConfigFn({ data: updates })
+      await updateWidgetConfig.mutateAsync(updates)
       startTransition(() => router.invalidate())
     } finally {
       setSaving(false)
@@ -270,7 +272,7 @@ function WidgetAppearanceControls({
                   setHomeTab(checked)
                   setSaving(true)
                   try {
-                    await updateWidgetConfigFn({ data: { tabs: { home: checked } } })
+                    await updateWidgetConfig.mutateAsync({ tabs: { home: checked } })
                     startTransition(() => router.invalidate())
                   } catch {
                     setHomeTab(!checked)
@@ -348,7 +350,7 @@ function WidgetAppearanceControls({
                     onTabsChange({ ...widgetTabs, help: checked })
                     setSaving(true)
                     try {
-                      await updateWidgetConfigFn({ data: { tabs: { help: checked } } })
+                      await updateWidgetConfig.mutateAsync({ tabs: { help: checked } })
                       startTransition(() => router.invalidate())
                     } catch {
                       setHelpTab(!checked)
@@ -657,6 +659,8 @@ function WidgetInstallation({
   baseUrl: string
 }) {
   const router = useRouter()
+  const updateWidgetConfig = useUpdateWidgetConfig()
+  const regenerateSecret = useRegenerateWidgetSecret()
   const [isPending, startTransition] = useTransition()
   const [saving, setSaving] = useState(false)
 
@@ -721,7 +725,7 @@ function WidgetInstallation({
     setVerifiedIdentityOnly(checked)
     setSaving(true)
     try {
-      await updateWidgetConfigFn({ data: { identifyVerification: checked } })
+      await updateWidgetConfig.mutateAsync({ identifyVerification: checked })
       startTransition(() => router.invalidate())
     } finally {
       setSaving(false)
@@ -744,7 +748,7 @@ function WidgetInstallation({
   async function handleRegenerate() {
     setRegenerating(true)
     try {
-      const newSecret = await regenerateWidgetSecretFn()
+      const newSecret = await regenerateSecret.mutateAsync()
       setCurrentSecret(newSecret)
       startTransition(() => router.invalidate())
     } finally {


### PR DESCRIPTION
## Summary

Toggling a permission on an admin settings page (for example "Allow anonymous interaction" on `/admin/settings/moderation`) saved successfully but reverted to the old value after navigating away and back. A hard refresh showed the correct saved value, confirming the DB write succeeded and the stale value came from the client cache.

## Root cause

Admin settings pages seed local `useState` from `settingsQueries.*`, which use a long `staleTime`. The route loaders warm those queries with `queryClient.ensureQueryData(...)`, and in TanStack Query v5 `ensureQueryData` returns a present-but-stale cache entry without refetching. After a save, the write went to the database but nothing invalidated the query, so the loader-warmed cache kept serving the pre-save value. On the next visit the component re-seeded `useState` from that stale cache and the toggle appeared to revert.

`router.invalidate()` does not fix this: it re-runs the loader, which reads the same cached `ensureQueryData`.

## Fix

The repo already has a mutation-hook convention in `apps/web/src/lib/client/mutations/settings.ts` (a `useMutation` whose `onSuccess` invalidates the matching `settingsQueries` key). The affected pages were the outliers calling raw server functions plus `router.invalidate()`. This PR brings them in line:

- Adds `useUpdatePortalConfig`, `useUpdateModerationDefault`, `useUpdateWidgetConfig`, `useRegenerateWidgetSecret`, `useUpdateHelpCenterConfig`, and `useSaveBrandingTheme`.
- Moderation, portal, help-center, conversations, widget, and branding pages call these hooks instead of raw server functions. Optimistic local state, reverts, and saving spinners are unchanged.

Because the invalidation key now rides with the write function inside each hook, a settings page can no longer save without refreshing its cache.

## Scope

Pages fixed: moderation (the reported one), portal welcome card, widget config and secret, help center config, conversations chat and portal-support toggles, and branding theme/CSS.

## Testing

- New `mutations/__tests__/settings.test.ts` asserts each hook invalidates the correct query key on success.
- `typecheck`, `lint`, and the client mutation and admin route test suites pass. The only failing suites in the repo are the pre-existing network-dependent DNS and SSRF tests, which are unrelated to this change.
