### PR TITLE
fix(settings): correct OIDC callback URL in Custom OIDC setup modal (#233)

### DIFF
--- a/apps/web/src/components/admin/settings/portal-auth/auth-provider-credentials-form.tsx
+++ b/apps/web/src/components/admin/settings/portal-auth/auth-provider-credentials-form.tsx
@@ -19,6 +19,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { OIDC_PRESETS, detectOidcProvider } from '@/lib/shared/oidc-presets'
+import { authProviderCallbackPath } from '@/lib/shared/auth-providers'
 import type { PlatformCredentialField } from '@/lib/shared/integration-types'
 
 interface AuthProviderCredentialsFormProps {
@@ -86,7 +87,9 @@ export function AuthProviderCredentialsForm({
   const saveMutation = useSaveAuthProviderCredentials()
   const deleteMutation = useDeleteAuthProviderCredentials()
 
-  const redirectUri = `${baseUrl}/api/auth/callback/${providerId}`
+  // Generic-OAuth providers (Custom OIDC) register a different callback path
+  // than built-in social providers, so derive it from the provider type. (#233)
+  const redirectUri = `${baseUrl}${authProviderCallbackPath(providerId)}`
 
   const handleStartEdit = () => {
     setValues({})

--- a/apps/web/src/lib/server/auth/__tests__/auth-providers.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/auth-providers.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { authProviderCallbackPath } from '../auth-providers'
+
+describe('authProviderCallbackPath', () => {
+  // Custom OIDC is served by the genericOAuth plugin, whose callback lives at
+  // /api/auth/oauth2/callback/<id> — not the social /api/auth/callback/<id>.
+  it('uses the genericOAuth callback path for Custom OIDC', () => {
+    expect(authProviderCallbackPath('custom-oidc')).toBe('/api/auth/oauth2/callback/custom-oidc')
+  })
+
+  it('uses the built-in social callback path for social providers', () => {
+    expect(authProviderCallbackPath('google')).toBe('/api/auth/callback/google')
+    expect(authProviderCallbackPath('github')).toBe('/api/auth/callback/github')
+  })
+
+  it('defaults to the social callback path for unknown providers', () => {
+    expect(authProviderCallbackPath('mystery')).toBe('/api/auth/callback/mystery')
+  })
+})

--- a/apps/web/src/lib/server/auth/auth-providers.ts
+++ b/apps/web/src/lib/server/auth/auth-providers.ts
@@ -220,6 +220,19 @@ export function getAuthProviderByProviderId(id: string): AuthProviderDefinition 
   return byProviderId.get(id)
 }
 
+/**
+ * The better-auth callback path to register at the IdP for a provider. Generic
+ * OAuth providers (Custom OIDC) are served by the genericOAuth plugin at
+ * `/api/auth/oauth2/callback/<id>`; built-in social providers (Google, GitHub,
+ * etc.) use `/api/auth/callback/<id>`. Unknown ids default to the social path.
+ */
+export function authProviderCallbackPath(providerId: string): string {
+  const provider = byProviderId.get(providerId)
+  return provider?.type === 'generic-oauth'
+    ? `/api/auth/oauth2/callback/${providerId}`
+    : `/api/auth/callback/${providerId}`
+}
+
 export function getAllAuthProviders(): AuthProviderDefinition[] {
   return AUTH_PROVIDERS
 }

--- a/apps/web/src/lib/shared/auth-providers.ts
+++ b/apps/web/src/lib/shared/auth-providers.ts
@@ -8,4 +8,5 @@ export {
   getAllAuthProviders,
   isAuthProviderCredentialType,
   credentialTypeForProvider,
+  authProviderCallbackPath,
 } from '@/lib/server/auth/auth-providers'


### PR DESCRIPTION
## Summary

Fixes #233 — the **Configure Custom OIDC** modal showed `https://<base>/api/auth/callback/custom-oidc` as the redirect/callback URI, but better-auth's `genericOAuth` plugin (which serves Custom OIDC) uses `https://<base>/api/auth/oauth2/callback/custom-oidc`. Registering the shown value at the IdP produced "callback mismatch / unauthorized_client".

## Why it isn't a one-liner

`AuthProviderCredentialsForm` is shared by **all** OAuth providers. better-auth uses two different callback conventions:
- built-in **social** providers (Google, GitHub, Microsoft-as-social) → `/api/auth/callback/<id>` (the current value is correct for these)
- **genericOAuth** providers (Custom OIDC) → `/api/auth/oauth2/callback/<id>`

So blindly switching to `/oauth2/callback` would have broken the social providers' displayed URL. The fix derives the path from the provider's `type` (already in `AUTH_PROVIDERS`) via a new pure helper `authProviderCallbackPath(providerId)`.

Team SSO was already correct (`sso.ts` → `/api/auth/oauth2/callback/sso`), so the issue's Team-SSO note was a misread.

## Testing

New unit test for `authProviderCallbackPath`: Custom OIDC → `/oauth2/callback/...`, social (Google/GitHub) → `/callback/...`, unknown → social default. `typecheck` clean · `eslint` clean.