### PR TITLE
chore(release): 0.12.1

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quackback/web",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "private": true,
   "license": "AGPL-3.0",
   "type": "module",


### PR DESCRIPTION
Bump `apps/web/package.json` to `0.12.1` (source of truth for `__APP_VERSION__`) ahead of cutting the v0.12.1 patch release.

0.12.1 is a fixes + security patch: admin sign-in regression (#234), OAuth-only portal sign-in (#235), settings persistence (#230), avatar load (#236), invite links (#228), plus auth/SSO/upload hardening (#217, #214, #219, #218). The conversations/Support Inbox/link-preview work on main stays dormant behind default-off Labs flags.