### PR TITLE
fix(integrations): deliver n8n/Make/Zapier/Monday events (channelId resolution)

### DIFF
--- a/apps/web/src/components/admin/settings/integrations/monday/__tests__/monday-config.test.tsx
+++ b/apps/web/src/components/admin/settings/integrations/monday/__tests__/monday-config.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+const mockMutate = vi.fn()
+
+vi.mock('@/lib/client/mutations', () => ({
+  useUpdateIntegration: () => ({
+    mutate: mockMutate,
+    isPending: false,
+    isError: false,
+    error: null,
+  }),
+}))
+
+vi.mock('@/lib/server/integrations/monday/functions', () => ({
+  fetchMondayBoardsFn: vi.fn().mockResolvedValue([{ id: '1234567890', name: 'Roadmap' }]),
+}))
+
+vi.mock('@/components/admin/settings/integrations/on-delete-config', () => ({
+  OnDeleteConfig: () => null,
+}))
+
+// Replace the Radix Select with a native <select> so we can fire change events.
+vi.mock('@/components/ui/select', () => ({
+  Select: ({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value: string
+    onValueChange: (v: string) => void
+    children: React.ReactNode
+  }) => (
+    <select
+      data-testid="board-select"
+      value={value}
+      onChange={(e) => onValueChange(e.target.value)}
+    >
+      {children}
+    </select>
+  ),
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => (
+    <option value={value}>{children}</option>
+  ),
+}))
+
+import { MondayConfig } from '../monday-config'
+
+describe('<MondayConfig> board selection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('saves the chosen board as both boardId and channelId', async () => {
+    render(
+      <MondayConfig
+        integrationId="integration_1"
+        initialConfig={{}}
+        initialEventMappings={[]}
+        enabled
+      />
+    )
+
+    await waitFor(() => expect(screen.getByText('Roadmap')).toBeTruthy())
+
+    fireEvent.change(screen.getByTestId('board-select'), { target: { value: '1234567890' } })
+
+    expect(mockMutate).toHaveBeenCalledWith({
+      id: 'integration_1',
+      config: { boardId: '1234567890', channelId: '1234567890' },
+    })
+  })
+})

--- a/apps/web/src/components/admin/settings/integrations/monday/__tests__/monday-config.test.tsx
+++ b/apps/web/src/components/admin/settings/integrations/monday/__tests__/monday-config.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 
 const mockMutate = vi.fn()
 
@@ -26,15 +26,18 @@ vi.mock('@/components/ui/select', () => ({
   Select: ({
     value,
     onValueChange,
+    disabled,
     children,
   }: {
     value: string
     onValueChange: (v: string) => void
+    disabled?: boolean
     children: React.ReactNode
   }) => (
     <select
       data-testid="board-select"
       value={value}
+      disabled={disabled}
       onChange={(e) => onValueChange(e.target.value)}
     >
       {children}
@@ -65,7 +68,7 @@ describe('<MondayConfig> board selection', () => {
       />
     )
 
-    await waitFor(() => expect(screen.getByText('Roadmap')).toBeTruthy())
+    await screen.findByText('Roadmap')
 
     fireEvent.change(screen.getByTestId('board-select'), { target: { value: '1234567890' } })
 

--- a/apps/web/src/components/admin/settings/integrations/monday/monday-config.tsx
+++ b/apps/web/src/components/admin/settings/integrations/monday/monday-config.tsx
@@ -80,7 +80,7 @@ export function MondayConfig({
 
   const handleBoardChange = (boardId: string) => {
     setSelectedBoard(boardId)
-    updateMutation.mutate({ id: integrationId, config: { boardId } })
+    updateMutation.mutate({ id: integrationId, config: { boardId, channelId: boardId } })
   }
 
   const handleEventToggle = (eventId: string, checked: boolean) => {

--- a/apps/web/src/lib/server/events/__tests__/integration-target-coverage.test.ts
+++ b/apps/web/src/lib/server/events/__tests__/integration-target-coverage.test.ts
@@ -72,11 +72,12 @@ const { getHookTargets } = await import('../targets')
 const { listIntegrationTypes, getIntegrationHook } = await import('@/lib/server/integrations')
 
 /**
- * The config a connected install has, per hook integration. Slack/Discord store
- * the target in actionConfig.channelId (via addNotificationChannelFn); every
- * other connector stores it in config.channelId. Stripe/Freshdesk/Salesforce use
- * a nominal placeholder — the resolver requires a non-empty channelId, but those
- * hooks ignore the resolved value.
+ * The config a connected install has, for each hook integration that resolves a
+ * delivery target. Slack/Discord store the target in actionConfig.channelId (via
+ * addNotificationChannelFn); every other connector stores it in config.channelId.
+ *
+ * Enrichment hooks that store NO channelId at connect time are listed in
+ * KNOWN_UNRESOLVED below, not here — do not fabricate a channelId for them.
  */
 const CONNECTED_FIXTURES: Record<string, { integrationConfig?: Record<string, unknown>; actionConfig?: Record<string, unknown> }> = {
   slack: { actionConfig: { channelId: 'C1' } },
@@ -96,10 +97,22 @@ const CONNECTED_FIXTURES: Record<string, { integrationConfig?: Record<string, un
   n8n: { integrationConfig: { channelId: 'https://n8n.example.com/webhook/a' } },
   make: { integrationConfig: { channelId: 'https://hook.make.com/a' } },
   zapier: { integrationConfig: { channelId: 'https://hooks.zapier.com/hooks/catch/1/a' } },
-  stripe: { integrationConfig: { channelId: 'stripe' } },
-  freshdesk: { integrationConfig: { channelId: 'freshdesk' } },
-  salesforce: { integrationConfig: { channelId: 'salesforce' } },
 }
+
+/**
+ * Hook-bearing integrations that do NOT currently resolve a delivery target.
+ * These "enrichment" hooks (Stripe/Freshdesk/Salesforce) store no channelId at
+ * connect time — their save paths write neither config.channelId nor
+ * actionConfig.channelId — so getIntegrationTargets() drops them. This is a
+ * separate, known gap (the same bug class, different fix: it needs a
+ * resolver-contract change to allow targetless hooks, not just a key rename) and
+ * is tracked as a follow-up.
+ *
+ * Pinned here so (a) the guard never fabricates a passing fixture for a connector
+ * that is broken in production, and (b) when one of these is genuinely fixed, the
+ * "known-gap" test below trips and forces moving it into CONNECTED_FIXTURES.
+ */
+const KNOWN_UNRESOLVED = new Set(['stripe', 'freshdesk', 'salesforce'])
 
 function makePostCreatedEvent() {
   return {
@@ -121,6 +134,7 @@ function makePostCreatedEvent() {
 }
 
 const hookTypes = listIntegrationTypes().filter((t) => getIntegrationHook(t))
+const resolvingTypes = hookTypes.filter((t) => !KNOWN_UNRESOLVED.has(t))
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -128,29 +142,52 @@ beforeEach(() => {
   mockCacheSet.mockResolvedValue(undefined)
 })
 
+/** A single enabled post.created mapping row for one integration. */
+function mappingRow(
+  type: string,
+  fixture: { integrationConfig?: Record<string, unknown>; actionConfig?: Record<string, unknown> }
+) {
+  return {
+    eventType: 'post.created',
+    integrationType: type,
+    secrets: JSON.stringify({ accessToken: 'token' }),
+    integrationConfig: fixture.integrationConfig ?? {},
+    actionConfig: fixture.actionConfig ?? {},
+    filters: null,
+  }
+}
+
 describe('integration target coverage', () => {
-  it('every hook-bearing integration has a connected-state fixture', () => {
+  it('every hook-bearing integration is accounted for (resolving fixture or known gap)', () => {
     expect(hookTypes, 'hookTypes is empty — registry not loaded').not.toHaveLength(0)
-    const missing = hookTypes.filter((t) => !CONNECTED_FIXTURES[t])
-    expect(missing, `add a CONNECTED_FIXTURES entry for: ${missing.join(', ')}`).toEqual([])
+    const unaccounted = hookTypes.filter((t) => !CONNECTED_FIXTURES[t] && !KNOWN_UNRESOLVED.has(t))
+    expect(
+      unaccounted,
+      `classify these hook integrations — add a CONNECTED_FIXTURES entry or list in KNOWN_UNRESOLVED: ${unaccounted.join(', ')}`
+    ).toEqual([])
   })
 
-  it.each(hookTypes)('resolves a delivery target for "%s" when connected', async (type) => {
-    const fixture = CONNECTED_FIXTURES[type] ?? {}
+  it.each(resolvingTypes)('resolves a delivery target for "%s" when connected', async (type) => {
     mockCacheGet
-      .mockResolvedValueOnce([
-        {
-          eventType: 'post.created',
-          integrationType: type,
-          secrets: JSON.stringify({ accessToken: 'token' }),
-          integrationConfig: fixture.integrationConfig ?? {},
-          actionConfig: fixture.actionConfig ?? {},
-          filters: null,
-        },
-      ]) // INTEGRATION_MAPPINGS
+      .mockResolvedValueOnce([mappingRow(type, CONNECTED_FIXTURES[type] ?? {})]) // INTEGRATION_MAPPINGS
       .mockResolvedValueOnce([]) // ACTIVE_WEBHOOKS
 
     const targets = await getHookTargets(makePostCreatedEvent())
     expect(targets.filter((t) => t.type === type).length).toBeGreaterThan(0)
   })
+
+  // Honest pin of the known gap: these enrichment hooks store no channelId, so
+  // they resolve to nothing today. If a fix makes one resolve, this trips and the
+  // connector must move into CONNECTED_FIXTURES. See KNOWN_UNRESOLVED above.
+  it.each([...KNOWN_UNRESOLVED])(
+    'does NOT yet resolve a target for known-gap enrichment hook "%s"',
+    async (type) => {
+      mockCacheGet
+        .mockResolvedValueOnce([mappingRow(type, {})]) // no channelId, as in production
+        .mockResolvedValueOnce([]) // ACTIVE_WEBHOOKS
+
+      const targets = await getHookTargets(makePostCreatedEvent())
+      expect(targets.filter((t) => t.type === type)).toHaveLength(0)
+    }
+  )
 })

--- a/apps/web/src/lib/server/events/__tests__/integration-target-coverage.test.ts
+++ b/apps/web/src/lib/server/events/__tests__/integration-target-coverage.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Registry guard: every integration that has an outbound hook must, when
+ * connected, resolve to a delivery target. This is the regression guard for the
+ * channelId-resolution bug class (n8n/Make/Zapier/Monday stored their target
+ * under a key the resolver never read). A new hook connector with no fixture, or
+ * a fixture that resolves to no target, fails this suite.
+ *
+ * Scope: proves resolution + coverage. It does NOT prove each save path writes
+ * its fixture's config — the per-connector save-fn tests do that for the
+ * webhook/Monday set.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// --- Redis cache mocks ---
+const mockCacheGet = vi.fn()
+const mockCacheSet = vi.fn()
+
+vi.mock('@/lib/server/redis', () => ({
+  cacheGet: (...args: unknown[]) => mockCacheGet(...args),
+  cacheSet: (...args: unknown[]) => mockCacheSet(...args),
+  cacheDel: vi.fn(),
+  CACHE_KEYS: {
+    TENANT_SETTINGS: 'settings:tenant',
+    INTEGRATION_MAPPINGS: 'hooks:integration-mappings',
+    ACTIVE_WEBHOOKS: 'hooks:webhooks-active',
+    SLACK_CHANNELS: 'slack:channels',
+  },
+}))
+
+// --- DB mock (mappings come from the cache mock, so the select chain is unused) ---
+vi.mock('@/lib/server/db', () => ({
+  db: {
+    select: () => ({ from: () => ({ innerJoin: () => ({ where: () => [] }) }) }),
+    query: { webhooks: { findMany: vi.fn().mockResolvedValue([]) } },
+  },
+  integrations: { id: 'id', integrationType: 'integrationType', secrets: 'secrets', config: 'config', status: 'status' },
+  integrationEventMappings: { integrationId: 'integrationId', eventType: 'eventType', actionConfig: 'actionConfig', filters: 'filters', enabled: 'enabled' },
+  webhooks: { status: 'status', deletedAt: 'deletedAt', $inferSelect: {} },
+  eq: vi.fn(),
+  and: vi.fn(),
+  isNull: vi.fn(),
+  inArray: vi.fn(),
+  principal: {},
+}))
+
+vi.mock('@/lib/server/integrations/encryption', () => ({
+  decryptSecrets: vi.fn((s: string) => JSON.parse(s)),
+}))
+vi.mock('@/lib/server/domains/webhooks/encryption', () => ({
+  decryptWebhookSecret: vi.fn((s: string) => s),
+}))
+vi.mock('@/lib/server/domains/subscriptions/subscription.service', () => ({
+  getSubscribersForEvent: vi.fn().mockResolvedValue([]),
+  batchGetNotificationPreferences: vi.fn().mockResolvedValue(new Map()),
+  batchGenerateUnsubscribeTokens: vi.fn().mockResolvedValue(new Map()),
+}))
+vi.mock('@/lib/server/domains/ai/config', () => ({
+  getOpenAI: vi.fn().mockReturnValue(null),
+}))
+vi.mock('../hook-context', () => ({
+  buildHookContext: vi.fn().mockResolvedValue({
+    workspaceName: 'Test',
+    portalBaseUrl: 'https://test.quackback.io',
+  }),
+}))
+vi.mock('../hook-utils', () => ({
+  stripHtml: vi.fn((s: string) => s),
+  truncate: vi.fn((s: string) => s),
+}))
+
+const { getHookTargets } = await import('../targets')
+const { listIntegrationTypes, getIntegrationHook } = await import('@/lib/server/integrations')
+
+/**
+ * The config a connected install has, per hook integration. Slack/Discord store
+ * the target in actionConfig.channelId (via addNotificationChannelFn); every
+ * other connector stores it in config.channelId. Stripe/Freshdesk/Salesforce use
+ * a nominal placeholder — the resolver requires a non-empty channelId, but those
+ * hooks ignore the resolved value.
+ */
+const CONNECTED_FIXTURES: Record<string, { integrationConfig?: Record<string, unknown>; actionConfig?: Record<string, unknown> }> = {
+  slack: { actionConfig: { channelId: 'C1' } },
+  discord: { actionConfig: { channelId: 'C1' } },
+  teams: { integrationConfig: { channelId: 'C1' } },
+  linear: { integrationConfig: { channelId: 'team_1' } },
+  jira: { integrationConfig: { channelId: 'PROJ:10001' } },
+  github: { integrationConfig: { channelId: 'octo/repo' } },
+  gitlab: { integrationConfig: { channelId: '42' } },
+  asana: { integrationConfig: { channelId: 'project_1' } },
+  clickup: { integrationConfig: { channelId: 'list_1' } },
+  shortcut: { integrationConfig: { channelId: 'group_1' } },
+  azure_devops: { integrationConfig: { channelId: 'Proj:Bug' } },
+  notion: { integrationConfig: { channelId: 'db_1' } },
+  trello: { integrationConfig: { channelId: 'list_1' } },
+  monday: { integrationConfig: { channelId: '1234567890' } },
+  n8n: { integrationConfig: { channelId: 'https://n8n.example.com/webhook/a' } },
+  make: { integrationConfig: { channelId: 'https://hook.make.com/a' } },
+  zapier: { integrationConfig: { channelId: 'https://hooks.zapier.com/hooks/catch/1/a' } },
+  stripe: { integrationConfig: { channelId: 'stripe' } },
+  freshdesk: { integrationConfig: { channelId: 'freshdesk' } },
+  salesforce: { integrationConfig: { channelId: 'salesforce' } },
+}
+
+function makePostCreatedEvent() {
+  return {
+    id: 'evt-1',
+    type: 'post.created' as const,
+    timestamp: '2025-01-01T00:00:00Z',
+    actor: { type: 'user' as const, userId: 'user_1', email: 'test@test.com' },
+    data: {
+      post: {
+        id: 'post_1',
+        title: 'Test',
+        content: 'Content',
+        boardId: 'board_1',
+        boardSlug: 'bugs',
+        voteCount: 0,
+      },
+    },
+  }
+}
+
+const hookTypes = listIntegrationTypes().filter((t) => getIntegrationHook(t))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockCacheGet.mockResolvedValue(null)
+  mockCacheSet.mockResolvedValue(undefined)
+})
+
+describe('integration target coverage', () => {
+  it('every hook-bearing integration has a connected-state fixture', () => {
+    expect(hookTypes, 'hookTypes is empty — registry not loaded').not.toHaveLength(0)
+    const missing = hookTypes.filter((t) => !CONNECTED_FIXTURES[t])
+    expect(missing, `add a CONNECTED_FIXTURES entry for: ${missing.join(', ')}`).toEqual([])
+  })
+
+  it.each(hookTypes)('resolves a delivery target for "%s" when connected', async (type) => {
+    const fixture = CONNECTED_FIXTURES[type] ?? {}
+    mockCacheGet
+      .mockResolvedValueOnce([
+        {
+          eventType: 'post.created',
+          integrationType: type,
+          secrets: JSON.stringify({ accessToken: 'token' }),
+          integrationConfig: fixture.integrationConfig ?? {},
+          actionConfig: fixture.actionConfig ?? {},
+          filters: null,
+        },
+      ]) // INTEGRATION_MAPPINGS
+      .mockResolvedValueOnce([]) // ACTIVE_WEBHOOKS
+
+    const targets = await getHookTargets(makePostCreatedEvent())
+    expect(targets.filter((t) => t.type === type).length).toBeGreaterThan(0)
+  })
+})

--- a/apps/web/src/lib/server/integrations/make/__tests__/functions.test.ts
+++ b/apps/web/src/lib/server/integrations/make/__tests__/functions.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+type AnyHandler = (args: { data: Record<string, unknown> }) => Promise<unknown>
+const handlers: AnyHandler[] = []
+
+vi.mock('@tanstack/react-start', () => ({
+  createServerFn: () => {
+    const chain = {
+      inputValidator() {
+        return chain
+      },
+      handler(fn: AnyHandler) {
+        handlers.push(fn)
+        return chain
+      },
+    }
+    return chain
+  },
+}))
+
+const hoisted = vi.hoisted(() => ({
+  mockRequireAuth: vi.fn(),
+  mockSaveIntegration: vi.fn(),
+  mockSafeFetch: vi.fn(),
+}))
+
+vi.mock('@/lib/server/functions/auth-helpers', () => ({
+  requireAuth: hoisted.mockRequireAuth,
+}))
+vi.mock('@/lib/server/integrations/save', () => ({
+  saveIntegration: hoisted.mockSaveIntegration,
+}))
+vi.mock('@/lib/server/content/ssrf-guard', () => ({
+  safeFetch: hoisted.mockSafeFetch,
+}))
+
+await import('../functions')
+
+describe('saveMakeWebhookFn', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    hoisted.mockRequireAuth.mockResolvedValue({ principal: { id: 'principal_1' } })
+    hoisted.mockSaveIntegration.mockResolvedValue('integration_1')
+    hoisted.mockSafeFetch.mockResolvedValue({ ok: true, status: 200 })
+  })
+
+  it('persists the webhook URL as config.channelId so the resolver can find it', async () => {
+    const webhookUrl = 'https://hook.eu1.make.com/abc123xyz'
+    await handlers[0]({ data: { webhookUrl } })
+
+    expect(hoisted.mockSaveIntegration).toHaveBeenCalledWith(
+      'make',
+      expect.objectContaining({
+        config: expect.objectContaining({ channelId: webhookUrl }),
+      })
+    )
+  })
+})

--- a/apps/web/src/lib/server/integrations/make/functions.ts
+++ b/apps/web/src/lib/server/integrations/make/functions.ts
@@ -40,7 +40,7 @@ export const saveMakeWebhookFn = createServerFn({ method: 'POST' })
     await saveIntegration('make', {
       principalId: auth.principal.id,
       accessToken: data.webhookUrl,
-      config: { webhookUrl: data.webhookUrl, workspaceName: 'Make' },
+      config: { webhookUrl: data.webhookUrl, channelId: data.webhookUrl, workspaceName: 'Make' },
     })
 
     return { success: true }

--- a/apps/web/src/lib/server/integrations/n8n/__tests__/functions.test.ts
+++ b/apps/web/src/lib/server/integrations/n8n/__tests__/functions.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+type AnyHandler = (args: { data: Record<string, unknown> }) => Promise<unknown>
+const handlers: AnyHandler[] = []
+
+vi.mock('@tanstack/react-start', () => ({
+  createServerFn: () => {
+    const chain = {
+      inputValidator() {
+        return chain
+      },
+      handler(fn: AnyHandler) {
+        handlers.push(fn)
+        return chain
+      },
+    }
+    return chain
+  },
+}))
+
+const hoisted = vi.hoisted(() => ({
+  mockRequireAuth: vi.fn(),
+  mockSaveIntegration: vi.fn(),
+  mockSafeFetch: vi.fn(),
+}))
+
+vi.mock('@/lib/server/functions/auth-helpers', () => ({
+  requireAuth: hoisted.mockRequireAuth,
+}))
+vi.mock('@/lib/server/integrations/save', () => ({
+  saveIntegration: hoisted.mockSaveIntegration,
+}))
+vi.mock('@/lib/server/content/ssrf-guard', () => ({
+  safeFetch: hoisted.mockSafeFetch,
+}))
+
+await import('../functions')
+
+describe('saveN8nWebhookFn', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    hoisted.mockRequireAuth.mockResolvedValue({ principal: { id: 'principal_1' } })
+    hoisted.mockSaveIntegration.mockResolvedValue('integration_1')
+    hoisted.mockSafeFetch.mockResolvedValue({ ok: true, status: 200 })
+  })
+
+  it('persists the webhook URL as config.channelId so the resolver can find it', async () => {
+    const webhookUrl = 'https://n8n.example.com/webhook/abc'
+    await handlers[0]({ data: { webhookUrl } })
+
+    expect(hoisted.mockSaveIntegration).toHaveBeenCalledWith(
+      'n8n',
+      expect.objectContaining({
+        config: expect.objectContaining({ channelId: webhookUrl }),
+      })
+    )
+  })
+})

--- a/apps/web/src/lib/server/integrations/n8n/functions.ts
+++ b/apps/web/src/lib/server/integrations/n8n/functions.ts
@@ -35,7 +35,7 @@ export const saveN8nWebhookFn = createServerFn({ method: 'POST' })
     await saveIntegration('n8n', {
       principalId: auth.principal.id,
       accessToken: data.webhookUrl,
-      config: { webhookUrl: data.webhookUrl, workspaceName: 'n8n' },
+      config: { webhookUrl: data.webhookUrl, channelId: data.webhookUrl, workspaceName: 'n8n' },
     })
 
     return { success: true }

--- a/apps/web/src/lib/server/integrations/zapier/__tests__/functions.test.ts
+++ b/apps/web/src/lib/server/integrations/zapier/__tests__/functions.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+type AnyHandler = (args: { data: Record<string, unknown> }) => Promise<unknown>
+const handlers: AnyHandler[] = []
+
+vi.mock('@tanstack/react-start', () => ({
+  createServerFn: () => {
+    const chain = {
+      inputValidator() {
+        return chain
+      },
+      handler(fn: AnyHandler) {
+        handlers.push(fn)
+        return chain
+      },
+    }
+    return chain
+  },
+}))
+
+const hoisted = vi.hoisted(() => ({
+  mockRequireAuth: vi.fn(),
+  mockSaveIntegration: vi.fn(),
+  mockSafeFetch: vi.fn(),
+}))
+
+vi.mock('@/lib/server/functions/auth-helpers', () => ({
+  requireAuth: hoisted.mockRequireAuth,
+}))
+vi.mock('@/lib/server/integrations/save', () => ({
+  saveIntegration: hoisted.mockSaveIntegration,
+}))
+vi.mock('@/lib/server/content/ssrf-guard', () => ({
+  safeFetch: hoisted.mockSafeFetch,
+}))
+
+await import('../functions')
+
+describe('saveZapierWebhookFn', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    hoisted.mockRequireAuth.mockResolvedValue({ principal: { id: 'principal_1' } })
+    hoisted.mockSaveIntegration.mockResolvedValue('integration_1')
+    hoisted.mockSafeFetch.mockResolvedValue({ ok: true, status: 200 })
+  })
+
+  it('persists the webhook URL as config.channelId so the resolver can find it', async () => {
+    const webhookUrl = 'https://hooks.zapier.com/hooks/catch/123456/abcdef'
+    await handlers[0]({ data: { webhookUrl } })
+
+    expect(hoisted.mockSaveIntegration).toHaveBeenCalledWith(
+      'zapier',
+      expect.objectContaining({
+        config: expect.objectContaining({ channelId: webhookUrl }),
+      })
+    )
+  })
+})

--- a/apps/web/src/lib/server/integrations/zapier/functions.ts
+++ b/apps/web/src/lib/server/integrations/zapier/functions.ts
@@ -39,7 +39,7 @@ export const saveZapierWebhookFn = createServerFn({ method: 'POST' })
     await saveIntegration('zapier', {
       principalId: auth.principal.id,
       accessToken: data.webhookUrl,
-      config: { webhookUrl: data.webhookUrl, workspaceName: 'Zapier' },
+      config: { webhookUrl: data.webhookUrl, channelId: data.webhookUrl, workspaceName: 'Zapier' },
     })
 
     return { success: true }

--- a/packages/db/drizzle/0113_integration_channelid_backfill.sql
+++ b/packages/db/drizzle/0113_integration_channelid_backfill.sql
@@ -1,0 +1,17 @@
+-- Heal integrations whose connect flow historically stored their delivery target
+-- under the wrong config key, so getIntegrationTargets() (which reads
+-- config.channelId) never resolved a target and silently dropped every event.
+-- The save paths are fixed going forward; this backfills already-connected rows.
+-- Idempotent: only touches rows that have the source key and lack channelId.
+
+UPDATE "integrations"
+SET "config" = "config" || jsonb_build_object('channelId', "config"->>'webhookUrl')
+WHERE "integration_type" IN ('n8n', 'make', 'zapier')
+  AND "config" ? 'webhookUrl'
+  AND NOT ("config" ? 'channelId');
+
+UPDATE "integrations"
+SET "config" = "config" || jsonb_build_object('channelId', "config"->>'boardId')
+WHERE "integration_type" = 'monday'
+  AND "config" ? 'boardId'
+  AND NOT ("config" ? 'channelId');

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -792,6 +792,13 @@
       "when": 1782345600000,
       "tag": "0112_invitation_magic_link_tokens",
       "breakpoints": true
+    },
+    {
+      "idx": 113,
+      "version": "7",
+      "when": 1782432000000,
+      "tag": "0113_integration_channelid_backfill",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Outbound event delivery silently dropped every event for n8n, Make, Zapier, and Monday. The event resolver reads an integration's destination from `config.channelId`, but these four connectors stored it under a different key (`config.webhookUrl` for the webhook connectors, `config.boardId` for Monday), so they resolved to nothing and never fired. Connecting them appeared to work (the connect-time test ping uses the URL directly), which is why this went unnoticed.

## What changed

- Store the delivery target as `config.channelId` (value unchanged, only the key) in the n8n, Make, and Zapier connect flows and the Monday board picker, matching the 13 connectors that already work this way.
- Add migration `0113` to backfill `config.channelId` for already-connected installs. Idempotent and scoped by integration type; it never overwrites an existing value.
- Add per-connector tests that drive the real save paths and assert the target is persisted, plus a registry guard test that requires every hook-bearing integration to resolve a delivery target. The guard closes the coverage gap that let this ship (the existing resolver tests only exercised channel-style configs).

## Known gap (separate follow-up)

The guard test surfaced that three enrichment hooks (Stripe, Freshdesk, Salesforce) also resolve to nothing: they store no destination at connect time, so the resolver drops them too. That needs a different fix (allowing targetless hooks) and is out of scope here. It is pinned honestly in the guard test as `KNOWN_UNRESOLVED`, so fixing one later trips the test.

## Test plan

- [x] `bun run typecheck` and `bun run lint` pass (only pre-existing unrelated warnings)
- [x] Full suite green: 4914 passed, 2 skipped
- [x] New per-connector tests fail before each fix, pass after
- [x] Registry guard would catch the original bug (verified by reverting a fixture to the pre-fix shape)
- [x] Migration `0113` backfills a channelId-stripped row (verified locally)

## Note for deployers

The resolver caches integration mappings for ~5 minutes. On a normal upgrade the app restarts and the cache is cold, so healed rows take effect immediately; if the migration is applied to a live process without a restart, expect up to 5 minutes before backfilled rows start delivering.