### PR TITLE
chore(release): 0.12.2

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quackback/web",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "license": "AGPL-3.0",
   "type": "module",


### PR DESCRIPTION
Bump to 0.12.2 for a follow-up patch shipping the Custom OIDC callback-URL fix (#233, via #238), which landed just after v0.12.1 was tagged.