### PR TITLE
chore(release): 0.12.4

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quackback/web",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "private": true,
   "license": "AGPL-3.0",
   "type": "module",


### PR DESCRIPTION
Bump `apps/web/package.json` to 0.12.4 ahead of tagging `v0.12.4`.

Changes since v0.12.3:
- feat(auth): allow portal users to sign in via SSO (#264)
- chore(web): stop logging healthy /api/health probe traffic (#257)
- refactor: remove app-level workspace suspension/deletion state (#267)
- docs: mark Quackback Cloud as available in README (#256)