### PR TITLE
feat(config): accept 'deleted' workspace state

### DIFF
--- a/apps/web/src/lib/server/config-file/deps.ts
+++ b/apps/web/src/lib/server/config-file/deps.ts
@@ -24,7 +24,7 @@ export function makeReconcileDeps(): ReconcileDeps {
         featureFlags: row.featureFlags,
         authConfig: row.authConfig ?? null,
         managedFieldPaths: (row.managedFieldPaths as string[] | null) ?? [],
-        state: (row.state as 'active' | 'suspended' | 'deleting' | null) ?? 'active',
+        state: (row.state as 'active' | 'suspended' | 'deleting' | 'deleted' | null) ?? 'active',
       } satisfies SettingsRow
     },
     updateSettings: async (update: SettingsUpdate) => {

--- a/apps/web/src/lib/server/config-file/reconciler.ts
+++ b/apps/web/src/lib/server/config-file/reconciler.ts
@@ -10,7 +10,7 @@ export interface SettingsRow {
   featureFlags: string | null
   authConfig: string | null
   managedFieldPaths: string[]
-  state: 'active' | 'suspended' | 'deleting'
+  state: 'active' | 'suspended' | 'deleting' | 'deleted'
 }
 
 export interface SettingsUpdate {
@@ -21,7 +21,7 @@ export interface SettingsUpdate {
   featureFlags?: string
   authConfig?: string
   managedFieldPaths: string[]
-  state?: 'active' | 'suspended' | 'deleting'
+  state?: 'active' | 'suspended' | 'deleting' | 'deleted'
 }
 
 /**
@@ -38,7 +38,7 @@ export interface SettingsInsert {
   featureFlags?: string
   authConfig?: string
   managedFieldPaths: string[]
-  state: 'active' | 'suspended' | 'deleting'
+  state: 'active' | 'suspended' | 'deleting' | 'deleted'
 }
 
 export interface ReconcileDeps {

--- a/apps/web/src/lib/server/config-file/schema.ts
+++ b/apps/web/src/lib/server/config-file/schema.ts
@@ -91,7 +91,7 @@ const featuresSchema = z.record(z.string(), z.boolean())
 
 // Workspace runtime state. The reconciler writes whatever the file
 // declares; absent → `settings.state` keeps its DB default of 'active'.
-const stateSchema = z.enum(['active', 'suspended', 'deleting'])
+const stateSchema = z.enum(['active', 'suspended', 'deleting', 'deleted'])
 
 // Auth surface: OAuth provider toggles + openSignup + optional OIDC SSO.
 // Provider secrets are never declared here — both OAuth client secrets

--- a/apps/web/src/lib/server/middleware/__tests__/suspension-guard.test.ts
+++ b/apps/web/src/lib/server/middleware/__tests__/suspension-guard.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import {
   _internalEnsureNotSuspended,
+  DeletingError,
   isSuspensionExempt,
   SUSPENSION_EXEMPT_PATHS,
 } from '../suspension-guard'
@@ -25,6 +26,14 @@ describe('_internalEnsureNotSuspended', () => {
       statusCode: 410,
       code: 'WORKSPACE_DELETING',
     })
+  })
+})
+
+describe('ensureNotSuspended — deleted state', () => {
+  it("treats 'deleted' as gone (410), like 'deleting'", async () => {
+    await expect(_internalEnsureNotSuspended(async () => 'deleted')).rejects.toBeInstanceOf(
+      DeletingError
+    )
   })
 })
 

--- a/apps/web/src/lib/server/middleware/suspension-guard.ts
+++ b/apps/web/src/lib/server/middleware/suspension-guard.ts
@@ -2,8 +2,8 @@
  * Suspension guard — server-only chokepoint helper for declarative
  * workspace suspension.
  *
- * `settings.state` carries the trinary 'active' | 'suspended' |
- * 'deleting' and is written by the config-file reconciler. With no
+ * `settings.state` carries 'active' | 'suspended' | 'deleting' |
+ * 'deleted' and is written by the config-file reconciler. With no
  * config file present, the column stays at its 'active' DB default and
  * this guard is a no-op for every request.
  *
@@ -49,16 +49,16 @@ export async function ensureNotSuspended(): Promise<void> {
   const { getTenantSettings } = await import('@/lib/server/domains/settings/settings.service')
   await _internalEnsureNotSuspended(async () => {
     const s = await getTenantSettings()
-    return (s?.state ?? 'active') as 'active' | 'suspended' | 'deleting'
+    return (s?.state ?? 'active') as 'active' | 'suspended' | 'deleting' | 'deleted'
   })
 }
 
 /** Test seam — accepts an injected reader so the unit tests stay
  *  free of DB / Redis imports. */
 export async function _internalEnsureNotSuspended(
-  readState: () => Promise<'active' | 'suspended' | 'deleting'>
+  readState: () => Promise<'active' | 'suspended' | 'deleting' | 'deleted'>
 ): Promise<void> {
   const state = await readState()
   if (state === 'suspended') throw new SuspendedError()
-  if (state === 'deleting') throw new DeletingError()
+  if (state === 'deleting' || state === 'deleted') throw new DeletingError()
 }

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -313,7 +313,10 @@ export const settings = pgTable('settings', {
    * non-`active` workspaces, and the root route redirects HTML hits to
    * `/suspended`.
    */
-  state: text('state').$type<'active' | 'suspended' | 'deleting'>().notNull().default('active'),
+  state: text('state')
+    .$type<'active' | 'suspended' | 'deleting' | 'deleted'>()
+    .notNull()
+    .default('active'),
   /**
    * Monotonic version bumped on every auth-instance-affecting write
    * (authConfig, ssoOidc, oauth toggles, platform credentials, tier


### PR DESCRIPTION
## What

The declarative config-file `state` enum now accepts `'deleted'` alongside `'active'` / `'suspended'` / `'deleting'`. The suspension guard treats `'deleted'` identically to `'deleting'` (HTTP 410); the reconciler and settings types carry it through.

This lets a config provider declare a workspace as `deleted` without the strict config schema rejecting the whole config block. Purely additive and backwards-compatible — existing `'active'`/`'suspended'`/`'deleting'` behaviour is unchanged.

## Changes

- `config-file/schema.ts`: `stateSchema` gains `'deleted'`.
- `config-file/reconciler.ts`, `config-file/deps.ts`, `packages/db` settings column: state unions widened to include `'deleted'`.
- `middleware/suspension-guard.ts`: `'deleted'` → `DeletingError` (410), same as `'deleting'`.

New unit test asserts `'deleted'` is treated as gone (410).

https://claude.ai/code/session_01FecthoJ7iAA7QwcUMZEiZP