### PR TITLE
docs: mark Quackback Cloud as available in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 ## Get Started
 
-**Cloud** coming soon at [quackback.io](https://quackback.io). Join the waitlist.
+**Cloud** — start free at [app.quackback.io](https://app.quackback.io/signup). We host, scale, and maintain it for you. No setup required.
 
 **Self-hosted** anywhere with [Docker](#docker) or [one click on Railway](#one-click-deploy).
 


### PR DESCRIPTION
Updates the README Get Started section to reflect that Quackback Cloud is now live with self-serve signup.

- Replaces "Cloud coming soon / join the waitlist" with a link to the live signup at app.quackback.io/signup
- Keeps it parallel with the Self-hosted line

🤖 Generated with [Claude Code](https://claude.com/claude-code)