### PR TITLE
feat(auth): allow portal users to sign in via SSO

### DIFF
--- a/apps/web/src/lib/server/auth/__tests__/auth-method-allowed.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/auth-method-allowed.test.ts
@@ -170,20 +170,9 @@ describe('isAuthMethodAllowed — portal role (user)', () => {
     expect(r).toEqual({ allowed: true })
   })
 
-  it('blocks sso for portal when not in portal oauth map', async () => {
-    mockGetPublicPortalConfig.mockResolvedValue({
-      oauth: { password: true, magicLink: false },
-    })
-    const r = await isAuthMethodAllowed('sso', 'user')
-    expect(r).toEqual({ allowed: false, error: 'oauth_method_not_allowed' })
-  })
-
-  it('allows sso for portal when explicitly enabled', async () => {
-    mockGetPublicPortalConfig.mockResolvedValue({
-      oauth: { password: true, magicLink: false, sso: true },
-    })
-    const r = await isAuthMethodAllowed('sso', 'user')
-    expect(r).toEqual({ allowed: true })
+  it('allows sso for portal users regardless of the portal oauth map (SSO is role-agnostic)', async () => {
+    mockGetPublicPortalConfig.mockResolvedValue({ oauth: {} })
+    expect(await isAuthMethodAllowed('sso', 'user')).toEqual({ allowed: true })
   })
 
   it('allows OAuth provider for portal when explicitly enabled', async () => {

--- a/apps/web/src/lib/server/auth/__tests__/hooks-after-integration.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/hooks-after-integration.test.ts
@@ -14,13 +14,11 @@
  *     workspace-recovery primitive, provision is the role-policy
  *     primitive), and reversing it would surprise readers.
  *
- *  2. `handleAutoProvisionAfter` runs BEFORE `handleCallbackPolicyCleanup`.
- *     Reversed, cleanup sees `role='user'` on a brand-new verified-
- *     domain SSO sign-in and routes through `checkPortalAuthMethod`,
- *     which blocks because portal `oauth.sso` isn't set (SSO is a
- *     team-side method only). The user's just-created session gets
- *     revoked and they bounce to `/auth/login`. This is the bug the
- *     ordering was introduced to fix.
+ *  2. For a successful SSO sign-in, `handleAutoProvisionAfter` sets the
+ *     verified-domain user's role from config and `handleCallbackPolicyCleanup`
+ *     leaves the session intact — the composition must not revoke a
+ *     legitimate sign-in. (SSO is allowed for every role, so verified-domain
+ *     users pass the policy cleanup.)
  *
  * We assert these by exercising `hooksAfter` end-to-end against a fully
  * mocked dependency graph and checking the side-effect tape.
@@ -165,7 +163,7 @@ beforeEach(() => {
   mockTxPrincipalFindFirst.mockResolvedValue({ id: 'principal_existing_admin' })
   mockUserFindFirst.mockResolvedValue({ createdAt: new Date(Date.now() - 60 * 60_000) })
   mockGetPublicPortalConfig.mockResolvedValue({
-    oauth: { password: true, magicLink: false /* sso NOT enabled */ },
+    oauth: { password: true, magicLink: false },
   })
 })
 
@@ -184,7 +182,7 @@ describe('hooksAfter — successful SSO sign-in by brand-new verified-domain use
     state.role = 'user'
   })
 
-  it('does NOT revoke the session (proves auto-provision ran before cleanup)', async () => {
+  it('does NOT revoke the session on a successful SSO sign-in', async () => {
     await hooksAfter(ssoCallbackCtx({ userId: 'user_new', email: 'alice@acme.com', token: 'tok' }))
 
     expect(mockDelete).not.toHaveBeenCalledWith(expect.objectContaining({ __name: 'session' }))

--- a/apps/web/src/lib/server/auth/__tests__/hooks-callback-cleanup.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/hooks-callback-cleanup.test.ts
@@ -190,7 +190,7 @@ describe('handleCallbackPolicyCleanup — guards', () => {
 })
 
 // ============================================================
-// SSO callback — always allowed for team
+// SSO callback — allowed for every role (team + portal)
 // ============================================================
 
 describe('handleCallbackPolicyCleanup — SSO provider', () => {
@@ -221,39 +221,17 @@ describe('handleCallbackPolicyCleanup — SSO provider', () => {
     expect(ctx.redirect).not.toHaveBeenCalled()
   })
 
-  it('blocks portal user when portalConfig.oauth.sso is not enabled', async () => {
+  it('keeps the session for a portal user (SSO is role-agnostic; verified-domain surfacing gates access)', async () => {
     mockPrincipalFindFirst.mockResolvedValue({ role: 'user' })
-    mockGetPublicPortalConfig.mockResolvedValue({
-      oauth: { password: true, magicLink: false },
-    })
     const ctx = ctxFor({
       path: '/oauth2/callback/:providerId',
       providerParam: 'sso',
       userId: 'user_1',
-      email: 'a@external.com',
-      token: 'tok',
-    })
-
-    await expect(handleCallbackPolicyCleanup(ctx, tenantSettings({}))).rejects.toThrow(
-      /\/auth\/login\?error=oauth_method_not_allowed/
-    )
-    expect(mockSessionDeleteWhere).toHaveBeenCalled()
-    expect(mockDeleteSessionCookie).toHaveBeenCalled()
-  })
-
-  it('allows portal user when portalConfig.oauth.sso is enabled', async () => {
-    mockPrincipalFindFirst.mockResolvedValue({ role: 'user' })
-    mockGetPublicPortalConfig.mockResolvedValue({
-      oauth: { password: true, magicLink: false, sso: true },
-    })
-    const ctx = ctxFor({
-      path: '/oauth2/callback/:providerId',
-      providerParam: 'sso',
-      userId: 'user_1',
-      email: 'a@external.com',
+      email: 'a@acme.com',
       token: 'tok',
     })
     await handleCallbackPolicyCleanup(ctx, tenantSettings({}))
+    expect(mockSessionDeleteWhere).not.toHaveBeenCalled()
     expect(ctx.redirect).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/lib/server/auth/__tests__/hooks-callback-cleanup.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/hooks-callback-cleanup.test.ts
@@ -221,18 +221,42 @@ describe('handleCallbackPolicyCleanup — SSO provider', () => {
     expect(ctx.redirect).not.toHaveBeenCalled()
   })
 
-  it('keeps the session for a portal user (SSO is role-agnostic; verified-domain surfacing gates access)', async () => {
+  it('keeps the session for a portal user at a verified domain', async () => {
     mockPrincipalFindFirst.mockResolvedValue({ role: 'user' })
     const ctx = ctxFor({
       path: '/oauth2/callback/:providerId',
       providerParam: 'sso',
       userId: 'user_1',
-      email: 'a@acme.com',
+      email: 'staff@acme.com',
       token: 'tok',
     })
-    await handleCallbackPolicyCleanup(ctx, tenantSettings({}))
+    await handleCallbackPolicyCleanup(
+      ctx,
+      tenantSettings({ verifiedDomains: [makeVerifiedDomain('acme.com', false)] })
+    )
     expect(mockSessionDeleteWhere).not.toHaveBeenCalled()
     expect(ctx.redirect).not.toHaveBeenCalled()
+  })
+
+  it('revokes a portal user signing in via SSO from a non-verified domain', async () => {
+    // A direct /sign-in/oauth2 start skips the verified-domain routing the
+    // login UI applies, so the callback is the gate that keeps portal SSO
+    // scoped to verified domains.
+    mockPrincipalFindFirst.mockResolvedValue({ role: 'user' })
+    const ctx = ctxFor({
+      path: '/oauth2/callback/:providerId',
+      providerParam: 'sso',
+      userId: 'user_1',
+      email: 'guest@external.com',
+      token: 'tok',
+    })
+    await expect(
+      handleCallbackPolicyCleanup(
+        ctx,
+        tenantSettings({ verifiedDomains: [makeVerifiedDomain('acme.com', false)] })
+      )
+    ).rejects.toThrow(/\/auth\/login\?error=oauth_method_not_allowed/)
+    expect(mockSessionDeleteWhere).toHaveBeenCalled()
   })
 })
 

--- a/apps/web/src/lib/server/auth/__tests__/hooks-callback-cleanup.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/hooks-callback-cleanup.test.ts
@@ -238,11 +238,48 @@ describe('handleCallbackPolicyCleanup — SSO provider', () => {
     expect(ctx.redirect).not.toHaveBeenCalled()
   })
 
-  it('revokes a portal user signing in via SSO from a non-verified domain', async () => {
-    // A direct /sign-in/oauth2 start skips the verified-domain routing the
-    // login UI applies, so the callback is the gate that keeps portal SSO
-    // scoped to verified domains.
+  it('keeps the session for a portal user at an enforced (Require SSO) domain', async () => {
+    // Require-SSO (enforced=true) hard-binds other methods but must still
+    // admit SSO itself — the lockout this feature was added to fix.
     mockPrincipalFindFirst.mockResolvedValue({ role: 'user' })
+    const ctx = ctxFor({
+      path: '/oauth2/callback/:providerId',
+      providerParam: 'sso',
+      userId: 'user_1',
+      email: 'staff@acme.com',
+      token: 'tok',
+    })
+    await handleCallbackPolicyCleanup(
+      ctx,
+      tenantSettings({ verifiedDomains: [makeVerifiedDomain('acme.com', true)] })
+    )
+    expect(mockSessionDeleteWhere).not.toHaveBeenCalled()
+    expect(ctx.redirect).not.toHaveBeenCalled()
+  })
+
+  it('revokes a portal user signing in via SSO from a non-verified domain', async () => {
+    mockPrincipalFindFirst.mockResolvedValue({ role: 'user' })
+    const ctx = ctxFor({
+      path: '/oauth2/callback/:providerId',
+      providerParam: 'sso',
+      userId: 'user_1',
+      email: 'guest@external.com',
+      token: 'tok',
+    })
+    await expect(
+      handleCallbackPolicyCleanup(
+        ctx,
+        tenantSettings({ verifiedDomains: [makeVerifiedDomain('acme.com', false)] })
+      )
+    ).rejects.toThrow(/\/auth\/login\?error=oauth_method_not_allowed/)
+    expect(mockSessionDeleteWhere).toHaveBeenCalled()
+  })
+
+  it('revokes an SSO sign-in from a non-verified domain even when no principal row exists', async () => {
+    // With no principal, role defaults to 'user' (most restrictive). The
+    // verified-domain SSO gate must still fire, fail-closed, rather than
+    // being skipped by the principal-row guard.
+    mockPrincipalFindFirst.mockResolvedValue(null)
     const ctx = ctxFor({
       path: '/oauth2/callback/:providerId',
       providerParam: 'sso',

--- a/apps/web/src/lib/server/auth/auth-restrictions.ts
+++ b/apps/web/src/lib/server/auth/auth-restrictions.ts
@@ -56,9 +56,11 @@ export async function isAuthMethodAllowed(
    *  redundant Redis round-trip per sign-in attempt. */
   tenantSettings?: Awaited<ReturnType<typeof getTenantSettings>>
 ): Promise<AuthMethodResult> {
-  // SSO is role-agnostic: a role governs what a user can do once signed
-  // in, not whether they may authenticate. Which emails are offered SSO is
-  // gated upstream by verified-domain routing and provider registration.
+  // SSO is enabled as a method for every role; role governs what a user can
+  // do once signed in, not whether the method exists. Eligibility is gated
+  // elsewhere: verified-domain routing and provider registration upstream,
+  // and — because the email isn't known here — a verified-domain check for
+  // portal users at the OAuth callback (`handleCallbackPolicyCleanup`).
   if (provider === 'sso') return { allowed: true }
 
   if (role === 'user') {

--- a/apps/web/src/lib/server/auth/auth-restrictions.ts
+++ b/apps/web/src/lib/server/auth/auth-restrictions.ts
@@ -26,6 +26,7 @@ import {
   getTenantSettings,
 } from '@/lib/server/domains/settings/settings.service'
 import { emailDomain } from '@/lib/server/auth/normalize-domain'
+import { isTeamMember } from '@/lib/shared/roles'
 import type { AuthConfig, VerifiedDomain } from '@/lib/server/domains/settings/settings.types'
 
 export type AuthProvider = 'email' | 'credential' | 'magic-link' | 'sso' | string
@@ -56,11 +57,9 @@ export async function isAuthMethodAllowed(
    *  redundant Redis round-trip per sign-in attempt. */
   tenantSettings?: Awaited<ReturnType<typeof getTenantSettings>>
 ): Promise<AuthMethodResult> {
-  // SSO is enabled as a method for every role; role governs what a user can
-  // do once signed in, not whether the method exists. Eligibility is gated
-  // elsewhere: verified-domain routing and provider registration upstream,
-  // and — because the email isn't known here — a verified-domain check for
-  // portal users at the OAuth callback (`handleCallbackPolicyCleanup`).
+  // SSO is a method for every role; role governs authorization, not whether
+  // the method exists. Portal-side eligibility (verified domain) is enforced
+  // at the callback — see `isSsoBlockedForRole` / `handleCallbackPolicyCleanup`.
   if (provider === 'sso') return { allowed: true }
 
   if (role === 'user') {
@@ -129,10 +128,9 @@ async function checkPortalAuthMethod(provider: AuthProvider): Promise<AuthMethod
     return enabled ? { allowed: true } : { allowed: false, error: 'magic_link_method_not_allowed' }
   }
 
-  // Any other OAuth provider (google, github, custom-oidc, …) — enabled
-  // iff its portal toggle is on (already filtered by credential
-  // availability). SSO never reaches here: it's allowed for every role in
-  // isAuthMethodAllowed.
+  // Any other OAuth provider (google, github, custom-oidc, …) — enabled iff
+  // its portal toggle is on (already filtered by credential availability).
+  // SSO is handled in isAuthMethodAllowed and never reaches here.
   const enabled = portalConfig.oauth[provider]
   return enabled ? { allowed: true } : { allowed: false, error: 'oauth_method_not_allowed' }
 }
@@ -165,6 +163,24 @@ export function isEmailAtVerifiedDomain(
   verifiedDomains: readonly VerifiedDomain[] | undefined
 ): boolean {
   return findVerifiedDomainForEmail(email, verifiedDomains) !== null
+}
+
+/**
+ * Portal-side SSO eligibility gate. A non-team role (portal user) may
+ * complete an SSO sign-in only from a verified domain; team roles
+ * (admin/member) are granted deliberately (bootstrap / invitation), so
+ * their SSO is unconditional. Evaluated at the OAuth callback where the
+ * IdP-asserted email is finally known: the login UI only *offers* SSO on a
+ * verified-domain match, but a direct OAuth start skips that routing, so
+ * this is the enforcing gate. Sibling of {@link isHardBound} — same inputs
+ * (email + verifiedDomains), complementary concern (SSO is never hard-bound).
+ */
+export function isSsoBlockedForRole(
+  role: Role,
+  email: string | null | undefined,
+  verifiedDomains: readonly VerifiedDomain[] | undefined
+): boolean {
+  return !isTeamMember(role) && !isEmailAtVerifiedDomain(email, verifiedDomains)
 }
 
 /**

--- a/apps/web/src/lib/server/auth/auth-restrictions.ts
+++ b/apps/web/src/lib/server/auth/auth-restrictions.ts
@@ -37,10 +37,11 @@ interface AuthMethodResult {
 }
 
 /**
- * Per-method enablement check for the team surface. Hard-binding for
- * verified-domain emails is handled separately by
- * {@link isHardBoundByVerifiedDomain} in `hooks.before` / `hooks.after`;
- * this function just answers "is method X turned on for the team?"
+ * Per-method enablement check. Answers "is method X allowed for role Y?"
+ * Team and portal roles take different paths ({@link checkPortalAuthMethod}
+ * handles `role: 'user'`), except SSO which is allowed for every role up
+ * front. Hard-binding for verified-domain emails is handled separately by
+ * {@link isHardBoundByVerifiedDomain} in `hooks.before` / `hooks.after`.
  *
  * @param provider - Path-derived provider id ('credential' | 'magic-link' | 'sso' | provider id)
  * @param role - The principal's role
@@ -55,6 +56,11 @@ export async function isAuthMethodAllowed(
    *  redundant Redis round-trip per sign-in attempt. */
   tenantSettings?: Awaited<ReturnType<typeof getTenantSettings>>
 ): Promise<AuthMethodResult> {
+  // SSO is role-agnostic: a role governs what a user can do once signed
+  // in, not whether they may authenticate. Which emails are offered SSO is
+  // gated upstream by verified-domain routing and provider registration.
+  if (provider === 'sso') return { allowed: true }
+
   if (role === 'user') {
     return checkPortalAuthMethod(provider)
   }
@@ -63,11 +69,11 @@ export async function isAuthMethodAllowed(
   const authConfig = tenant?.authConfig
 
   // Magic-link is gated by the team-side `authConfig.oauth.magicLink`
-  // toggle, mirroring the password toggle. Defaults to enabled — pre-
-  // 0.12 tenants had no `magicLink` key and we keep their team sign-in
-  // working post-upgrade. Verified-domain hard-binding can still block
-  // magic-link for a specific email; that check runs in hooks before
-  // this function is reached.
+  // toggle, mirroring the password toggle. An absent key defaults to
+  // enabled, so a tenant that never set it keeps team sign-in working.
+  // Verified-domain hard-binding can still block magic-link for a
+  // specific email; that check runs in hooks before this function is
+  // reached.
   //
   // Internal token-mint paths (invitations, recovery-code-mint,
   // password-reset) bypass this gate entirely because they write the
@@ -78,14 +84,10 @@ export async function isAuthMethodAllowed(
     return enabled ? { allowed: true } : { allowed: false, error: 'magic_link_method_not_allowed' }
   }
 
-  if (provider === 'sso') return { allowed: true }
-
-  // Password is gated by the team-side authConfig.oauth.password.
-  // Defaults to enabled when the key is absent so v0.9.9 tenants who
-  // never had `password` in their stored authConfig keep their team
-  // sign-in working after upgrade. Explicit `false` blocks.
-  // toggle. Default-false in DEFAULT_AUTH_CONFIG matches the previous
-  // hardcoded /admin/login behavior.
+  // Password is gated by the team-side `authConfig.oauth.password`
+  // toggle. An absent key defaults to enabled, so a tenant that never
+  // set it keeps team sign-in working; an explicit `false` blocks it.
+  // (`DEFAULT_AUTH_CONFIG` seeds it off, so fresh tenants opt in.)
   if (provider === 'credential' || provider === 'password') {
     const enabled = authConfig?.oauth?.password !== false
     return enabled ? { allowed: true } : { allowed: false, error: 'password_method_not_allowed' }
@@ -125,7 +127,10 @@ async function checkPortalAuthMethod(provider: AuthProvider): Promise<AuthMethod
     return enabled ? { allowed: true } : { allowed: false, error: 'magic_link_method_not_allowed' }
   }
 
-  // Any OAuth provider — check if enabled (already filtered by credential availability)
+  // Any other OAuth provider (google, github, custom-oidc, …) — enabled
+  // iff its portal toggle is on (already filtered by credential
+  // availability). SSO never reaches here: it's allowed for every role in
+  // isAuthMethodAllowed.
   const enabled = portalConfig.oauth[provider]
   return enabled ? { allowed: true } : { allowed: false, error: 'oauth_method_not_allowed' }
 }

--- a/apps/web/src/lib/server/auth/hooks.ts
+++ b/apps/web/src/lib/server/auth/hooks.ts
@@ -571,7 +571,7 @@ export async function handleCallbackPolicyCleanup(
   } = await import('@/lib/server/db')
   type UserId = `user_${string}`
 
-  const { isHardBound, isAuthMethodAllowed, isEmailAtVerifiedDomain } =
+  const { isHardBound, isAuthMethodAllowed, isSsoBlockedForRole } =
     await import('./auth-restrictions')
   const verifiedDomains = tenant?.verifiedDomains
 
@@ -603,6 +603,14 @@ export async function handleCallbackPolicyCleanup(
     await db.delete(userTable).where(eq(userTable.id, userId as UserId))
   }
 
+  // Revoke the just-created session, drop brand-new shells, and redirect.
+  // Shared by every reject branch below.
+  const blockSignIn = async (errorCode: string): Promise<never> => {
+    await revokeSession(ctx as SessionCtx, token)
+    await wipeBrandNewShellsIfFresh()
+    throw blockedRedirect(errorCode)
+  }
+
   // Pre-compute viability so `isHardBound` fails open on runtime
   // unavailability (tier downgrade, secret missing). See the
   // `isHardBound` docstring for the self-lockout rationale.
@@ -624,35 +632,25 @@ export async function handleCallbackPolicyCleanup(
     typeof userEmail === 'string' &&
     isHardBound(provider, userEmail, role, tenant?.authConfig, verifiedDomains, ssoRegistered)
   ) {
-    await revokeSession(ctx as SessionCtx, token)
-    await wipeBrandNewShellsIfFresh()
-    throw blockedRedirect('verified_domain_requires_sso')
+    await blockSignIn('verified_domain_requires_sso')
+  }
+
+  // Portal SSO requires a verified domain (see `isSsoBlockedForRole`). The
+  // login UI only offers SSO on a verified-domain match, but a direct
+  // /sign-in/oauth2 start skips that routing, so this callback is the gate.
+  // Sits with the hard-binding gate above the principal-row guard: it's an
+  // email-driven policy, and `role` defaulting to 'user' (the most
+  // restrictive audience) keeps it fail-closed if the principal is missing.
+  if (provider === 'sso' && isSsoBlockedForRole(role, userEmail, verifiedDomains)) {
+    await blockSignIn('oauth_method_not_allowed')
   }
 
   if (!principalRow) return
 
-  // Portal users (role 'user') may use SSO only from a verified domain.
-  // The email-first login UI only offers SSO to verified-domain addresses,
-  // but a direct /sign-in/oauth2 start skips that routing — so this is the
-  // gate that keeps portal SSO scoped to verified domains. Team roles are
-  // assigned deliberately (invitation / provisioning), so their SSO is
-  // unconditional, matching the policy oracle.
-  if (
-    provider === 'sso' &&
-    role === 'user' &&
-    !isEmailAtVerifiedDomain(userEmail, verifiedDomains)
-  ) {
-    await revokeSession(ctx as SessionCtx, token)
-    await wipeBrandNewShellsIfFresh()
-    throw blockedRedirect('oauth_method_not_allowed')
-  }
-
   const result = await isAuthMethodAllowed(provider, role, tenant)
   if (result.allowed) return
 
-  await revokeSession(ctx as SessionCtx, token)
-  await wipeBrandNewShellsIfFresh()
-  throw blockedRedirect(result.error ?? 'auth_method_blocked')
+  await blockSignIn(result.error ?? 'auth_method_blocked')
 }
 
 /**

--- a/apps/web/src/lib/server/auth/hooks.ts
+++ b/apps/web/src/lib/server/auth/hooks.ts
@@ -571,7 +571,8 @@ export async function handleCallbackPolicyCleanup(
   } = await import('@/lib/server/db')
   type UserId = `user_${string}`
 
-  const { isHardBound, isAuthMethodAllowed } = await import('./auth-restrictions')
+  const { isHardBound, isAuthMethodAllowed, isEmailAtVerifiedDomain } =
+    await import('./auth-restrictions')
   const verifiedDomains = tenant?.verifiedDomains
 
   // Look up the principal once — both the role-aware redirect (for the
@@ -629,6 +630,22 @@ export async function handleCallbackPolicyCleanup(
   }
 
   if (!principalRow) return
+
+  // Portal users (role 'user') may use SSO only from a verified domain.
+  // The email-first login UI only offers SSO to verified-domain addresses,
+  // but a direct /sign-in/oauth2 start skips that routing — so this is the
+  // gate that keeps portal SSO scoped to verified domains. Team roles are
+  // assigned deliberately (invitation / provisioning), so their SSO is
+  // unconditional, matching the policy oracle.
+  if (
+    provider === 'sso' &&
+    role === 'user' &&
+    !isEmailAtVerifiedDomain(userEmail, verifiedDomains)
+  ) {
+    await revokeSession(ctx as SessionCtx, token)
+    await wipeBrandNewShellsIfFresh()
+    throw blockedRedirect('oauth_method_not_allowed')
+  }
 
   const result = await isAuthMethodAllowed(provider, role, tenant)
   if (result.allowed) return

--- a/apps/web/src/lib/server/auth/hooks.ts
+++ b/apps/web/src/lib/server/auth/hooks.ts
@@ -1128,17 +1128,13 @@ export async function handleCountryCapture(ctx: {
  *
  *  1. `handleSsoCallbackAfter` — bootstrap admin promotion +
  *     lastSsoSignInAt stamp. Only fires on SSO callbacks.
- *  2. `handleAutoProvisionAfter` — promote brand-new verified-domain
- *     sign-ins from `role='user'` (default) up to `member`/`admin`
- *     per the workspace's autoProvisionRole / attributeMapping
- *     config. MUST run before the policy cleanup, otherwise the
- *     cleanup sees role='user' and runs `checkPortalAuthMethod('sso')`,
- *     which blocks the sign-in because `portalConfig.oauth.sso`
- *     isn't set (SSO is configured on the team side, not the portal).
+ *  2. `handleAutoProvisionAfter` — for SSO callbacks, set a verified-domain
+ *     user's role from the workspace's autoProvisionRole / attributeMapping
+ *     config (brand-new sign-ins default to `role='user'`).
  *  3. `handleCallbackPolicyCleanup` — revoke sessions that violate
- *     per-domain enforcement or workspace policy. Now sees the
- *     post-provision role, so SSO callbacks for verified-domain
- *     users are correctly classified as team and allowed through.
+ *     per-domain SSO enforcement or a disabled per-method toggle. SSO is
+ *     allowed for every role, so verified-domain users pass this step; it
+ *     gates the non-SSO providers.
  *  4. `handleCredentialPostSignInGate` — Require-2FA gate for the
  *     password path.
  *  5. `handleMagicLinkPostSignInGate` — Require-2FA gate for magic-


### PR DESCRIPTION
## What

Let Portal Users (`role: user`) sign in through the workspace SSO connection, gated on a verified domain. Team roles (admin/member) — reached only via bootstrap or a deliberate invite — keep SSO unconditionally.

## Why

Closes #263. A workspace run as a private/internal tool authenticates everyone through one IdP (e.g. Microsoft Entra) but keeps most staff as restricted portal users. Those users were offered "Continue with SSO" (verified-domain routing is role-blind) yet rejected at the callback, because portal SSO was gated on a `portalConfig.oauth.sso` flag no UI ever set — a sign-in loop.

## How

- `isAuthMethodAllowed` treats SSO as an enabled method for every role; role governs authorization, not whether the method exists.
- The eligibility gate lives at the OAuth callback (`handleCallbackPolicyCleanup`), where the IdP email is known: a **portal user** (`role: 'user'`) signing in via SSO must be at a **verified domain** (DNS-proven `sso_verified_domain`), else the session is revoked. Team roles are exempt — they're only granted via bootstrap or invitation, so their SSO stays unconditional (the first-admin bootstrap and invited cross-domain members both depend on this).
- Aligns the policy with the surfacing (`lookupAuthMethodsFn` only offers SSO on a verified-domain match) and closes the direct `/sign-in/oauth2` start that bypasses that routing.

## Safety

- No privilege change: allowing the SSO method for a role doesn't change the role; assignment stays gated (invite / verified-domain provisioning).
- A non-verified IdP identity can only reach a portal session via SSO, and that path is now blocked; the first-admin bootstrap (no admin, no verified domain yet) still works.
- Account linking unchanged (SSO is a trusted provider).

## Review

All Codex findings addressed; threads resolved.