### PR TITLE
feat(sso): provider editor: consolidate default role, claim mapping + autocomplete

### DIFF
--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-editor.test.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-editor.test.tsx
@@ -17,7 +17,9 @@ import type { IdentityProvider } from '@/lib/server/domains/settings/identity-pr
 import { ProviderEditor } from '../provider-editor'
 
 const { upsertSpy } = vi.hoisted(() => ({
-  upsertSpy: vi.fn(async (_args: { data: { kind: string | null } }) => undefined),
+  upsertSpy: vi.fn(
+    async (_args: { data: { kind: string | null; attributeMapping: unknown } }) => undefined
+  ),
 }))
 
 // useServerFn just unwraps the server fn in the browser — return it as-is so
@@ -94,6 +96,38 @@ function renderEditor(provider: IdentityProvider) {
 
 beforeEach(() => {
   upsertSpy.mockClear()
+})
+
+describe('<ProviderEditor> provisioning consolidation', () => {
+  it('shows a single Default role and a collapsed group-mapping disclosure when no rules', () => {
+    renderEditor(
+      makeProvider({ autoCreateUsers: true, autoProvisionRole: 'user', attributeMapping: null })
+    )
+    // One default-role control, bound to autoProvisionRole.
+    expect(screen.getByLabelText('Default role')).toBeInTheDocument()
+    // The group-mapping section is present but the rules are collapsed.
+    expect(screen.getByRole('button', { name: /Map roles from IdP groups/ })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    )
+    // No nested "default role" duplicate inside the mapping.
+    expect(screen.queryByText('No rules — everyone gets the default role.')).not.toBeInTheDocument()
+  })
+
+  it('hides the role controls entirely when auto-create is off', () => {
+    renderEditor(makeProvider({ autoCreateUsers: false }))
+    expect(screen.queryByLabelText('Default role')).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /Map roles from IdP groups/ })
+    ).not.toBeInTheDocument()
+  })
+
+  it('persists attributeMapping=null when saved with no rules and sync off', async () => {
+    renderEditor(makeProvider({ autoCreateUsers: true, attributeMapping: null }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => expect(upsertSpy).toHaveBeenCalled())
+    expect(upsertSpy.mock.calls.at(-1)![0].data.attributeMapping).toBeNull()
+  })
 })
 
 describe('<ProviderEditor> IdP shortcut persistence', () => {

--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-editor.test.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-editor.test.tsx
@@ -233,4 +233,22 @@ describe('<ProviderEditor> claim-mapping assist', () => {
     // Disclosure auto-opens because a mapping object exists; hint is shown.
     expect(screen.getByText(/Run a test sign-in to map roles/)).toBeInTheDocument()
   })
+
+  it('locks the claim-path selector once a rule is added', async () => {
+    ssoTestRef.current = {
+      registrationId: 'oidc_x',
+      allClaims: { groups: ['G1'], roles: ['R1'] },
+    }
+    renderEditor(makeProvider({ autoCreateUsers: true, attributeMapping: null }))
+
+    // Selector is enabled initially (no rules yet).
+    const selector = screen.getByRole('combobox', { name: 'Claim to map' })
+    expect(selector).not.toBeDisabled()
+
+    // Click the first Add button — this pins the claim path.
+    fireEvent.click(screen.getAllByRole('button', { name: 'Add' })[0])
+
+    // Selector is now locked.
+    expect(screen.getByRole('combobox', { name: 'Claim to map' })).toBeDisabled()
+  })
 })

--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-editor.test.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-editor.test.tsx
@@ -9,8 +9,15 @@
  * persisted, the editor must always reopen on the tile the admin selected, and
  * a save must carry that `kind` to the server.
  */
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.setPointerCapture = vi.fn()
+  Element.prototype.releasePointerCapture = vi.fn()
+})
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { IdentityProviderId } from '@quackback/ids'
 import type { IdentityProvider } from '@/lib/server/domains/settings/identity-providers.service'
@@ -195,60 +202,33 @@ describe('<ProviderEditor> connection-test status', () => {
   })
 })
 
-describe('<ProviderEditor> claim-mapping assist', () => {
-  it('shows suggestions from a matching test sign-in and adds a rule on click', async () => {
+describe('<ProviderEditor> claim-mapping autocomplete', () => {
+  it('names the observed claims inline and drops the old assist block', () => {
     ssoTestRef.current = {
       registrationId: 'oidc_x', // matches makeProvider().registrationId
-      allClaims: { groups: ['11111111-2222', 'feedback-admins'] },
+      allClaims: { groups: ['11111111-2222'], roles: ['admin'] },
     }
     renderEditor(makeProvider({ autoCreateUsers: true, attributeMapping: null }))
-
-    // The block is visible with the observed values (disclosure auto-opens).
-    expect(screen.getByText('From your test sign-in')).toBeInTheDocument()
-    expect(screen.getByText('11111111-2222')).toBeInTheDocument()
-
-    // Add the first value as a rule, then save and assert it was persisted.
-    fireEvent.click(screen.getAllByRole('button', { name: 'Add' })[0])
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
-    await waitFor(() => expect(upsertSpy).toHaveBeenCalled())
-    const mapping = upsertSpy.mock.calls.at(-1)![0].data.attributeMapping as {
-      claimPath: string
-      rules: { whenContains: string; role: string }[]
-    }
-    expect(mapping.claimPath).toBe('groups')
-    expect(mapping.rules).toContainEqual({ whenContains: '11111111-2222', role: 'member' })
+    // Inline hint names the observed claims (disclosure auto-opens on suggestions).
+    expect(screen.getByText('From your test sign-in: groups, roles')).toBeInTheDocument()
+    // The old batch-add block's caption is gone.
+    expect(screen.queryByText(/Run a test as another user/)).not.toBeInTheDocument()
+    // Claim path is now an autocomplete (combobox), not a plain textbox.
+    expect(screen.getByRole('combobox', { name: 'Claim path' })).toBeInTheDocument()
   })
 
-  it('does not show the block for a test of a different provider', () => {
-    ssoTestRef.current = { registrationId: 'oidc_other', allClaims: { groups: ['x'] } }
+  it('auto-fills the claim path when the test returned exactly one array claim', () => {
+    ssoTestRef.current = { registrationId: 'oidc_x', allClaims: { roles: ['admin'] } }
     renderEditor(makeProvider({ autoCreateUsers: true, attributeMapping: null }))
-    expect(screen.queryByText('From your test sign-in')).not.toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: 'Claim path' })).toHaveTextContent('roles')
   })
 
-  it('shows the run-a-test hint when there is no test result', () => {
-    ssoTestRef.current = null
+  it('shows no inline suggestions for a test of a different provider', () => {
+    ssoTestRef.current = { registrationId: 'oidc_other', allClaims: { roles: ['admin'] } }
     renderEditor(
       makeProvider({ autoCreateUsers: true, attributeMapping: { claimPath: 'groups', rules: [] } })
     )
-    // Disclosure auto-opens because a mapping object exists; hint is shown.
-    expect(screen.getByText(/Run a test sign-in to map roles/)).toBeInTheDocument()
-  })
-
-  it('locks the claim-path selector once a rule is added', async () => {
-    ssoTestRef.current = {
-      registrationId: 'oidc_x',
-      allClaims: { groups: ['G1'], roles: ['R1'] },
-    }
-    renderEditor(makeProvider({ autoCreateUsers: true, attributeMapping: null }))
-
-    // Selector is enabled initially (no rules yet).
-    const selector = screen.getByRole('combobox', { name: 'Claim to map' })
-    expect(selector).not.toBeDisabled()
-
-    // Click the first Add button — this pins the claim path.
-    fireEvent.click(screen.getAllByRole('button', { name: 'Add' })[0])
-
-    // Selector is now locked.
-    expect(screen.getByRole('combobox', { name: 'Claim to map' })).toBeDisabled()
+    // Disclosure auto-opens because a mapping object exists; no "from your test" hint.
+    expect(screen.queryByText(/From your test sign-in:/)).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-editor.test.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-editor.test.tsx
@@ -22,6 +22,15 @@ const { upsertSpy } = vi.hoisted(() => ({
   ),
 }))
 
+const { ssoTestRef } = vi.hoisted(() => ({
+  ssoTestRef: {
+    current: null as null | { registrationId: string; allClaims: Record<string, unknown> },
+  },
+}))
+vi.mock('../../sso/use-sso-test-sign-in', () => ({
+  useSsoTestSignIn: () => ({ open: vi.fn(), lastSuccess: ssoTestRef.current }),
+}))
+
 // useServerFn just unwraps the server fn in the browser — return it as-is so
 // the editor calls our spies directly.
 vi.mock('@tanstack/react-start', () => ({ useServerFn: (fn: unknown) => fn }))
@@ -96,6 +105,7 @@ function renderEditor(provider: IdentityProvider) {
 
 beforeEach(() => {
   upsertSpy.mockClear()
+  ssoTestRef.current = null
 })
 
 describe('<ProviderEditor> provisioning consolidation', () => {
@@ -182,5 +192,45 @@ describe('<ProviderEditor> connection-test status', () => {
       })
     )
     expect(screen.getByText(/changed since the last test/)).toBeInTheDocument()
+  })
+})
+
+describe('<ProviderEditor> claim-mapping assist', () => {
+  it('shows suggestions from a matching test sign-in and adds a rule on click', async () => {
+    ssoTestRef.current = {
+      registrationId: 'oidc_x', // matches makeProvider().registrationId
+      allClaims: { groups: ['11111111-2222', 'feedback-admins'] },
+    }
+    renderEditor(makeProvider({ autoCreateUsers: true, attributeMapping: null }))
+
+    // The block is visible with the observed values (disclosure auto-opens).
+    expect(screen.getByText('From your test sign-in')).toBeInTheDocument()
+    expect(screen.getByText('11111111-2222')).toBeInTheDocument()
+
+    // Add the first value as a rule, then save and assert it was persisted.
+    fireEvent.click(screen.getAllByRole('button', { name: 'Add' })[0])
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => expect(upsertSpy).toHaveBeenCalled())
+    const mapping = upsertSpy.mock.calls.at(-1)![0].data.attributeMapping as {
+      claimPath: string
+      rules: { whenContains: string; role: string }[]
+    }
+    expect(mapping.claimPath).toBe('groups')
+    expect(mapping.rules).toContainEqual({ whenContains: '11111111-2222', role: 'member' })
+  })
+
+  it('does not show the block for a test of a different provider', () => {
+    ssoTestRef.current = { registrationId: 'oidc_other', allClaims: { groups: ['x'] } }
+    renderEditor(makeProvider({ autoCreateUsers: true, attributeMapping: null }))
+    expect(screen.queryByText('From your test sign-in')).not.toBeInTheDocument()
+  })
+
+  it('shows the run-a-test hint when there is no test result', () => {
+    ssoTestRef.current = null
+    renderEditor(
+      makeProvider({ autoCreateUsers: true, attributeMapping: { claimPath: 'groups', rules: [] } })
+    )
+    // Disclosure auto-opens because a mapping object exists; hint is shown.
+    expect(screen.getByText(/Run a test sign-in to map roles/)).toBeInTheDocument()
   })
 })

--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-editor.test.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-editor.test.tsx
@@ -105,21 +105,19 @@ describe('<ProviderEditor> provisioning consolidation', () => {
     )
     // One default-role control, bound to autoProvisionRole.
     expect(screen.getByLabelText('Default role')).toBeInTheDocument()
-    // The group-mapping section is present but the rules are collapsed.
-    expect(screen.getByRole('button', { name: /Map roles from IdP groups/ })).toHaveAttribute(
+    // The claim-mapping section is present but the rules are collapsed.
+    expect(screen.getByRole('button', { name: /Map roles from claims/ })).toHaveAttribute(
       'aria-expanded',
       'false'
     )
     // No nested "default role" duplicate inside the mapping.
-    expect(screen.queryByText('No rules — everyone gets the default role.')).not.toBeInTheDocument()
+    expect(screen.queryByText('No rules. Everyone gets the default role.')).not.toBeInTheDocument()
   })
 
   it('hides the role controls entirely when auto-create is off', () => {
     renderEditor(makeProvider({ autoCreateUsers: false }))
     expect(screen.queryByLabelText('Default role')).not.toBeInTheDocument()
-    expect(
-      screen.queryByRole('button', { name: /Map roles from IdP groups/ })
-    ).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Map roles from claims/ })).not.toBeInTheDocument()
   })
 
   it('persists attributeMapping=null when saved with no rules and sync off', async () => {
@@ -160,5 +158,29 @@ describe('<ProviderEditor> IdP shortcut persistence', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save' }))
     await waitFor(() => expect(upsertSpy).toHaveBeenCalled())
     expect(upsertSpy.mock.calls.at(-1)![0].data.kind).toBe('auth0')
+  })
+})
+
+describe('<ProviderEditor> connection-test status', () => {
+  it('shows "Not tested yet" when the provider has no successful test', () => {
+    renderEditor(makeProvider({ lastSuccessfulTestAt: null }))
+    expect(screen.getByText(/Not tested yet/)).toBeInTheDocument()
+  })
+
+  it('shows the verified status (ready to enforce) for a fresh successful test', () => {
+    renderEditor(
+      makeProvider({ lastSuccessfulTestAt: '2026-05-02T00:00:00.000Z', detailsChangedAt: null })
+    )
+    expect(screen.getByText(/ready to enforce SSO/)).toBeInTheDocument()
+  })
+
+  it('shows the stale status when the connection changed since the last test', () => {
+    renderEditor(
+      makeProvider({
+        lastSuccessfulTestAt: '2026-05-01T00:00:00.000Z',
+        detailsChangedAt: '2026-05-02T00:00:00.000Z',
+      })
+    )
+    expect(screen.getByText(/changed since the last test/)).toBeInTheDocument()
   })
 })

--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-editor.test.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-editor.test.tsx
@@ -11,6 +11,10 @@
  */
 import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { IdentityProviderId } from '@quackback/ids'
+import type { IdentityProvider } from '@/lib/server/domains/settings/identity-providers.service'
+import { ProviderEditor } from '../provider-editor'
 
 beforeAll(() => {
   Element.prototype.scrollIntoView = vi.fn()
@@ -18,10 +22,6 @@ beforeAll(() => {
   Element.prototype.setPointerCapture = vi.fn()
   Element.prototype.releasePointerCapture = vi.fn()
 })
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import type { IdentityProviderId } from '@quackback/ids'
-import type { IdentityProvider } from '@/lib/server/domains/settings/identity-providers.service'
-import { ProviderEditor } from '../provider-editor'
 
 const { upsertSpy } = vi.hoisted(() => ({
   upsertSpy: vi.fn(

--- a/apps/web/src/components/admin/settings/security/identity-providers/provider-editor.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/provider-editor.tsx
@@ -1082,7 +1082,9 @@ function ClaimMappingEditor({
     value: v,
   }))
 
-  const [open, setOpen] = useState(hasConfig)
+  // Initialize open with hasSuggestions too, so a matching test sign-in's
+  // suggestions don't cause a closed-then-open flash on mount.
+  const [open, setOpen] = useState(hasConfig || hasSuggestions)
   useEffect(() => {
     if (hasSuggestions) setOpen(true)
   }, [hasSuggestions])

--- a/apps/web/src/components/admin/settings/security/identity-providers/provider-editor.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/provider-editor.tsx
@@ -760,7 +760,7 @@ function DomainsSection({
             <WarningBox
               variant="warning"
               title="Before you enforce"
-              description="Enforcing requires email delivery (break-glass) + one successful sign-in through this provider first."
+              description="Run a successful test sign-in and generate recovery codes first — they're your break-glass if SSO ever breaks."
             />
           )}
 

--- a/apps/web/src/components/admin/settings/security/identity-providers/provider-editor.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/provider-editor.tsx
@@ -1101,11 +1101,15 @@ function ClaimSuggestionsBlock({
   disabled: boolean
   onChange: (mapping: Mapping) => void
 }) {
-  // The mapping holds one claim path. Default the active path to the mapping's
-  // own path when it is one of the observed ones, else the first observed path.
-  const activePath = suggestions.paths.includes(current.claimPath)
+  // Once rules exist the claim path is locked to prevent orphaning them: if
+  // the admin switches paths while rules reference the old one, those rules
+  // silently never match at sign-in.
+  const locked = current.rules.length > 0
+  const activePath = locked
     ? current.claimPath
-    : suggestions.paths[0]
+    : suggestions.paths.includes(current.claimPath)
+      ? current.claimPath
+      : suggestions.paths[0]
   const values = suggestions.valuesByPath[activePath] ?? []
   const mapped = new Set(current.rules.map((r) => r.whenContains.toLowerCase()))
 
@@ -1114,22 +1118,29 @@ function ClaimSuggestionsBlock({
       <div className="flex items-center justify-between gap-2">
         <Label className="text-xs font-medium">From your test sign-in</Label>
         {suggestions.paths.length > 1 && (
-          <Select
-            value={activePath}
-            onValueChange={(p) => onChange({ ...current, claimPath: p })}
-            disabled={disabled}
-          >
-            <SelectTrigger className="h-7 w-[180px] text-xs">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {suggestions.paths.map((p) => (
-                <SelectItem key={p} value={p}>
-                  {p}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <div className="flex flex-col items-end gap-1">
+            <Select
+              value={activePath}
+              onValueChange={(p) => onChange({ ...current, claimPath: p })}
+              disabled={disabled || locked}
+            >
+              <SelectTrigger className="h-7 w-[180px] text-xs" aria-label="Claim to map">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {suggestions.paths.map((p) => (
+                  <SelectItem key={p} value={p}>
+                    {p}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {locked && (
+              <p className="text-[11px] text-muted-foreground">
+                Clear the rules to map a different claim.
+              </p>
+            )}
+          </div>
         )}
       </div>
       <div className="space-y-1.5">
@@ -1158,9 +1169,10 @@ function ClaimSuggestionsBlock({
 
 /**
  * Claim-to-role mapping: an optional override on top of the provider's Default
- * role. With no rules everyone gets the default. Collapsed by default; auto-expands
- * when the provider already has rules or sign-in sync configured. The parent's
- * handleSave persists null unless the mapping carries rules or sync.
+ * role. With no rules everyone gets the default. Opens when `mapping !== null`
+ * (the provider already has a mapping) or when a matching test sign-in produces
+ * suggestions. The parent's handleSave persists null unless the mapping carries
+ * rules or sync.
  */
 function ClaimMappingEditor({
   mapping,

--- a/apps/web/src/components/admin/settings/security/identity-providers/provider-editor.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/provider-editor.tsx
@@ -185,6 +185,10 @@ export function ProviderEditor({
       toast.error('Client ID is required.')
       return
     }
+    // A group mapping with no rules and no sign-in sync does nothing, so persist
+    // null (the canonical "no mapping" state). A custom claim path alone is inert.
+    const mappingToSave =
+      mapping && (mapping.rules.length > 0 || mapping.syncOnEverySignIn === true) ? mapping : null
     setSaving(true)
     try {
       const saved = await upsert({
@@ -209,7 +213,7 @@ export function ProviderEditor({
           // Role only applies when auto-create is on; null it out otherwise
           // so a stale role doesn't linger on a provisioning-off provider.
           autoProvisionRole: autoCreateUsers ? autoProvisionRole : null,
-          attributeMapping: mapping,
+          attributeMapping: mappingToSave,
           showButton,
         },
       })
@@ -393,19 +397,36 @@ export function ProviderEditor({
           <div className="space-y-4 border-t border-border/40 pt-5">
             <div className="flex items-start justify-between gap-4">
               <div className="flex-1">
-                <Label className="font-medium">New users get role</Label>
+                <Label className="font-medium">Auto-create accounts on first sign-in</Label>
                 <p className="mt-1 text-xs text-muted-foreground">
-                  Auto-create accounts on first sign-in with this role.
+                  Create an account the first time someone signs in through this provider.
                 </p>
               </div>
-              <div className="flex items-center gap-3 shrink-0">
-                {autoCreateUsers && (
+              <Switch
+                checked={autoCreateUsers}
+                onCheckedChange={setAutoCreateUsers}
+                disabled={saving}
+                aria-label="Auto-create accounts on first sign-in"
+                className="mt-0.5 shrink-0"
+              />
+            </div>
+
+            {autoCreateUsers && (
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="idp-default-role" className="font-medium">
+                    Default role
+                  </Label>
                   <Select
                     value={autoProvisionRole}
                     onValueChange={(r) => setAutoProvisionRole(r as Role)}
                     disabled={saving}
                   >
-                    <SelectTrigger className="h-9 w-[160px] text-xs" aria-label="Default role">
+                    <SelectTrigger
+                      id="idp-default-role"
+                      className="w-[220px]"
+                      aria-label="Default role"
+                    >
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
@@ -414,17 +435,14 @@ export function ProviderEditor({
                       <SelectItem value="user">User (portal only)</SelectItem>
                     </SelectContent>
                   </Select>
-                )}
-                <Switch
-                  checked={autoCreateUsers}
-                  onCheckedChange={setAutoCreateUsers}
-                  disabled={saving}
-                  aria-label="Auto-create accounts on first sign-in"
-                />
-              </div>
-            </div>
+                  <p className="text-xs text-muted-foreground">
+                    New users get this role unless a rule below matches their IdP group.
+                  </p>
+                </div>
 
-            <AttributeMappingEditor mapping={mapping} disabled={saving} onChange={setMapping} />
+                <GroupMappingEditor mapping={mapping} disabled={saving} onChange={setMapping} />
+              </div>
+            )}
           </div>
         </div>
 
@@ -949,12 +967,12 @@ function DomainRow({
 }
 
 /**
- * IdP-attribute → role mapping. Same shape as the single-SSO
- * `attribute-mapping-section`, but the draft is owned by the editor and
- * persisted in the parent `upsertIdentityProviderFn` call rather than via
- * `updateAuthConfigFn`.
+ * IdP-group → role mapping: an optional override on top of the provider's Default
+ * role. With no rules everyone gets the default. Collapsed by default; auto-expands
+ * when the provider already has rules or sign-in sync configured. The parent's
+ * handleSave persists null unless the mapping carries rules or sync.
  */
-function AttributeMappingEditor({
+function GroupMappingEditor({
   mapping,
   disabled,
   onChange,
@@ -963,55 +981,40 @@ function AttributeMappingEditor({
   disabled: boolean
   onChange: (mapping: Mapping | null) => void
 }) {
-  const [open, setOpen] = useState(false)
-  const enabled = mapping !== null
+  const ruleCount = mapping?.rules.length ?? 0
+  const hasConfig = ruleCount > 0 || mapping?.syncOnEverySignIn === true
+  const [open, setOpen] = useState(hasConfig)
+  // Vestigial defaultRole satisfies the Mapping type until Task 4 removes the field.
   const current: Mapping = mapping ?? { claimPath: 'groups', rules: [], defaultRole: 'member' }
-
   const update = (patch: Partial<Mapping>) => onChange({ ...current, ...patch })
 
   return (
-    <div className="space-y-3">
-      <div className="flex items-start justify-between gap-4">
-        <div className="flex items-start gap-2">
-          <AdjustmentsHorizontalIcon className="mt-0.5 size-4 text-muted-foreground" />
-          <div>
-            <Label className="font-medium">Attribute → role</Label>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Source the role from an IdP claim. Rules are first-match-wins.
-            </p>
-          </div>
-        </div>
-        <div className="flex items-center gap-3">
-          {enabled && (
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="h-8"
-              onClick={() => setOpen((o) => !o)}
-            >
-              {open ? 'Done' : 'Configure…'}
-            </Button>
+    <div className="rounded-md border border-border/50 bg-muted/10">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex w-full items-center justify-between px-3 py-2 text-left"
+        aria-expanded={open}
+      >
+        <span className="flex items-center gap-2 text-sm font-medium">
+          <AdjustmentsHorizontalIcon className="size-4 text-muted-foreground" />
+          Map roles from IdP groups
+          {ruleCount > 0 && (
+            <span className="text-xs font-normal text-muted-foreground">
+              · {ruleCount} rule{ruleCount === 1 ? '' : 's'}
+            </span>
           )}
-          <Switch
-            checked={enabled}
-            onCheckedChange={(v) => {
-              if (v) {
-                onChange(current)
-                setOpen(true)
-              } else {
-                onChange(null)
-                setOpen(false)
-              }
-            }}
-            disabled={disabled}
-            aria-label="Enable attribute mapping"
-          />
-        </div>
-      </div>
+        </span>
+        <span className="text-muted-foreground">{open ? '−' : '+'}</span>
+      </button>
 
-      {enabled && open && (
-        <div className="space-y-4 pl-6">
+      {open && (
+        <div className="space-y-4 border-t border-border/40 px-3 py-3">
+          <p className="text-xs text-muted-foreground">
+            Source the role from an IdP claim. Rules are first-match-wins; with no rules everyone
+            gets the default role above.
+          </p>
+
           <div className="space-y-2">
             <Label htmlFor="idp-claim-path">Claim path</Label>
             <Input
@@ -1096,26 +1099,6 @@ function AttributeMappingEditor({
             </Button>
           </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="idp-default-role">Default role</Label>
-            <Select
-              value={current.defaultRole}
-              onValueChange={(r) => update({ defaultRole: r as Role })}
-              disabled={disabled}
-            >
-              <SelectTrigger id="idp-default-role" className="w-48">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {ROLES.map((r) => (
-                  <SelectItem key={r} value={r}>
-                    {r}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
           <label className="flex items-start gap-2 text-xs">
             <Switch
               checked={current.syncOnEverySignIn ?? false}
@@ -1124,8 +1107,8 @@ function AttributeMappingEditor({
               disabled={disabled}
             />
             <span>
-              <span className="font-medium">Sync on every sign-in.</span> Re-resolve the role on
-              each sign-in. Demotes members when their IdP group changes.
+              <span className="font-medium">Sync role on every sign-in.</span> Re-resolve the role
+              on each sign-in. Demotes members when their IdP group changes.
             </span>
           </label>
         </div>

--- a/apps/web/src/components/admin/settings/security/identity-providers/provider-editor.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/provider-editor.tsx
@@ -74,7 +74,8 @@ import type { VerifiedDomain } from '@/lib/server/domains/settings/settings.type
 import { getIdpShortcut, inferIdpKind, IDP_KIND_NAMES, type IdpKind } from '../idp-shortcuts'
 import { TestSignInButton } from '../sso/test-sign-in-button'
 import { useSsoTestSignIn } from '../sso/use-sso-test-sign-in'
-import { deriveClaimSuggestions, type ClaimSuggestions } from '@/lib/shared/claim-suggestions'
+import { deriveClaimSuggestions } from '@/lib/shared/claim-suggestions'
+import { Autocomplete } from '@/components/ui/autocomplete'
 
 type Role = 'admin' | 'member' | 'user'
 type Mapping = NonNullable<IdentityProvider['attributeMapping']>
@@ -1042,137 +1043,13 @@ function DomainRow({
   )
 }
 
-/** One observed claim value with a role picker + Add. Role state is local so
- *  each row remembers its own choice until added. */
-function ClaimSuggestionRow({
-  value,
-  added,
-  disabled,
-  onAdd,
-}: {
-  value: string
-  added: boolean
-  disabled: boolean
-  onAdd: (role: Role) => void
-}) {
-  const [role, setRole] = useState<Role>('member')
-  return (
-    <div className="flex items-center gap-2">
-      <code className="min-w-0 flex-1 truncate rounded bg-muted/40 px-1.5 py-1 text-[11px]">
-        {value}
-      </code>
-      <span className="shrink-0 text-xs text-muted-foreground">→</span>
-      <Select value={role} onValueChange={(r) => setRole(r as Role)} disabled={disabled || added}>
-        <SelectTrigger className="h-7 w-28 text-xs">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {ROLES.map((r) => (
-            <SelectItem key={r} value={r}>
-              {r}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-      <Button
-        type="button"
-        size="sm"
-        variant={added ? 'ghost' : 'secondary'}
-        className="h-7"
-        disabled={disabled || added}
-        onClick={() => onAdd(role)}
-      >
-        {added ? 'Added' : 'Add'}
-      </Button>
-    </div>
-  )
-}
-
-/** "From your test sign-in" assist: lists the observed values at the active
- *  claim path; clicking Add appends a rule and pins the claim path. */
-function ClaimSuggestionsBlock({
-  suggestions,
-  current,
-  disabled,
-  onChange,
-}: {
-  suggestions: ClaimSuggestions
-  current: Mapping
-  disabled: boolean
-  onChange: (mapping: Mapping) => void
-}) {
-  // Once rules exist the claim path is locked to prevent orphaning them: if
-  // the admin switches paths while rules reference the old one, those rules
-  // silently never match at sign-in.
-  const locked = current.rules.length > 0
-  const activePath = locked
-    ? current.claimPath
-    : suggestions.paths.includes(current.claimPath)
-      ? current.claimPath
-      : suggestions.paths[0]
-  const values = suggestions.valuesByPath[activePath] ?? []
-  const mapped = new Set(current.rules.map((r) => r.whenContains.toLowerCase()))
-
-  return (
-    <div className="space-y-2 rounded-md border border-border/50 bg-muted/10 p-3">
-      <div className="flex items-center justify-between gap-2">
-        <Label className="text-xs font-medium">From your test sign-in</Label>
-        {suggestions.paths.length > 1 && (
-          <div className="flex flex-col items-end gap-1">
-            <Select
-              value={activePath}
-              onValueChange={(p) => onChange({ ...current, claimPath: p })}
-              disabled={disabled || locked}
-            >
-              <SelectTrigger className="h-7 w-[180px] text-xs" aria-label="Claim to map">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {suggestions.paths.map((p) => (
-                  <SelectItem key={p} value={p}>
-                    {p}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {locked && (
-              <p className="text-[11px] text-muted-foreground">
-                Clear the rules to map a different claim.
-              </p>
-            )}
-          </div>
-        )}
-      </div>
-      <div className="space-y-1.5">
-        {values.map((value) => (
-          <ClaimSuggestionRow
-            key={value}
-            value={value}
-            added={mapped.has(value.toLowerCase())}
-            disabled={disabled}
-            onAdd={(role) =>
-              onChange({
-                ...current,
-                claimPath: activePath,
-                rules: [...current.rules, { whenContains: value, role }],
-              })
-            }
-          />
-        ))}
-      </div>
-      <p className="text-[11px] text-muted-foreground">
-        From your last test sign-in. Run a test as another user to see their groups too.
-      </p>
-    </div>
-  )
-}
-
 /**
  * Claim-to-role mapping: an optional override on top of the provider's Default
- * role. With no rules everyone gets the default. Opens when `mapping !== null`
- * (the provider already has a mapping) or when a matching test sign-in produces
- * suggestions. The parent's handleSave persists null unless the mapping carries
- * rules or sync.
+ * role. With no rules everyone gets the default. The Claim path and each rule
+ * value are creatable autocompletes sourced from the last matching test sign-in
+ * (free text still allowed). Opens when `mapping !== null` or when a matching
+ * test produced suggestions. The parent's handleSave persists null unless the
+ * mapping carries rules or sync.
  */
 function ClaimMappingEditor({
   mapping,
@@ -1196,11 +1073,26 @@ function ClaimMappingEditor({
       ? deriveClaimSuggestions(lastSuccess.allClaims)
       : null
   const hasSuggestions = (suggestions?.paths.length ?? 0) > 0
+  const pathSuggestions = (suggestions?.paths ?? []).map((p) => ({ value: p }))
+  const valueSuggestions = (suggestions?.valuesByPath[current.claimPath] ?? []).map((v) => ({
+    value: v,
+  }))
 
   const [open, setOpen] = useState(hasConfig)
   useEffect(() => {
     if (hasSuggestions) setOpen(true)
   }, [hasSuggestions])
+
+  // Auto-fill the claim path when the IdP returned exactly one array claim and
+  // the provider has no mapping yet. Only overrides the untouched `groups`
+  // default; never fights a value the admin chose. Self-settles: once filled,
+  // `mapping` is non-null so this no-ops.
+  const onlyPath = suggestions && suggestions.paths.length === 1 ? suggestions.paths[0] : null
+  useEffect(() => {
+    if (mapping === null && onlyPath && onlyPath !== 'groups') {
+      onChange({ claimPath: onlyPath, rules: [] })
+    }
+  }, [mapping, onlyPath, onChange])
 
   return (
     <div className="rounded-md border border-border/50 bg-muted/10">
@@ -1224,32 +1116,28 @@ function ClaimMappingEditor({
 
       {open && (
         <div className="space-y-4 border-t border-border/40 px-3 py-3">
-          {hasSuggestions && suggestions ? (
-            <ClaimSuggestionsBlock
-              suggestions={suggestions}
-              current={current}
-              disabled={disabled}
-              onChange={onChange}
-            />
-          ) : current.rules.length === 0 ? (
-            <p className="text-xs text-muted-foreground">
-              Run a test sign-in to map roles from the claims your IdP returns.
-            </p>
-          ) : null}
           <p className="text-xs text-muted-foreground">
             Source the role from an IdP claim. Rules are first-match-wins; with no rules everyone
             gets the default role above.
           </p>
 
-          <div className="space-y-2">
+          <div className="space-y-1.5">
             <Label htmlFor="idp-claim-path">Claim path</Label>
-            <Input
-              id="idp-claim-path"
+            <Autocomplete
               value={current.claimPath}
-              onChange={(e) => update({ claimPath: e.target.value })}
+              onValueChange={(v) => update({ claimPath: v })}
+              suggestions={pathSuggestions}
+              ariaLabel="Claim path"
               placeholder="groups, realm_access.roles, https://acme.com/roles"
+              emptyHint="Run a test sign-in to autocomplete your IdP's claims."
               disabled={disabled}
+              className="w-full"
             />
+            {hasSuggestions && suggestions && (
+              <p className="text-xs text-muted-foreground">
+                From your test sign-in: {suggestions.paths.join(', ')}
+              </p>
+            )}
           </div>
 
           <div className="space-y-2">
@@ -1262,17 +1150,21 @@ function ClaimMappingEditor({
             {current.rules.map((rule, index) => (
               <div key={index} className="flex items-center gap-2">
                 <span className="shrink-0 text-xs text-muted-foreground">contains</span>
-                <Input
+                <Autocomplete
                   value={rule.whenContains}
-                  onChange={(e) =>
+                  onValueChange={(v) =>
                     update({
                       rules: current.rules.map((r, i) =>
-                        i === index ? { ...r, whenContains: e.target.value } : r
+                        i === index ? { ...r, whenContains: v } : r
                       ),
                     })
                   }
-                  placeholder="admins"
+                  suggestions={valueSuggestions}
+                  ariaLabel="Claim value to match"
+                  placeholder="value to match"
+                  emptyHint="No values seen yet. Type the value to match."
                   disabled={disabled}
+                  className="flex-1"
                 />
                 <span className="shrink-0 text-xs text-muted-foreground">→</span>
                 <Select

--- a/apps/web/src/components/admin/settings/security/identity-providers/provider-editor.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/provider-editor.tsx
@@ -984,8 +984,7 @@ function GroupMappingEditor({
   const ruleCount = mapping?.rules.length ?? 0
   const hasConfig = ruleCount > 0 || mapping?.syncOnEverySignIn === true
   const [open, setOpen] = useState(hasConfig)
-  // Vestigial defaultRole satisfies the Mapping type until Task 4 removes the field.
-  const current: Mapping = mapping ?? { claimPath: 'groups', rules: [], defaultRole: 'member' }
+  const current: Mapping = mapping ?? { claimPath: 'groups', rules: [] }
   const update = (patch: Partial<Mapping>) => onChange({ ...current, ...patch })
 
   return (

--- a/apps/web/src/components/admin/settings/security/identity-providers/provider-editor.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/provider-editor.tsx
@@ -44,6 +44,7 @@ import { Switch } from '@/components/ui/switch'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { WarningBox } from '@/components/shared/warning-box'
+import { ScrollArea } from '@/components/ui/scroll-area'
 import {
   Select,
   SelectContent,
@@ -107,6 +108,27 @@ function redirectUriFor(baseUrl: string | undefined, registrationId: string): st
  *  migration; drives the redirect URI + `account.provider_id`). */
 function newRegistrationId(): string {
   return `oidc_${Math.random().toString(36).slice(2, 10)}`
+}
+
+/** Connection-test freshness from the provider's last successful test vs. its
+ *  last redirect-affecting change. Drives the connection status line and the
+ *  enforcement-unlock gate — only `verified` may turn enforcement on. Mirrors
+ *  the server-side `isSsoEnforcementUnlocked(provider, null)` predicate. */
+type ConnectionTestState =
+  | { kind: 'unsaved' | 'untested' | 'stale' }
+  | { kind: 'verified'; testedAt: string }
+
+function getConnectionTestState(provider: IdentityProvider | null): ConnectionTestState {
+  if (!provider) return { kind: 'unsaved' }
+  const testedMs = provider.lastSuccessfulTestAt
+    ? new Date(provider.lastSuccessfulTestAt).getTime()
+    : null
+  if (testedMs === null || Number.isNaN(testedMs)) return { kind: 'untested' }
+  const changedMs = provider.detailsChangedAt ? new Date(provider.detailsChangedAt).getTime() : null
+  if (changedMs !== null && !Number.isNaN(changedMs) && testedMs <= changedMs) {
+    return { kind: 'stale' }
+  }
+  return { kind: 'verified', testedAt: provider.lastSuccessfulTestAt! }
 }
 
 export function ProviderEditor({
@@ -185,7 +207,7 @@ export function ProviderEditor({
       toast.error('Client ID is required.')
       return
     }
-    // A group mapping with no rules and no sign-in sync does nothing, so persist
+    // A claim mapping with no rules and no sign-in sync does nothing, so persist
     // null (the canonical "no mapping" state). A custom claim path alone is inert.
     const mappingToSave =
       mapping && (mapping.rules.length > 0 || mapping.syncOnEverySignIn === true) ? mapping : null
@@ -255,7 +277,7 @@ export function ProviderEditor({
 
   return (
     <Dialog open={open} onOpenChange={(o) => (saving ? undefined : onOpenChange(o))}>
-      <DialogContent className="flex max-h-[calc(100dvh-2rem)] max-w-2xl flex-col gap-0 p-0">
+      <DialogContent className="flex h-[85vh] max-w-2xl flex-col gap-0 overflow-hidden p-0">
         <DialogHeader className="shrink-0 border-b border-border/50 px-6 py-4">
           <DialogTitle>{provider ? 'Edit identity provider' : 'Add identity provider'}</DialogTitle>
           <DialogDescription>
@@ -263,94 +285,94 @@ export function ProviderEditor({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="flex-1 space-y-6 overflow-y-auto px-6 py-5">
-          {/* Display name */}
-          <div className="space-y-2">
-            <Label htmlFor="idp-label">Display name</Label>
-            <Input
-              id="idp-label"
-              value={label}
-              onChange={(e) => setLabel(e.target.value)}
-              placeholder="Acme SSO"
-              disabled={saving}
-            />
-            {label.trim() && (
-              <p className="text-xs text-muted-foreground">
-                Button reads: &ldquo;Sign in with {label.trim()}&rdquo;
-              </p>
-            )}
-          </div>
-
-          {/* Identity provider picker + discovery */}
-          <div className="space-y-3">
-            <Label>Identity provider</Label>
-            <RadioGroup
-              value={kind}
-              onValueChange={(v) => {
-                const next = v as IdpKind
-                setKind(next)
-                // Fixed-discovery kinds (Google) have no shortcut input — seed
-                // the canonical URL now so the saved row is well-formed without
-                // a render-time state write.
-                const def = getIdpShortcut(next)
-                if (next !== 'other' && def.fields.length === 0) {
-                  const url = def.build({})
-                  if (url) setDiscoveryUrl(url)
-                }
-              }}
-              className="grid grid-cols-2 gap-2.5 sm:grid-cols-3"
-            >
-              {IDP_KIND_OPTIONS.map((k) => (
-                <RadioGroupPrimitive.Item
-                  key={k}
-                  value={k}
-                  id={`idp-kind-${k}`}
-                  disabled={saving}
-                  className={cn(
-                    'flex items-center gap-2.5 rounded-lg border border-border/50 bg-card p-3 text-left shadow-sm outline-none transition-all',
-                    'hover:border-border hover:bg-accent/40',
-                    'focus-visible:ring-2 focus-visible:ring-ring/50',
-                    'data-[state=checked]:border-primary data-[state=checked]:ring-2 data-[state=checked]:ring-primary/30',
-                    'disabled:cursor-not-allowed disabled:opacity-60'
-                  )}
-                >
-                  <IdpLogo
-                    kind={k}
-                    className="h-8 w-8 shrink-0"
-                    iconClassName="h-[18px] w-[18px]"
-                  />
-                  <span className="truncate text-sm font-medium">{IDP_KIND_NAMES[k]}</span>
-                </RadioGroupPrimitive.Item>
-              ))}
-            </RadioGroup>
-            <IdpDiscoveryFields
-              kind={kind}
-              discoveryUrl={discoveryUrl}
-              disabled={saving}
-              onChange={setDiscoveryUrl}
-            />
-            {kind === 'other' && (
-              <ManualEndpointsSection
-                values={manual}
+        <ScrollArea className="flex-1 min-h-0">
+          <div className="space-y-6 px-6 py-5">
+            {/* Display name */}
+            <div className="space-y-2">
+              <Label htmlFor="idp-label">Display name</Label>
+              <Input
+                id="idp-label"
+                value={label}
+                onChange={(e) => setLabel(e.target.value)}
+                placeholder="Acme SSO"
                 disabled={saving}
-                onChange={(patch) => setManual((m) => ({ ...m, ...patch }))}
               />
-            )}
-          </div>
+              {label.trim() && (
+                <p className="text-xs text-muted-foreground">
+                  Button reads: &ldquo;Sign in with {label.trim()}&rdquo;
+                </p>
+              )}
+            </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="idp-client-id">Client ID</Label>
-            <Input
-              id="idp-client-id"
-              value={clientId}
-              onChange={(e) => setClientId(e.target.value)}
-              disabled={saving}
-            />
-          </div>
+            {/* Identity provider picker + discovery */}
+            <div className="space-y-3">
+              <Label>Identity provider</Label>
+              <RadioGroup
+                value={kind}
+                onValueChange={(v) => {
+                  const next = v as IdpKind
+                  setKind(next)
+                  // Fixed-discovery kinds (Google) have no shortcut input — seed
+                  // the canonical URL now so the saved row is well-formed without
+                  // a render-time state write.
+                  const def = getIdpShortcut(next)
+                  if (next !== 'other' && def.fields.length === 0) {
+                    const url = def.build({})
+                    if (url) setDiscoveryUrl(url)
+                  }
+                }}
+                className="grid grid-cols-2 gap-2.5 sm:grid-cols-3"
+              >
+                {IDP_KIND_OPTIONS.map((k) => (
+                  <RadioGroupPrimitive.Item
+                    key={k}
+                    value={k}
+                    id={`idp-kind-${k}`}
+                    disabled={saving}
+                    className={cn(
+                      'flex items-center gap-2.5 rounded-lg border border-border/50 bg-card p-3 text-left shadow-sm outline-none transition-all',
+                      'hover:border-border hover:bg-accent/40',
+                      'focus-visible:ring-2 focus-visible:ring-ring/50',
+                      'data-[state=checked]:border-primary data-[state=checked]:ring-2 data-[state=checked]:ring-primary/30',
+                      'disabled:cursor-not-allowed disabled:opacity-60'
+                    )}
+                  >
+                    <IdpLogo
+                      kind={k}
+                      className="h-8 w-8 shrink-0"
+                      iconClassName="h-[18px] w-[18px]"
+                    />
+                    <span className="truncate text-sm font-medium">{IDP_KIND_NAMES[k]}</span>
+                  </RadioGroupPrimitive.Item>
+                ))}
+              </RadioGroup>
+              <IdpDiscoveryFields
+                kind={kind}
+                discoveryUrl={discoveryUrl}
+                disabled={saving}
+                onChange={setDiscoveryUrl}
+              />
+              {kind === 'other' && (
+                <ManualEndpointsSection
+                  values={manual}
+                  disabled={saving}
+                  onChange={(patch) => setManual((m) => ({ ...m, ...patch }))}
+                />
+              )}
+            </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="idp-client-secret">Client secret</Label>
-            <div className="flex items-center gap-2">
+            <div className="space-y-2">
+              <Label htmlFor="idp-client-id">Client ID</Label>
+              <Input
+                id="idp-client-id"
+                value={clientId}
+                onChange={(e) => setClientId(e.target.value)}
+                disabled={saving}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="idp-client-secret">Client secret</Label>
               <Input
                 id="idp-client-secret"
                 type="password"
@@ -361,97 +383,105 @@ export function ProviderEditor({
                 placeholder={provider ? 'Leave blank to keep the current secret' : ''}
                 disabled={saving}
               />
-              <TestSignInButton registrationId={registrationId} disabled={saving || !provider} />
             </div>
-          </div>
 
-          <RedirectUriCallout uri={redirectUriFor(baseUrl, registrationId)} />
+            <RedirectUriCallout uri={redirectUriFor(baseUrl, registrationId)} />
 
-          {/* Domains */}
-          <DomainsSection provider={provider} disabled={saving} />
+            {/* Connection test — the capstone of the connection block. A
+              successful test validates discovery + credentials + the registered
+              redirect URI, and is the precondition that unlocks enforcement. */}
+            <ConnectionTestRow
+              provider={provider}
+              registrationId={registrationId}
+              disabled={saving}
+            />
 
-          {/* Visibility — only meaningful once a verified domain routes by
+            {/* Domains */}
+            <DomainsSection provider={provider} disabled={saving} />
+
+            {/* Visibility — only meaningful once a verified domain routes by
               default; a domain-less provider is always a public button. */}
-          {hasVerifiedDomain && (
-            <div className="space-y-2 border-t border-border/40 pt-5">
-              <Label className="font-medium">Visibility</Label>
-              <label className="flex items-start gap-2 text-sm">
-                <Checkbox
-                  checked={showButton}
-                  onCheckedChange={(v) => setShowButton(v === true)}
-                  disabled={saving}
-                  aria-label="Also show a sign-in button"
-                  className="mt-0.5"
-                />
-                <span>
-                  Also show a &ldquo;Sign in with {label.trim() || 'this provider'}&rdquo; button
-                  <span className="mt-0.5 block text-xs text-muted-foreground">
-                    Off = routed only; hidden from the public portal.
-                  </span>
-                </span>
-              </label>
-            </div>
-          )}
-
-          {/* Provisioning */}
-          <div className="space-y-4 border-t border-border/40 pt-5">
-            <div className="flex items-start justify-between gap-4">
-              <div className="flex-1">
-                <Label className="font-medium">Auto-create accounts on first sign-in</Label>
-                <p className="mt-1 text-xs text-muted-foreground">
-                  Create an account the first time someone signs in through this provider.
-                </p>
-              </div>
-              <Switch
-                checked={autoCreateUsers}
-                onCheckedChange={setAutoCreateUsers}
-                disabled={saving}
-                aria-label="Auto-create accounts on first sign-in"
-                className="mt-0.5 shrink-0"
-              />
-            </div>
-
-            {autoCreateUsers && (
-              <div className="space-y-4">
-                <div className="space-y-2">
-                  <Label htmlFor="idp-default-role" className="font-medium">
-                    Default role
-                  </Label>
-                  <Select
-                    value={autoProvisionRole}
-                    onValueChange={(r) => setAutoProvisionRole(r as Role)}
+            {hasVerifiedDomain && (
+              <div className="space-y-2 border-t border-border/40 pt-5">
+                <Label className="font-medium">Visibility</Label>
+                <label className="flex items-start gap-2 text-sm">
+                  <Checkbox
+                    checked={showButton}
+                    onCheckedChange={(v) => setShowButton(v === true)}
                     disabled={saving}
-                  >
-                    <SelectTrigger
-                      id="idp-default-role"
-                      className="w-[220px]"
-                      aria-label="Default role"
-                    >
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="admin">Admin</SelectItem>
-                      <SelectItem value="member">Member</SelectItem>
-                      <SelectItem value="user">User (portal only)</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <p className="text-xs text-muted-foreground">
-                    New users get this role unless a rule below matches their IdP group.
-                  </p>
-                </div>
-
-                <GroupMappingEditor mapping={mapping} disabled={saving} onChange={setMapping} />
+                    aria-label="Also show a sign-in button"
+                    className="mt-0.5"
+                  />
+                  <span>
+                    Also show a &ldquo;Sign in with {label.trim() || 'this provider'}&rdquo; button
+                    <span className="mt-0.5 block text-xs text-muted-foreground">
+                      Off = routed only; hidden from the public portal.
+                    </span>
+                  </span>
+                </label>
               </div>
             )}
+
+            {/* Provisioning */}
+            <div className="space-y-4 border-t border-border/40 pt-5">
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex-1">
+                  <Label className="font-medium">Auto-create accounts on first sign-in</Label>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Create an account the first time someone signs in through this provider.
+                  </p>
+                </div>
+                <Switch
+                  checked={autoCreateUsers}
+                  onCheckedChange={setAutoCreateUsers}
+                  disabled={saving}
+                  aria-label="Auto-create accounts on first sign-in"
+                  className="mt-0.5 shrink-0"
+                />
+              </div>
+
+              {autoCreateUsers && (
+                <div className="space-y-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="idp-default-role" className="font-medium">
+                      Default role
+                    </Label>
+                    <Select
+                      value={autoProvisionRole}
+                      onValueChange={(r) => setAutoProvisionRole(r as Role)}
+                      disabled={saving}
+                    >
+                      <SelectTrigger
+                        id="idp-default-role"
+                        className="w-[220px]"
+                        aria-label="Default role"
+                      >
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="admin">Admin</SelectItem>
+                        <SelectItem value="member">Member</SelectItem>
+                        <SelectItem value="user">User (portal only)</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <p className="text-xs text-muted-foreground">
+                      New users get this role unless a rule below matches one of their claims.
+                    </p>
+                  </div>
+
+                  <ClaimMappingEditor mapping={mapping} disabled={saving} onChange={setMapping} />
+                </div>
+              )}
+            </div>
           </div>
-        </div>
+        </ScrollArea>
 
         <DialogFooter className="shrink-0 items-center border-t border-border/50 px-6 py-4 sm:justify-between">
           {provider ? (
             <span
               title={
                 isOnlyMethod
-                  ? 'This is the only enabled sign-in method — enable another before removing it.'
+                  ? 'This is the only enabled sign-in method. Enable another before removing it.'
                   : undefined
               }
             >
@@ -668,6 +698,57 @@ function RedirectUriCallout({ uri }: { uri: string }) {
 }
 
 /**
+ * Connection-test capstone for the connection block: one "Test sign-in" action
+ * plus a status line reflecting whether the connection is verified, never
+ * tested, or stale since the last config change. A fresh successful test is
+ * what unlocks SSO enforcement, so the row names that payoff.
+ */
+function ConnectionTestRow({
+  provider,
+  registrationId,
+  disabled,
+}: {
+  provider: IdentityProvider | null
+  registrationId: string
+  disabled: boolean
+}) {
+  const state = getConnectionTestState(provider)
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <div className="flex-1">
+        <Label className="font-medium">Connection</Label>
+        <div className="mt-1 text-xs">
+          {state.kind === 'unsaved' && (
+            <span className="text-muted-foreground">
+              Save the provider first, then sign in through it to verify the connection.
+            </span>
+          )}
+          {state.kind === 'untested' && (
+            <span className="text-muted-foreground">
+              Not tested yet. Sign in through this provider to verify it. Required before you can
+              enforce SSO.
+            </span>
+          )}
+          {state.kind === 'verified' && (
+            <span className="inline-flex items-center gap-1 text-green-600 dark:text-green-400">
+              <CheckCircleIcon className="size-3.5 shrink-0" />
+              Verified <TimeAgo date={state.testedAt} />, ready to enforce SSO.
+            </span>
+          )}
+          {state.kind === 'stale' && (
+            <span className="inline-flex items-center gap-1 text-amber-600 dark:text-amber-400">
+              <ClockIcon className="size-3.5 shrink-0" />
+              Connection changed since the last test. Re-test to enforce SSO.
+            </span>
+          )}
+        </div>
+      </div>
+      <TestSignInButton registrationId={registrationId} disabled={disabled || !provider} />
+    </div>
+  )
+}
+
+/**
  * Per-provider verified-domain list. Rewires `verified-domains-section` from
  * the workspace-wide single-SSO queries onto the provider's own `domains[]`
  * and the per-provider domain fns. No domains => the provider is a public
@@ -689,21 +770,9 @@ function DomainsSection({
 
   const domains = provider?.domains ?? []
   const hasVerified = domains.some((d) => d.verifiedAt)
-  // Enforcement is available once the provider has a valid test sign-in that
-  // postdates the last connection-affecting change. Mirrors the server-side
-  // `isSsoEnforcementUnlocked(provider, null)` predicate (pure, no DB).
-  const enforceable = (() => {
-    if (!provider) return false
-    const testedMs = provider.lastSuccessfulTestAt
-      ? new Date(provider.lastSuccessfulTestAt).getTime()
-      : null
-    if (testedMs === null || Number.isNaN(testedMs)) return false
-    const changedMs = provider.detailsChangedAt
-      ? new Date(provider.detailsChangedAt).getTime()
-      : null
-    if (changedMs === null || Number.isNaN(changedMs)) return true
-    return testedMs > changedMs
-  })()
+  // Enforcement is available once the provider has a fresh test sign-in — same
+  // predicate that drives the connection status line (see getConnectionTestState).
+  const enforceable = getConnectionTestState(provider).kind === 'verified'
 
   const refresh = () => queryClient.invalidateQueries({ queryKey: IDENTITY_PROVIDERS_KEY })
 
@@ -760,7 +829,7 @@ function DomainsSection({
             <WarningBox
               variant="warning"
               title="Before you enforce"
-              description="Run a successful test sign-in and generate recovery codes first — they're your break-glass if SSO ever breaks."
+              description="Run a successful test sign-in and generate recovery codes first. They're your break-glass if SSO ever breaks."
             />
           )}
 
@@ -860,7 +929,7 @@ function DomainRow({
       const msg = err instanceof Error ? err.message : ''
       setEnforceError(
         msg === 'recovery_codes_required'
-          ? 'Generate recovery codes before enforcing SSO — they are the only break-glass way back in.'
+          ? 'Generate recovery codes before enforcing SSO. They are the only break-glass way back in.'
           : msg || 'Could not update enforcement.'
       )
     } finally {
@@ -967,12 +1036,12 @@ function DomainRow({
 }
 
 /**
- * IdP-group → role mapping: an optional override on top of the provider's Default
+ * Claim-to-role mapping: an optional override on top of the provider's Default
  * role. With no rules everyone gets the default. Collapsed by default; auto-expands
  * when the provider already has rules or sign-in sync configured. The parent's
  * handleSave persists null unless the mapping carries rules or sync.
  */
-function GroupMappingEditor({
+function ClaimMappingEditor({
   mapping,
   disabled,
   onChange,
@@ -997,7 +1066,7 @@ function GroupMappingEditor({
       >
         <span className="flex items-center gap-2 text-sm font-medium">
           <AdjustmentsHorizontalIcon className="size-4 text-muted-foreground" />
-          Map roles from IdP groups
+          Map roles from claims
           {ruleCount > 0 && (
             <span className="text-xs font-normal text-muted-foreground">
               · {ruleCount} rule{ruleCount === 1 ? '' : 's'}
@@ -1029,7 +1098,7 @@ function GroupMappingEditor({
             <Label>Rules</Label>
             {current.rules.length === 0 && (
               <p className="text-xs text-muted-foreground">
-                No rules — everyone gets the default role.
+                No rules. Everyone gets the default role.
               </p>
             )}
             {current.rules.map((rule, index) => (
@@ -1106,8 +1175,9 @@ function GroupMappingEditor({
               disabled={disabled}
             />
             <span>
-              <span className="font-medium">Sync role on every sign-in.</span> Re-resolve the role
-              on each sign-in. Demotes members when their IdP group changes.
+              <span className="font-medium">Sync role on every sign-in.</span> Re-applies the rules
+              so a role can be promoted or demoted when their claims change. Off: set once, on first
+              sign-in.
             </span>
           </label>
         </div>

--- a/apps/web/src/components/admin/settings/security/identity-providers/provider-editor.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/provider-editor.tsx
@@ -17,7 +17,7 @@
  *    public button, so the toggle would be meaningless.
  *  - per-domain enforcement is a checkbox guarded by a precondition warning.
  */
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useServerFn } from '@tanstack/react-start'
 import { useRouteContext } from '@tanstack/react-router'
 import { useQueryClient } from '@tanstack/react-query'
@@ -73,6 +73,8 @@ import type { IdentityProvider } from '@/lib/server/domains/settings/identity-pr
 import type { VerifiedDomain } from '@/lib/server/domains/settings/settings.types'
 import { getIdpShortcut, inferIdpKind, IDP_KIND_NAMES, type IdpKind } from '../idp-shortcuts'
 import { TestSignInButton } from '../sso/test-sign-in-button'
+import { useSsoTestSignIn } from '../sso/use-sso-test-sign-in'
+import { deriveClaimSuggestions, type ClaimSuggestions } from '@/lib/shared/claim-suggestions'
 
 type Role = 'admin' | 'member' | 'user'
 type Mapping = NonNullable<IdentityProvider['attributeMapping']>
@@ -469,7 +471,12 @@ export function ProviderEditor({
                     </p>
                   </div>
 
-                  <ClaimMappingEditor mapping={mapping} disabled={saving} onChange={setMapping} />
+                  <ClaimMappingEditor
+                    mapping={mapping}
+                    disabled={saving}
+                    registrationId={registrationId}
+                    onChange={setMapping}
+                  />
                 </div>
               )}
             </div>
@@ -1035,6 +1042,120 @@ function DomainRow({
   )
 }
 
+/** One observed claim value with a role picker + Add. Role state is local so
+ *  each row remembers its own choice until added. */
+function ClaimSuggestionRow({
+  value,
+  added,
+  disabled,
+  onAdd,
+}: {
+  value: string
+  added: boolean
+  disabled: boolean
+  onAdd: (role: Role) => void
+}) {
+  const [role, setRole] = useState<Role>('member')
+  return (
+    <div className="flex items-center gap-2">
+      <code className="min-w-0 flex-1 truncate rounded bg-muted/40 px-1.5 py-1 text-[11px]">
+        {value}
+      </code>
+      <span className="shrink-0 text-xs text-muted-foreground">→</span>
+      <Select value={role} onValueChange={(r) => setRole(r as Role)} disabled={disabled || added}>
+        <SelectTrigger className="h-7 w-28 text-xs">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {ROLES.map((r) => (
+            <SelectItem key={r} value={r}>
+              {r}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Button
+        type="button"
+        size="sm"
+        variant={added ? 'ghost' : 'secondary'}
+        className="h-7"
+        disabled={disabled || added}
+        onClick={() => onAdd(role)}
+      >
+        {added ? 'Added' : 'Add'}
+      </Button>
+    </div>
+  )
+}
+
+/** "From your test sign-in" assist: lists the observed values at the active
+ *  claim path; clicking Add appends a rule and pins the claim path. */
+function ClaimSuggestionsBlock({
+  suggestions,
+  current,
+  disabled,
+  onChange,
+}: {
+  suggestions: ClaimSuggestions
+  current: Mapping
+  disabled: boolean
+  onChange: (mapping: Mapping) => void
+}) {
+  // The mapping holds one claim path. Default the active path to the mapping's
+  // own path when it is one of the observed ones, else the first observed path.
+  const activePath = suggestions.paths.includes(current.claimPath)
+    ? current.claimPath
+    : suggestions.paths[0]
+  const values = suggestions.valuesByPath[activePath] ?? []
+  const mapped = new Set(current.rules.map((r) => r.whenContains.toLowerCase()))
+
+  return (
+    <div className="space-y-2 rounded-md border border-border/50 bg-muted/10 p-3">
+      <div className="flex items-center justify-between gap-2">
+        <Label className="text-xs font-medium">From your test sign-in</Label>
+        {suggestions.paths.length > 1 && (
+          <Select
+            value={activePath}
+            onValueChange={(p) => onChange({ ...current, claimPath: p })}
+            disabled={disabled}
+          >
+            <SelectTrigger className="h-7 w-[180px] text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {suggestions.paths.map((p) => (
+                <SelectItem key={p} value={p}>
+                  {p}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+      </div>
+      <div className="space-y-1.5">
+        {values.map((value) => (
+          <ClaimSuggestionRow
+            key={value}
+            value={value}
+            added={mapped.has(value.toLowerCase())}
+            disabled={disabled}
+            onAdd={(role) =>
+              onChange({
+                ...current,
+                claimPath: activePath,
+                rules: [...current.rules, { whenContains: value, role }],
+              })
+            }
+          />
+        ))}
+      </div>
+      <p className="text-[11px] text-muted-foreground">
+        From your last test sign-in. Run a test as another user to see their groups too.
+      </p>
+    </div>
+  )
+}
+
 /**
  * Claim-to-role mapping: an optional override on top of the provider's Default
  * role. With no rules everyone gets the default. Collapsed by default; auto-expands
@@ -1044,17 +1165,30 @@ function DomainRow({
 function ClaimMappingEditor({
   mapping,
   disabled,
+  registrationId,
   onChange,
 }: {
   mapping: Mapping | null
   disabled: boolean
+  registrationId: string
   onChange: (mapping: Mapping | null) => void
 }) {
   const ruleCount = mapping?.rules.length ?? 0
-  const hasConfig = ruleCount > 0 || mapping?.syncOnEverySignIn === true
-  const [open, setOpen] = useState(hasConfig)
+  const hasConfig = mapping !== null
   const current: Mapping = mapping ?? { claimPath: 'groups', rules: [] }
   const update = (patch: Partial<Mapping>) => onChange({ ...current, ...patch })
+
+  const { lastSuccess } = useSsoTestSignIn()
+  const suggestions =
+    lastSuccess && lastSuccess.registrationId === registrationId
+      ? deriveClaimSuggestions(lastSuccess.allClaims)
+      : null
+  const hasSuggestions = (suggestions?.paths.length ?? 0) > 0
+
+  const [open, setOpen] = useState(hasConfig)
+  useEffect(() => {
+    if (hasSuggestions) setOpen(true)
+  }, [hasSuggestions])
 
   return (
     <div className="rounded-md border border-border/50 bg-muted/10">
@@ -1078,6 +1212,18 @@ function ClaimMappingEditor({
 
       {open && (
         <div className="space-y-4 border-t border-border/40 px-3 py-3">
+          {hasSuggestions && suggestions ? (
+            <ClaimSuggestionsBlock
+              suggestions={suggestions}
+              current={current}
+              disabled={disabled}
+              onChange={onChange}
+            />
+          ) : current.rules.length === 0 ? (
+            <p className="text-xs text-muted-foreground">
+              Run a test sign-in to map roles from the claims your IdP returns.
+            </p>
+          ) : null}
           <p className="text-xs text-muted-foreground">
             Source the role from an IdP claim. Rules are first-match-wins; with no rules everyone
             gets the default role above.

--- a/apps/web/src/components/admin/settings/security/identity-providers/provider-editor.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/provider-editor.tsx
@@ -476,6 +476,7 @@ export function ProviderEditor({
                     mapping={mapping}
                     disabled={saving}
                     registrationId={registrationId}
+                    canTest={!!provider}
                     onChange={setMapping}
                   />
                 </div>
@@ -1055,11 +1056,14 @@ function ClaimMappingEditor({
   mapping,
   disabled,
   registrationId,
+  canTest,
   onChange,
 }: {
   mapping: Mapping | null
   disabled: boolean
   registrationId: string
+  /** True once the provider is saved, so a test sign-in can actually run. */
+  canTest: boolean
   onChange: (mapping: Mapping | null) => void
 }) {
   const ruleCount = mapping?.rules.length ?? 0
@@ -1086,7 +1090,8 @@ function ClaimMappingEditor({
   // Auto-fill the claim path when the IdP returned exactly one array claim and
   // the provider has no mapping yet. Only overrides the untouched `groups`
   // default; never fights a value the admin chose. Self-settles: once filled,
-  // `mapping` is non-null so this no-ops.
+  // `mapping` is non-null so this no-ops (relies on `onChange` being the stable
+  // `setMapping` setter that flips `mapping` non-null).
   const onlyPath = suggestions && suggestions.paths.length === 1 ? suggestions.paths[0] : null
   useEffect(() => {
     if (mapping === null && onlyPath && onlyPath !== 'groups') {
@@ -1129,7 +1134,20 @@ function ClaimMappingEditor({
               suggestions={pathSuggestions}
               ariaLabel="Claim path"
               placeholder="groups, realm_access.roles, https://acme.com/roles"
-              emptyHint="Run a test sign-in to autocomplete your IdP's claims."
+              emptyHint={
+                <div className="space-y-2 px-1 py-3 text-center">
+                  <p className="text-xs text-muted-foreground">
+                    Run a test sign-in to discover your IdP&apos;s claims.
+                  </p>
+                  <p className="text-[11px] text-muted-foreground">
+                    Or type a path like groups, realm_access.roles, or https://acme.com/roles.
+                  </p>
+                  <TestSignInButton
+                    registrationId={registrationId}
+                    disabled={disabled || !canTest}
+                  />
+                </div>
+              }
               disabled={disabled}
               className="w-full"
             />
@@ -1160,7 +1178,7 @@ function ClaimMappingEditor({
                     })
                   }
                   suggestions={valueSuggestions}
-                  ariaLabel="Claim value to match"
+                  ariaLabel={`Claim value to match (rule ${index + 1})`}
                   placeholder="value to match"
                   emptyHint="No values seen yet. Type the value to match."
                   disabled={disabled}

--- a/apps/web/src/components/admin/settings/security/sso/use-sso-test-sign-in.tsx
+++ b/apps/web/src/components/admin/settings/security/sso/use-sso-test-sign-in.tsx
@@ -48,7 +48,7 @@ import {
   type WireResult,
   type SsoTestState,
 } from './sso-test-state'
-import type { JsonValue } from '@/lib/server/audit/log'
+import type { JsonValue } from '@/lib/shared/json'
 
 const POLL_INTERVAL_MS = 2000
 // 150 polls * 2s = 5 minutes. Redis test-session TTL is 10 minutes;

--- a/apps/web/src/components/admin/settings/security/sso/use-sso-test-sign-in.tsx
+++ b/apps/web/src/components/admin/settings/security/sso/use-sso-test-sign-in.tsx
@@ -48,6 +48,7 @@ import {
   type WireResult,
   type SsoTestState,
 } from './sso-test-state'
+import type { JsonValue } from '@/lib/server/audit/log'
 
 const POLL_INTERVAL_MS = 2000
 // 150 polls * 2s = 5 minutes. Redis test-session TTL is 10 minutes;
@@ -75,6 +76,9 @@ interface OpenOptions {
 
 interface SsoTestSignInContextValue {
   open: (opts?: OpenOptions) => void
+  /** The most recent successful test sign-in, tagged with the provider it ran
+   *  against so a consumer only uses claims from a test of THAT provider. */
+  lastSuccess: { registrationId: string; allClaims: Record<string, JsonValue> } | null
 }
 
 const SsoTestSignInContext = createContext<SsoTestSignInContextValue | null>(null)
@@ -93,6 +97,10 @@ export function SsoTestSignInProvider({ children }: { children: ReactNode }) {
   const pollResult = useServerFn(getSsoTestResultFn)
   const [state, dispatch] = useReducer(ssoTestReducer, initialSsoTestState)
   const [applying, setApplying] = useState(false)
+  const [lastSuccess, setLastSuccess] = useState<{
+    registrationId: string
+    allClaims: Record<string, JsonValue>
+  } | null>(null)
 
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const onSuccessRef = useRef<OnSuccess | null>(null)
@@ -159,7 +167,13 @@ export function SsoTestSignInProvider({ children }: { children: ReactNode }) {
       clearPoll()
       clearPopup()
       dispatch({ type: 'resolved', result, identityMatched })
-      if (result.ok) void runAutoApply()
+      if (result.ok) {
+        setLastSuccess({
+          registrationId: registrationIdRef.current,
+          allClaims: result.allClaims ?? {},
+        })
+        void runAutoApply()
+      }
     },
     [clearPoll, clearPopup, runAutoApply]
   )
@@ -257,7 +271,7 @@ export function SsoTestSignInProvider({ children }: { children: ReactNode }) {
   }, [startTest, pollResult, trackPopup, clearPoll, clearPopup, resolveTest])
 
   return (
-    <SsoTestSignInContext.Provider value={{ open }}>
+    <SsoTestSignInContext.Provider value={{ open, lastSuccess }}>
       {children}
       <SsoTestSignInModal
         state={state}

--- a/apps/web/src/components/admin/settings/security/sso/use-sso-test-sign-in.tsx
+++ b/apps/web/src/components/admin/settings/security/sso/use-sso-test-sign-in.tsx
@@ -521,7 +521,7 @@ function TestResultPanel({
          *  wrong account, but the SSO connection itself is verified. */}
         {identityMatched === false && result.claims.email ? (
           <div className="rounded border border-muted bg-muted/30 p-2 text-xs text-muted-foreground">
-            Tested as {result.claims.email} — a different account than yours. The connection still
+            Tested as {result.claims.email}, a different account than yours. The connection still
             works.
           </div>
         ) : null}
@@ -530,7 +530,11 @@ function TestResultPanel({
             Show IdP response
           </summary>
           <pre className="mt-2 overflow-auto rounded bg-muted/30 p-2 font-mono text-[11px]">
-            {JSON.stringify({ claims: result.claims, tokenInfo: result.tokenInfo }, null, 2)}
+            {JSON.stringify(
+              { claims: result.allClaims ?? result.claims, tokenInfo: result.tokenInfo },
+              null,
+              2
+            )}
           </pre>
         </details>
       </div>

--- a/apps/web/src/components/ui/__tests__/autocomplete.test.tsx
+++ b/apps/web/src/components/ui/__tests__/autocomplete.test.tsx
@@ -77,4 +77,18 @@ describe('Autocomplete', () => {
     fireEvent.click(screen.getByRole('combobox', { name: 'Claim path' }))
     expect(screen.getByText('Run a test sign-in.')).toBeInTheDocument()
   })
+
+  it('renders a node empty hint so callers can include an action', () => {
+    render(
+      <Autocomplete
+        value=""
+        onValueChange={vi.fn()}
+        ariaLabel="Claim path"
+        suggestions={[]}
+        emptyHint={<button type="button">Test sign-in</button>}
+      />
+    )
+    fireEvent.click(screen.getByRole('combobox', { name: 'Claim path' }))
+    expect(screen.getByRole('button', { name: 'Test sign-in' })).toBeInTheDocument()
+  })
 })

--- a/apps/web/src/components/ui/__tests__/autocomplete.test.tsx
+++ b/apps/web/src/components/ui/__tests__/autocomplete.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeAll } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { Autocomplete } from '../autocomplete'
+
+// Radix Popover + cmdk touch these APIs that happy-dom does not implement.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.setPointerCapture = vi.fn()
+  Element.prototype.releasePointerCapture = vi.fn()
+})
+
+const opts = [{ value: 'roles' }, { value: 'groups' }]
+
+describe('Autocomplete', () => {
+  it('shows the placeholder and opens to its suggestions', () => {
+    render(
+      <Autocomplete
+        value=""
+        onValueChange={vi.fn()}
+        placeholder="pick…"
+        ariaLabel="Claim path"
+        suggestions={opts}
+      />
+    )
+    const trigger = screen.getByRole('combobox', { name: 'Claim path' })
+    expect(trigger).toHaveTextContent('pick…')
+    fireEvent.click(trigger)
+    expect(screen.getByText('roles')).toBeInTheDocument()
+    expect(screen.getByText('groups')).toBeInTheDocument()
+  })
+
+  it('commits a selected suggestion', () => {
+    const onValueChange = vi.fn()
+    render(
+      <Autocomplete
+        value=""
+        onValueChange={onValueChange}
+        ariaLabel="Claim path"
+        suggestions={opts}
+      />
+    )
+    fireEvent.click(screen.getByRole('combobox', { name: 'Claim path' }))
+    fireEvent.click(screen.getByText('roles'))
+    expect(onValueChange).toHaveBeenCalledWith('roles')
+  })
+
+  it('commits free text the suggestions do not contain', () => {
+    const onValueChange = vi.fn()
+    render(
+      <Autocomplete
+        value=""
+        onValueChange={onValueChange}
+        ariaLabel="Claim path"
+        suggestions={opts}
+      />
+    )
+    fireEvent.click(screen.getByRole('combobox', { name: 'Claim path' }))
+    fireEvent.change(screen.getByPlaceholderText('Search or type…'), {
+      target: { value: 'realm_access.roles' },
+    })
+    fireEvent.click(screen.getByText(/Use [""]realm_access\.roles[""]/))
+    expect(onValueChange).toHaveBeenCalledWith('realm_access.roles')
+  })
+
+  it('shows the empty hint when there are no suggestions', () => {
+    render(
+      <Autocomplete
+        value=""
+        onValueChange={vi.fn()}
+        ariaLabel="Claim path"
+        suggestions={[]}
+        emptyHint="Run a test sign-in."
+      />
+    )
+    fireEvent.click(screen.getByRole('combobox', { name: 'Claim path' }))
+    expect(screen.getByText('Run a test sign-in.')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/ui/autocomplete.tsx
+++ b/apps/web/src/components/ui/autocomplete.tsx
@@ -1,0 +1,140 @@
+import { useState } from 'react'
+import { ChevronUpDownIcon, CheckIcon } from '@heroicons/react/24/solid'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/shared/utils'
+
+export interface AutocompleteSuggestion {
+  value: string
+  label?: string
+  description?: string
+}
+
+interface AutocompleteProps {
+  value: string
+  onValueChange: (value: string) => void
+  suggestions: AutocompleteSuggestion[]
+  placeholder?: string
+  searchPlaceholder?: string
+  ariaLabel?: string
+  /** Shown in the list when there are no suggestions (e.g. no test sign-in yet). */
+  emptyHint?: string
+  disabled?: boolean
+  size?: 'default' | 'sm'
+  className?: string
+}
+
+/**
+ * Creatable single-value autocomplete: pick a suggestion OR commit free text.
+ * Built on Popover + cmdk Command so it matches the app's Combobox, but unlike
+ * Combobox the committed value is an arbitrary string, not constrained to the
+ * option list. The "Use ..." item commits whatever the admin typed.
+ */
+export function Autocomplete({
+  value,
+  onValueChange,
+  suggestions,
+  placeholder,
+  searchPlaceholder,
+  ariaLabel,
+  emptyHint,
+  disabled,
+  size = 'default',
+  className,
+}: AutocompleteProps) {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+
+  const commit = (v: string) => {
+    onValueChange(v)
+    setQuery('')
+    setOpen(false)
+  }
+
+  const trimmed = query.trim()
+  const exactMatch = suggestions.some((s) => s.value.toLowerCase() === trimmed.toLowerCase())
+  const showCreate = trimmed.length > 0 && !exactMatch
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(o) => {
+        setOpen(o)
+        if (!o) setQuery('')
+      }}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size={size}
+          role="combobox"
+          aria-label={ariaLabel}
+          aria-expanded={open}
+          disabled={disabled}
+          className={cn('justify-between font-normal', className)}
+        >
+          <span className={cn('truncate', !value && 'text-muted-foreground')}>
+            {value || placeholder || 'Select…'}
+          </span>
+          <ChevronUpDownIcon className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-(--radix-popover-trigger-width) p-0">
+        {open && (
+          <Command>
+            <CommandInput
+              value={query}
+              onValueChange={setQuery}
+              placeholder={searchPlaceholder ?? 'Search or type…'}
+            />
+            <CommandList>
+              <CommandEmpty>{emptyHint ?? 'No matches.'}</CommandEmpty>
+              {showCreate && (
+                <CommandGroup>
+                  <CommandItem value={trimmed} onSelect={() => commit(trimmed)}>
+                    <span>{`Use "${trimmed}"`}</span>
+                  </CommandItem>
+                </CommandGroup>
+              )}
+              {suggestions.length > 0 && (
+                <CommandGroup>
+                  {suggestions.map((s) => (
+                    <CommandItem
+                      key={s.value}
+                      value={`${s.value} ${s.label ?? ''} ${s.description ?? ''}`}
+                      onSelect={() => commit(s.value)}
+                    >
+                      <CheckIcon
+                        className={cn(
+                          'mr-2 h-4 w-4',
+                          s.value === value ? 'opacity-100' : 'opacity-0'
+                        )}
+                      />
+                      <div className="flex min-w-0 flex-col gap-0.5">
+                        <span className="truncate">{s.label ?? s.value}</span>
+                        {s.description && (
+                          <span className="truncate text-xs text-muted-foreground">
+                            {s.description}
+                          </span>
+                        )}
+                      </div>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              )}
+            </CommandList>
+          </Command>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/web/src/components/ui/autocomplete.tsx
+++ b/apps/web/src/components/ui/autocomplete.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, type ReactNode } from 'react'
 import { ChevronUpDownIcon, CheckIcon } from '@heroicons/react/24/solid'
 import {
   Command,
@@ -25,8 +25,9 @@ interface AutocompleteProps {
   placeholder?: string
   searchPlaceholder?: string
   ariaLabel?: string
-  /** Shown in the list when there are no suggestions (e.g. no test sign-in yet). */
-  emptyHint?: string
+  /** Shown in the list when there are no suggestions (e.g. no test sign-in yet).
+   *  A node so callers can include an action (e.g. a "Test sign-in" button). */
+  emptyHint?: ReactNode
   disabled?: boolean
   size?: 'default' | 'sm'
   className?: string

--- a/apps/web/src/components/ui/autocomplete.tsx
+++ b/apps/web/src/components/ui/autocomplete.tsx
@@ -111,7 +111,7 @@ export function Autocomplete({
                   {suggestions.map((s) => (
                     <CommandItem
                       key={s.value}
-                      value={`${s.value} ${s.label ?? ''} ${s.description ?? ''}`}
+                      value={[s.value, s.label, s.description].filter(Boolean).join(' ')}
                       onSelect={() => commit(s.value)}
                     >
                       <CheckIcon

--- a/apps/web/src/lib/server/audit/log.ts
+++ b/apps/web/src/lib/server/audit/log.ts
@@ -15,14 +15,10 @@ import { logger } from '@/lib/server/logger'
 
 const log = logger.child({ component: 'audit' })
 
-/** A JSON-shaped value — fits into a Postgres jsonb column. */
-export type JsonValue =
-  | string
-  | number
-  | boolean
-  | null
-  | { [key: string]: JsonValue }
-  | JsonValue[]
+/** A JSON-shaped value — fits into a Postgres jsonb column. Re-exported from the
+ *  shared module so client/shared code can reference it without importing from
+ *  `@/lib/server`. */
+export type { JsonValue } from '@/lib/shared/json'
 
 /**
  * Closed taxonomy of audit event types.

--- a/apps/web/src/lib/server/auth/__tests__/jit-role.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/jit-role.test.ts
@@ -58,7 +58,6 @@ type SsoOidc = {
   attributeMapping?: {
     claimPath: string
     rules: { whenContains: string; role: 'admin' | 'member' | 'user' }[]
-    defaultRole: 'admin' | 'member' | 'user'
     syncOnEverySignIn?: boolean
   }
 }
@@ -218,7 +217,6 @@ describe('handleAutoProvisionAfter -- syncOnEverySignIn', () => {
         attributeMapping: {
           claimPath: 'roles',
           rules: [],
-          defaultRole: 'member',
           syncOnEverySignIn: true,
         },
       },
@@ -230,16 +228,15 @@ describe('handleAutoProvisionAfter -- syncOnEverySignIn', () => {
     mockFindFirst.mockResolvedValue({ role: 'admin' })
     mockAccountFindFirst.mockResolvedValue({ idToken: null })
     // With sync on, the resolved-from-claims role is authoritative on
-    // every sign-in. attributeMapping has no rules and defaultRole='user',
-    // so the IdP is effectively saying "this user has no team role". An
-    // existing admin gets demoted to portal-user.
+    // every sign-in. attributeMapping has no matching rules, so the resolver
+    // returns null and falls back to autoProvisionRole='user' — effectively
+    // saying "this user has no team role". An existing admin gets demoted.
     await callHandlerWith({
       ssoOidc: {
         autoProvisionRole: 'user',
         attributeMapping: {
           claimPath: 'roles',
           rules: [],
-          defaultRole: 'user',
           syncOnEverySignIn: true,
         },
       },
@@ -281,7 +278,7 @@ describe('handleAutoProvisionAfter -- audit on role change', () => {
       providerId: 'custom-oidc',
       registeredIds: new Set(['custom-oidc']),
       ssoOidc: {
-        attributeMapping: { claimPath: 'roles', rules: [], defaultRole: 'member' },
+        attributeMapping: { claimPath: 'roles', rules: [] },
       },
     })
     expect(mockEq).toHaveBeenCalledWith('account.providerId', 'custom-oidc')
@@ -297,7 +294,6 @@ describe('handleAutoProvisionAfter -- audit on role change', () => {
         attributeMapping: {
           claimPath: 'roles',
           rules: [],
-          defaultRole: 'member',
         },
       },
     })

--- a/apps/web/src/lib/server/auth/__tests__/resolve-sso-role.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/resolve-sso-role.test.ts
@@ -69,17 +69,17 @@ describe('resolveSsoRole', () => {
     expect(role).toBe('admin')
   })
 
-  it('falls back to defaultRole when no rule matches', () => {
+  it('returns null when no rule matches (caller supplies the default)', () => {
     const role = resolveSsoRole(
       { groups: ['support'] },
-      mapping([{ whenContains: 'admins', role: 'admin' }], 'user')
+      mapping([{ whenContains: 'admins', role: 'admin' }])
     )
-    expect(role).toBe('user')
+    expect(role).toBeNull()
   })
 
-  it('falls back to defaultRole when the claim is missing', () => {
-    const role = resolveSsoRole({}, mapping([{ whenContains: 'admins', role: 'admin' }], 'member'))
-    expect(role).toBe('member')
+  it('returns null when the claim is missing', () => {
+    const role = resolveSsoRole({}, mapping([{ whenContains: 'admins', role: 'admin' }]))
+    expect(role).toBeNull()
   })
 
   it('is case-insensitive when matching', () => {

--- a/apps/web/src/lib/server/auth/__tests__/resolve-sso-role.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/resolve-sso-role.test.ts
@@ -7,7 +7,7 @@
  */
 import { describe, it, expect } from 'vitest'
 import { getNestedClaim, resolveSsoRole } from '../resolve-sso-role'
-import type { AuthConfig } from '@/lib/server/domains/settings/settings.types'
+import type { IdentityProviderAttributeMapping } from '@/lib/server/db'
 
 describe('getNestedClaim', () => {
   it('reads a dotted path', () => {
@@ -41,12 +41,10 @@ describe('getNestedClaim', () => {
 })
 
 const mapping = (
-  rules: Array<{ whenContains: string; role: 'admin' | 'member' | 'user' }>,
-  defaultRole: 'admin' | 'member' | 'user' = 'member'
-): NonNullable<AuthConfig['ssoOidc']>['attributeMapping'] => ({
+  rules: Array<{ whenContains: string; role: 'admin' | 'member' | 'user' }>
+): IdentityProviderAttributeMapping => ({
   claimPath: 'groups',
   rules,
-  defaultRole,
 })
 
 describe('resolveSsoRole', () => {
@@ -96,7 +94,6 @@ describe('resolveSsoRole', () => {
       {
         claimPath: 'https://acme.com/roles',
         rules: [{ whenContains: 'platform-admins', role: 'admin' }],
-        defaultRole: 'member',
       }
     )
     expect(role).toBe('admin')

--- a/apps/web/src/lib/server/auth/__tests__/sso-test-handshake.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/sso-test-handshake.test.ts
@@ -107,8 +107,8 @@ describe('runHandshake', () => {
 
     const issuer = 'https://idp.example'
     const idToken = await new SignJWT({
-      email: 'james.morton@quackback.io',
-      name: 'James Morton',
+      email: 'alice@idp.example',
+      name: 'Alice Example',
       nonce: 'nonce789',
       // The non-standard claim the curated `claims` view drops but admins need.
       groups: ['11111111-2222-3333-4444-555555555555', 'feedback-admins'],
@@ -147,7 +147,7 @@ describe('runHandshake', () => {
     if (!result.ok) throw new Error(`expected success, got ${result.stage}: ${result.hint}`)
 
     // The curated subset still works for the friendly display + identity match.
-    expect(result.claims.email).toBe('james.morton@quackback.io')
+    expect(result.claims.email).toBe('alice@idp.example')
     // ...and the full payload is surfaced verbatim, including `groups`.
     expect(result.allClaims).toBeDefined()
     expect(result.allClaims?.groups).toEqual([

--- a/apps/web/src/lib/server/auth/__tests__/sso-test-handshake.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/sso-test-handshake.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { SignJWT, exportJWK, generateKeyPair } from 'jose'
 import { runHandshake, type HandshakeInput } from '../sso-test-handshake'
 
 // runHandshake fetches discovery / token / JWKS / userinfo through
@@ -96,5 +97,64 @@ describe('runHandshake', () => {
     expect(result.stage).toBe('token-exchange')
     expect(result.errorCode).toBe('invalid_grant')
     expect(result.hint).toMatch(/PKCE|code reuse|expired|redirect URI/i)
+  })
+
+  it('surfaces the full ID token payload (allClaims) on success, including non-standard claims', async () => {
+    const { publicKey, privateKey } = await generateKeyPair('RS256', { extractable: true })
+    const publicJwk = await exportJWK(publicKey)
+    publicJwk.kid = 'test-key'
+    publicJwk.alg = 'RS256'
+
+    const issuer = 'https://idp.example'
+    const idToken = await new SignJWT({
+      email: 'james.morton@quackback.io',
+      name: 'James Morton',
+      nonce: 'nonce789',
+      // The non-standard claim the curated `claims` view drops but admins need.
+      groups: ['11111111-2222-3333-4444-555555555555', 'feedback-admins'],
+    })
+      .setProtectedHeader({ alg: 'RS256', kid: 'test-key' })
+      .setIssuer(issuer)
+      .setAudience('cid')
+      .setSubject('user-sub-123')
+      .setIssuedAt()
+      .setExpirationTime('5m')
+      .sign(privateKey)
+
+    // Fetch order: 1) discovery  2) token  3) JWKS.
+    safeFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ issuer, token_endpoint: `${issuer}/token`, jwks_uri: `${issuer}/jwks` }),
+        { status: 200 }
+      )
+    )
+    safeFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          id_token: idToken,
+          access_token: 'at',
+          token_type: 'Bearer',
+          expires_in: 3600,
+        }),
+        { status: 200 }
+      )
+    )
+    safeFetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ keys: [publicJwk] }), { status: 200 })
+    )
+
+    const result = await runHandshake(baseInput)
+    if (!result.ok) throw new Error(`expected success, got ${result.stage}: ${result.hint}`)
+
+    // The curated subset still works for the friendly display + identity match.
+    expect(result.claims.email).toBe('james.morton@quackback.io')
+    // ...and the full payload is surfaced verbatim, including `groups`.
+    expect(result.allClaims).toBeDefined()
+    expect(result.allClaims?.groups).toEqual([
+      '11111111-2222-3333-4444-555555555555',
+      'feedback-admins',
+    ])
+    expect(result.allClaims?.iss).toBe(issuer)
+    expect(result.allClaims?.sub).toBe('user-sub-123')
   })
 })

--- a/apps/web/src/lib/server/auth/resolve-sso-role.ts
+++ b/apps/web/src/lib/server/auth/resolve-sso-role.ts
@@ -9,10 +9,9 @@
  *
  * resolveSsoRole matches the resolved claim value against the
  * mapping's rules (first-match-wins). Arrays are scanned member-wise;
- * scalars are compared via case-insensitive equality. When no rule
- * matches we fall back to `defaultRole`. When no mapping is set
- * (or the mapping is undefined), returns `null` so the caller can
- * decide whether to fall back to the legacy `autoProvisionRole`.
+ * scalars are compared via case-insensitive equality. Returns null when
+ * no rule matches (or no mapping is set) so the caller can fall back to
+ * the provider's default role (`autoProvisionRole`).
  */
 
 import type { AuthConfig } from '@/lib/server/domains/settings/settings.types'
@@ -50,8 +49,8 @@ function matchesRule(claim: unknown, whenContains: string): boolean {
 
 /**
  * Look up the user's role from their ID-token claims. Returns null
- * when the workspace hasn't configured attribute mapping — caller
- * falls back to the legacy autoProvisionRole field in that case.
+ * when no rule matches or the workspace hasn't configured attribute
+ * mapping — the caller falls back to the provider's autoProvisionRole.
  */
 export function resolveSsoRole(claims: Claims, mapping: AttributeMapping | undefined): Role | null {
   if (!mapping) return null
@@ -61,5 +60,6 @@ export function resolveSsoRole(claims: Claims, mapping: AttributeMapping | undef
       return rule.role
     }
   }
-  return mapping.defaultRole
+  // No rule matched — the caller falls back to the provider's default role.
+  return null
 }

--- a/apps/web/src/lib/server/auth/resolve-sso-role.ts
+++ b/apps/web/src/lib/server/auth/resolve-sso-role.ts
@@ -14,10 +14,9 @@
  * the provider's default role (`autoProvisionRole`).
  */
 
-import type { AuthConfig } from '@/lib/server/domains/settings/settings.types'
+import type { IdentityProviderAttributeMapping } from '@/lib/server/db'
 
 type Claims = Record<string, unknown>
-type AttributeMapping = NonNullable<NonNullable<AuthConfig['ssoOidc']>['attributeMapping']>
 type Role = 'admin' | 'member' | 'user'
 
 /** Resolve a claim by dotted path OR by literal URL-shaped key. */
@@ -52,7 +51,10 @@ function matchesRule(claim: unknown, whenContains: string): boolean {
  * when no rule matches or the workspace hasn't configured attribute
  * mapping — the caller falls back to the provider's autoProvisionRole.
  */
-export function resolveSsoRole(claims: Claims, mapping: AttributeMapping | undefined): Role | null {
+export function resolveSsoRole(
+  claims: Claims,
+  mapping: IdentityProviderAttributeMapping | undefined
+): Role | null {
   if (!mapping) return null
   const claim = getNestedClaim(claims, mapping.claimPath)
   for (const rule of mapping.rules) {

--- a/apps/web/src/lib/server/auth/sso-test-handshake.ts
+++ b/apps/web/src/lib/server/auth/sso-test-handshake.ts
@@ -12,6 +12,7 @@
  */
 
 import { jwtVerify, createLocalJWKSet, decodeProtectedHeader, decodeJwt } from 'jose'
+import type { JsonValue } from '@/lib/server/audit/log'
 import { explainAuthorizeError, explainTokenError } from './oidc-error-explain'
 
 export type HandshakeStage =
@@ -73,6 +74,11 @@ export type HandshakeResult =
         hasRefreshToken: boolean
         expiresIn?: number
       }
+      /** Full decoded ID-token payload, exactly as the IdP returned it. Lets
+       *  admins see non-standard claims (groups, roles, ...) when debugging
+       *  claim-to-role mapping. The curated `claims` above is for the friendly
+       *  display + identity match; this is the complete set. */
+      allClaims?: Record<string, JsonValue>
     }
   | {
       ok: false
@@ -391,5 +397,6 @@ export async function runHandshake(input: HandshakeInput): Promise<HandshakeResu
       hasRefreshToken: !!tokens.refresh_token,
       expiresIn: tokens.expires_in,
     },
+    allClaims: verifiedPayload as unknown as Record<string, JsonValue>,
   }
 }

--- a/apps/web/src/lib/server/domains/settings/settings.types.ts
+++ b/apps/web/src/lib/server/domains/settings/settings.types.ts
@@ -70,7 +70,10 @@ export interface AuthConfig {
      * Optional IdP-attribute → role mapping. When set, the SSO callback
      * resolves the user's role from a claim on the ID token instead of
      * falling back to `autoProvisionRole`. The mapping is first-match-
-     * wins against `rules`; nothing matches → `defaultRole`.
+     * wins against `rules`; when none matches, `resolveSsoRole` returns null
+     * and the caller falls back to the provider's `autoProvisionRole` (the
+     * per-provider model dropped this blob's `defaultRole`, kept here only for
+     * the legacy config shape).
      *
      * Resolved on every sign-in when `syncOnEverySignIn=true` so role
      * changes in the IdP propagate down. Default `false` keeps JIT

--- a/apps/web/src/lib/server/domains/settings/settings.types.ts
+++ b/apps/web/src/lib/server/domains/settings/settings.types.ts
@@ -121,9 +121,9 @@ export interface AuthConfig {
  *    default on the login form.
  *  - `enforced: true` (with `verifiedAt: <ISO>`) — emails at this domain
  *    are hard-bound to SSO; password / magic-link / non-SSO OAuth are
- *    blocked. Toggling `enforced=true` requires the calling admin to
- *    have signed in via SSO within the bootstrap window (lockout guard)
- *    AND email-delivery configured (break-glass precondition).
+ *    blocked. Toggling `enforced=true` requires a successful test sign-in
+ *    through the owning provider (lockout guard) AND active recovery codes —
+ *    the break-glass to sign back in if the IdP is ever unavailable.
  */
 export interface VerifiedDomain {
   id: `domain_${string}`

--- a/apps/web/src/lib/server/functions/__tests__/sso-domain-guards.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/sso-domain-guards.test.ts
@@ -576,4 +576,17 @@ describe('setDomainEnforcedFn — recovery-code guard', () => {
     ).resolves.not.toThrow()
     expect(hoisted.mockHasActiveRecoveryCodes).not.toHaveBeenCalled()
   })
+
+  it('allows enforcement without email delivery — recovery codes, not magic link, are the break-glass', async () => {
+    // Magic-link/password are hard-bound off for enforced-domain emails, so
+    // email delivery is NOT the break-glass; recovery codes are. Enforcement
+    // must not be gated on SMTP/Resend being configured.
+    hoisted.mockHasActiveRecoveryCodes.mockResolvedValue(true)
+    hoisted.mockIsEmailConfigured.mockReturnValue(false)
+
+    await expect(
+      setDomainEnforced({ data: { id: domainId, enforced: true } })
+    ).resolves.not.toThrow()
+    expect(mockSetVerifiedDomainEnforced).toHaveBeenCalledWith(domainId, true)
+  })
 })

--- a/apps/web/src/lib/server/functions/sso-test.ts
+++ b/apps/web/src/lib/server/functions/sso-test.ts
@@ -25,6 +25,7 @@ import { createServerFn } from '@tanstack/react-start'
 import { z } from 'zod'
 import { requireAuth } from './auth-helpers'
 import type { DiagnosticStep, HandshakeStage } from '@/lib/server/auth/sso-test-handshake'
+import type { JsonValue } from '@/lib/server/audit/log'
 import { DEFAULT_OIDC_SCOPES } from '@/lib/server/auth/build-oauth-configs'
 import { ssoTestResultKey, ssoTestSessionKey } from '@/lib/shared/sso-test-keys'
 
@@ -229,6 +230,9 @@ export type SsoTestDiagnostic = {
           hasRefreshToken: boolean
           expiresIn?: number
         }
+        /** Full decoded ID-token payload as the IdP returned it (groups, roles,
+         *  and any other non-standard claims), for claim-mapping debugging. */
+        allClaims?: Record<string, JsonValue>
       }
     | {
         ok: false

--- a/apps/web/src/lib/server/functions/sso.ts
+++ b/apps/web/src/lib/server/functions/sso.ts
@@ -442,7 +442,9 @@ const setDomainEnforcedInput = z.object({
  *     sign-in fallback) deliberately: `principal.lastSsoSignInAt` is
  *     provider-independent, so accepting it would let a sign-in via provider B
  *     unlock never-validated provider A.
- *  2. Magic-link delivery configured (break-glass for the rest of the team).
+ *  2. Active recovery codes generated — the break-glass to sign back in if the
+ *     IdP becomes unavailable. Password / magic-link are hard-bound off for
+ *     enforced-domain emails, so recovery codes are the only way back.
  * Disabling skips both.
  */
 export const setDomainEnforcedFn = createServerFn({ method: 'POST' })
@@ -497,14 +499,6 @@ export const setDomainEnforcedFn = createServerFn({ method: 'POST' })
             throw new ForbiddenError(
               'SSO_TEST_REQUIRED',
               'Run a successful test sign-in before enabling enforcement.'
-            )
-          }
-
-          const { isEmailConfigured } = await import('@quackback/email')
-          if (!isEmailConfigured()) {
-            throw new ConflictError(
-              'SSO_NO_BREAKGLASS',
-              'Configure email delivery (SMTP/Resend) before requiring SSO. Magic-link is the only fallback when SSO breaks.'
             )
           }
 

--- a/apps/web/src/lib/server/functions/sso.ts
+++ b/apps/web/src/lib/server/functions/sso.ts
@@ -157,7 +157,6 @@ const idpRole = z.enum(['admin', 'member', 'user'])
 const attributeMappingSchema = z.object({
   claimPath: z.string(),
   rules: z.array(z.object({ whenContains: z.string(), role: idpRole })),
-  defaultRole: idpRole,
   syncOnEverySignIn: z.boolean().optional(),
 })
 

--- a/apps/web/src/lib/shared/__tests__/claim-suggestions.test.ts
+++ b/apps/web/src/lib/shared/__tests__/claim-suggestions.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { deriveClaimSuggestions } from '../claim-suggestions'
+
+describe('deriveClaimSuggestions', () => {
+  it('surfaces a top-level string[] claim as a path with its values', () => {
+    const out = deriveClaimSuggestions({ groups: ['admins', 'devs'] })
+    expect(out.paths).toEqual(['groups'])
+    expect(out.valuesByPath).toEqual({ groups: ['admins', 'devs'] })
+  })
+
+  it('finds a nested array claim at depth 2 (Keycloak realm_access.roles)', () => {
+    const out = deriveClaimSuggestions({ realm_access: { roles: ['admin'] } })
+    expect(out.paths).toEqual(['realm_access.roles'])
+    expect(out.valuesByPath['realm_access.roles']).toEqual(['admin'])
+  })
+
+  it('records a URL-shaped claim key literally, not split on slashes', () => {
+    const out = deriveClaimSuggestions({ 'https://acme.com/roles': ['platform-admins'] })
+    expect(out.paths).toEqual(['https://acme.com/roles'])
+    expect(out.valuesByPath['https://acme.com/roles']).toEqual(['platform-admins'])
+  })
+
+  it('excludes standard identity claims and scalars', () => {
+    const out = deriveClaimSuggestions({
+      iss: 'https://idp',
+      sub: 'u1',
+      email: 'a@b.com',
+      tid: '6045704a-f241-4b8d-99ba-4f91f4fc2e4b',
+      ver: '2.0',
+    })
+    expect(out.paths).toEqual([])
+  })
+
+  it('skips empty arrays and dedupes + filters non-strings, preserving order', () => {
+    const out = deriveClaimSuggestions({
+      groups: ['a', 'a', 5 as unknown as string, 'b'],
+      roles: [],
+    })
+    expect(out.paths).toEqual(['groups'])
+    expect(out.valuesByPath.groups).toEqual(['a', 'b'])
+  })
+})

--- a/apps/web/src/lib/shared/claim-suggestions.ts
+++ b/apps/web/src/lib/shared/claim-suggestions.ts
@@ -1,0 +1,87 @@
+/**
+ * Turns a decoded ID-token payload into mappable claim suggestions for the
+ * rule editor: the array-of-string claims (groups/roles) and their distinct
+ * values. Array claims only -- scalar claims (e.g. Entra `tid`/`oid`) are not
+ * roles, and standard identity claims are never mappable. Pure + client-safe.
+ */
+import type { JsonValue } from '@/lib/server/audit/log'
+
+export type ClaimSuggestions = {
+  /** Dotted (or literal URL) claim paths whose value is a non-empty string[]. */
+  paths: string[]
+  /** Distinct string values at each path, first-seen order. */
+  valuesByPath: Record<string, string[]>
+}
+
+/** Standard OIDC/identity claims that are never role/group mappings. */
+const STANDARD_CLAIMS = new Set([
+  'iss',
+  'sub',
+  'aud',
+  'exp',
+  'iat',
+  'nbf',
+  'jti',
+  'nonce',
+  'azp',
+  'at_hash',
+  'c_hash',
+  'email',
+  'email_verified',
+  'name',
+  'preferred_username',
+  'given_name',
+  'family_name',
+  'ver',
+  'tid',
+  'oid',
+  'rh',
+  'uti',
+  'aio',
+])
+
+function dedupeStrings(arr: JsonValue[]): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const v of arr) {
+    if (typeof v === 'string' && !seen.has(v)) {
+      seen.add(v)
+      out.push(v)
+    }
+  }
+  return out
+}
+
+export function deriveClaimSuggestions(allClaims: Record<string, JsonValue>): ClaimSuggestions {
+  const paths: string[] = []
+  const valuesByPath: Record<string, string[]> = {}
+
+  const record = (path: string, value: JsonValue) => {
+    if (!Array.isArray(value)) return
+    const values = dedupeStrings(value)
+    if (values.length === 0) return
+    paths.push(path)
+    valuesByPath[path] = values
+  }
+
+  for (const [key, value] of Object.entries(allClaims)) {
+    if (STANDARD_CLAIMS.has(key)) continue
+    // URL-shaped keys are literal (never split); only record array leaves.
+    if (key.includes('://')) {
+      record(key, value)
+      continue
+    }
+    if (Array.isArray(value)) {
+      record(key, value)
+    } else if (value !== null && typeof value === 'object') {
+      // Depth-2 only, e.g. realm_access.roles. Skip URL-shaped child keys so
+      // the dotted path stays resolvable by getNestedClaim at sign-in.
+      for (const [childKey, childValue] of Object.entries(value)) {
+        if (childKey.includes('://')) continue
+        record(`${key}.${childKey}`, childValue as JsonValue)
+      }
+    }
+  }
+
+  return { paths, valuesByPath }
+}

--- a/apps/web/src/lib/shared/claim-suggestions.ts
+++ b/apps/web/src/lib/shared/claim-suggestions.ts
@@ -4,7 +4,7 @@
  * values. Array claims only -- scalar claims (e.g. Entra `tid`/`oid`) are not
  * roles, and standard identity claims are never mappable. Pure + client-safe.
  */
-import type { JsonValue } from '@/lib/server/audit/log'
+import type { JsonValue } from '@/lib/shared/json'
 
 export type ClaimSuggestions = {
   /** Dotted (or literal URL) claim paths whose value is a non-empty string[]. */
@@ -38,13 +38,18 @@ const STANDARD_CLAIMS = new Set([
   'rh',
   'uti',
   'aio',
+  // Auth-method/context claims: `amr` is a standard array (e.g. ['pwd','mfa'])
+  // that must not be offered as a role/group mapping.
+  'amr',
+  'acr',
+  'sid',
 ])
 
 function dedupeStrings(arr: JsonValue[]): string[] {
   const seen = new Set<string>()
   const out: string[] = []
   for (const v of arr) {
-    if (typeof v === 'string' && !seen.has(v)) {
+    if (typeof v === 'string' && v !== '' && !seen.has(v)) {
       seen.add(v)
       out.push(v)
     }

--- a/apps/web/src/lib/shared/json.ts
+++ b/apps/web/src/lib/shared/json.ts
@@ -1,0 +1,10 @@
+/** A JSON-shaped value (fits a Postgres jsonb column, serializes over the wire).
+ *  Lives in `shared` so client, server, and shared code can all reference it
+ *  without crossing the server-only `@/lib/server` boundary. */
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: JsonValue }
+  | JsonValue[]

--- a/packages/db/drizzle/0118_identity_provider_consolidate_default_role.sql
+++ b/packages/db/drizzle/0118_identity_provider_consolidate_default_role.sql
@@ -1,0 +1,15 @@
+-- Consolidate the two SSO "default role" controls into one (auto_provision_role).
+-- When attribute mapping was enabled, the live default was attribute_mapping.defaultRole
+-- (auto_provision_role was unreachable). Promote it to the single source of truth
+-- before the code stops reading the nested field, then drop the redundant key.
+-- Idempotent: re-running is a no-op once defaultRole is gone.
+UPDATE "identity_provider"
+SET "auto_provision_role" = "attribute_mapping"->>'defaultRole'
+WHERE "attribute_mapping" IS NOT NULL
+  AND "attribute_mapping" ? 'defaultRole'
+  AND "auto_provision_role" IS DISTINCT FROM ("attribute_mapping"->>'defaultRole');
+--> statement-breakpoint
+UPDATE "identity_provider"
+SET "attribute_mapping" = "attribute_mapping" - 'defaultRole'
+WHERE "attribute_mapping" IS NOT NULL
+  AND "attribute_mapping" ? 'defaultRole';

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -827,6 +827,13 @@
       "when": 1782950400000,
       "tag": "0117_identity_provider_jwks_issuer",
       "breakpoints": true
+    },
+    {
+      "idx": 118,
+      "version": "7",
+      "when": 1783036800000,
+      "tag": "0118_identity_provider_consolidate_default_role",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/__tests__/migration-0118-consolidate-default-role.test.ts
+++ b/packages/db/src/__tests__/migration-0118-consolidate-default-role.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, afterAll } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { sql } from 'drizzle-orm'
+import { createDb, type Database } from '../client'
+
+// 0118 collapses the duplicate SSO default-role controls. Single regression pin:
+// a mapping-on row whose live default lived in attribute_mapping.defaultRole must
+// have that value promoted to auto_provision_role (which was unreachable while
+// mapping was on), and the nested key stripped — so behavior is preserved when the
+// code stops reading defaultRole.
+const MIGRATION_SQL = readFileSync(
+  join(__dirname, '../../drizzle/0118_identity_provider_consolidate_default_role.sql'),
+  'utf8'
+)
+  .split('--> statement-breakpoint')
+  .map((s) => s.trim())
+  .filter(Boolean)
+
+const DB_URL = process.env.DATABASE_URL
+let db: Database | null = null
+const dbAvailable = !!DB_URL
+if (DB_URL) db = createDb(DB_URL, { max: 1 })
+
+afterAll(async () => {
+  // @ts-expect-error optional teardown
+  await db?.$client?.end?.()
+})
+
+describe.skipIf(!dbAvailable)('migration 0118 consolidate default role', () => {
+  it('promotes attribute_mapping.defaultRole into auto_provision_role and strips the key (regression pin)', async () => {
+    if (!db) return
+    await db
+      .transaction(async (tx) => {
+        const mapping = {
+          claimPath: 'groups',
+          rules: [{ whenContains: 'admins', role: 'admin' }],
+          defaultRole: 'admin',
+          syncOnEverySignIn: true,
+        }
+        const inserted = await tx.execute<{ id: string }>(sql`
+          INSERT INTO "identity_provider"
+            (id, registration_id, label, client_id, enabled, auto_create_users,
+             auto_provision_role, attribute_mapping, show_button)
+          VALUES
+            (gen_random_uuid(), 'oidc_m0118', 'M0118', 'cid', true, true,
+             NULL, ${JSON.stringify(mapping)}::jsonb, false)
+          RETURNING id
+        `)
+        const id = (inserted as unknown as { id: string }[])[0].id
+
+        for (const stmt of MIGRATION_SQL) {
+          await tx.execute(sql.raw(stmt))
+        }
+
+        const rows = await tx.execute<{
+          auto_provision_role: string
+          attribute_mapping: Record<string, unknown>
+        }>(sql`
+          SELECT auto_provision_role, attribute_mapping
+          FROM "identity_provider" WHERE id = ${id}
+        `)
+        const row = (
+          rows as unknown as {
+            auto_provision_role: string
+            attribute_mapping: Record<string, unknown>
+          }[]
+        )[0]
+        expect(row.auto_provision_role).toBe('admin') // promoted from the nested default
+        expect(row.attribute_mapping.defaultRole).toBeUndefined() // key stripped
+        expect(Array.isArray(row.attribute_mapping.rules)).toBe(true) // rules preserved
+        expect(row.attribute_mapping.syncOnEverySignIn).toBe(true) // other keys preserved
+
+        throw new Error('__ROLLBACK__') // abort the tx so dev/test data is untouched
+      })
+      .catch((e) => {
+        if (!(e instanceof Error) || e.message !== '__ROLLBACK__') throw e
+      })
+  })
+})

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -339,8 +339,6 @@ export type IdentityProviderAttributeMapping = {
   claimPath: string
   /** First-match-wins role assignment from the resolved claim. */
   rules: Array<{ whenContains: string; role: 'admin' | 'member' | 'user' }>
-  /** Used when no rule matches. */
-  defaultRole: 'admin' | 'member' | 'user'
   /** When true, every sign-in re-resolves and may demote/promote. */
   syncOnEverySignIn?: boolean
 }


### PR DESCRIPTION
Follow-up to #284 (unified authentication). A cohesive pass on the identity-provider editor and SSO role mapping.

## Default role + claim mapping
- Consolidate the two redundant "default role" controls into one (`autoProvisionRole`). `resolveSsoRole` now returns null on no-match and the caller supplies the default. Migration 0118 backfills `auto_provision_role` from the old nested `defaultRole`, so existing providers keep their behavior.
- Map roles from an IdP claim: a single Default role plus optional first-match-wins rules against a configurable claim path (`groups`, `roles`, `realm_access.roles`, namespaced URLs).
- After a test sign-in, the Claim path and rule-value inputs autocomplete from the claims the IdP actually returned (creatable, so you can still type your own), with a Test sign-in button in the empty state.

## Enforcement
- Recovery codes are the break-glass when SSO is enforced, not email. Drops the email-delivery precondition from the enforce gate and corrects the copy: magic-link is hard-bound off for enforced-domain emails, so it was never a usable fallback for the people enforcement affects.

## Provider editor polish
- Test sign-in moved to its own connection-status row (verified / untested / stale).
- Modal body uses the shadcn ScrollArea with a definite height so it scrolls with the header and footer pinned.
- The connection test surfaces the full ID token (groups/roles were previously hidden from the result).
- Terminology standardized on "claims".

## Verification
- Typecheck clean, lint clean, full suite green (5111 passed / 2 skipped, 478 files).
- New units: a shared `Autocomplete` primitive, `deriveClaimSuggestions`, migration 0118 with a regression pin, plus tests across the SSO test handshake, claim mapping, and provider editor.
