### PR TITLE
fix(portal): show "Signing in…" instead of flashing Log in/Sign up after login

### DIFF
--- a/apps/web/src/components/public/portal-header.tsx
+++ b/apps/web/src/components/public/portal-header.tsx
@@ -18,6 +18,7 @@ import {
 import { Avatar } from '@/components/ui/avatar'
 import { UserStatsBar } from '@/components/shared/user-stats'
 import {
+  ArrowPathIcon,
   ArrowRightStartOnRectangleIcon,
   Cog6ToothIcon,
   ComputerDesktopIcon,
@@ -79,6 +80,11 @@ export function PortalHeader({
   const openAuthPopover = authPopover?.openAuthPopover
   const { theme, setTheme } = useTheme()
   const [mounted, setMounted] = useState(false)
+  // True while a just-completed sign-in is being applied (router.invalidate
+  // refetches the session). Bridges the window where the old session is still
+  // logged-out so the header shows "Signing in…" instead of flashing the
+  // Log in / Sign up buttons.
+  const [signingIn, setSigningIn] = useState(false)
 
   // Avoid hydration mismatch for theme toggle
   useEffect(() => {
@@ -88,10 +94,13 @@ export function PortalHeader({
   // Listen for auth success to refetch session and role via router invalidation
   useAuthBroadcast({
     onSuccess: () => {
+      setSigningIn(true)
       // Invalidate user-scoped queries so reaction highlights and vote data refresh
       queryClient.invalidateQueries({ queryKey: ['portal', 'post'] })
       queryClient.invalidateQueries({ queryKey: ['votedPosts'] })
-      router.invalidate() // Refetch loaders (includes session and userRole)
+      // Refetch loaders (includes session and userRole); clear the transitional
+      // state once the new session has loaded.
+      void router.invalidate().finally(() => setSigningIn(false))
     },
   })
 
@@ -279,6 +288,16 @@ export function PortalHeader({
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
+      ) : signingIn ? (
+        // Sign-in just succeeded; the session refetch is in flight. Show a
+        // transitional state instead of flashing the Log in / Sign up buttons.
+        <div
+          className="flex items-center gap-2 px-3 text-sm text-muted-foreground"
+          aria-live="polite"
+        >
+          <ArrowPathIcon className="h-4 w-4 animate-spin" aria-hidden="true" />
+          <FormattedMessage id="portal.auth.signingIn" defaultMessage="Signing in..." />
+        </div>
       ) : openAuthPopover && portalAuthEnabled ? (
         // Anonymous user with auth popover available - show login/signup buttons
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## Problem
After a successful **inline** sign-in (the portal's Log in dialog, or an OAuth/OTP popup), the header briefly showed the **Log in / Sign up** buttons again before the user menu appeared.

## Cause
On success the auth form broadcasts `auth-success`; the header reacts with `router.invalidate()` to refetch the session. During that refetch the route-context `session` is still the logged-out value, so `isLoggedIn` is `false` and the header renders the logged-out buttons until the new session lands. (The full-page `/auth/login` reloads authenticated, so it never flashed.)

## Fix
Bridge that window with a transitional state in `portal-header.tsx`:
- Set a `signingIn` flag when the `auth-success` broadcast fires; clear it on `router.invalidate().finally(...)` (once the new session has loaded).
- Render **"Signing in…"** (spinner + `aria-live="polite"`) in place of the buttons while `signingIn` is true:

  `isLoggedIn ? <UserMenu> : signingIn ? "Signing in…" : <Log in / Sign up>`

Reuses the existing, already-translated `portal.auth.signingIn` key (localized in all 8 locales; no new key, parity test unaffected). Covers every flashing path (email/password dialog + OAuth/OTP popup, which both broadcast).

## Verification
typecheck clean · lint clean · existing `portal-header-nav` test passes. (A live dev-server demo was attempted but the full stack wouldn't boot in an isolated worktree due to an SSR module-resolution quirk unrelated to this change; the behavior is straightforward to confirm in a normal dev env by signing in via the portal dialog.)