### PR TITLE
chore(release): 0.12.3

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quackback/web",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "private": true,
   "license": "AGPL-3.0",
   "type": "module",


### PR DESCRIPTION
Bumps `apps/web/package.json` to 0.12.3 (source of truth for `__APP_VERSION__`). Release notes are on the GitHub release for v0.12.3.