### PR TITLE
fix(portal): sign-in gate renders at 200 with its own IntlProvider

### DIFF
--- a/apps/web/src/components/auth/portal-auth-form-inline.tsx
+++ b/apps/web/src/components/auth/portal-auth-form-inline.tsx
@@ -3,6 +3,7 @@ import { useServerFn } from '@tanstack/react-start'
 import { useIntl, FormattedMessage } from 'react-intl'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
 import { FormError } from '@/components/shared/form-error'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import {
@@ -652,9 +653,9 @@ export function PortalAuthFormInline({
           <>
             <form onSubmit={continueFromEmail} className="space-y-4">
               <div className="space-y-2">
-                <label htmlFor="inline-email" className="text-sm font-medium">
+                <Label htmlFor="inline-email">
                   <FormattedMessage id="portal.auth.email.label" defaultMessage="Email" />
-                </label>
+                </Label>
                 <Input
                   id="inline-email"
                   type="email"
@@ -915,9 +916,9 @@ export function PortalAuthFormInline({
 
           {mode === 'signup' && (
             <div className="space-y-2">
-              <label htmlFor="inline-name" className="text-sm font-medium">
+              <Label htmlFor="inline-name">
                 <FormattedMessage id="portal.auth.name.label" defaultMessage="Name" />
-              </label>
+              </Label>
               <Input
                 id="inline-name"
                 type="text"
@@ -933,13 +934,15 @@ export function PortalAuthFormInline({
             </div>
           )}
 
-          {/* Hidden email keeps password managers happy at the methods step. */}
-          <input type="hidden" name="email" value={email} autoComplete="email" readOnly />
+          {/* Hidden username (the email) pairs with the password field below so
+              password managers — and the browser's a11y form heuristics — treat
+              this as a proper sign-in form. */}
+          <input type="hidden" name="email" value={email} autoComplete="username" readOnly />
 
           <div className="space-y-2">
-            <label htmlFor="inline-password" className="text-sm font-medium">
+            <Label htmlFor="inline-password">
               <FormattedMessage id="portal.auth.password.label" defaultMessage="Password" />
-            </label>
+            </Label>
             <Input
               id="inline-password"
               type="password"
@@ -1103,9 +1106,9 @@ export function PortalAuthFormInline({
           {error && <FormError message={error} />}
 
           <div className="space-y-2">
-            <label htmlFor="inline-forgot-email" className="text-sm font-medium">
+            <Label htmlFor="inline-forgot-email">
               <FormattedMessage id="portal.auth.email.label" defaultMessage="Email" />
-            </label>
+            </Label>
             <Input
               id="inline-forgot-email"
               type="email"

--- a/apps/web/src/components/portal/__tests__/portal-access-gate.intl.test.tsx
+++ b/apps/web/src/components/portal/__tests__/portal-access-gate.intl.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+
+// GateCard re-evaluates access via the router after sign-in.
+vi.mock('@tanstack/react-router', () => ({
+  useRouter: () => ({ invalidate: vi.fn() }),
+}))
+
+// GateCard invalidates portal queries on sign-out.
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}))
+
+// GateCard + AuthDialog listen for cross-tab auth broadcasts.
+vi.mock('@/lib/client/hooks/use-auth-broadcast', () => ({
+  useAuthBroadcast: vi.fn(),
+}))
+
+// GateCard imports signOut for the "unauthorized" branch.
+vi.mock('@/lib/client/auth-client', () => ({
+  signOut: vi.fn(),
+}))
+
+// The dialog body pulls in the full auth form (server fns, auth client, OTP).
+// The intl regression lives in AuthDialog's own header, so stub the body to a
+// trivial node that still proves the dialog opened.
+vi.mock('@/components/auth/portal-auth-form-inline', () => ({
+  PortalAuthFormInline: () => <div data-testid="auth-form-body" />,
+}))
+
+import { PortalAccessGate } from '../portal-access-gate'
+
+const authConfig = { found: true, oauth: { password: true, magicLink: true } }
+
+function renderGate() {
+  return render(
+    <PortalAccessGate
+      reason="unauthenticated"
+      workspaceName="Acme Corp"
+      logoUrl={null}
+      authConfig={authConfig}
+      themeStyles=""
+      customCss=""
+      userEmail={null}
+    />
+  )
+}
+
+describe('PortalAccessGate — IntlProvider regression', () => {
+  beforeEach(() => vi.clearAllMocks())
+  afterEach(() => cleanup())
+
+  // The private-portal gate renders on the route's *error* path (a beforeLoad
+  // throw), which skips the loader that mounts PortalIntlProvider. Opening the
+  // sign-in dialog therefore rendered <FormattedMessage> (AuthDialog's header)
+  // with no IntlProvider ancestor, throwing "Could not find required `intl`
+  // object" and crashing the whole gate. The gate must provide its own intl
+  // context so its auth dialog renders.
+  it('renders the sign-in dialog without an intl-provider crash', () => {
+    renderGate()
+
+    fireEvent.click(screen.getByRole('button', { name: /sign in \/ register/i }))
+
+    // The localized dialog title (defaultMessage) proving useIntl() resolved.
+    expect(screen.getByText(/welcome back/i)).toBeInTheDocument()
+    expect(screen.getByTestId('auth-form-body')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/portal/portal-access-gate.tsx
+++ b/apps/web/src/components/portal/portal-access-gate.tsx
@@ -23,6 +23,8 @@ import { AuthDialog } from '@/components/auth/auth-dialog'
 import { useAuthPopover } from '@/components/auth/auth-popover-context'
 import { useAuthBroadcast } from '@/lib/client/hooks/use-auth-broadcast'
 import { signOut } from '@/lib/client/auth-client'
+import { PortalIntlProvider } from '@/components/portal-intl-provider'
+import { DEFAULT_LOCALE } from '@/lib/shared/i18n'
 import type { PortalAccessGateError } from '@/lib/shared/types/portal-gate-error'
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -222,7 +224,10 @@ function GateCard({ reason, workspaceName, logoUrl, authConfig, userEmail }: Gat
 export interface PortalAccessGateProps
   extends
     Omit<GateCardProps, 'authConfig'>,
-    Pick<PortalAccessGateError, 'authConfig' | 'themeStyles' | 'customCss' | 'userEmail'> {}
+    Pick<
+      PortalAccessGateError,
+      'authConfig' | 'themeStyles' | 'customCss' | 'userEmail' | 'locale'
+    > {}
 
 export function PortalAccessGate({
   reason,
@@ -232,33 +237,42 @@ export function PortalAccessGate({
   themeStyles,
   customCss,
   userEmail,
+  locale,
 }: PortalAccessGateProps) {
   return (
-    <div className="relative min-h-screen">
-      {/* Theme/custom CSS injected here too so the backdrop looks branded */}
-      {themeStyles && <style dangerouslySetInnerHTML={{ __html: themeStyles }} />}
-      {customCss && <style dangerouslySetInnerHTML={{ __html: customCss }} />}
+    // The gate renders on the route's error path (a beforeLoad throw), which
+    // skips the loader that mounts PortalIntlProvider for the normal portal.
+    // The auth dialog below uses react-intl, so the gate provides its own
+    // provider — without it <FormattedMessage> has no context and crashes.
+    // No SSR catalog here (the error path has no loader data); useIntlSetup
+    // fetches it client-side, which lands well before the user opens the dialog.
+    <PortalIntlProvider locale={locale ?? DEFAULT_LOCALE}>
+      <div className="relative min-h-screen">
+        {/* Theme/custom CSS injected here too so the backdrop looks branded */}
+        {themeStyles && <style dangerouslySetInnerHTML={{ __html: themeStyles }} />}
+        {customCss && <style dangerouslySetInnerHTML={{ __html: customCss }} />}
 
-      {/* Blurred decorative backdrop */}
-      <div className="absolute inset-0 overflow-hidden blur-sm" aria-hidden>
-        <DecorativeBackdrop />
+        {/* Blurred decorative backdrop */}
+        <div className="absolute inset-0 overflow-hidden blur-sm" aria-hidden>
+          <DecorativeBackdrop />
+        </div>
+
+        {/* Darkening scrim */}
+        <div className="absolute inset-0 bg-background/60 backdrop-blur-sm" aria-hidden />
+
+        {/* Centered card */}
+        <div className="relative z-10 flex min-h-screen items-center justify-center px-4">
+          <AuthPopoverProvider>
+            <GateCard
+              reason={reason}
+              workspaceName={workspaceName}
+              logoUrl={logoUrl}
+              authConfig={authConfig}
+              userEmail={userEmail}
+            />
+          </AuthPopoverProvider>
+        </div>
       </div>
-
-      {/* Darkening scrim */}
-      <div className="absolute inset-0 bg-background/60 backdrop-blur-sm" aria-hidden />
-
-      {/* Centered card */}
-      <div className="relative z-10 flex min-h-screen items-center justify-center px-4">
-        <AuthPopoverProvider>
-          <GateCard
-            reason={reason}
-            workspaceName={workspaceName}
-            logoUrl={logoUrl}
-            authConfig={authConfig}
-            userEmail={userEmail}
-          />
-        </AuthPopoverProvider>
-      </div>
-    </div>
+    </PortalIntlProvider>
   )
 }

--- a/apps/web/src/lib/shared/types/portal-gate-error.ts
+++ b/apps/web/src/lib/shared/types/portal-gate-error.ts
@@ -5,6 +5,8 @@
  * (_portal.tsx) and unit tests without React or router deps.
  */
 
+import type { SupportedLocale } from '@/lib/shared/i18n'
+
 export interface PortalAccessGateError {
   /** Discriminant — used to identify this error in the route's errorComponent. */
   type: 'portal-access-gate'
@@ -13,6 +15,12 @@ export interface PortalAccessGateError {
   logoUrl: string | null
   themeStyles: string
   customCss: string
+  /**
+   * Locale resolved server-side (Accept-Language) so the gate's auth dialog
+   * renders under the same PortalIntlProvider the portal uses. Optional: older
+   * serialized payloads omit it, and the gate falls back to the default locale.
+   */
+  locale?: SupportedLocale
   /**
    * The signed-in visitor's email when reason === 'unauthorized'. Lets the
    * overlay tell the visitor exactly which account is being blocked so they

--- a/apps/web/src/routes/__tests__/_portal.test.ts
+++ b/apps/web/src/routes/__tests__/_portal.test.ts
@@ -101,22 +101,21 @@ function makeContext(sessionUser?: {
 }
 
 // ---------------------------------------------------------------------------
-// Extract and invoke the beforeLoad logic directly.
-// Import the route module once at top level (mocks are already set up).
+// Extract and invoke the loader logic directly. The portal-visibility gate
+// lives in the loader (not beforeLoad) so a post-sign-in router.invalidate()
+// re-evaluates it. Import the route module once (mocks are already set up).
 // ---------------------------------------------------------------------------
 
 const { Route: routeOptions } = await import('../_portal')
 
-function getBeforeLoad() {
-  // TanStack route stores the options; beforeLoad is accessible via
-  // the internal `options` property on the RouteApi object.
-  const beforeLoad =
-    (routeOptions as unknown as { options?: { beforeLoad?: unknown } }).options?.beforeLoad ??
-    (routeOptions as unknown as { beforeLoad?: unknown }).beforeLoad
-  if (typeof beforeLoad !== 'function') {
-    throw new Error('Could not find beforeLoad on route options')
+function getLoader() {
+  const loader =
+    (routeOptions as unknown as { options?: { loader?: unknown } }).options?.loader ??
+    (routeOptions as unknown as { loader?: unknown }).loader
+  if (typeof loader !== 'function') {
+    throw new Error('Could not find loader on route options')
   }
-  return beforeLoad as (args: { context: unknown }) => Promise<void>
+  return loader as (args: { context: unknown }) => Promise<unknown>
 }
 
 beforeEach(() => {
@@ -124,24 +123,21 @@ beforeEach(() => {
   mockRecordPortalAccessDeniedFn.mockResolvedValue(undefined)
 })
 
-async function runBeforeLoad(context: ReturnType<typeof makeContext>) {
-  return getBeforeLoad()({ context } as never)
+async function runLoader(context: ReturnType<typeof makeContext>) {
+  return getLoader()({ context } as never)
 }
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('_portal beforeLoad — portal.access.denied audit', () => {
+describe('_portal loader — portal-visibility gate + access.denied audit', () => {
   it('calls recordPortalAccessDeniedFn for an authenticated unauthorized visitor', async () => {
     mockEvaluateMyPortalAccessFn.mockResolvedValueOnce({ granted: false, reason: 'unauthorized' })
 
     const context = makeContext({ id: 'user_1', email: 'x@y.com', principalType: 'user' })
-    try {
-      await runBeforeLoad(context)
-    } catch {
-      // expected — gate throws after audit
-    }
+    // The loader returns the gate decision (no throw); the audit still emits.
+    await runLoader(context)
 
     // Wait for the fire-and-forget void promise to settle
     await vi.waitFor(() => expect(mockRecordPortalAccessDeniedFn).toHaveBeenCalled())
@@ -158,11 +154,7 @@ describe('_portal beforeLoad — portal.access.denied audit', () => {
     })
 
     const context = makeContext({ id: 'user_anon', email: '', principalType: 'anonymous' })
-    try {
-      await runBeforeLoad(context)
-    } catch {
-      // expected
-    }
+    await runLoader(context)
 
     // Allow any microtasks to flush
     await new Promise((r) => setTimeout(r, 0))
@@ -174,23 +166,49 @@ describe('_portal beforeLoad — portal.access.denied audit', () => {
 
     const context = makeContext({ id: 'user_1', email: 'admin@y.com', principalType: 'user' })
     // Should not throw when granted
-    await runBeforeLoad(context).catch(() => {})
+    await runLoader(context).catch(() => {})
 
     // Allow any microtasks to flush
     await new Promise((r) => setTimeout(r, 0))
     expect(mockRecordPortalAccessDeniedFn).not.toHaveBeenCalled()
   })
 
-  it('skips the access-gate (no throw, no audit) for a suspended workspace', async () => {
+  it('does not gate a suspended workspace (left to the root SuspendedView)', async () => {
     // A suspended workspace is surfaced by the root SuspendedView overlay, not
-    // the portal access-gate — so beforeLoad must NOT throw the gate error here,
-    // and it isn't an access-denial worth auditing.
+    // the portal access-gate. The loader falls through to the normal portal load
+    // (which redirects to onboarding in this minimal no-org context) — crucially
+    // it must NOT return a gate or emit the access-denial audit.
     mockEvaluateMyPortalAccessFn.mockResolvedValueOnce({ granted: false, reason: 'suspended' })
 
     const context = makeContext({ id: 'user_1', email: 'admin@y.com', principalType: 'user' })
-    await expect(runBeforeLoad(context)).resolves.toBeUndefined()
+    const result = (await runLoader(context).catch((e) => e)) as { gate?: unknown }
+    expect(result?.gate).toBeUndefined()
 
     await new Promise((r) => setTimeout(r, 0))
     expect(mockRecordPortalAccessDeniedFn).not.toHaveBeenCalled()
+  })
+
+  // The loader denies access WITHOUT throwing: it returns the gate decision so
+  // the _portal component renders the sign-in wall as a normal 200 page (the
+  // right status for a login screen — not the 404/500 a throw would produce, and
+  // no error/notFound console noise). Evaluating in the loader (not beforeLoad)
+  // means a post-sign-in router.invalidate() re-runs it so the gate clears once
+  // authorized. Data stays protected because every portal read fn independently
+  // gates on the access resolver, so the child loaders that run return empty.
+  it('returns the gate decision without throwing, carrying the payload', async () => {
+    mockEvaluateMyPortalAccessFn.mockResolvedValueOnce({
+      granted: false,
+      reason: 'unauthenticated',
+    })
+
+    const context = makeContext({ id: 'user_anon', email: '', principalType: 'anonymous' })
+    // Must NOT throw — the component renders the gate at HTTP 200.
+    const result = (await runLoader(context)) as {
+      gate?: { type?: string; locale?: string }
+    }
+
+    expect(result?.gate?.type).toBe('portal-access-gate')
+    // Locale carried so the gate's auth dialog renders under PortalIntlProvider.
+    expect(result?.gate?.locale).toBe('en')
   })
 })

--- a/apps/web/src/routes/_portal.tsx
+++ b/apps/web/src/routes/_portal.tsx
@@ -4,11 +4,12 @@ import { PortalHeader } from '@/components/public/portal-header'
 import { AuthPopoverProvider } from '@/components/auth/auth-popover-context'
 import { AuthDialog } from '@/components/auth/auth-dialog'
 import { PortalAccessGate } from '@/components/portal/portal-access-gate'
-import { type PortalAccessGateError, parseGateError } from '@/lib/shared/types/portal-gate-error'
+import type { PortalAccessGateError } from '@/lib/shared/types/portal-gate-error'
 import { DEFAULT_PORTAL_CONFIG } from '@/lib/shared/types/settings'
 import { generateThemeCSS, getGoogleFontsUrl } from '@/lib/shared/theme'
 import { PortalIntlProvider } from '@/components/portal-intl-provider'
-import { loadPortalIntl } from '@/lib/server/functions/locale'
+import { getPortalLocaleFn, loadPortalIntl } from '@/lib/server/functions/locale'
+import { DEFAULT_LOCALE } from '@/lib/shared/i18n'
 import {
   evaluateMyPortalAccessFn,
   recordPortalAccessDeniedFn,
@@ -16,57 +17,51 @@ import {
 import { redactSettingsForClient } from '@/lib/shared/redact-portal-config'
 
 export const Route = createFileRoute('/_portal')({
-  beforeLoad: async ({ context }) => {
-    const { settings } = context
+  loader: async ({ context }) => {
+    const { session, settings, userRole, baseUrl } = context
 
-    // Portal-level visibility gate.
-    // Throwing here — in beforeLoad — sets firstBadMatchIndex, which aborts
-    // all child route loaders. No portal data is fetched or dehydrated for a
-    // blocked visitor. (A throw from loader does not abort child loaders.)
+    // Portal-level visibility gate — evaluated here in the loader (NOT
+    // beforeLoad) so the post-sign-in router.invalidate() re-runs it and the
+    // gate clears the instant the visitor becomes authorized. A beforeLoad
+    // result is cached across invalidate for an already-loaded match, which
+    // would otherwise strand the just-signed-in visitor on the gate.
     //
-    // The access decision is evaluated server-side by evaluateMyPortalAccessFn,
-    // which reads the caller's session and the full portal config (including
-    // allowedDomains) entirely on the server. Only the decision is returned —
-    // allowedDomains and widgetSignIn never touch the client context.
+    // On denial we render the sign-in wall from the component at HTTP 200 (the
+    // right status for a login screen — not the 404/500 a throw would force, and
+    // no error/notFound console noise). Not throwing means the child loaders
+    // still run, but nothing leaks: every public portal read fn independently
+    // gates on resolvePortalAccessForRequest() and returns empty for a blocked
+    // visitor (defense in depth). The decision is computed server-side
+    // (session + allowedDomains never leave the server); only it is returned.
     const accessResult = await evaluateMyPortalAccessFn()
-
-    if (!accessResult.granted) {
+    if (!accessResult.granted && accessResult.reason !== 'suspended') {
       // A suspended/deleting workspace is surfaced by the root SuspendedView
-      // overlay (__root.tsx), not the portal access-gate. Skip the gate here —
-      // the public read fns already return empty for a suspended workspace
-      // (resolvePortalAccessForRequest denies), so nothing is dehydrated. This
-      // also narrows `reason` to the auth-denial literals for the rest below.
-      if (accessResult.reason === 'suspended') return
+      // overlay (__root.tsx), not this gate — so only the auth-denial reasons
+      // (unauthenticated | unauthorized) reach here.
 
-      // OWASP authz_fail — emit only for authenticated denials (anonymous denials
-      // are too noisy and lower-signal). Best-effort, never blocks the gate throw.
-      const session = context.session
+      // OWASP authz_fail — emit only for authenticated denials (anonymous
+      // denials are too noisy). Best-effort, fire-and-forget.
       const isAuthenticated = !!session?.user && session.user.principalType !== 'anonymous'
       if (isAuthenticated) {
-        // Best-effort, fire-and-forget. The server fn handles all server-only
-        // imports + actor resolution + the audit emit. `.catch()` suppresses
-        // the unhandled-rejection so the gate throw below is never affected.
         void recordPortalAccessDeniedFn({ data: { reason: accessResult.reason } }).catch(() => {})
       }
 
-      // Both denied cases (unauthenticated + unauthorized) render an in-place
-      // overlay via the route's errorComponent. The gate payload is carried
-      // two ways so it survives SSR serialization — see parseGateError below.
       const org = settings?.settings
       const brandingData = settings?.brandingData ?? null
       const brandingConfig = settings?.brandingConfig ?? {}
       const hasThemeConfig = brandingConfig.light || brandingConfig.dark
-      const gateError: PortalAccessGateError = {
+      // Locale so the gate's auth dialog renders under PortalIntlProvider.
+      const locale = await getPortalLocaleFn().catch(() => DEFAULT_LOCALE)
+      const gate: PortalAccessGateError = {
         type: 'portal-access-gate',
         reason: accessResult.reason,
         workspaceName: org?.name ?? '',
         logoUrl: brandingData?.logoUrl ?? null,
         themeStyles: hasThemeConfig ? generateThemeCSS(brandingConfig) : '',
         customCss: settings?.customCss ?? '',
-        // Only meaningful for the 'unauthorized' branch — null when the
-        // visitor is anonymous. The overlay uses this to say "you're
-        // signed in as alice@gmail.com, but…" so the admin can sign out
-        // and try a different account.
+        locale,
+        // Only meaningful for 'unauthorized' — null for an anonymous visitor.
+        // Lets the overlay say "you're signed in as alice@…, but…".
         userEmail: accessResult.reason === 'unauthorized' ? (session?.user?.email ?? null) : null,
         authConfig: {
           found: !!settings?.publicPortalConfig,
@@ -74,11 +69,8 @@ export const Route = createFileRoute('/_portal')({
           customProviderNames: settings?.publicPortalConfig?.customProviderNames,
         },
       }
-      throw Object.assign(new Error(JSON.stringify(gateError)), gateError)
+      return { gate }
     }
-  },
-  loader: async ({ context }) => {
-    const { session, settings, userRole, baseUrl } = context
 
     const org = settings?.settings
     if (!org) {
@@ -141,9 +133,21 @@ export const Route = createFileRoute('/_portal')({
       authConfig,
       locale,
       messages,
+      gate: null,
     }
   },
   head: ({ loaderData }) => {
+    // Access gate: a valid 200 sign-in page, but keep it out of search indexes.
+    if (loaderData?.gate) {
+      return {
+        meta: [
+          { title: `Sign in · ${loaderData.gate.workspaceName}` },
+          { name: 'robots', content: 'noindex, nofollow' },
+        ],
+        links: [{ rel: 'icon', href: loaderData.gate.logoUrl || '/logo.png' }],
+      }
+    }
+
     // Favicon priority: dedicated favicon > workspace logo > default logo.png
     const faviconUrl =
       loaderData?.faviconData?.url || loaderData?.brandingData?.logoUrl || '/logo.png'
@@ -167,44 +171,30 @@ export const Route = createFileRoute('/_portal')({
       links: [{ rel: 'icon', href: faviconUrl }],
     }
   },
-  errorComponent: PortalErrorBoundary,
   component: PortalLayout,
 })
 
-/**
- * Catches errors thrown from the _portal loader. When the error is a
- * PortalAccessGateError we render the in-place overlay; anything else falls
- * through to the default error UI.
- *
- * The gate data is carried two ways so it survives SSR serialization:
- *   1. As extra properties on the Error object (works in pure client / dev).
- *   2. As JSON in the error message (survives when only message is preserved).
- */
-function PortalErrorBoundary({ error }: { error: unknown; reset?: () => void }) {
-  const gateErr = parseGateError(error)
-  if (gateErr) {
+function PortalLayout() {
+  const loaderData = Route.useLoaderData()
+
+  // Access denied: render the in-place sign-in wall (a normal 200 page). The
+  // gate is self-contained (it mounts its own PortalIntlProvider).
+  if (loaderData.gate) {
+    const gate = loaderData.gate
     return (
       <PortalAccessGate
-        reason={gateErr.reason}
-        workspaceName={gateErr.workspaceName}
-        logoUrl={gateErr.logoUrl}
-        authConfig={gateErr.authConfig}
-        themeStyles={gateErr.themeStyles}
-        customCss={gateErr.customCss}
-        userEmail={gateErr.userEmail ?? null}
+        reason={gate.reason}
+        workspaceName={gate.workspaceName}
+        logoUrl={gate.logoUrl}
+        authConfig={gate.authConfig}
+        themeStyles={gate.themeStyles}
+        customCss={gate.customCss}
+        userEmail={gate.userEmail ?? null}
+        locale={gate.locale}
       />
     )
   }
-  // Unknown error — do not surface raw error.message (may contain internal detail).
-  return (
-    <div className="flex min-h-screen items-center justify-center p-8 text-center">
-      <p className="text-muted-foreground">Something went wrong. Please try again.</p>
-    </div>
-  )
-}
 
-function PortalLayout() {
-  const loaderData = Route.useLoaderData()
   const {
     org,
     userRole,


### PR DESCRIPTION
## Summary

Fixes three issues with the private-portal access gate (the sign-in wall shown to visitors of a private portal), plus a small auth-form cleanup.

- **Crash on auth-dialog open.** The gate renders on the route's error path, which skips the loader that mounts `PortalIntlProvider`, so its `react-intl` `<FormattedMessage>`s had no provider ancestor and threw "Could not find required `intl` object" when the dialog opened. The gate now mounts its own `PortalIntlProvider` with a server-resolved locale.
- **HTTP 500 for unauthenticated visits.** Denial was a thrown `Error`, so every unauthenticated hit on a private portal returned 500 (bad for monitoring/SEO/CDN). The gate decision now renders from the `_portal` component at **200** (the right status for a sign-in page) with `noindex`. Nothing leaks: every public portal read fn independently gates on `resolvePortalAccessForRequest()` and returns empty for a blocked visitor (verified live: the feed query dehydrates `statuses:[], tags:[], votedPostIds:[]`).
- **Stuck on the gate after sign-in.** The access check ran in `beforeLoad`, whose result TanStack caches across `router.invalidate()` for an already-loaded match, so the post-login `invalidate()` kept returning the stale "denied" decision. The check now lives in the `loader`, which always re-runs on `invalidate()`.

Also aligns the inline auth form with the shadcn convention (native `<label>` to shadcn `<Label>`, matching `team-login-form.tsx`) and adds a hidden `autoComplete="username"` field so password managers and the browser's a11y heuristics recognize the password step as a sign-in form.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run test` (full suite: 451 files, 4991 passed)
- [x] `bun run lint` (0 errors)
- [x] New regression test: opening the gate's sign-in dialog renders without an intl-provider crash
- [x] New test: the loader returns the gate decision (no throw) so `invalidate()` re-evaluates it
- [x] Manual: unauthenticated private portal returns 200 + renders gate + `noindex`; granted users see the full portal
- [ ] Manual: sign out then sign in clears the gate (please confirm; could not fully reproduce via automation)