### PR TITLE
fix(auth): wrap /admin/login in PortalIntlProvider (#232)

### DIFF
--- a/apps/web/src/routes/__tests__/admin.login.intl.test.tsx
+++ b/apps/web/src/routes/__tests__/admin.login.intl.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment happy-dom
+import type { ComponentType, ReactNode } from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+
+// Stub the router: `createFileRoute` so we can drive `useLoaderData`, and
+// `Link` so the page's "use a recovery code" link renders without a real
+// RouterProvider.
+const useLoaderDataMock = vi.fn()
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => (opts: Record<string, unknown>) => ({
+    ...opts,
+    // Lazy indirection: the factory is hoisted above `useLoaderDataMock`, so
+    // read it at call time (render) rather than at admin.login import time.
+    useLoaderData: () => useLoaderDataMock(),
+  }),
+  Link: ({ to, children }: { to: unknown; children: ReactNode }) => (
+    <a href={typeof to === 'string' ? to : '#'}>{children}</a>
+  ),
+  redirect: (opts: unknown) => opts,
+  // PortalBrandMark (via AdminAuthShell) reads branding off the root context;
+  // an empty context falls back to the default Quackback mark.
+  useRouteContext: () => ({}),
+}))
+
+// `useServerFn(lookupAuthMethodsFn)` is the email→methods classifier we drive.
+// `createServerFn` is only needed so locale.ts's module-load `getPortalLocaleFn`
+// doesn't crash on import once the fix wires it in.
+const lookupMock = vi.fn()
+vi.mock('@tanstack/react-start', () => ({
+  useServerFn: () => lookupMock,
+  createServerFn: () => ({ handler: () => vi.fn() }),
+}))
+
+vi.mock('@/lib/server/functions/auth', () => ({
+  lookupAuthMethodsFn: vi.fn(),
+  SSO_UNAVAILABLE_MESSAGE: 'SSO unavailable',
+}))
+
+// Plain constant map in a server path — stub to avoid pulling server-only deps.
+vi.mock('@/lib/server/auth/redirect-errors', () => ({ AUTH_BLOCK_MESSAGES: {} }))
+
+vi.mock('@/lib/client/auth-client', () => ({
+  authClient: {
+    signIn: { email: vi.fn(), emailOtp: vi.fn(), oauth2: vi.fn() },
+    signUp: { email: vi.fn() },
+    requestPasswordReset: vi.fn(),
+  },
+}))
+
+vi.mock('@/components/auth/oauth-buttons', () => ({
+  OAuthButtons: () => <div data-testid="oauth-buttons" />,
+  getEnabledOAuthProviders: vi.fn(() => []),
+}))
+
+// input-otp schedules real setTimeouts on mount that can fire after teardown
+// under happy-dom; the password step we exercise never shows it, but
+// PortalAuthForm imports it at module load — stub to a plain input.
+vi.mock('@/components/ui/input-otp', () => ({
+  InputOTP: (props: Record<string, unknown>) => <input {...(props as object)} />,
+  InputOTPGroup: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  InputOTPSlot: () => null,
+  InputOTPSeparator: () => null,
+}))
+
+import { Route } from '../admin.login'
+
+// `createFileRoute` is mocked above, so at runtime `Route` is the plain options
+// object — reach its `component` through `unknown` since the real route type
+// doesn't surface it.
+const AdminLoginPage = (Route as unknown as { component: ComponentType }).component
+
+describe('/admin/login — IntlProvider regression (#232)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useLoaderDataMock.mockReturnValue({
+      errorMessage: null,
+      safeCallbackUrl: '/admin',
+      authConfig: { password: true, magicLink: false },
+      locale: 'en',
+    })
+  })
+  afterEach(() => cleanup())
+
+  // TeamLoginForm hands off to PortalAuthForm (which calls `useIntl()`) once the
+  // typed email is classified as `methods`. Before this fix /admin/login had no
+  // PortalIntlProvider ancestor, so that handoff threw "Could not find required
+  // `intl` object", crashing every non-SSO admin sign-in on 0.12.0.
+  it('renders the methods step (PortalAuthForm) without an intl-provider crash', async () => {
+    lookupMock.mockResolvedValue({
+      kind: 'methods',
+      authConfig: { password: true, magicLink: false },
+      ssoEnabled: false,
+    })
+
+    render(<AdminLoginPage />)
+
+    fireEvent.change(screen.getByLabelText(/work email/i), {
+      target: { value: 'admin@example.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }))
+
+    await waitFor(() => expect(lookupMock).toHaveBeenCalledOnce())
+
+    // PortalAuthForm rendered under the provider — its intl-labelled password
+    // field is present, proving useIntl() resolved instead of throwing.
+    expect(await screen.findByLabelText(/password/i)).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/routes/admin.login.tsx
+++ b/apps/web/src/routes/admin.login.tsx
@@ -2,10 +2,12 @@ import { createFileRoute, Link, redirect } from '@tanstack/react-router'
 import { z } from 'zod'
 import { TeamLoginForm } from '@/components/auth/team-login-form'
 import { AdminAuthShell } from '@/components/auth/admin-auth-shell'
+import { PortalIntlProvider } from '@/components/portal-intl-provider'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { ExclamationCircleIcon } from '@heroicons/react/24/solid'
 import { isSafeCallbackUrl } from '@/lib/shared/routing'
 import { AUTH_BLOCK_MESSAGES } from '@/lib/server/auth/redirect-errors'
+import { getPortalLocaleFn } from '@/lib/server/functions/locale'
 
 // Pre-check codes (password_method_not_allowed, rate_limited, etc.)
 // share copy with the portal-side auth-client hook via
@@ -67,10 +69,17 @@ export const Route = createFileRoute('/admin/login')({
 
     const authConfig = settings.publicAuthConfig.oauth
 
+    // `<TeamLoginForm>` hands off to `<PortalAuthForm>`, which calls
+    // `useIntl()` — so the page needs a `PortalIntlProvider` ancestor just
+    // like /auth/login. Resolve the locale here so the provider has it on
+    // first paint (no flash of the wrong language).
+    const locale = await getPortalLocaleFn()
+
     return {
       errorMessage,
       safeCallbackUrl,
       authConfig,
+      locale,
     }
   },
   component: AdminLoginPage,
@@ -88,26 +97,28 @@ export const Route = createFileRoute('/admin/login')({
  * Layer A registration filter skips disabled providers.
  */
 function AdminLoginPage() {
-  const { errorMessage, safeCallbackUrl, authConfig } = Route.useLoaderData()
+  const { errorMessage, safeCallbackUrl, authConfig, locale } = Route.useLoaderData()
 
   return (
-    <AdminAuthShell heading="Sign in to your workspace">
-      {errorMessage && (
-        <Alert variant="destructive">
-          <ExclamationCircleIcon className="h-4 w-4" />
-          <AlertDescription>{errorMessage}</AlertDescription>
-        </Alert>
-      )}
-      <TeamLoginForm callbackUrl={safeCallbackUrl} authConfig={authConfig} />
-      <p className="mt-6 text-center text-xs text-muted-foreground">
-        SSO unavailable?{' '}
-        <Link
-          to="/auth/recovery"
-          className="font-medium text-foreground hover:underline underline-offset-4"
-        >
-          Use a recovery code
-        </Link>
-      </p>
-    </AdminAuthShell>
+    <PortalIntlProvider locale={locale}>
+      <AdminAuthShell heading="Sign in to your workspace">
+        {errorMessage && (
+          <Alert variant="destructive">
+            <ExclamationCircleIcon className="h-4 w-4" />
+            <AlertDescription>{errorMessage}</AlertDescription>
+          </Alert>
+        )}
+        <TeamLoginForm callbackUrl={safeCallbackUrl} authConfig={authConfig} />
+        <p className="mt-6 text-center text-xs text-muted-foreground">
+          SSO unavailable?{' '}
+          <Link
+            to="/auth/recovery"
+            className="font-medium text-foreground hover:underline underline-offset-4"
+          >
+            Use a recovery code
+          </Link>
+        </p>
+      </AdminAuthShell>
+    </PortalIntlProvider>
   )
 }


### PR DESCRIPTION
## Summary

Fixes #232 — on 0.12.0, every non-SSO admin sign-in (email/password **and** custom OIDC) crashes on an error page showing `[React Intl] Could not find required \`intl\` object`.

## Root cause

`/admin/login` renders `TeamLoginForm → PortalAuthForm`. Once the typed email is classified as `methods` (no verified-SSO-domain match), `TeamLoginForm` hands off to `PortalAuthForm`, which calls `useIntl()`. That `useIntl()` dependency was **added to the auth forms in the 0.12.0 i18n rollout**, but `/admin/login` was never given an `IntlProvider` ancestor — so the handoff throws and bubbles to the root error page. The sibling `/auth/*` routes (login/signup/recovery/reset-password) all already wrap; this one was missed. This is a clean 0.11.0 to 0.12.0 regression (rolling the image back to 0.11.0 against a 0.12.0 DB resolves it).

Note: the reporter's hypothesis was that the error boundary itself isn't wrapped in `IntlProvider`. That's not it — the root error page (`DefaultErrorPage`) is intl-free and renders fine; the `[React Intl]` text is the **underlying** error's message surfaced in its "Technical details". So the boundary needs no change; removing the underlying throw is the fix. `admin.signup` only redirects, so `/admin/login` was the sole gap.

## Fix

Mirror the established `/auth/login` pattern: resolve the locale in the route loader via `getPortalLocaleFn()` and wrap the page in `PortalIntlProvider`.

## Testing

- New red/green regression test `admin.login.intl.test.tsx` renders the real `AdminLoginPage`, drives it to the methods step, and asserts the form renders. It fails with the exact `<PortalAuthForm>` intl crash before the fix and passes after.
- `typecheck` clean, `eslint` clean, 62/62 tests pass across `routes/__tests__` + `components/auth`.