### PR TITLE
feat(i18n): set <html lang> and dir during SSR

### DIFF
--- a/apps/web/src/components/widget/__tests__/widget-auth-provider-locale.test.tsx
+++ b/apps/web/src/components/widget/__tests__/widget-auth-provider-locale.test.tsx
@@ -37,7 +37,7 @@ function LocaleProbe() {
   return <span data-testid="locale">{useIntl().locale}</span>
 }
 
-function renderWidget(initialLocale?: 'en' | 'de' | 'fr') {
+function renderWidget(initialLocale?: 'en' | 'de' | 'fr' | 'ar') {
   const qc = new QueryClient()
   return render(
     <QueryClientProvider client={qc}>
@@ -62,5 +62,16 @@ describe('WidgetAuthProvider locale (hydration safety #133)', () => {
     // Pre-fix this fell through to navigator.language ('fr'), so a French
     // browser hydrated a French tree over an English SSR tree → React #418.
     expect(renderWidget().getByTestId('locale').textContent).toBe('en')
+  })
+
+  it('owns its iframe document lang/dir (RTL for an RTL locale)', () => {
+    // The widget is a separate document with a runtime-changeable locale, so it
+    // sets its own <html lang>/dir rather than relying on the root document.
+    renderWidget('ar')
+    expect(document.documentElement.lang).toBe('ar')
+    expect(document.documentElement.dir).toBe('rtl')
+    renderWidget('de')
+    expect(document.documentElement.lang).toBe('de')
+    expect(document.documentElement.dir).toBe('ltr')
   })
 })

--- a/apps/web/src/components/widget/widget-auth-provider.tsx
+++ b/apps/web/src/components/widget/widget-auth-provider.tsx
@@ -23,13 +23,8 @@ import { widgetQueryKeys } from '@/lib/client/hooks/use-widget-vote'
 import { authClient } from '@/lib/client/auth-client'
 import { resolveIdentifyAction, type SessionSource } from './identify-precedence'
 import type { WidgetMetadata, WidgetEventName, WidgetEventMap } from '@/lib/shared/widget/types'
-import {
-  normalizeLocale,
-  isRtlLocale,
-  isRtlForced,
-  DEFAULT_LOCALE,
-  type SupportedLocale,
-} from '@/lib/shared/i18n'
+import { normalizeLocale, DEFAULT_LOCALE, type SupportedLocale } from '@/lib/shared/i18n'
+import { htmlLangDir } from '@/lib/shared/document-locale'
 import { useIntlSetup } from '@/lib/client/hooks/use-intl-setup'
 import { onIntlError } from '@/lib/client/intl-error'
 import { createWidgetIdentifyTokenFn } from '@/lib/server/functions/widget'
@@ -105,10 +100,12 @@ export function WidgetAuthProvider({
 
   // The widget is its own iframe document, and its locale can change at runtime
   // (the `quackback:locale` postMessage below). Unlike the portal, the root
-  // document can't track that, so the widget owns its own `<html lang>`/`dir`.
+  // document can't track that, so the widget owns its own `<html lang>`/`dir`,
+  // formatted the same way the root document does.
   useEffect(() => {
-    document.documentElement.lang = locale
-    document.documentElement.dir = isRtlForced() || isRtlLocale(locale) ? 'rtl' : 'ltr'
+    const { lang, dir } = htmlLangDir(locale)
+    document.documentElement.lang = lang
+    document.documentElement.dir = dir
   }, [locale])
 
   const sessionVersionRef = useRef(0)

--- a/apps/web/src/components/widget/widget-auth-provider.tsx
+++ b/apps/web/src/components/widget/widget-auth-provider.tsx
@@ -23,7 +23,13 @@ import { widgetQueryKeys } from '@/lib/client/hooks/use-widget-vote'
 import { authClient } from '@/lib/client/auth-client'
 import { resolveIdentifyAction, type SessionSource } from './identify-precedence'
 import type { WidgetMetadata, WidgetEventName, WidgetEventMap } from '@/lib/shared/widget/types'
-import { normalizeLocale, DEFAULT_LOCALE, type SupportedLocale } from '@/lib/shared/i18n'
+import {
+  normalizeLocale,
+  isRtlLocale,
+  isRtlForced,
+  DEFAULT_LOCALE,
+  type SupportedLocale,
+} from '@/lib/shared/i18n'
 import { useIntlSetup } from '@/lib/client/hooks/use-intl-setup'
 import { onIntlError } from '@/lib/client/intl-error'
 import { createWidgetIdentifyTokenFn } from '@/lib/server/functions/widget'
@@ -96,6 +102,14 @@ export function WidgetAuthProvider({
   // first client render matches the server (see issue #133).
   const [locale, setLocale] = useState<SupportedLocale>(initialLocale ?? DEFAULT_LOCALE)
   const messages = useIntlSetup(locale)
+
+  // The widget is its own iframe document, and its locale can change at runtime
+  // (the `quackback:locale` postMessage below). Unlike the portal, the root
+  // document can't track that, so the widget owns its own `<html lang>`/`dir`.
+  useEffect(() => {
+    document.documentElement.lang = locale
+    document.documentElement.dir = isRtlForced() || isRtlLocale(locale) ? 'rtl' : 'ltr'
+  }, [locale])
 
   const sessionVersionRef = useRef(0)
   const storeToken = useCallback((token: string) => {

--- a/apps/web/src/lib/client/hooks/use-intl-setup.ts
+++ b/apps/web/src/lib/client/hooks/use-intl-setup.ts
@@ -1,9 +1,12 @@
 import { useEffect, useRef, useState } from 'react'
-import { loadMessages, isRtlLocale, isRtlForced, type SupportedLocale } from '@/lib/shared/i18n'
+import { loadMessages, type SupportedLocale } from '@/lib/shared/i18n'
 
 /**
- * Shared hook that loads locale messages and sets `lang`/`dir` on <html>.
- * Used by both PortalIntlProvider and WidgetAuthProvider.
+ * Shared hook that loads the message catalog for a locale (used by
+ * PortalIntlProvider and WidgetAuthProvider). It does NOT touch `<html lang>`/
+ * `dir`: the root document owns those reactively (see `documentLocale`), so
+ * only one place decides the document language. The widget, a separate iframe
+ * document with its own runtime locale, sets its own `lang`/`dir`.
  *
  * Pass `initialMessages` (loaded server-side and serialized into the route's
  * loader data) so SSR renders translated and the client hydrates from the same
@@ -32,17 +35,6 @@ export function useIntlSetup(
     return () => {
       cancelled = true
     }
-  }, [locale])
-
-  // Keep `<html lang/dir>` in step with runtime locale changes (e.g. the widget's
-  // `quackback:locale` postMessage). The root document already sets the correct
-  // value for the initial render/navigation, so this only nudges it forward and
-  // must NOT restore a captured value on cleanup: doing so re-applies a stale
-  // locale when unmounting (e.g. leaving a localized page for the English admin
-  // app), fighting the root document's reactive value.
-  useEffect(() => {
-    document.documentElement.lang = locale
-    document.documentElement.dir = isRtlForced() || isRtlLocale(locale) ? 'rtl' : 'ltr'
   }, [locale])
 
   return messages

--- a/apps/web/src/lib/client/hooks/use-intl-setup.ts
+++ b/apps/web/src/lib/client/hooks/use-intl-setup.ts
@@ -34,15 +34,15 @@ export function useIntlSetup(
     }
   }, [locale])
 
+  // Keep `<html lang/dir>` in step with runtime locale changes (e.g. the widget's
+  // `quackback:locale` postMessage). The root document already sets the correct
+  // value for the initial render/navigation, so this only nudges it forward and
+  // must NOT restore a captured value on cleanup: doing so re-applies a stale
+  // locale when unmounting (e.g. leaving a localized page for the English admin
+  // app), fighting the root document's reactive value.
   useEffect(() => {
-    const prevLang = document.documentElement.lang
-    const prevDir = document.documentElement.dir
     document.documentElement.lang = locale
     document.documentElement.dir = isRtlForced() || isRtlLocale(locale) ? 'rtl' : 'ltr'
-    return () => {
-      document.documentElement.lang = prevLang
-      document.documentElement.dir = prevDir || 'ltr'
-    }
   }, [locale])
 
   return messages

--- a/apps/web/src/lib/server/functions/bootstrap.ts
+++ b/apps/web/src/lib/server/functions/bootstrap.ts
@@ -1,5 +1,6 @@
 import { createServerFn, createServerOnlyFn } from '@tanstack/react-start'
 import { getThemeCookie, type Theme } from '@/lib/shared/theme'
+import { resolveLocale, type SupportedLocale } from '@/lib/shared/i18n'
 import type { Session, PrincipalType } from '@/lib/server/auth/session'
 import type { TenantSettings } from '@/lib/server/domains/settings'
 import type { SessionId, UserId } from '@quackback/ids'
@@ -23,6 +24,10 @@ export interface BootstrapData {
    *  `auth_sso` row in `platform_credentials` will NOT include 'sso'
    *  here, so the UI never renders an SSO button that would 404. */
   registeredAuthProviders: string[]
+  /** Locale resolved from the request's Accept-Language header, used by the
+   *  root document to set `<html lang>`/`dir` during SSR. Resolved here so it
+   *  rides the bootstrap request without a separate round-trip. */
+  acceptLanguageLocale: SupportedLocale
 }
 
 // Returns both the session (with principalType) AND the user role in
@@ -142,6 +147,7 @@ const getBootstrapDataInternal = createServerOnlyFn(async (): Promise<BootstrapD
 
   const headers = getRequestHeaders()
   const themeCookie = getThemeCookie(headers.get('cookie') ?? null)
+  const acceptLanguageLocale = resolveLocale(headers.get('accept-language'))
 
   return {
     baseUrl: config.baseUrl,
@@ -152,6 +158,7 @@ const getBootstrapDataInternal = createServerOnlyFn(async (): Promise<BootstrapD
     managedFieldPaths: settings?.managedFieldPaths ?? [],
     state: settings?.state ?? 'active',
     registeredAuthProviders,
+    acceptLanguageLocale,
   }
 })
 

--- a/apps/web/src/lib/shared/__tests__/document-locale.test.ts
+++ b/apps/web/src/lib/shared/__tests__/document-locale.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { documentLocale } from '../document-locale'
+import { documentLocale, htmlLangDir } from '../document-locale'
 
 // The argument is the matched route-id chain (root -> leaf), as exposed by
 // useRouterState's `matches`.
@@ -30,5 +30,19 @@ describe('documentLocale', () => {
     expect(documentLocale(['__root__', '/apps'], 'zh-cn')).toBe('en')
     expect(documentLocale(['__root__', '/unsubscribe'], 'zh-cn')).toBe('en')
     expect(documentLocale(['__root__', '/verify-magic-link'], 'zh-cn')).toBe('en')
+  })
+})
+
+describe('htmlLangDir', () => {
+  it('emits a canonical BCP-47 lang (upper-cased region subtag)', () => {
+    expect(htmlLangDir('zh-cn').lang).toBe('zh-CN')
+    expect(htmlLangDir('zh-tw').lang).toBe('zh-TW')
+    expect(htmlLangDir('pt-br').lang).toBe('pt-BR')
+    expect(htmlLangDir('en').lang).toBe('en') // no region subtag, unchanged
+  })
+  it('sets dir from the locale', () => {
+    expect(htmlLangDir('ar').dir).toBe('rtl')
+    expect(htmlLangDir('en').dir).toBe('ltr')
+    expect(htmlLangDir('zh-cn').dir).toBe('ltr')
   })
 })

--- a/apps/web/src/lib/shared/__tests__/document-locale.test.ts
+++ b/apps/web/src/lib/shared/__tests__/document-locale.test.ts
@@ -1,27 +1,32 @@
 import { describe, it, expect } from 'vitest'
 import { documentLocale } from '../document-locale'
 
+// The argument is the matched route-id chain (root -> leaf), as exposed by
+// useRouterState's `matches`.
 describe('documentLocale', () => {
-  it('uses the resolved locale on localized public surfaces', () => {
-    expect(documentLocale('/', 'zh-cn')).toBe('zh-cn')
-    expect(documentLocale('/changelog', 'zh-cn')).toBe('zh-cn')
-    expect(documentLocale('/roadmap', 'zh-tw')).toBe('zh-tw')
-    expect(documentLocale('/auth/login', 'zh-tw')).toBe('zh-tw')
-    expect(documentLocale('/widget', 'ar')).toBe('ar')
+  it('localizes any page under the portal layout', () => {
+    expect(documentLocale(['__root__', '/_portal', '/_portal/'], 'zh-cn')).toBe('zh-cn')
+    expect(documentLocale(['__root__', '/_portal', '/_portal/hc'], 'zh-cn')).toBe('zh-cn')
+    expect(documentLocale(['__root__', '/_portal', '/_portal/roadmap/'], 'zh-tw')).toBe('zh-tw')
   })
-  it('keeps the English admin app on the default locale', () => {
-    expect(documentLocale('/admin', 'zh-cn')).toBe('en')
-    expect(documentLocale('/admin/posts', 'zh-cn')).toBe('en')
-    expect(documentLocale('/admin/settings/branding', 'ar')).toBe('en')
+  it('localizes the standalone auth/admin-login/widget routes', () => {
+    expect(documentLocale(['__root__', '/auth/login'], 'zh-tw')).toBe('zh-tw')
+    expect(documentLocale(['__root__', '/auth/reset-password'], 'zh-cn')).toBe('zh-cn')
+    expect(documentLocale(['__root__', '/admin/login'], 'zh-cn')).toBe('zh-cn')
+    expect(documentLocale(['__root__', '/widget'], 'ar')).toBe('ar')
   })
-  it('localizes the admin sign-in page (it renders translated, unlike the rest of /admin)', () => {
-    expect(documentLocale('/admin/login', 'zh-cn')).toBe('zh-cn')
-    expect(documentLocale('/admin/login', 'zh-tw')).toBe('zh-tw')
+  it('keeps untranslated auth utility pages on the default locale', () => {
+    // These render hard-coded English with no IntlProvider — labeling them
+    // `lang="ar" dir="rtl"` would misstate the language and flip the layout.
+    expect(documentLocale(['__root__', '/auth/two-factor'], 'ar')).toBe('en')
+    expect(documentLocale(['__root__', '/auth/auth-complete'], 'zh-cn')).toBe('en')
+    expect(documentLocale(['__root__', '/auth/widget-handoff'], 'zh-tw')).toBe('en')
   })
-  it('keeps non-portal system routes on the default locale', () => {
-    expect(documentLocale('/onboarding', 'ar')).toBe('en')
-    expect(documentLocale('/api/v1/posts', 'zh-cn')).toBe('en')
-    expect(documentLocale('/complete-signup/abc', 'zh-cn')).toBe('en')
-    expect(documentLocale('/oauth/callback', 'zh-cn')).toBe('en')
+  it('keeps the English admin app and standalone system routes on the default', () => {
+    expect(documentLocale(['__root__', '/admin/posts'], 'zh-cn')).toBe('en')
+    expect(documentLocale(['__root__', '/onboarding'], 'ar')).toBe('en')
+    expect(documentLocale(['__root__', '/apps'], 'zh-cn')).toBe('en')
+    expect(documentLocale(['__root__', '/unsubscribe'], 'zh-cn')).toBe('en')
+    expect(documentLocale(['__root__', '/verify-magic-link'], 'zh-cn')).toBe('en')
   })
 })

--- a/apps/web/src/lib/shared/__tests__/document-locale.test.ts
+++ b/apps/web/src/lib/shared/__tests__/document-locale.test.ts
@@ -9,10 +9,9 @@ describe('documentLocale', () => {
     expect(documentLocale(['__root__', '/_portal', '/_portal/hc'], 'zh-cn')).toBe('zh-cn')
     expect(documentLocale(['__root__', '/_portal', '/_portal/roadmap/'], 'zh-tw')).toBe('zh-tw')
   })
-  it('localizes the standalone auth/admin-login/widget routes', () => {
+  it('localizes the standalone auth and widget routes', () => {
     expect(documentLocale(['__root__', '/auth/login'], 'zh-tw')).toBe('zh-tw')
     expect(documentLocale(['__root__', '/auth/reset-password'], 'zh-cn')).toBe('zh-cn')
-    expect(documentLocale(['__root__', '/admin/login'], 'zh-cn')).toBe('zh-cn')
     expect(documentLocale(['__root__', '/widget'], 'ar')).toBe('ar')
   })
   it('keeps untranslated auth utility pages on the default locale', () => {
@@ -22,7 +21,10 @@ describe('documentLocale', () => {
     expect(documentLocale(['__root__', '/auth/auth-complete'], 'zh-cn')).toBe('en')
     expect(documentLocale(['__root__', '/auth/widget-handoff'], 'zh-tw')).toBe('en')
   })
-  it('keeps the English admin app and standalone system routes on the default', () => {
+  it('keeps the admin app (incl. its English-first login) and system routes on the default', () => {
+    // /admin/login renders an English heading + email stage on first paint, so
+    // it stays English until that copy is localized.
+    expect(documentLocale(['__root__', '/admin/login'], 'ar')).toBe('en')
     expect(documentLocale(['__root__', '/admin/posts'], 'zh-cn')).toBe('en')
     expect(documentLocale(['__root__', '/onboarding'], 'ar')).toBe('en')
     expect(documentLocale(['__root__', '/apps'], 'zh-cn')).toBe('en')

--- a/apps/web/src/lib/shared/__tests__/document-locale.test.ts
+++ b/apps/web/src/lib/shared/__tests__/document-locale.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { documentLocale } from '../document-locale'
+
+describe('documentLocale', () => {
+  it('uses the resolved locale on localized public surfaces', () => {
+    expect(documentLocale('/', 'zh-cn')).toBe('zh-cn')
+    expect(documentLocale('/changelog', 'zh-cn')).toBe('zh-cn')
+    expect(documentLocale('/roadmap', 'zh-tw')).toBe('zh-tw')
+    expect(documentLocale('/auth/login', 'zh-tw')).toBe('zh-tw')
+    expect(documentLocale('/widget', 'ar')).toBe('ar')
+  })
+  it('keeps the English admin app on the default locale', () => {
+    expect(documentLocale('/admin', 'zh-cn')).toBe('en')
+    expect(documentLocale('/admin/posts', 'zh-cn')).toBe('en')
+    expect(documentLocale('/admin/settings/branding', 'ar')).toBe('en')
+  })
+  it('localizes the admin sign-in page (it renders translated, unlike the rest of /admin)', () => {
+    expect(documentLocale('/admin/login', 'zh-cn')).toBe('zh-cn')
+    expect(documentLocale('/admin/login', 'zh-tw')).toBe('zh-tw')
+  })
+  it('keeps non-portal system routes on the default locale', () => {
+    expect(documentLocale('/onboarding', 'ar')).toBe('en')
+    expect(documentLocale('/api/v1/posts', 'zh-cn')).toBe('en')
+    expect(documentLocale('/complete-signup/abc', 'zh-cn')).toBe('en')
+    expect(documentLocale('/oauth/callback', 'zh-cn')).toBe('en')
+  })
+})

--- a/apps/web/src/lib/shared/document-locale.ts
+++ b/apps/web/src/lib/shared/document-locale.ts
@@ -4,16 +4,17 @@ import { DEFAULT_LOCALE, type SupportedLocale } from './i18n'
 // `/settings`, ...) is wrapped in PortalIntlProvider, so it's localized.
 const PORTAL_LAYOUT_ROUTE_ID = '/_portal'
 
-// Standalone routes (outside the portal layout) that also render translated
-// content. Everything NOT in this set and NOT under the portal layout — the
-// English admin app, onboarding, and auth utility pages like /auth/two-factor —
-// renders hard-coded English with no provider.
+// Standalone routes (outside the portal layout) that render translated content
+// from their first paint. Everything NOT in this set and NOT under the portal
+// layout renders hard-coded English: the admin app, onboarding, the auth utility
+// pages like /auth/two-factor, and /admin/login (its AdminAuthShell heading and
+// email stage are English; only a later stage hands off to a translated form, so
+// the document stays English until that first-render copy is localized).
 const LOCALIZED_ROUTE_IDS = new Set([
   '/auth/login',
   '/auth/signup',
   '/auth/recovery',
   '/auth/reset-password',
-  '/admin/login',
   '/widget',
 ])
 

--- a/apps/web/src/lib/shared/document-locale.ts
+++ b/apps/web/src/lib/shared/document-locale.ts
@@ -1,0 +1,26 @@
+import { DEFAULT_LOCALE, type SupportedLocale } from './i18n'
+
+// Routes that render in English regardless of the visitor's language: the admin
+// app and the non-portal system routes. `/admin/login` is the exception — it
+// renders translated like the public auth pages, so it's handled before this.
+const ENGLISH_ONLY_PREFIXES = [
+  '/admin',
+  '/onboarding',
+  '/api',
+  '/complete-signup',
+  '/oauth',
+  '/.well-known',
+]
+
+/**
+ * The locale the SSR document's `<html lang>` (and `dir`) should advertise for a
+ * given path. Localized surfaces — the public portal, `/auth/*`, `/admin/login`,
+ * and the widget — use the resolved locale; the English admin UI and system
+ * routes stay on the default. Keeps `<html lang>` matching the rendered content
+ * instead of mislabeling an English admin page with the visitor's language.
+ */
+export function documentLocale(pathname: string, resolved: SupportedLocale): SupportedLocale {
+  if (pathname.startsWith('/admin/login')) return resolved
+  if (ENGLISH_ONLY_PREFIXES.some((prefix) => pathname.startsWith(prefix))) return DEFAULT_LOCALE
+  return resolved
+}

--- a/apps/web/src/lib/shared/document-locale.ts
+++ b/apps/web/src/lib/shared/document-locale.ts
@@ -1,26 +1,36 @@
 import { DEFAULT_LOCALE, type SupportedLocale } from './i18n'
 
-// Routes that render in English regardless of the visitor's language: the admin
-// app and the non-portal system routes. `/admin/login` is the exception — it
-// renders translated like the public auth pages, so it's handled before this.
-const ENGLISH_ONLY_PREFIXES = [
-  '/admin',
-  '/onboarding',
-  '/api',
-  '/complete-signup',
-  '/oauth',
-  '/.well-known',
-]
+// The portal layout route. Every page rendered under it (`/`, `/hc`, `/roadmap`,
+// `/settings`, ...) is wrapped in PortalIntlProvider, so it's localized.
+const PORTAL_LAYOUT_ROUTE_ID = '/_portal'
+
+// Standalone routes (outside the portal layout) that also render translated
+// content. Everything NOT in this set and NOT under the portal layout — the
+// English admin app, onboarding, and auth utility pages like /auth/two-factor —
+// renders hard-coded English with no provider.
+const LOCALIZED_ROUTE_IDS = new Set([
+  '/auth/login',
+  '/auth/signup',
+  '/auth/recovery',
+  '/auth/reset-password',
+  '/admin/login',
+  '/widget',
+])
 
 /**
- * The locale the SSR document's `<html lang>` (and `dir`) should advertise for a
- * given path. Localized surfaces — the public portal, `/auth/*`, `/admin/login`,
- * and the widget — use the resolved locale; the English admin UI and system
- * routes stay on the default. Keeps `<html lang>` matching the rendered content
- * instead of mislabeling an English admin page with the visitor's language.
+ * The locale the SSR document's `<html lang>`/`dir` should advertise, decided
+ * from the matched route IDs rather than the pathname: the path can't tell a
+ * localized portal page (`/hc`) from an English standalone one (`/help`), or a
+ * localized `/auth/login` from an English `/auth/two-factor`. Mislabeling an
+ * English page (e.g. `lang="ar" dir="rtl"`) is worse than the gap it fixes, so
+ * only known-localized routes get the resolved locale; everything else stays on
+ * the default.
  */
-export function documentLocale(pathname: string, resolved: SupportedLocale): SupportedLocale {
-  if (pathname.startsWith('/admin/login')) return resolved
-  if (ENGLISH_ONLY_PREFIXES.some((prefix) => pathname.startsWith(prefix))) return DEFAULT_LOCALE
-  return resolved
+export function documentLocale(
+  routeIds: readonly string[],
+  resolved: SupportedLocale
+): SupportedLocale {
+  const localized =
+    routeIds.includes(PORTAL_LAYOUT_ROUTE_ID) || routeIds.some((id) => LOCALIZED_ROUTE_IDS.has(id))
+  return localized ? resolved : DEFAULT_LOCALE
 }

--- a/apps/web/src/lib/shared/document-locale.ts
+++ b/apps/web/src/lib/shared/document-locale.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_LOCALE, type SupportedLocale } from './i18n'
+import { DEFAULT_LOCALE, isRtlLocale, isRtlForced, type SupportedLocale } from './i18n'
 
 // The portal layout route. Every page rendered under it (`/`, `/hc`, `/roadmap`,
 // `/settings`, ...) is wrapped in PortalIntlProvider, so it's localized.
@@ -34,4 +34,18 @@ export function documentLocale(
   const localized =
     routeIds.includes(PORTAL_LAYOUT_ROUTE_ID) || routeIds.some((id) => LOCALIZED_ROUTE_IDS.has(id))
   return localized ? resolved : DEFAULT_LOCALE
+}
+
+/**
+ * The `<html lang>`/`dir` attributes for a locale. `lang` is a canonical BCP-47
+ * tag — our locale ids are lowercase (e.g. `zh-cn`), so the region subtag is
+ * upper-cased (`zh-CN`, `pt-BR`). `dir` honors the `?rtl=1` debug override.
+ * Shared by the root document (SSR) and the widget so both format identically.
+ */
+export function htmlLangDir(locale: SupportedLocale): { lang: string; dir: 'ltr' | 'rtl' } {
+  const [language, region] = locale.split('-')
+  return {
+    lang: region ? `${language}-${region.toUpperCase()}` : language,
+    dir: isRtlForced() || isRtlLocale(locale) ? 'rtl' : 'ltr',
+  }
 }

--- a/apps/web/src/locales/__tests__/locale-runtime.test.tsx
+++ b/apps/web/src/locales/__tests__/locale-runtime.test.tsx
@@ -42,7 +42,7 @@ describe('Chinese locale runtime wiring', () => {
     expect(screen.getByTestId('nav-ssr').textContent).toBe('路线图')
   })
 
-  it('renders Simplified Chinese through PortalIntlProvider and sets <html lang>', async () => {
+  it('renders Simplified Chinese through PortalIntlProvider', async () => {
     render(
       <PortalIntlProvider locale="zh-cn">
         <span data-testid="nav">
@@ -52,10 +52,9 @@ describe('Chinese locale runtime wiring', () => {
     )
     const node = await screen.findByTestId('nav')
     // Renders the English defaultMessage first, then swaps once the async
-    // catalog load resolves — wait for the Chinese to apply.
+    // catalog load resolves — wait for the Chinese to apply. (`<html lang>`/`dir`
+    // are owned by the root document, not the provider, so aren't asserted here.)
     await waitFor(() => expect(node.textContent).toBe('路线图'))
-    expect(document.documentElement.lang).toBe('zh-cn')
-    expect(document.documentElement.dir).toBe('ltr') // Chinese is LTR
   })
 
   it('formats the collapsed other-only plural with the count substituted', async () => {
@@ -73,23 +72,5 @@ describe('Chinese locale runtime wiring', () => {
     const node = await screen.findByTestId('plural')
     await waitFor(() => expect(node.textContent).toBe('3 則留言'))
     expect(node.textContent).not.toMatch(/comment/i) // English plural did not leak
-  })
-
-  it('does not restore a stale document locale when a localized provider unmounts', async () => {
-    // Simulate the SSR baseline the root document set for a localized page.
-    document.documentElement.lang = 'ar'
-    document.documentElement.dir = 'rtl'
-    const { unmount } = render(
-      <PortalIntlProvider locale="zh-cn">
-        <span />
-      </PortalIntlProvider>
-    )
-    await waitFor(() => expect(document.documentElement.lang).toBe('zh-cn'))
-    unmount()
-    // The root document owns the baseline; unmount must NOT revert lang/dir to
-    // the captured 'ar'/'rtl' (that would mislabel + RTL-flip the next, English
-    // route on a client navigation).
-    expect(document.documentElement.lang).toBe('zh-cn')
-    expect(document.documentElement.dir).toBe('ltr')
   })
 })

--- a/apps/web/src/locales/__tests__/locale-runtime.test.tsx
+++ b/apps/web/src/locales/__tests__/locale-runtime.test.tsx
@@ -74,4 +74,22 @@ describe('Chinese locale runtime wiring', () => {
     await waitFor(() => expect(node.textContent).toBe('3 則留言'))
     expect(node.textContent).not.toMatch(/comment/i) // English plural did not leak
   })
+
+  it('does not restore a stale document locale when a localized provider unmounts', async () => {
+    // Simulate the SSR baseline the root document set for a localized page.
+    document.documentElement.lang = 'ar'
+    document.documentElement.dir = 'rtl'
+    const { unmount } = render(
+      <PortalIntlProvider locale="zh-cn">
+        <span />
+      </PortalIntlProvider>
+    )
+    await waitFor(() => expect(document.documentElement.lang).toBe('zh-cn'))
+    unmount()
+    // The root document owns the baseline; unmount must NOT revert lang/dir to
+    // the captured 'ar'/'rtl' (that would mislabel + RTL-flip the next, English
+    // route on a client navigation).
+    expect(document.documentElement.lang).toBe('zh-cn')
+    expect(document.documentElement.dir).toBe('ltr')
+  })
 })

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -20,14 +20,8 @@ import { DefaultErrorPage } from '@/components/shared/error-page'
 import { OttHandler } from '@/components/shared/ott-handler'
 import { SuspendedView } from '@/components/shared/suspended-view'
 import { isSuspensionExempt } from '@/lib/server/middleware/suspension-paths'
-import { documentLocale } from '@/lib/shared/document-locale'
-import {
-  isRtlLocale,
-  isRtlForced,
-  normalizeLocale,
-  DEFAULT_LOCALE,
-  type SupportedLocale,
-} from '@/lib/shared/i18n'
+import { documentLocale, htmlLangDir } from '@/lib/shared/document-locale'
+import { normalizeLocale, DEFAULT_LOCALE, type SupportedLocale } from '@/lib/shared/i18n'
 
 export interface RouterContext {
   queryClient: QueryClient
@@ -231,7 +225,12 @@ const NON_PORTAL_PREFIXES = ['/admin', '/onboarding', '/api', '/complete-signup'
 function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
   const { settings, themeCookie, acceptLanguageLocale } = Route.useRouteContext()
   const pathname = useRouterState({ select: (s) => s.location.pathname })
-  const routeIds = useRouterState({ select: (s) => s.matches.map((m) => m.routeId) })
+  // structuralSharing keeps the array reference stable across store updates that
+  // don't change the matched routes, so RootDocument doesn't re-render every tick.
+  const routeIds = useRouterState({
+    select: (s) => s.matches.map((m) => m.routeId),
+    structuralSharing: true,
+  })
   // The widget honors a `?locale=` override (its SDK appends it); read it so the
   // iframe document advertises the widget's actual language, not just the
   // Accept-Language one. Only the widget route reads this param.
@@ -257,11 +256,10 @@ function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
   const widgetOverride =
     routeIds.includes('/widget') && widgetLocaleParam ? normalizeLocale(widgetLocaleParam) : null
   const resolvedLocale = widgetOverride ?? acceptLanguageLocale ?? DEFAULT_LOCALE
-  const htmlLocale = documentLocale(routeIds, resolvedLocale)
-  const dir = isRtlForced() || isRtlLocale(htmlLocale) ? 'rtl' : 'ltr'
+  const { lang, dir } = htmlLangDir(documentLocale(routeIds, resolvedLocale))
 
   return (
-    <html lang={htmlLocale} dir={dir} suppressHydrationWarning>
+    <html lang={lang} dir={dir} suppressHydrationWarning>
       <head>
         <HeadContent />
       </head>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -225,6 +225,7 @@ const NON_PORTAL_PREFIXES = ['/admin', '/onboarding', '/api', '/complete-signup'
 function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
   const { settings, themeCookie, acceptLanguageLocale } = Route.useRouteContext()
   const pathname = useRouterState({ select: (s) => s.location.pathname })
+  const routeIds = useRouterState({ select: (s) => s.matches.map((m) => m.routeId) })
 
   // Portal routes can force a specific theme (light/dark) via branding config.
   // Admin and other non-portal routes always respect the user's preference.
@@ -238,8 +239,9 @@ function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
 
   // Advertise the rendered language on the document during SSR so non-English
   // visitors don't get an English `<html lang>` (and so RTL locales aren't laid
-  // out LTR until hydration). The admin app stays English; see documentLocale.
-  const htmlLocale = documentLocale(pathname, acceptLanguageLocale ?? DEFAULT_LOCALE)
+  // out LTR until hydration). Decided from the matched route IDs so only
+  // actually-localized routes are tagged; see documentLocale.
+  const htmlLocale = documentLocale(routeIds, acceptLanguageLocale ?? DEFAULT_LOCALE)
   const dir = isRtlForced() || isRtlLocale(htmlLocale) ? 'rtl' : 'ltr'
 
   return (

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -21,7 +21,13 @@ import { OttHandler } from '@/components/shared/ott-handler'
 import { SuspendedView } from '@/components/shared/suspended-view'
 import { isSuspensionExempt } from '@/lib/server/middleware/suspension-paths'
 import { documentLocale } from '@/lib/shared/document-locale'
-import { isRtlLocale, isRtlForced, DEFAULT_LOCALE, type SupportedLocale } from '@/lib/shared/i18n'
+import {
+  isRtlLocale,
+  isRtlForced,
+  normalizeLocale,
+  DEFAULT_LOCALE,
+  type SupportedLocale,
+} from '@/lib/shared/i18n'
 
 export interface RouterContext {
   queryClient: QueryClient
@@ -226,6 +232,12 @@ function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
   const { settings, themeCookie, acceptLanguageLocale } = Route.useRouteContext()
   const pathname = useRouterState({ select: (s) => s.location.pathname })
   const routeIds = useRouterState({ select: (s) => s.matches.map((m) => m.routeId) })
+  // The widget honors a `?locale=` override (its SDK appends it); read it so the
+  // iframe document advertises the widget's actual language, not just the
+  // Accept-Language one. Only the widget route reads this param.
+  const widgetLocaleParam = useRouterState({
+    select: (s) => (s.location.search as { locale?: string }).locale,
+  })
 
   // Portal routes can force a specific theme (light/dark) via branding config.
   // Admin and other non-portal routes always respect the user's preference.
@@ -240,8 +252,12 @@ function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
   // Advertise the rendered language on the document during SSR so non-English
   // visitors don't get an English `<html lang>` (and so RTL locales aren't laid
   // out LTR until hydration). Decided from the matched route IDs so only
-  // actually-localized routes are tagged; see documentLocale.
-  const htmlLocale = documentLocale(routeIds, acceptLanguageLocale ?? DEFAULT_LOCALE)
+  // actually-localized routes are tagged; see documentLocale. On the widget a
+  // valid `?locale=` override wins, matching what the widget itself renders.
+  const widgetOverride =
+    routeIds.includes('/widget') && widgetLocaleParam ? normalizeLocale(widgetLocaleParam) : null
+  const resolvedLocale = widgetOverride ?? acceptLanguageLocale ?? DEFAULT_LOCALE
+  const htmlLocale = documentLocale(routeIds, resolvedLocale)
   const dir = isRtlForced() || isRtlLocale(htmlLocale) ? 'rtl' : 'ltr'
 
   return (

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -20,6 +20,8 @@ import { DefaultErrorPage } from '@/components/shared/error-page'
 import { OttHandler } from '@/components/shared/ott-handler'
 import { SuspendedView } from '@/components/shared/suspended-view'
 import { isSuspensionExempt } from '@/lib/server/middleware/suspension-paths'
+import { documentLocale } from '@/lib/shared/document-locale'
+import { isRtlLocale, isRtlForced, DEFAULT_LOCALE, type SupportedLocale } from '@/lib/shared/i18n'
 
 export interface RouterContext {
   queryClient: QueryClient
@@ -31,6 +33,7 @@ export interface RouterContext {
   managedFieldPaths?: string[]
   state?: 'active' | 'suspended' | 'deleting'
   registeredAuthProviders?: string[]
+  acceptLanguageLocale?: SupportedLocale
 }
 
 // Paths that are allowed before onboarding is complete
@@ -61,6 +64,7 @@ export const Route = createRootRouteWithContext<RouterContext>()({
       managedFieldPaths,
       state,
       registeredAuthProviders,
+      acceptLanguageLocale,
     } = await getBootstrapData()
 
     if (!isOnboardingExempt(location.pathname)) {
@@ -116,6 +120,7 @@ export const Route = createRootRouteWithContext<RouterContext>()({
       managedFieldPaths,
       state,
       registeredAuthProviders,
+      acceptLanguageLocale,
     }
   },
   head: () => ({
@@ -218,7 +223,7 @@ class SafeRootDocument extends Component<{ children: ReactNode }, { hasError: bo
 const NON_PORTAL_PREFIXES = ['/admin', '/onboarding', '/api', '/complete-signup']
 
 function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
-  const { settings, themeCookie } = Route.useRouteContext()
+  const { settings, themeCookie, acceptLanguageLocale } = Route.useRouteContext()
   const pathname = useRouterState({ select: (s) => s.location.pathname })
 
   // Portal routes can force a specific theme (light/dark) via branding config.
@@ -231,8 +236,14 @@ function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
   // We pass the resolved default so the script knows what to apply.
   const defaultTheme = forcedTheme ?? themeCookie ?? 'system'
 
+  // Advertise the rendered language on the document during SSR so non-English
+  // visitors don't get an English `<html lang>` (and so RTL locales aren't laid
+  // out LTR until hydration). The admin app stays English; see documentLocale.
+  const htmlLocale = documentLocale(pathname, acceptLanguageLocale ?? DEFAULT_LOCALE)
+  const dir = isRtlForced() || isRtlLocale(htmlLocale) ? 'rtl' : 'ltr'
+
   return (
-    <html suppressHydrationWarning>
+    <html lang={htmlLocale} dir={dir} suppressHydrationWarning>
       <head>
         <HeadContent />
       </head>


### PR DESCRIPTION
Follow-up to #244 (now merged). #244 made the portal render translated content during SSR, but `<html lang>` and `dir` were still set only in a client effect: the server shipped a document with no `lang`, and RTL locales (Arabic) were laid out LTR until hydration flipped them, which #244's content-in-SSR change made more noticeable. This sets `lang` and `dir` on the server.

## Changes
- `getBootstrapData` resolves the Accept-Language locale and returns it. It already reads the request headers for the theme cookie, so there's no extra round-trip.
- `documentLocale(routeIds, resolved)` decides the document locale from the **matched route IDs**, not the pathname: localize pages under the portal layout (`/_portal`) plus the standalone `auth login/signup/recovery/reset`, `admin-login`, and `widget` routes; everything else stays on the default. The path can't distinguish a localized portal page (`/hc`) from an English standalone one (`/help`), or a localized `/auth/login` from an English `/auth/two-factor`.
- `RootDocument` renders `<html lang dir>` from it. The existing client effect still applies runtime locale changes (e.g. the widget's `?locale` switch).

## Verification
- Unit test for `documentLocale`: portal layout, the standalone localized routes, untranslated auth utility pages, admin app, and system routes.
- typecheck + lint clean; existing i18n / parity / runtime / admin-login tests pass.
- Live dev server, raw SSR HTML:
  - `/` and `/hc` (portal) with `ar` -> `<html lang="ar" dir="rtl">`; with `zh-CN` -> `lang="zh-cn"`.
  - `/auth/login`, `/admin/login` -> resolved locale.
  - `/auth/two-factor`, `/auth/widget-handoff`, `/apps`, `/unsubscribe`, the rest of `/admin` -> `lang="en" dir="ltr"`.

## Review
- Codex flagged (P2) that the initial path-based carve-out mislabeled English auth utility pages; addressed by switching to the route-ID signal above (commit 2).