### PR TITLE
fix(ui): load avatar image eagerly (SSR) instead of Radix post-hydration deferral

### DIFF
--- a/apps/web/src/components/ui/__tests__/avatar.test.tsx
+++ b/apps/web/src/components/ui/__tests__/avatar.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { Avatar } from '../avatar'
+
+// happy-dom doesn't actually load images, so drive the loaded/failed state via
+// the standard `complete` / `naturalWidth` signals the component reads on mount.
+let imgComplete = false
+let imgNaturalWidth = 0
+
+beforeEach(() => {
+  imgComplete = false
+  imgNaturalWidth = 0
+  Object.defineProperty(HTMLImageElement.prototype, 'complete', {
+    configurable: true,
+    get: () => imgComplete,
+  })
+  Object.defineProperty(HTMLImageElement.prototype, 'naturalWidth', {
+    configurable: true,
+    get: () => imgNaturalWidth,
+  })
+})
+
+afterEach(() => cleanup())
+
+describe('Avatar (simple API)', () => {
+  // The image must be in the initial DOM so the browser fetches it during the
+  // SSR/initial parse — like the plain <img> org logo. Radix Avatar.Image instead
+  // loads via a post-hydration effect, which made avatars lag behind. This test
+  // asserts the <img> (with its src) is present on first render, not deferred.
+  it('renders the image eagerly with its src on first render', () => {
+    render(<Avatar src="https://example.com/a.png" name="Jane Doe" />)
+    const img = screen.getByRole('img')
+    expect(img).toHaveAttribute('src', 'https://example.com/a.png')
+    expect(img).toHaveAttribute('alt', 'Jane Doe')
+    // Prioritize the avatar fetch among page resources.
+    expect(img).toHaveAttribute('fetchpriority', 'high')
+  })
+
+  // The <img> must be in the server-rendered HTML so the browser fetches it
+  // during the initial parse (effects don't run on the server, so this is exactly
+  // what SSR emits — proves the eager-fetch claim).
+  it('server-renders the <img> with its src', () => {
+    const html = renderToStaticMarkup(<Avatar src="https://example.com/a.png" name="Jane Doe" />)
+    expect(html).toContain('src="https://example.com/a.png"')
+  })
+
+  // While loading, the initials show underneath; once the image loads the
+  // fallback must be removed so transparent avatars (PNG/WebP/GIF) render as
+  // authored rather than showing the muted initials through transparent pixels.
+  it('hides the initials fallback once the image loads', () => {
+    render(<Avatar src="https://example.com/a.png" name="Jane Doe" />)
+    expect(screen.getByText('JD')).toBeInTheDocument()
+    fireEvent.load(screen.getByRole('img'))
+    expect(screen.queryByText('JD')).not.toBeInTheDocument()
+    expect(screen.getByRole('img')).toBeInTheDocument()
+  })
+
+  it('drops the image and shows initials when it fails to load', () => {
+    render(<Avatar src="https://example.com/broken.png" name="Jane Doe" />)
+    fireEvent.error(screen.getByRole('img'))
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    expect(screen.getByText('JD')).toBeInTheDocument()
+  })
+
+  // SSR: the browser starts fetching during the initial parse, so the image can
+  // finish/fail before React attaches onLoad/onError at hydration — those events
+  // are missed. The component reconciles from the DOM (complete/naturalWidth) on
+  // mount.
+  it('falls back to initials when the image already failed before hydration', () => {
+    imgComplete = true
+    imgNaturalWidth = 0
+    render(<Avatar src="https://example.com/broken.png" name="Jane Doe" />)
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    expect(screen.getByText('JD')).toBeInTheDocument()
+  })
+
+  it('hides the fallback when the image already loaded before hydration', () => {
+    imgComplete = true
+    imgNaturalWidth = 64
+    render(<Avatar src="https://example.com/a.png" name="Jane Doe" />)
+    expect(screen.getByRole('img')).toBeInTheDocument()
+    expect(screen.queryByText('JD')).not.toBeInTheDocument()
+  })
+
+  it('renders initials only when no src is provided', () => {
+    render(<Avatar name="Jane Doe" />)
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    expect(screen.getByText('JD')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/ui/avatar.tsx
+++ b/apps/web/src/components/ui/avatar.tsx
@@ -67,6 +67,20 @@ function Avatar({
   // Simple API: auto-render image and fallback
   const initials = fallback ?? getInitials(name)
   const altText = name || 'Avatar'
+  // Shared fallback (initials). `absolute inset-0` only when an image layers over
+  // it (the `src` case below); standalone otherwise.
+  const fallbackEl = (
+    <div
+      data-slot="avatar-fallback"
+      className={cn(
+        'bg-muted flex size-full items-center justify-center rounded-full',
+        src && 'absolute inset-0',
+        fallbackClassName
+      )}
+    >
+      {initials}
+    </div>
+  )
 
   // If no src provided, render fallback directly (no Radix image loading state)
   if (!src) {
@@ -76,28 +90,69 @@ function Avatar({
         className={cn('relative flex size-8 shrink-0 overflow-hidden rounded-full', className)}
         {...props}
       >
-        <div
-          data-slot="avatar-fallback"
-          className={cn(
-            'bg-muted flex size-full items-center justify-center rounded-full',
-            fallbackClassName
-          )}
-        >
-          {initials}
-        </div>
+        {fallbackEl}
       </AvatarPrimitive.Root>
     )
   }
 
+  // Render an eager <img> over the initials — see AvatarImageWithFallback. Keyed
+  // by src so a new URL resets its load state.
   return (
     <AvatarPrimitive.Root
       data-slot="avatar"
       className={cn('relative flex size-8 shrink-0 overflow-hidden rounded-full', className)}
       {...props}
     >
-      <AvatarImage src={src} alt={altText} />
-      <AvatarFallback className={fallbackClassName}>{initials}</AvatarFallback>
+      <AvatarImageWithFallback key={src} src={src} alt={altText} fallback={fallbackEl} />
     </AvatarPrimitive.Root>
+  )
+}
+
+/**
+ * Eager `<img>` for the simple Avatar API. A plain `<img>` is part of the SSR
+ * HTML, so the browser fetches it during the initial parse — unlike Radix
+ * Avatar.Image, which loads via a post-hydration effect (why avatars lagged
+ * behind the SSR'd org logo). The fallback shows while loading and on error, and
+ * is removed once the image loads so transparent avatars render as authored
+ * rather than showing initials through transparent pixels. Caller keys this by
+ * src so a new URL resets the load state.
+ */
+function AvatarImageWithFallback({
+  src,
+  alt,
+  fallback,
+}: {
+  src: string
+  alt: string
+  fallback: React.ReactNode
+}) {
+  const [status, setStatus] = React.useState<'loading' | 'loaded' | 'error'>('loading')
+  const ref = React.useRef<HTMLImageElement>(null)
+
+  // The <img> is server-rendered, so the browser may finish/fail loading before
+  // React attaches onLoad/onError at hydration — those events are then missed.
+  // Reconcile from the DOM on mount.
+  React.useEffect(() => {
+    const img = ref.current
+    if (img?.complete) setStatus(img.naturalWidth === 0 ? 'error' : 'loaded')
+  }, [])
+
+  return (
+    <>
+      {status !== 'loaded' && fallback}
+      {status !== 'error' && (
+        <img
+          ref={ref}
+          data-slot="avatar-image"
+          src={src}
+          alt={alt}
+          fetchPriority="high"
+          className="absolute inset-0 aspect-square size-full object-cover"
+          onLoad={() => setStatus('loaded')}
+          onError={() => setStatus('error')}
+        />
+      )}
+    </>
   )
 }
 


### PR DESCRIPTION
## Problem

The admin sidebar's user avatar (bottom-left) loads noticeably slower than the org logo (top-left), even though both URLs are available at SSR time.

## Root cause

- The **org logo** renders as a plain `<img src>`, so it's in the SSR HTML and the browser's preload scanner fetches it during the initial parse. Instant.
- The **user avatar** uses the shared `<Avatar src>` simple API, which renders Radix `Avatar.Image`. Radix loads the image via a **post-hydration effect** (`new window.Image()` in `useImageLoadingStatus`) and only mounts the `<img>` once it reports `loaded`. So no `<img>` is in the SSR HTML, and the fetch can't even **start** until JS downloads + hydrates. That's the lag.

(`fetchUserAvatar` returns a regular S3/`user.image` URL, so it takes the deferred Radix path; the component already fast-paths `data:` URLs to a plain `<img>`.)

## Fix

Change the simple-API `Avatar` to render a plain `<img>` (in the SSR HTML, fetched during initial parse — same as the org logo) over the initials fallback, in a small keyed `AvatarImageWithFallback` that tracks load state:

- **Fallback visible while loading and on error**; **removed once the image loads**, so transparent avatars (PNG/WebP/GIF) render as authored instead of showing the muted initials through transparent pixels.
- **`onLoad` / `onError`** handle outcomes after React attaches handlers at hydration.
- **Mount-time `complete` / `naturalWidth` reconcile** handles the SSR race: the `<img>` is server-rendered, so the browser can finish or fail the fetch *before* hydration, when those events would be missed. `complete && naturalWidth > 0` → loaded (hide fallback); `complete && naturalWidth === 0` → error (show fallback).
- Keyed by `src` so a new avatar URL resets the load state.

Applies to all simple-API `<Avatar src>` usages (admin sidebar, etc.). The advanced API (`<AvatarImage>` / `<AvatarFallback>`, used directly in ~8 comment/list components) is **unchanged** and still uses Radix — out of scope here.

## Testing

`avatar.test.tsx` (red→green, 6 cases): image renders eagerly with its `src` on first render; **fallback hidden once the image loads**; drops to initials on `onError`; reconciles an image that **already failed before hydration**; **hides the fallback for an image that already loaded before hydration**; and renders initials only when no `src`. `typecheck` clean · `eslint` clean · 6/6 pass.