### PR TITLE
refactor(widget): single-source the locale list and enforce app parity

### DIFF
--- a/apps/web/src/lib/shared/__tests__/widget-locale-parity.test.ts
+++ b/apps/web/src/lib/shared/__tests__/widget-locale-parity.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { SUPPORTED_LOCALES } from '@/lib/shared/i18n'
+
+// The widget SDK is a standalone published package, so it can't import the app's
+// SUPPORTED_LOCALES and keeps its own WIDGET_LOCALES list. This test is the one
+// place that sees both and enforces SUPPORTED_LOCALES as the source of truth: if
+// a locale is added/removed in the app, the widget list must follow.
+//
+// We read the widget source as text rather than importing it: apps/web is a
+// composite TS project (a relative import trips TS6307) and the package resolves
+// to its built dist, so neither route reaches the source cleanly — and a
+// text read needs no cross-package dependency.
+function readWidgetLocales(): string[] {
+  const path = fileURLToPath(
+    new URL('../../../../../../packages/widget/src/types.ts', import.meta.url)
+  )
+  const src = readFileSync(path, 'utf8')
+  const block = src.match(/WIDGET_LOCALES\s*=\s*\[([^\]]*)\]/)?.[1] ?? ''
+  return [...block.matchAll(/['"]([^'"]+)['"]/g)].map((m) => m[1])
+}
+
+describe('widget locale list', () => {
+  it('covers exactly the app SUPPORTED_LOCALES (BCP-47 casing aside)', () => {
+    const widget = readWidgetLocales()
+    // Guard against the parse silently returning nothing.
+    expect(widget.length).toBeGreaterThan(0)
+    // The widget uses display casing (pt-BR, zh-CN); normalizeLocale lowercases
+    // on the way in, so compare case-insensitively.
+    expect(new Set(widget.map((l) => l.toLowerCase()))).toEqual(
+      new Set(SUPPORTED_LOCALES.map((l) => l.toLowerCase()))
+    )
+  })
+})

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -1,6 +1,25 @@
 // Tenant Quackback URL — e.g. "https://feedback.acme.com"
 export type InstanceUrl = string
 
+/**
+ * Languages Quackback ships catalogs for, as BCP-47 tags (autocomplete hints
+ * for the `locale` option). This is the single source for the `locale` type
+ * below. The widget is a standalone published package and can't import the
+ * app's `SUPPORTED_LOCALES`, so a parity test in apps/web guarantees this list
+ * never drifts from it.
+ */
+export const WIDGET_LOCALES = [
+  'en',
+  'fr',
+  'de',
+  'es',
+  'ar',
+  'ru',
+  'pt-BR',
+  'zh-CN',
+  'zh-TW',
+] as const
+
 /** Passed to `Quackback("init", ...)` or `Quackback.init(...)`. */
 export interface InitOptions {
   /** Tenant Quackback instance URL — required when using the npm package. */
@@ -12,10 +31,10 @@ export interface InitOptions {
   /**
    * Override the auto-detected UI language. Accepts any BCP-47 tag — the host
    * forwards it and the Quackback instance resolves the closest catalog it has.
-   * The literals are autocomplete hints for the languages Quackback ships today;
-   * keep them in sync with `SUPPORTED_LOCALES` in the app's `lib/shared/i18n`.
+   * The literals are autocomplete hints for the languages Quackback ships today
+   * (see WIDGET_LOCALES).
    */
-  locale?: 'en' | 'fr' | 'de' | 'es' | 'ar' | 'ru' | 'pt-BR' | 'zh-CN' | 'zh-TW' | (string & {})
+  locale?: (typeof WIDGET_LOCALES)[number] | (string & {})
   /** Bundle identity into init — shorthand for init + identify. */
   identity?: Identity
 }


### PR DESCRIPTION
The widget SDK's `locale` type was a hand-maintained literal union that had drifted from the app's `SUPPORTED_LOCALES` before (it was missing `ru`/`pt-br` until #244 fixed it). This makes the central list the source of truth.

## Changes
- `packages/widget/src/types.ts`: introduce a single `WIDGET_LOCALES` const and derive the `locale` option's type from it (`(typeof WIDGET_LOCALES)[number] | (string & {})`) instead of a duplicated literal union.
- `apps/web/.../widget-locale-parity.test.ts`: a test asserting `WIDGET_LOCALES` matches `SUPPORTED_LOCALES` (case-insensitively, since the widget uses display casing like `pt-BR`/`zh-CN`). Adding or removing an app locale now fails CI until the widget list follows.

## Why a text read instead of an import
The widget is a standalone, zero-dependency published package, so it can't import the app's `SUPPORTED_LOCALES` (that would invert the dependency direction). The reverse — apps/web importing the widget — also doesn't work cleanly: apps/web is a composite TS project (a relative import trips TS6307) and the package resolves to its built `dist`. So the test reads the widget source as text and extracts the list, which needs no cross-package dependency and keeps the SDK dependency-free.

The widget already listed all 9 locales today; this guarantees it stays that way.