### PR TITLE
fix(auth): hide email entry on portal sign-in when only OAuth is enabled (#231)

### DIFF
--- a/apps/web/src/components/auth/__tests__/portal-auth-form-inline.test.tsx
+++ b/apps/web/src/components/auth/__tests__/portal-auth-form-inline.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment happy-dom
+import type { ReactNode } from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render as rtlRender, screen, fireEvent, cleanup } from '@testing-library/react'
+import { IntlProvider } from 'react-intl'
+
+// lookup is only invoked on Continue; the Stage-1 render under test never calls it.
+vi.mock('@tanstack/react-start', () => ({ useServerFn: () => vi.fn() }))
+
+vi.mock('@/lib/server/functions/auth', () => ({
+  lookupAuthMethodsFn: vi.fn(),
+  SSO_UNAVAILABLE_MESSAGE: 'SSO unavailable',
+}))
+
+vi.mock('@/lib/server/auth/client', () => ({ stashTwoFactorCallbackUrl: vi.fn() }))
+
+vi.mock('@/lib/client/auth-client', () => ({
+  authClient: {
+    signIn: { email: vi.fn(), emailOtp: vi.fn(), oauth2: vi.fn(), social: vi.fn() },
+    signUp: { email: vi.fn() },
+    requestPasswordReset: vi.fn(),
+  },
+}))
+
+// Control which providers Stage 1 shows; the form renders its own OAuthButton.
+const getEnabledOAuthProvidersMock = vi.fn(() => [] as Array<Record<string, unknown>>)
+vi.mock('@/components/auth/oauth-buttons', () => ({
+  getEnabledOAuthProviders: () => getEnabledOAuthProvidersMock(),
+  getOAuthRedirectUrl: vi.fn(),
+}))
+
+// usePopupTracker opens a BroadcastChannel on mount — stub the whole module.
+vi.mock('@/lib/client/hooks/use-auth-broadcast', () => ({
+  usePopupTracker: () => ({
+    trackPopup: vi.fn(),
+    clearPopup: vi.fn(),
+    hasPopup: () => false,
+    focusPopup: vi.fn(),
+  }),
+  openAuthPopup: vi.fn(),
+  postAuthSuccess: vi.fn(),
+}))
+
+// OtpCodeStep imports input-otp, which schedules real setTimeouts on mount.
+vi.mock('@/components/ui/input-otp', () => ({
+  InputOTP: (props: Record<string, unknown>) => <input {...(props as object)} />,
+  InputOTPGroup: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  InputOTPSlot: () => null,
+  InputOTPSeparator: () => null,
+}))
+
+import { PortalAuthFormInline } from '../portal-auth-form-inline'
+
+function render(ui: React.ReactElement) {
+  return rtlRender(
+    <IntlProvider locale="en" defaultLocale="en" messages={{}}>
+      {ui}
+    </IntlProvider>
+  )
+}
+
+describe('PortalAuthFormInline — OAuth-only Stage 1 (#231)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getEnabledOAuthProvidersMock.mockReturnValue([])
+  })
+  afterEach(() => cleanup())
+
+  // With both email methods off, the email field at Stage 1 has nowhere to
+  // route, so only the OAuth provider buttons should render.
+  it('hides the email field, divider, and create-account when only OAuth is enabled', () => {
+    getEnabledOAuthProvidersMock.mockReturnValue([
+      { id: 'custom-oidc', name: 'Custom OIDC', type: 'generic-oauth' },
+    ])
+    render(
+      <PortalAuthFormInline
+        mode="login"
+        authConfig={{
+          found: true,
+          oauth: { password: false, magicLink: false, 'custom-oidc': true },
+        }}
+        onModeSwitch={() => {}}
+      />
+    )
+    expect(screen.getByRole('button', { name: /sign in with custom oidc/i })).toBeInTheDocument()
+    expect(screen.queryByLabelText(/email/i)).not.toBeInTheDocument()
+    expect(screen.queryByText('or')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /create an account/i })).not.toBeInTheDocument()
+  })
+
+  it('shows a no-methods message when neither email methods nor OAuth are configured', () => {
+    render(
+      <PortalAuthFormInline
+        mode="login"
+        authConfig={{ found: true, oauth: { password: false, magicLink: false } }}
+      />
+    )
+    expect(screen.queryByLabelText(/email/i)).not.toBeInTheDocument()
+    expect(screen.getByText(/no sign-in methods are configured/i)).toBeInTheDocument()
+  })
+
+  // The OAuth tiles set `error` on popup/redirect failure; that error must show
+  // even in OAuth-only setups where the email form (its old home) is hidden.
+  it('surfaces an OAuth provider error when the email form is hidden', async () => {
+    getEnabledOAuthProvidersMock.mockReturnValue([
+      { id: 'custom-oidc', name: 'Custom OIDC', type: 'generic-oauth' },
+    ])
+    const broadcast = await import('@/lib/client/hooks/use-auth-broadcast')
+    vi.mocked(broadcast.openAuthPopup).mockReturnValueOnce({
+      location: { href: '' },
+      close: vi.fn(),
+    } as unknown as Window)
+    // getOAuthRedirectUrl (mocked) returns undefined → initiateOAuth's error path.
+    render(
+      <PortalAuthFormInline
+        mode="login"
+        authConfig={{
+          found: true,
+          oauth: { password: false, magicLink: false, 'custom-oidc': true },
+        }}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /sign in with custom oidc/i }))
+    expect(await screen.findByText(/failed to initiate sign in/i)).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/auth/__tests__/portal-auth-form.test.tsx
+++ b/apps/web/src/components/auth/__tests__/portal-auth-form.test.tsx
@@ -421,3 +421,42 @@ describe('PortalAuthForm — methods step variants', () => {
     ).not.toBeInTheDocument()
   })
 })
+
+describe('PortalAuthForm — OAuth-only Stage 1 (#231)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+  afterEach(() => cleanup())
+
+  // With both email methods off, the email field at Stage 1 has nowhere to
+  // route (Stage 2 has no password/magic-link sub-screen), so it must not
+  // render — only the OAuth provider buttons should show.
+  it('hides the email field, divider, and create-account when only OAuth is enabled', async () => {
+    const oauth = await import('../oauth-buttons')
+    vi.mocked(oauth.getEnabledOAuthProviders).mockReturnValueOnce([
+      { id: 'custom-oidc', name: 'Custom OIDC', type: 'generic-oauth' },
+    ])
+    render(
+      <PortalAuthForm
+        authConfig={{ password: false, magicLink: false, 'custom-oidc': true }}
+        onModeSwitch={() => {}}
+      />
+    )
+    // The provider button is the only sign-in path.
+    expect(screen.getByTestId('oauth-buttons')).toBeInTheDocument()
+    // The dead-end email entry must be gone (the email-submit Continue lives
+    // inside this form, so its absence follows from the field's).
+    expect(screen.queryByLabelText(/email/i)).not.toBeInTheDocument()
+    // No dangling "or" divider under the tiles, and no create-account link.
+    expect(screen.queryByText('or')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /create an account/i })).not.toBeInTheDocument()
+  })
+
+  // Defensive: the server blocks saving zero methods, but if it ever happens
+  // the form should explain rather than render a dead-end email field.
+  it('shows a no-methods message when neither email methods nor OAuth are configured', () => {
+    render(<PortalAuthForm authConfig={{ password: false, magicLink: false }} />)
+    expect(screen.queryByLabelText(/email/i)).not.toBeInTheDocument()
+    expect(screen.getByText(/no sign-in methods are configured/i)).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/auth/portal-auth-form-inline.tsx
+++ b/apps/web/src/components/auth/portal-auth-form-inline.tsx
@@ -528,6 +528,11 @@ export function PortalAuthFormInline({
     authConfig?.customProviderNames
   )
   const showOAuth = enabledProviders.length > 0
+  // Email entry (and the "or" divider + create-account link) only makes sense
+  // when a portal email method is enabled (password or magic-link); with both
+  // off it dead-ends at an empty Stage 2, so show only the OAuth tiles. Team
+  // members (incl. SSO) sign in at /admin/login, not here. (#231)
+  const emailEntryEnabled = passwordEnabled || magicLinkEnabled
 
   // Loading invitation
   if (loadingInvitation) {
@@ -605,6 +610,10 @@ export function PortalAuthFormInline({
   if (view.stage === 'email') {
     return (
       <div className="space-y-6">
+        {/* OAuth tile failures (initiateOAuth) set `error` too, so surface it
+            above both paths — not only inside the email form, which is hidden in
+            OAuth-only setups. */}
+        {error && <FormError message={error} />}
         {showOAuth && (
           <>
             <div className="space-y-3">
@@ -623,86 +632,103 @@ export function PortalAuthFormInline({
                 )
               })}
             </div>
-            <div className="relative">
-              <div className="absolute inset-0 flex items-center">
-                <div className="w-full border-t border-border" />
+            {/* Divider only when an email path follows the tiles. */}
+            {emailEntryEnabled && (
+              <div className="relative">
+                <div className="absolute inset-0 flex items-center">
+                  <div className="w-full border-t border-border" />
+                </div>
+                <div className="relative flex justify-center text-sm">
+                  <span className="bg-background px-2 text-muted-foreground">
+                    <FormattedMessage id="portal.auth.dividerOr" defaultMessage="or" />
+                  </span>
+                </div>
               </div>
-              <div className="relative flex justify-center text-sm">
-                <span className="bg-background px-2 text-muted-foreground">
-                  <FormattedMessage id="portal.auth.dividerOr" defaultMessage="or" />
-                </span>
-              </div>
-            </div>
+            )}
           </>
         )}
 
-        <form onSubmit={continueFromEmail} className="space-y-4">
-          {error && <FormError message={error} />}
-          <div className="space-y-2">
-            <label htmlFor="inline-email" className="text-sm font-medium">
-              <FormattedMessage id="portal.auth.email.label" defaultMessage="Email" />
-            </label>
-            <Input
-              id="inline-email"
-              type="email"
-              autoComplete="email"
-              autoFocus
-              placeholder={intl.formatMessage({
-                id: 'portal.auth.email.placeholder',
-                defaultMessage: 'you@example.com',
-              })}
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              disabled={loadingAction !== null}
-              required
-            />
-          </div>
-          <Button
-            type="submit"
-            disabled={loadingAction !== null || !email.trim()}
-            className="w-full"
-          >
-            {loadingAction === 'continue' ? (
-              <ArrowPathIcon className="h-4 w-4 animate-spin" />
-            ) : (
-              <>
-                <FormattedMessage id="portal.auth.continue" defaultMessage="Continue" /> &rarr;
-              </>
-            )}
-          </Button>
-        </form>
+        {emailEntryEnabled && (
+          <>
+            <form onSubmit={continueFromEmail} className="space-y-4">
+              <div className="space-y-2">
+                <label htmlFor="inline-email" className="text-sm font-medium">
+                  <FormattedMessage id="portal.auth.email.label" defaultMessage="Email" />
+                </label>
+                <Input
+                  id="inline-email"
+                  type="email"
+                  autoComplete="email"
+                  autoFocus
+                  placeholder={intl.formatMessage({
+                    id: 'portal.auth.email.placeholder',
+                    defaultMessage: 'you@example.com',
+                  })}
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  disabled={loadingAction !== null}
+                  required
+                />
+              </div>
+              <Button
+                type="submit"
+                disabled={loadingAction !== null || !email.trim()}
+                className="w-full"
+              >
+                {loadingAction === 'continue' ? (
+                  <ArrowPathIcon className="h-4 w-4 animate-spin" />
+                ) : (
+                  <>
+                    <FormattedMessage id="portal.auth.continue" defaultMessage="Continue" /> &rarr;
+                  </>
+                )}
+              </Button>
+            </form>
 
-        {onModeSwitch && (
-          <p className="text-center text-sm text-muted-foreground">
-            {mode === 'login' ? (
-              <>
-                <FormattedMessage id="portal.auth.switch.newHere" defaultMessage="New here?" />{' '}
-                <button
-                  type="button"
-                  onClick={() => onModeSwitch('signup')}
-                  className="text-primary hover:underline font-medium"
-                >
-                  <FormattedMessage
-                    id="portal.auth.switch.createAccount"
-                    defaultMessage="Create an account"
-                  />
-                </button>
-              </>
-            ) : (
-              <>
-                <FormattedMessage
-                  id="portal.auth.switch.haveAccount"
-                  defaultMessage="Have an account?"
-                />{' '}
-                <button
-                  type="button"
-                  onClick={() => onModeSwitch('login')}
-                  className="text-primary hover:underline font-medium"
-                >
-                  <FormattedMessage id="portal.auth.switch.signIn" defaultMessage="Sign in" />
-                </button>
-              </>
+            {onModeSwitch && (
+              <p className="text-center text-sm text-muted-foreground">
+                {mode === 'login' ? (
+                  <>
+                    <FormattedMessage id="portal.auth.switch.newHere" defaultMessage="New here?" />{' '}
+                    <button
+                      type="button"
+                      onClick={() => onModeSwitch('signup')}
+                      className="text-primary hover:underline font-medium"
+                    >
+                      <FormattedMessage
+                        id="portal.auth.switch.createAccount"
+                        defaultMessage="Create an account"
+                      />
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    <FormattedMessage
+                      id="portal.auth.switch.haveAccount"
+                      defaultMessage="Have an account?"
+                    />{' '}
+                    <button
+                      type="button"
+                      onClick={() => onModeSwitch('login')}
+                      className="text-primary hover:underline font-medium"
+                    >
+                      <FormattedMessage id="portal.auth.switch.signIn" defaultMessage="Sign in" />
+                    </button>
+                  </>
+                )}
+              </p>
             )}
+          </>
+        )}
+
+        {/* Misconfiguration safety net — updatePortalConfig blocks saving zero
+            methods, but never strand the user on a blank card if it happens. */}
+        {!showOAuth && !emailEntryEnabled && (
+          <p className="text-center text-sm text-muted-foreground">
+            <FormattedMessage
+              id="portal.auth.noMethods"
+              defaultMessage="No sign-in methods are configured. Contact your workspace administrator."
+            />
           </p>
         )}
       </div>

--- a/apps/web/src/components/auth/portal-auth-form.tsx
+++ b/apps/web/src/components/auth/portal-auth-form.tsx
@@ -467,88 +467,112 @@ export function PortalAuthForm({
   // Stage 1 — email entry
   // ============================================================
   if (view.stage === 'email') {
+    const showOAuth = oauthProviders.length > 0
+    // Email entry (and the "or" divider + create-account link) only makes sense
+    // when a portal email method is enabled (password or magic-link); with both
+    // off it dead-ends at an empty Stage 2, so show only the OAuth tiles. Team
+    // members (incl. SSO) sign in at /admin/login, not here. (#231)
+    const emailEntryEnabled = passwordEnabled || magicLinkEnabled
     return (
       <div className="space-y-6">
         {/* OAuth tiles bypass Stage 2 entirely. */}
-        {oauthProviders.length > 0 && (
+        {showOAuth && (
           <>
             <OAuthButtons callbackUrl={callbackUrl} providers={oauthProviders} />
-            <div className="relative">
-              <div className="absolute inset-0 flex items-center">
-                <div className="w-full border-t border-border" />
+            {/* Divider only when an email path follows the tiles. */}
+            {emailEntryEnabled && (
+              <div className="relative">
+                <div className="absolute inset-0 flex items-center">
+                  <div className="w-full border-t border-border" />
+                </div>
+                <div className="relative flex justify-center text-sm">
+                  <span className="bg-background px-2 text-muted-foreground">
+                    <FormattedMessage id="portal.auth.dividerOr" defaultMessage="or" />
+                  </span>
+                </div>
               </div>
-              <div className="relative flex justify-center text-sm">
-                <span className="bg-background px-2 text-muted-foreground">
-                  <FormattedMessage id="portal.auth.dividerOr" defaultMessage="or" />
-                </span>
-              </div>
-            </div>
+            )}
           </>
         )}
 
-        <form onSubmit={continueFromEmail} className="space-y-4">
-          {error && <FormError message={error} />}
-          <div className="space-y-2">
-            <label htmlFor="email" className="text-sm font-medium">
-              <FormattedMessage id="portal.auth.email.label" defaultMessage="Email" />
-            </label>
-            <Input
-              id="email"
-              type="email"
-              autoComplete="email"
-              autoFocus
-              placeholder={intl.formatMessage({
-                id: 'portal.auth.email.placeholder',
-                defaultMessage: 'you@example.com',
-              })}
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              disabled={continueLoading}
-              required
-            />
-          </div>
-          <Button type="submit" disabled={continueLoading || !email.trim()} className="w-full">
-            {continueLoading ? (
-              <ArrowPathIcon className="h-4 w-4 animate-spin" />
-            ) : (
-              <>
-                <FormattedMessage id="portal.auth.continue" defaultMessage="Continue" /> &rarr;
-              </>
-            )}
-          </Button>
-        </form>
+        {emailEntryEnabled && (
+          <>
+            <form onSubmit={continueFromEmail} className="space-y-4">
+              {error && <FormError message={error} />}
+              <div className="space-y-2">
+                <label htmlFor="email" className="text-sm font-medium">
+                  <FormattedMessage id="portal.auth.email.label" defaultMessage="Email" />
+                </label>
+                <Input
+                  id="email"
+                  type="email"
+                  autoComplete="email"
+                  autoFocus
+                  placeholder={intl.formatMessage({
+                    id: 'portal.auth.email.placeholder',
+                    defaultMessage: 'you@example.com',
+                  })}
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  disabled={continueLoading}
+                  required
+                />
+              </div>
+              <Button type="submit" disabled={continueLoading || !email.trim()} className="w-full">
+                {continueLoading ? (
+                  <ArrowPathIcon className="h-4 w-4 animate-spin" />
+                ) : (
+                  <>
+                    <FormattedMessage id="portal.auth.continue" defaultMessage="Continue" /> &rarr;
+                  </>
+                )}
+              </Button>
+            </form>
 
-        {onModeSwitch && (
-          <p className="text-center text-sm text-muted-foreground">
-            {mode === 'login' ? (
-              <>
-                <FormattedMessage id="portal.auth.switch.newHere" defaultMessage="New here?" />{' '}
-                <button
-                  type="button"
-                  onClick={() => onModeSwitch('signup')}
-                  className="text-primary hover:underline font-medium"
-                >
-                  <FormattedMessage
-                    id="portal.auth.switch.createAccount"
-                    defaultMessage="Create an account"
-                  />
-                </button>
-              </>
-            ) : (
-              <>
-                <FormattedMessage
-                  id="portal.auth.switch.haveAccount"
-                  defaultMessage="Have an account?"
-                />{' '}
-                <button
-                  type="button"
-                  onClick={() => onModeSwitch('login')}
-                  className="text-primary hover:underline font-medium"
-                >
-                  <FormattedMessage id="portal.auth.switch.signIn" defaultMessage="Sign in" />
-                </button>
-              </>
+            {onModeSwitch && (
+              <p className="text-center text-sm text-muted-foreground">
+                {mode === 'login' ? (
+                  <>
+                    <FormattedMessage id="portal.auth.switch.newHere" defaultMessage="New here?" />{' '}
+                    <button
+                      type="button"
+                      onClick={() => onModeSwitch('signup')}
+                      className="text-primary hover:underline font-medium"
+                    >
+                      <FormattedMessage
+                        id="portal.auth.switch.createAccount"
+                        defaultMessage="Create an account"
+                      />
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    <FormattedMessage
+                      id="portal.auth.switch.haveAccount"
+                      defaultMessage="Have an account?"
+                    />{' '}
+                    <button
+                      type="button"
+                      onClick={() => onModeSwitch('login')}
+                      className="text-primary hover:underline font-medium"
+                    >
+                      <FormattedMessage id="portal.auth.switch.signIn" defaultMessage="Sign in" />
+                    </button>
+                  </>
+                )}
+              </p>
             )}
+          </>
+        )}
+
+        {/* Misconfiguration safety net — updatePortalConfig blocks saving zero
+            methods, but never strand the user on a blank card if it happens. */}
+        {!showOAuth && !emailEntryEnabled && (
+          <p className="text-center text-sm text-muted-foreground">
+            <FormattedMessage
+              id="portal.auth.noMethods"
+              defaultMessage="No sign-in methods are configured. Contact your workspace administrator."
+            />
           </p>
         )}
       </div>

--- a/apps/web/src/routes/admin.login.tsx
+++ b/apps/web/src/routes/admin.login.tsx
@@ -95,6 +95,12 @@ export const Route = createFileRoute('/admin/login')({
  * `<TeamLoginForm>` (invitation-claim mechanism + SSO break-glass).
  * Password and other-OAuth pass through whatever the tenant configured;
  * Layer A registration filter skips disabled providers.
+ *
+ * Counterpart: the portal/end-user sign-in (`<PortalAuthForm>` on
+ * /auth/login and `<PortalAuthFormInline>` in the portal dialog) only
+ * surfaces the workspace's public methods and can hide email entry when
+ * none are enabled — team members always have this always-on email + SSO
+ * path here.
  */
 function AdminLoginPage() {
   const { errorMessage, safeCallbackUrl, authConfig, locale } = Route.useLoaderData()


### PR DESCRIPTION
## Summary

Fixes #231 and #186 — the same OAuth-only dead-end across two providers (custom OIDC in #231, Discord in #186). When a workspace disabled **both** password and magic-link and enabled only an OAuth/OIDC provider, the portal sign-in modal (and `/auth/login`) still showed the email field, an "or" divider, and "Create an account". Typing an email and hitting Continue dead-ended on an empty "Welcome back" methods step, because Stage 2 has no password/magic-link sub-screen to route to. The OAuth tile worked, but the email path looked broken.

This is a fully supported config: `updatePortalConfig` requires ≥1 method but counts OAuth, so OAuth-only is valid.

## Fix

In both `PortalAuthForm` (standalone `/auth/login`, `/auth/signup`) and `PortalAuthFormInline` (the portal modal):

- Derive `emailEntryEnabled = passwordEnabled || magicLinkEnabled` and gate the **email form**, the **"or" divider**, and **"Create an account"** on it. OAuth-only setups now show just the provider button(s). The gate is provider-agnostic, so it covers custom OIDC, Discord, and any other configured tile.
- Surface OAuth tile errors **above** the email form so popup/redirect failures show even when the email form is hidden.
- Add a defensive **"No sign-in methods are configured…"** message for the (server-blocked) zero-method case.

`/admin/login` is unaffected — team sign-in (incl. SSO) force-enables magic-link, so an email method always exists there. The portal intentionally surfaces only end-user methods; team/SSO members use `/admin/login`.

## Testing (red→green TDD)

- Extended `portal-auth-form.test.tsx` and added `portal-auth-form-inline.test.tsx`: assert OAuth-only hides the email field/divider/create-account and shows only the provider button, the zero-method fallback message, and (inline) that an OAuth error is surfaced when the email form is hidden. Each failed first on the unfixed code, then passed.
- `typecheck` clean · `eslint` clean · 30/30 auth tests pass.

## Out of scope

- Both forms duplicate this Stage-1 logic (and ~30 i18n strings) — consolidating the two ~1000-line forms is pre-existing tech debt, deliberately deferred.
- Portal-only SSO (`autoProvisionRole='user'`) isn't special-cased; such a workspace keeps a portal method or OAuth tile enabled.