### PR TITLE
fix(portal): bridge private-portal sign-in transition + password-form username fields

### DIFF
--- a/apps/web/src/components/auth/portal-auth-form.tsx
+++ b/apps/web/src/components/auth/portal-auth-form.tsx
@@ -784,9 +784,9 @@ export function PortalAuthForm({
             </div>
           )}
 
-          {/* Email is fixed at this stage — hidden field keeps password
-              managers happy. */}
-          <input type="hidden" name="email" value={email} autoComplete="email" readOnly />
+          {/* Email is fixed at this stage — hidden username field keeps
+              password managers happy and pairs with the password input. */}
+          <input type="hidden" name="email" value={email} autoComplete="username" readOnly />
 
           <div className="space-y-2">
             <label htmlFor="password" className="text-sm font-medium">

--- a/apps/web/src/components/portal/__tests__/portal-access-gate.signin-bridge.test.tsx
+++ b/apps/web/src/components/portal/__tests__/portal-access-gate.signin-bridge.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act, cleanup } from '@testing-library/react'
+
+// Capture the GateCard's auth-broadcast onSuccess so the test can fire it as if
+// a sign-in just completed, and hand the router a controllable invalidate so we
+// can drive the post-login refetch window open and closed deterministically.
+const hoisted = vi.hoisted(() => ({
+  gateOnSuccess: null as null | (() => void),
+  resolveInvalidate: null as null | (() => void),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useRouter: () => ({
+    invalidate: () =>
+      new Promise<void>((resolve) => {
+        hoisted.resolveInvalidate = resolve
+      }),
+  }),
+}))
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}))
+
+// GateCard subscribes without an `enabled` flag; the nested AuthDialog passes
+// one — use that to grab the gate's handler specifically.
+vi.mock('@/lib/client/hooks/use-auth-broadcast', () => ({
+  useAuthBroadcast: (opts: { onSuccess?: () => void; enabled?: boolean }) => {
+    if (opts && !('enabled' in opts)) hoisted.gateOnSuccess = opts.onSuccess ?? null
+  },
+}))
+
+vi.mock('@/lib/client/auth-client', () => ({ signOut: vi.fn() }))
+
+// The dialog body pulls in the full auth form (server fns, OTP, etc.); stub it.
+vi.mock('@/components/auth/portal-auth-form-inline', () => ({
+  PortalAuthFormInline: () => <div data-testid="auth-form-body" />,
+}))
+
+import { PortalAccessGate } from '../portal-access-gate'
+
+const authConfig = { found: true, oauth: { password: true, magicLink: true } }
+
+function renderGate() {
+  return render(
+    <PortalAccessGate
+      reason="unauthenticated"
+      workspaceName="Acme Corp"
+      logoUrl={null}
+      authConfig={authConfig}
+      themeStyles=""
+      customCss=""
+      userEmail={null}
+    />
+  )
+}
+
+const cta = () => screen.queryByRole('button', { name: /sign in \/ register/i })
+
+describe('PortalAccessGate — post-sign-in bridge', () => {
+  beforeEach(() => {
+    hoisted.gateOnSuccess = null
+    hoisted.resolveInvalidate = null
+    vi.clearAllMocks()
+  })
+  afterEach(() => cleanup())
+
+  // After a successful sign-in the _portal loader re-runs (router.invalidate).
+  // While that refetch is in flight the gate stays mounted, so it must show a
+  // transitional state instead of flashing its "Sign in / Register" CTA back —
+  // mirrors the PortalHeader "Signing in…" bridge (#249).
+  it('swaps the Sign in / Register CTA for a Signing in… state during the post-login refetch', () => {
+    renderGate()
+
+    expect(cta()).toBeInTheDocument()
+    expect(screen.queryByText(/signing in/i)).not.toBeInTheDocument()
+
+    expect(typeof hoisted.gateOnSuccess).toBe('function')
+    act(() => {
+      hoisted.gateOnSuccess?.()
+    })
+
+    expect(cta()).not.toBeInTheDocument()
+    expect(screen.getByText(/signing in/i)).toBeInTheDocument()
+  })
+
+  // Regression: when the refetch *resolves*, the gate must not flash the CTA
+  // back for a frame before it unmounts (access granted) or re-renders into the
+  // unauthorized branch. The transitional state holds until the gate goes away.
+  it('does not flash the CTA back when the post-login refetch resolves', async () => {
+    renderGate()
+    expect(typeof hoisted.gateOnSuccess).toBe('function')
+
+    act(() => {
+      hoisted.gateOnSuccess?.()
+    })
+    expect(cta()).not.toBeInTheDocument()
+
+    // The loader finishes — drive the invalidate promise to resolution and let
+    // any resulting state updates flush.
+    await act(async () => {
+      hoisted.resolveInvalidate?.()
+      await Promise.resolve()
+    })
+
+    expect(cta()).not.toBeInTheDocument()
+    expect(screen.getByText(/signing in/i)).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/portal/portal-access-gate.tsx
+++ b/apps/web/src/components/portal/portal-access-gate.tsx
@@ -14,6 +14,7 @@
 import { useState } from 'react'
 import { useRouter } from '@tanstack/react-router'
 import { useQueryClient } from '@tanstack/react-query'
+import { FormattedMessage } from 'react-intl'
 import { toast } from 'sonner'
 import { ArrowPathIcon } from '@heroicons/react/24/solid'
 import { Button } from '@/components/ui/button'
@@ -109,23 +110,30 @@ function GateCard({ reason, workspaceName, logoUrl, authConfig, userEmail }: Gat
   const queryClient = useQueryClient()
   const { openAuthPopover } = useAuthPopover()
   const [signingOut, setSigningOut] = useState(false)
+  // A one-way latch: true from a successful sign-in until this gate unmounts.
+  // The gate stays mounted during the post-login loader re-run, so it shows a
+  // "Signing in…" state instead of flashing the "Sign in / Register" CTA — the
+  // same window PortalHeader bridges (#249). We deliberately never clear it:
+  // once auth succeeds the gate either unmounts (access granted) or re-renders
+  // into the unauthorized branch, so the CTA is never needed again. Clearing it
+  // would flash the CTA for a frame as the loader settles, before unmount.
+  const [signingIn, setSigningIn] = useState(false)
 
-  // After a successful sign-in, re-evaluate access by re-running the loader.
+  // A successful sign-in (same-tab inline via postAuthSuccess, OAuth popup, or
+  // another tab) re-runs the loader to re-evaluate access. A broadcast only
+  // fires on a real sign-in, so `reason` always moves off 'unauthenticated' and
+  // the latch can't get stuck on this branch.
   useAuthBroadcast({
     onSuccess: () => {
-      router.invalidate()
+      setSigningIn(true)
+      void router.invalidate()
     },
   })
 
+  // The dialog's onAuthSuccess closes the dialog and the broadcast above drives
+  // the loader re-run, so the CTA only needs to open the dialog.
   const handleSignIn = () => {
-    openAuthPopover({
-      mode: 'login',
-      onSuccess: () => {
-        // onAuthSuccess in the context already closes the dialog; invalidate
-        // here so the _portal loader re-runs immediately after.
-        router.invalidate()
-      },
-    })
+    openAuthPopover({ mode: 'login' })
   }
 
   // Sign out + invalidate so the gate re-evaluates as unauthenticated and
@@ -178,9 +186,19 @@ function GateCard({ reason, workspaceName, logoUrl, authConfig, userEmail }: Gat
                 This portal is private. Sign in or create an account to continue.
               </p>
             </div>
-            <Button className="w-full" onClick={handleSignIn}>
-              Sign in / Register
-            </Button>
+            {signingIn ? (
+              <div
+                className="flex h-9 items-center justify-center gap-2 text-sm text-muted-foreground"
+                aria-live="polite"
+              >
+                <ArrowPathIcon className="h-4 w-4 animate-spin" aria-hidden="true" />
+                <FormattedMessage id="portal.auth.signingIn" defaultMessage="Signing in..." />
+              </div>
+            ) : (
+              <Button className="w-full" onClick={handleSignIn}>
+                Sign in / Register
+              </Button>
+            )}
           </>
         ) : (
           <>

--- a/apps/web/src/routes/auth.reset-password.tsx
+++ b/apps/web/src/routes/auth.reset-password.tsx
@@ -166,6 +166,11 @@ function ResetPasswordContent({ token, urlError }: { token: string; urlError: st
       <form onSubmit={handleSubmit} className="space-y-4">
         {error && <FormError message={error} />}
 
+        {/* Token-based reset: the account email isn't in scope here, but a
+            hidden username field still pairs with the password inputs so
+            password managers and the a11y heuristic stop complaining. */}
+        <input type="text" name="username" autoComplete="username" hidden readOnly />
+
         <div className="space-y-2">
           <label htmlFor="new-password" className="text-sm font-medium">
             <FormattedMessage

--- a/apps/web/src/routes/complete-signup.$id.tsx
+++ b/apps/web/src/routes/complete-signup.$id.tsx
@@ -304,6 +304,11 @@ function WelcomeContent({
         )}
 
         <form onSubmit={handleSubmit} className="space-y-4">
+          {/* Email is fixed by the invite; a hidden username field lets
+              password managers save the credential against it (and pairs
+              with the password input for the a11y heuristic). */}
+          <input type="hidden" name="email" value={invite.email} autoComplete="username" readOnly />
+
           <div className="space-y-2">
             <label htmlFor="name" className="text-sm font-medium">
               Your name


### PR DESCRIPTION
Two portal auth-UX fixes, both verified locally.

## Private-portal sign-in transition

On a private portal, the access gate re-runs the `_portal` loader on sign-in (`router.invalidate()`). The gate stays mounted during that refetch, so it **flashed its "Sign in / Register" CTA** the whole time.

- The gate now shows a transitional **"Signing in…"** state (reusing the `portal.auth.signingIn` key), mirroring the `PortalHeader` bridge from #249.
- The flag is a **one-way latch, never cleared**: once auth succeeds the gate either unmounts (access granted) or re-renders into the `unauthorized` branch, so the CTA is never needed again. Clearing it would flash the CTA back for a single frame as the loader settles (the residual flicker caught in testing).
- Removed the redundant per-open `onSuccess` invalidate — the auth broadcast already drives the re-run.

## Password-form username fields

Browsers warn that password forms should have an (optionally hidden) username field for accessibility and password managers.

- Added hidden `autocomplete="username"` fields to the **reset-password** and **complete-signup** forms.
- Switched the standalone **portal auth form**'s hidden field from `autocomplete="email"` to `"username"`, matching the already-correct inline variant.

## Tests

Adds `portal-access-gate.signin-bridge.test.tsx`:
- Shows "Signing in…" instead of the CTA during the post-login refetch.
- Regression: does not flash the CTA back when the refetch resolves.

Verified: `bun run typecheck` clean; gate tests pass (3); reset-password username field confirmed in-browser (no DOM warning).