### PR TITLE
chore(web): stop logging healthy /api/health probe traffic

### DIFF
--- a/apps/web/src/lib/server/middleware/__tests__/request-context.test.ts
+++ b/apps/web/src/lib/server/middleware/__tests__/request-context.test.ts
@@ -70,6 +70,51 @@ describe('handleRequestWithContext', () => {
     expect(completed.request_id).toBeDefined()
   })
 
+  it('does NOT log completion for a healthy /api/health probe', async () => {
+    const cap = capture()
+    const request = new Request('http://localhost/api/health')
+
+    await handleRequestWithContext({
+      request,
+      log: cap.log,
+      next: async () => ({ response: new Response('ok', { status: 200 }) }),
+    })
+
+    expect(cap.records().find((r) => r.msg === 'request completed')).toBeUndefined()
+  })
+
+  it('still logs /api/health when the probe is unhealthy (status >= 400)', async () => {
+    const cap = capture()
+    const request = new Request('http://localhost/api/health')
+
+    await handleRequestWithContext({
+      request,
+      log: cap.log,
+      next: async () => ({ response: new Response('unhealthy', { status: 503 }) }),
+    })
+
+    const completed = cap.records().find((r) => r.msg === 'request completed')
+    expect(completed).toBeDefined()
+    expect(completed.status).toBe(503)
+  })
+
+  it('still logs failure when /api/health throws', async () => {
+    const cap = capture()
+    const request = new Request('http://localhost/api/health')
+
+    await expect(
+      handleRequestWithContext({
+        request,
+        log: cap.log,
+        next: async () => {
+          throw new Error('probe boom')
+        },
+      })
+    ).rejects.toThrow('probe boom')
+
+    expect(cap.records().find((r) => r.msg === 'request failed')).toBeDefined()
+  })
+
   it('logs failure and rethrows when next() throws', async () => {
     const cap = capture()
     const request = new Request('http://localhost/boom')
@@ -82,7 +127,7 @@ describe('handleRequestWithContext', () => {
         next: async () => {
           throw boom
         },
-      }),
+      })
     ).rejects.toThrow('kaboom')
 
     const failed = cap.records().find((r) => r.msg === 'request failed')

--- a/apps/web/src/lib/server/middleware/request-context.ts
+++ b/apps/web/src/lib/server/middleware/request-context.ts
@@ -18,6 +18,14 @@ import { createMiddleware } from '@tanstack/react-start'
 import { logger } from '@/lib/server/logger'
 import { runWithLogContext } from '@/lib/server/log-context'
 
+/**
+ * k8s liveness/readiness probe path. Hit every ~2s per pod, so a successful
+ * probe is pure access-log noise (~40k lines/day/tenant). We skip the
+ * completion line for healthy probes only — an unhealthy probe (status >= 400)
+ * or a thrown error is still logged, since those are the signal we care about.
+ */
+const HEALTH_PATH = '/api/health'
+
 function deriveRequestId(request: Request): string {
   const header = request.headers.get('x-request-id') ?? request.headers.get('x-correlation-id')
   // Cap to keep a malicious/huge header out of every log line.
@@ -44,7 +52,8 @@ export async function handleRequestWithContext<T extends NextResult>({
   log?: AppLogger
 }): Promise<T> {
   const requestId = deriveRequestId(request)
-  const route = `${request.method} ${new URL(request.url).pathname}`
+  const pathname = new URL(request.url).pathname
+  const route = `${request.method} ${pathname}`
   const start = performance.now()
 
   return runWithLogContext({ request_id: requestId, route }, async () => {
@@ -58,7 +67,12 @@ export async function handleRequestWithContext<T extends NextResult>({
         // Some responses have immutable headers; correlation still works
         // via the logged request_id.
       }
-      log.info({ status: result.response.status, duration_ms: durationMs }, 'request completed')
+      const status = result.response.status
+      // Suppress the completion line for successful health probes (see
+      // HEALTH_PATH). Everything else — and unhealthy probes — still logs.
+      if (!(pathname === HEALTH_PATH && status < 400)) {
+        log.info({ status, duration_ms: durationMs }, 'request completed')
+      }
       return result
     } catch (err) {
       const durationMs = Math.round(performance.now() - start)


### PR DESCRIPTION
Skip the `request completed` access log for **successful** `/api/health` probes — the k8s probe hits it every ~2s, ~40k noise lines/day/tenant. Unhealthy probes (status ≥ 400) and thrown errors still log.

Tests green (TDD), typecheck/lint/build pass.