### PR TITLE
feat(changelog): add display date override for published entries

### DIFF
--- a/apps/web/e2e/tests/admin/changelog.spec.ts
+++ b/apps/web/e2e/tests/admin/changelog.spec.ts
@@ -668,11 +668,11 @@ test.describe('Changelog - Admin/Public Publishing Pipeline', () => {
     const dialog = page.getByRole('dialog')
     await expect(dialog).toBeVisible({ timeout: 10000 })
 
-    const displayDateLabel = dialog.getByText('Display date', { exact: true })
+    const displayDateLabel = dialog.getByText('Published date', { exact: true })
     await expect(displayDateLabel).toBeVisible({ timeout: 5000 })
 
     const displayDateRow = dialog.locator('div').filter({
-      has: page.getByText('Display date', { exact: true }),
+      has: page.getByText('Published date', { exact: true }),
     })
     await displayDateRow.getByRole('button').first().click()
 

--- a/apps/web/e2e/tests/admin/changelog.spec.ts
+++ b/apps/web/e2e/tests/admin/changelog.spec.ts
@@ -67,9 +67,7 @@ test.describe('Changelog admin navigation', () => {
 
   test('page shows entry list or empty state', async ({ page }) => {
     // Either an h3 (entry title) or an empty-state message should be visible
-    const content = page
-      .getByText('No changelog entries yet')
-      .or(page.locator('h3').first())
+    const content = page.getByText('No changelog entries yet').or(page.locator('h3').first())
 
     await expect(content.first()).toBeVisible({ timeout: 10000 })
   })
@@ -415,8 +413,11 @@ test.describe('Changelog delete entry', () => {
 
     await page.waitForLoadState('networkidle')
 
-    const row = page.locator('h3').filter({ hasText: title })
-      .locator('xpath=ancestor::div[contains(@class,"group")]').first()
+    const row = page
+      .locator('h3')
+      .filter({ hasText: title })
+      .locator('xpath=ancestor::div[contains(@class,"group")]')
+      .first()
 
     await row.hover()
 
@@ -429,7 +430,9 @@ test.describe('Changelog delete entry', () => {
     await deleteItem.click()
 
     // Confirmation dialog should appear
-    const confirmDialog = page.getByRole('alertdialog').or(page.getByRole('dialog').filter({ hasText: /delete/i }))
+    const confirmDialog = page
+      .getByRole('alertdialog')
+      .or(page.getByRole('dialog').filter({ hasText: /delete/i }))
     await expect(confirmDialog).toBeVisible({ timeout: 5000 })
 
     // Cancel — don't actually delete
@@ -442,8 +445,11 @@ test.describe('Changelog delete entry', () => {
 
     await page.waitForLoadState('networkidle')
 
-    const row = page.locator('h3').filter({ hasText: title })
-      .locator('xpath=ancestor::div[contains(@class,"group")]').first()
+    const row = page
+      .locator('h3')
+      .filter({ hasText: title })
+      .locator('xpath=ancestor::div[contains(@class,"group")]')
+      .first()
 
     await row.hover()
     const menuBtn = row.locator('button').last()
@@ -453,9 +459,9 @@ test.describe('Changelog delete entry', () => {
     if ((await deleteItem.count()) === 0) return
     await deleteItem.click()
 
-    const confirmDialog = page.getByRole('alertdialog').or(
-      page.getByRole('dialog').filter({ hasText: /delete/i })
-    )
+    const confirmDialog = page
+      .getByRole('alertdialog')
+      .or(page.getByRole('dialog').filter({ hasText: /delete/i }))
     await expect(confirmDialog).toBeVisible({ timeout: 5000 })
 
     // Click Cancel
@@ -473,8 +479,11 @@ test.describe('Changelog delete entry', () => {
 
     await page.waitForLoadState('networkidle')
 
-    const row = page.locator('h3').filter({ hasText: title })
-      .locator('xpath=ancestor::div[contains(@class,"group")]').first()
+    const row = page
+      .locator('h3')
+      .filter({ hasText: title })
+      .locator('xpath=ancestor::div[contains(@class,"group")]')
+      .first()
 
     await row.hover()
     const menuBtn = row.locator('button').last()
@@ -484,9 +493,9 @@ test.describe('Changelog delete entry', () => {
     if ((await deleteItem.count()) === 0) return
     await deleteItem.click()
 
-    const confirmDialog = page.getByRole('alertdialog').or(
-      page.getByRole('dialog').filter({ hasText: /delete/i })
-    )
+    const confirmDialog = page
+      .getByRole('alertdialog')
+      .or(page.getByRole('dialog').filter({ hasText: /delete/i }))
     await expect(confirmDialog).toBeVisible({ timeout: 5000 })
 
     // Confirm deletion
@@ -542,10 +551,7 @@ async function createAndPublishEntry(
  * Helper: revert a published entry back to draft via the edit modal.
  * Expects to be called from /admin/changelog with the entry visible.
  */
-async function unpublishEntry(
-  page: import('@playwright/test').Page,
-  title: string
-): Promise<void> {
+async function unpublishEntry(page: import('@playwright/test').Page, title: string): Promise<void> {
   const card = entryCard(page, title)
   await card.click()
 
@@ -647,6 +653,52 @@ test.describe('Changelog - Admin/Public Publishing Pipeline', () => {
     await expect(page.locator('h2').filter({ hasText: title })).toBeVisible({ timeout: 10000 })
 
     // Clean up
+    await deleteEntryByTitle(page, title)
+  })
+
+  test('display date override appears on public /changelog', async ({ page }) => {
+    const title = `Display Date Test ${Date.now()}`
+
+    const published = await createAndPublishEntry(page, title)
+    if (!published) return
+
+    await page.waitForLoadState('networkidle')
+
+    await entryCard(page, title).click()
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible({ timeout: 10000 })
+
+    const displayDateLabel = dialog.getByText('Display date', { exact: true })
+    await expect(displayDateLabel).toBeVisible({ timeout: 5000 })
+
+    const displayDateRow = dialog.locator('div').filter({
+      has: page.getByText('Display date', { exact: true }),
+    })
+    await displayDateRow.getByRole('button').first().click()
+
+    const prevMonth = page.getByRole('button', { name: /previous month/i })
+    for (let i = 0; i < 24; i++) {
+      const caption = page.locator('[class*="CaptionLabel"]')
+      const text = (await caption.textContent()) ?? ''
+      if (/january 2024/i.test(text)) break
+      if ((await prevMonth.count()) === 0) break
+      await prevMonth.click()
+    }
+
+    await page.getByRole('button', { name: /^15$/ }).first().click()
+
+    await dialog.getByRole('button', { name: /update & publish/i }).click()
+    await expect(dialog).toBeHidden({ timeout: 15000 })
+    await page.waitForLoadState('networkidle')
+
+    await page.goto('/changelog')
+    await page.waitForLoadState('networkidle')
+
+    const entry = page.locator('article').filter({ hasText: title })
+    await expect(entry.locator('time').first()).toContainText('January 15, 2024', {
+      timeout: 10000,
+    })
+
     await deleteEntryByTitle(page, title)
   })
 

--- a/apps/web/src/components/admin/changelog/changelog-list-item.tsx
+++ b/apps/web/src/components/admin/changelog/changelog-list-item.tsx
@@ -1,3 +1,4 @@
+import { isSameDay } from 'date-fns'
 import { Button } from '@/components/ui/button'
 import { StatusBadge } from '@/components/ui/status-badge'
 import { TimeAgo } from '@/components/ui/time-ago'
@@ -23,6 +24,7 @@ interface ChangelogListItemProps {
   content: string
   status: 'draft' | 'scheduled' | 'published'
   publishedAt: string | null
+  displayDate?: string | null
   createdAt: string
   author: {
     id: PrincipalId
@@ -50,6 +52,7 @@ export function ChangelogListItem({
   content,
   status,
   publishedAt,
+  displayDate,
   createdAt,
   author,
   linkedPosts,
@@ -58,6 +61,13 @@ export function ChangelogListItem({
 }: ChangelogListItemProps) {
   const config = STATUS_CONFIG[status]
   const contentPreview = stripMarkdownPreview(content, 150)
+  const portalDisplayDate =
+    status === 'published' &&
+    displayDate &&
+    publishedAt &&
+    !isSameDay(new Date(displayDate), new Date(publishedAt))
+      ? displayDate
+      : null
 
   return (
     <div
@@ -104,6 +114,19 @@ export function ChangelogListItem({
               </>
             )}
           </span>
+          {portalDisplayDate && (
+            <>
+              <span className="text-muted-foreground/40">·</span>
+              <span className="text-muted-foreground/70">
+                Showing as{' '}
+                {new Date(portalDisplayDate).toLocaleDateString('en-US', {
+                  month: 'short',
+                  day: 'numeric',
+                  year: 'numeric',
+                })}
+              </span>
+            </>
+          )}
           {linkedPosts.length > 0 && (
             <span className="flex items-center gap-1 text-muted-foreground/50 ml-auto">
               <LinkIcon className="h-3.5 w-3.5" />

--- a/apps/web/src/components/admin/changelog/changelog-list.tsx
+++ b/apps/web/src/components/admin/changelog/changelog-list.tsx
@@ -184,6 +184,7 @@ export function ChangelogList() {
                       content={entry.content}
                       status={entry.status}
                       publishedAt={entry.publishedAt}
+                      displayDate={entry.displayDate}
                       createdAt={entry.createdAt}
                       author={entry.author}
                       linkedPosts={entry.linkedPosts}

--- a/apps/web/src/components/admin/changelog/changelog-metadata-sidebar-content.tsx
+++ b/apps/web/src/components/admin/changelog/changelog-metadata-sidebar-content.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { format } from 'date-fns'
 import {
   DocumentTextIcon,
   PlusIcon,
@@ -32,6 +33,10 @@ interface ChangelogMetadataSidebarContentProps {
   linkedPostIds: PostId[]
   onLinkedPostsChange: (postIds: PostId[]) => void
   authorName?: string | null
+  publishedAt?: string | null
+  displayDateValue?: Date
+  onDisplayDateChange?: (value: Date | undefined) => void
+  onDisplayDateClear?: () => void
 }
 
 const PUBLISH_STATUS_OPTIONS: readonly StatusOption[] = [
@@ -46,6 +51,10 @@ export function ChangelogMetadataSidebarContent({
   linkedPostIds,
   onLinkedPostsChange,
   authorName,
+  publishedAt,
+  displayDateValue,
+  onDisplayDateChange = () => {},
+  onDisplayDateClear = () => {},
 }: ChangelogMetadataSidebarContentProps) {
   const [postsOpen, setPostsOpen] = useState(false)
   const [search, setSearch] = useState('')
@@ -60,6 +69,13 @@ export function ChangelogMetadataSidebarContent({
     tomorrow.setHours(9, 0, 0, 0)
     return tomorrow
   })
+
+  const displayPlaceholder =
+    publishedAt != null
+      ? format(new Date(publishedAt), 'MMM d, yyyy')
+      : publishState.type === 'published'
+        ? format(publishState.publishAt ?? new Date(), 'MMM d, yyyy')
+        : 'Pick a date'
 
   // Search shipped posts
   const { data: posts = [], isLoading: postsLoading } = useQuery({
@@ -88,6 +104,12 @@ export function ChangelogMetadataSidebarContent({
       if (publishState.type === 'scheduled') {
         onPublishStateChange({ type: 'scheduled', publishAt: date })
       }
+    }
+  }
+
+  const handleDisplayDateChange = (date: Date | undefined) => {
+    if (date) {
+      onDisplayDateChange(date)
     }
   }
 
@@ -135,6 +157,22 @@ export function ChangelogMetadataSidebarContent({
             onChange={handleDateTimeChange}
             minDate={new Date()}
             className="h-7 text-xs"
+          />
+        </div>
+      )}
+
+      {/* Display date - only when published */}
+      {publishState.type === 'published' && (
+        <div className="flex items-center justify-between gap-2 min-w-0">
+          <span className="text-sm text-muted-foreground shrink-0">Display date</span>
+          <DateTimePicker
+            value={displayDateValue}
+            onChange={handleDisplayDateChange}
+            onClear={displayDateValue !== undefined ? onDisplayDateClear : undefined}
+            maxDate={new Date()}
+            dateOnly
+            placeholder={displayPlaceholder}
+            className="h-7 min-w-0 max-w-[11rem] text-xs"
           />
         </div>
       )}

--- a/apps/web/src/components/admin/changelog/changelog-metadata-sidebar-content.tsx
+++ b/apps/web/src/components/admin/changelog/changelog-metadata-sidebar-content.tsx
@@ -6,9 +6,11 @@ import {
   MagnifyingGlassIcon,
   ChevronUpIcon,
   UserIcon,
+  InformationCircleIcon,
 } from '@heroicons/react/24/outline'
 import { CheckIcon } from '@heroicons/react/24/solid'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Checkbox } from '@/components/ui/checkbox'
 import { DateTimePicker } from '@/components/ui/datetime-picker'
@@ -161,10 +163,23 @@ export function ChangelogMetadataSidebarContent({
         </div>
       )}
 
-      {/* Display date - only when published */}
+      {/* Published date shown on the public changelog - only when published */}
       {publishState.type === 'published' && (
         <div className="flex items-center justify-between gap-2 min-w-0">
-          <span className="text-sm text-muted-foreground shrink-0">Display date</span>
+          <span className="flex items-center gap-1 text-sm text-muted-foreground shrink-0">
+            Published date
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <InformationCircleIcon className="h-3.5 w-3.5 text-muted-foreground/60" />
+              </TooltipTrigger>
+              <TooltipContent className="max-w-[15rem]">
+                <p>
+                  The date shown on your public changelog. Changing it won&apos;t send
+                  notifications.
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          </span>
           <DateTimePicker
             value={displayDateValue}
             onChange={handleDisplayDateChange}

--- a/apps/web/src/components/admin/changelog/changelog-metadata-sidebar.tsx
+++ b/apps/web/src/components/admin/changelog/changelog-metadata-sidebar.tsx
@@ -11,6 +11,10 @@ interface ChangelogMetadataSidebarProps {
   linkedPostIds: PostId[]
   onLinkedPostsChange: (postIds: PostId[]) => void
   authorName?: string | null
+  publishedAt?: string | null
+  displayDateValue?: Date
+  onDisplayDateChange?: (value: Date | undefined) => void
+  onDisplayDateClear?: () => void
 }
 
 export function ChangelogMetadataSidebar({
@@ -19,6 +23,10 @@ export function ChangelogMetadataSidebar({
   linkedPostIds,
   onLinkedPostsChange,
   authorName,
+  publishedAt,
+  displayDateValue,
+  onDisplayDateChange,
+  onDisplayDateClear,
 }: ChangelogMetadataSidebarProps) {
   return (
     <SidebarContainer className="overflow-y-auto">
@@ -28,6 +36,10 @@ export function ChangelogMetadataSidebar({
         linkedPostIds={linkedPostIds}
         onLinkedPostsChange={onLinkedPostsChange}
         authorName={authorName}
+        publishedAt={publishedAt}
+        displayDateValue={displayDateValue}
+        onDisplayDateChange={onDisplayDateChange}
+        onDisplayDateClear={onDisplayDateClear}
       />
     </SidebarContainer>
   )

--- a/apps/web/src/components/admin/changelog/changelog-modal.tsx
+++ b/apps/web/src/components/admin/changelog/changelog-modal.tsx
@@ -37,6 +37,8 @@ function ChangelogModalContent({ entryId, onClose }: ChangelogModalContentProps)
   const [contentJson, setContentJson] = useState<JSONContent | null>(null)
   const [linkedPostIds, setLinkedPostIds] = useState<PostId[]>([])
   const [publishState, setPublishState] = useState<PublishState>({ type: 'draft' })
+  const [displayDateOverride, setDisplayDateOverride] = useState<Date | undefined>(undefined)
+  const [displayDateTouched, setDisplayDateTouched] = useState(false)
   const [mobileSettingsOpen, setMobileSettingsOpen] = useState(false)
   const [hasInitialized, setHasInitialized] = useState(false)
 
@@ -66,6 +68,8 @@ function ChangelogModalContent({ entryId, onClose }: ChangelogModalContentProps)
       setContentJson(entry.contentJson as JSONContent | null)
       setLinkedPostIds(entry.linkedPosts.map((p) => p.id))
       setPublishState(toPublishState(entry.status, entry.publishedAt))
+      setDisplayDateOverride(entry.displayDate ? new Date(entry.displayDate) : undefined)
+      setDisplayDateTouched(false)
       setHasInitialized(true)
     }
   }, [entry, form, hasInitialized])
@@ -78,7 +82,25 @@ function ChangelogModalContent({ entryId, onClose }: ChangelogModalContentProps)
     [form]
   )
 
+  function handleDisplayDateChange(value: Date | undefined) {
+    if (value) {
+      setDisplayDateOverride(value)
+      setDisplayDateTouched(true)
+    }
+  }
+
+  function handleDisplayDateClear() {
+    setDisplayDateOverride(undefined)
+    setDisplayDateTouched(true)
+  }
+
   const handleSubmit = form.handleSubmit((data) => {
+    const displayDatePayload = displayDateTouched
+      ? displayDateOverride === undefined
+        ? null
+        : displayDateOverride
+      : undefined
+
     updateChangelogMutation.mutate(
       {
         id: entryId,
@@ -87,6 +109,7 @@ function ChangelogModalContent({ entryId, onClose }: ChangelogModalContentProps)
         contentJson: contentJson as TiptapContent | null,
         linkedPostIds,
         publishState,
+        ...(displayDatePayload !== undefined && { displayDate: displayDatePayload }),
       },
       {
         onSuccess: () => {
@@ -152,6 +175,10 @@ function ChangelogModalContent({ entryId, onClose }: ChangelogModalContentProps)
             linkedPostIds={linkedPostIds}
             onLinkedPostsChange={setLinkedPostIds}
             authorName={entry?.author?.name}
+            publishedAt={entry?.publishedAt}
+            displayDateValue={displayDateOverride}
+            onDisplayDateChange={handleDisplayDateChange}
+            onDisplayDateClear={handleDisplayDateClear}
           />
         </div>
 
@@ -180,6 +207,10 @@ function ChangelogModalContent({ entryId, onClose }: ChangelogModalContentProps)
                   linkedPostIds={linkedPostIds}
                   onLinkedPostsChange={setLinkedPostIds}
                   authorName={entry?.author?.name}
+                  publishedAt={entry?.publishedAt}
+                  displayDateValue={displayDateOverride}
+                  onDisplayDateChange={handleDisplayDateChange}
+                  onDisplayDateClear={handleDisplayDateClear}
                 />
               </div>
             </SheetContent>

--- a/apps/web/src/components/admin/changelog/create-changelog-dialog.tsx
+++ b/apps/web/src/components/admin/changelog/create-changelog-dialog.tsx
@@ -29,6 +29,7 @@ export function CreateChangelogDialog({ onChangelogCreated }: CreateChangelogDia
   const [contentJson, setContentJson] = useState<JSONContent | null>(null)
   const [linkedPostIds, setLinkedPostIds] = useState<PostId[]>([])
   const [publishState, setPublishState] = useState<PublishState>({ type: 'draft' })
+  const [displayDateOverride, setDisplayDateOverride] = useState<Date | undefined>(undefined)
   const [mobileSettingsOpen, setMobileSettingsOpen] = useState(false)
   const createChangelogMutation = useCreateChangelog()
 
@@ -50,6 +51,32 @@ export function CreateChangelogDialog({ onChangelogCreated }: CreateChangelogDia
     [form]
   )
 
+  function handlePublishStateChange(state: PublishState) {
+    setPublishState(state)
+    if (state.type !== 'published') {
+      setDisplayDateOverride(undefined)
+    }
+  }
+
+  function handleDisplayDateChange(value: Date | undefined) {
+    if (value) {
+      setDisplayDateOverride(value)
+    }
+  }
+
+  function handleDisplayDateClear() {
+    setDisplayDateOverride(undefined)
+  }
+
+  function resetFormState() {
+    form.reset()
+    setContentJson(null)
+    setLinkedPostIds([])
+    setPublishState({ type: 'draft' })
+    setDisplayDateOverride(undefined)
+    createChangelogMutation.reset()
+  }
+
   const handleSubmit = form.handleSubmit((data) => {
     createChangelogMutation.mutate(
       {
@@ -58,14 +85,13 @@ export function CreateChangelogDialog({ onChangelogCreated }: CreateChangelogDia
         contentJson: contentJson as TiptapContent | null,
         linkedPostIds,
         publishState,
+        ...(publishState.type === 'published' &&
+          displayDateOverride !== undefined && { displayDate: displayDateOverride }),
       },
       {
         onSuccess: () => {
           setOpen(false)
-          form.reset()
-          setContentJson(null)
-          setLinkedPostIds([])
-          setPublishState({ type: 'draft' })
+          resetFormState()
           onChangelogCreated?.()
         },
       }
@@ -75,11 +101,7 @@ export function CreateChangelogDialog({ onChangelogCreated }: CreateChangelogDia
   function handleOpenChange(isOpen: boolean) {
     setOpen(isOpen)
     if (!isOpen) {
-      form.reset()
-      setContentJson(null)
-      setLinkedPostIds([])
-      setPublishState({ type: 'draft' })
-      createChangelogMutation.reset()
+      resetFormState()
     }
   }
 
@@ -135,9 +157,12 @@ export function CreateChangelogDialog({ onChangelogCreated }: CreateChangelogDia
               {/* Right: Metadata sidebar (desktop only) */}
               <ChangelogMetadataSidebar
                 publishState={publishState}
-                onPublishStateChange={setPublishState}
+                onPublishStateChange={handlePublishStateChange}
                 linkedPostIds={linkedPostIds}
                 onLinkedPostsChange={setLinkedPostIds}
+                displayDateValue={displayDateOverride}
+                onDisplayDateChange={handleDisplayDateChange}
+                onDisplayDateClear={handleDisplayDateClear}
               />
             </div>
 
@@ -162,9 +187,12 @@ export function CreateChangelogDialog({ onChangelogCreated }: CreateChangelogDia
                   <div className="py-4 overflow-y-auto">
                     <ChangelogMetadataSidebarContent
                       publishState={publishState}
-                      onPublishStateChange={setPublishState}
+                      onPublishStateChange={handlePublishStateChange}
                       linkedPostIds={linkedPostIds}
                       onLinkedPostsChange={setLinkedPostIds}
+                      displayDateValue={displayDateOverride}
+                      onDisplayDateChange={handleDisplayDateChange}
+                      onDisplayDateClear={handleDisplayDateClear}
                     />
                   </div>
                 </SheetContent>

--- a/apps/web/src/components/ui/datetime-picker.tsx
+++ b/apps/web/src/components/ui/datetime-picker.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import * as React from 'react'
-import { format } from 'date-fns'
-import { CalendarIcon, ClockIcon } from '@heroicons/react/24/outline'
+import { format, isSameDay, parseISO, startOfDay } from 'date-fns'
+import { CalendarIcon, ClockIcon, XMarkIcon } from '@heroicons/react/24/outline'
 
 import { cn } from '@/lib/shared/utils'
 import { Button } from '@/components/ui/button'
@@ -15,12 +15,29 @@ interface DateTimePickerProps {
   onChange: (date: Date | undefined) => void
   /** Minimum selectable date */
   minDate?: Date
+  /** Maximum selectable date */
+  maxDate?: Date
   /** Placeholder text when no date selected */
   placeholder?: string
   /** Whether the picker is disabled */
   disabled?: boolean
+  /** Date-only mode: calendar without time input */
+  dateOnly?: boolean
+  /** Called when the inline clear control is clicked (shown when value is set) */
+  onClear?: () => void
   /** Additional class names for trigger button */
   className?: string
+}
+
+function clampToBounds(date: Date, minDate?: Date, maxDate?: Date): Date {
+  let result = new Date(date)
+  if (minDate && result < minDate) {
+    result = new Date(minDate)
+  }
+  if (maxDate && result > maxDate) {
+    result = new Date(maxDate)
+  }
+  return result
 }
 
 /**
@@ -30,11 +47,23 @@ export function DateTimePicker({
   value,
   onChange,
   minDate,
-  placeholder = 'Pick date & time',
+  maxDate,
+  placeholder,
   disabled = false,
+  dateOnly = false,
+  onClear,
   className,
 }: DateTimePickerProps) {
   const [open, setOpen] = React.useState(false)
+
+  const defaultPlaceholder = dateOnly ? 'Pick a date' : 'Pick date & time'
+  const resolvedPlaceholder = placeholder ?? defaultPlaceholder
+  const displayFormat = dateOnly ? 'MMM d, yyyy' : 'MMM d, yyyy · HH:mm'
+
+  const applyBounds = React.useCallback(
+    (date: Date) => clampToBounds(date, minDate, maxDate),
+    [minDate, maxDate]
+  )
 
   // Format time as HH:mm:ss for the input
   const timeValue = value
@@ -42,64 +71,130 @@ export function DateTimePicker({
     : '09:00:00'
 
   const handleDateSelect = (date: Date | undefined) => {
-    if (date) {
-      const newDate = new Date(date)
-      // Preserve existing time or default to 9:00
-      if (value) {
-        newDate.setHours(value.getHours(), value.getMinutes(), 0, 0)
-      } else {
-        newDate.setHours(9, 0, 0, 0)
-      }
-      onChange(newDate)
+    if (!date) return
+
+    if (dateOnly) {
+      onChange(applyBounds(parseISO(`${format(date, 'yyyy-MM-dd')}T12:00:00.000Z`)))
+      setOpen(false)
+      return
     }
+
+    const newDate = new Date(date)
+    // Preserve existing time or default to 9:00
+    if (value) {
+      newDate.setHours(value.getHours(), value.getMinutes(), 0, 0)
+    } else {
+      newDate.setHours(9, 0, 0, 0)
+    }
+    onChange(applyBounds(newDate))
   }
 
   const handleTimeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const [hours, minutes] = e.target.value.split(':').map(Number)
     if (!isNaN(hours) && !isNaN(minutes)) {
-      const newDate = value ? new Date(value) : new Date()
-      newDate.setHours(hours, minutes, 0, 0)
-      onChange(newDate)
+      const base = value ? new Date(value) : maxDate ? new Date(maxDate) : new Date()
+      base.setHours(hours, minutes, 0, 0)
+      onChange(applyBounds(base))
     }
   }
 
+  const isDateDisabled = (date: Date) => {
+    if (minDate && date < startOfDay(minDate)) return true
+    if (maxDate && date > startOfDay(maxDate)) return true
+    return false
+  }
+
+  const timeMax = maxDate && value && isSameDay(value, maxDate) ? maxDate : undefined
+  const showClear = value !== undefined && onClear !== undefined
+
+  const triggerContent = (
+    <>
+      <CalendarIcon className="mr-2 h-4 w-4 shrink-0" />
+      <span className="min-w-0 flex-1 truncate">
+        {value ? format(value, displayFormat) : resolvedPlaceholder}
+      </span>
+    </>
+  )
+
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          disabled={disabled}
+      {showClear ? (
+        <div
           className={cn(
-            'justify-start text-left font-normal',
-            !value && 'text-muted-foreground',
+            'inline-flex max-w-full items-stretch overflow-hidden rounded-md border border-border/50 bg-transparent',
+            disabled && 'pointer-events-none opacity-50',
             className
           )}
         >
-          <CalendarIcon className="mr-2 h-4 w-4" />
-          {value ? format(value, 'MMM d, yyyy · HH:mm') : <span>{placeholder}</span>}
-        </Button>
-      </PopoverTrigger>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              disabled={disabled}
+              className={cn(
+                'inline-flex min-w-0 flex-1 items-center px-2 text-left text-xs font-normal transition-colors hover:bg-muted/40',
+                !value && 'text-muted-foreground'
+              )}
+            >
+              {triggerContent}
+            </button>
+          </PopoverTrigger>
+          <button
+            type="button"
+            disabled={disabled}
+            onClick={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              onClear()
+            }}
+            className="inline-flex shrink-0 items-center justify-center border-l border-border/50 px-1.5 text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+            aria-label="Clear date"
+          >
+            <XMarkIcon className="h-3 w-3" />
+          </button>
+        </div>
+      ) : (
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            disabled={disabled}
+            className={cn(
+              'max-w-full justify-start text-left font-normal',
+              !value && 'text-muted-foreground',
+              className
+            )}
+          >
+            {triggerContent}
+          </Button>
+        </PopoverTrigger>
+      )}
       <PopoverContent className="w-auto p-0" align="end">
         <Calendar
           mode="single"
           selected={value}
           onSelect={handleDateSelect}
-          disabled={(date) => (minDate ? date < minDate : false)}
+          disabled={isDateDisabled}
           initialFocus
         />
-        <div className="border-t border-border/50 px-3 py-2">
-          <div className="flex items-center gap-2">
-            <ClockIcon className="h-4 w-4 text-muted-foreground" />
-            <span className="text-sm text-muted-foreground">Time</span>
-            <Input
-              type="time"
-              step="60"
-              value={timeValue}
-              onChange={handleTimeChange}
-              className="ml-auto h-8 w-24 bg-background appearance-none [&::-webkit-calendar-picker-indicator]:hidden [&::-webkit-calendar-picker-indicator]:appearance-none"
-            />
+        {!dateOnly && (
+          <div className="border-t border-border/50 px-3 py-2">
+            <div className="flex items-center gap-2">
+              <ClockIcon className="h-4 w-4 text-muted-foreground" />
+              <span className="text-sm text-muted-foreground">Time</span>
+              <Input
+                type="time"
+                step="60"
+                value={timeValue}
+                max={
+                  timeMax
+                    ? `${String(timeMax.getHours()).padStart(2, '0')}:${String(timeMax.getMinutes()).padStart(2, '0')}`
+                    : undefined
+                }
+                onChange={handleTimeChange}
+                className="ml-auto h-8 w-24 bg-background appearance-none [&::-webkit-calendar-picker-indicator]:hidden [&::-webkit-calendar-picker-indicator]:appearance-none"
+              />
+            </div>
           </div>
-        </div>
+        )}
       </PopoverContent>
     </Popover>
   )

--- a/apps/web/src/lib/server/domains/api/schemas/changelog.ts
+++ b/apps/web/src/lib/server/domains/api/schemas/changelog.ts
@@ -21,6 +21,9 @@ const ChangelogEntrySchema = z.object({
   publishedAt: NullableTimestampSchema.meta({
     description: 'When the entry was published (null if draft)',
   }),
+  displayDate: NullableTimestampSchema.meta({
+    description: 'Optional portal display override (null uses publishedAt for display)',
+  }),
   createdAt: TimestampSchema,
   updatedAt: TimestampSchema,
 })
@@ -52,6 +55,10 @@ const UpdateChangelogEntrySchema = z
       .nullable()
       .optional()
       .meta({ description: 'Set to null to unpublish' }),
+    displayDate: z.string().datetime().nullable().optional().meta({
+      description:
+        'Portal display override for published entries. Null clears override. Must not be in the future.',
+    }),
   })
   .meta({ description: 'Update changelog entry request body' })
 

--- a/apps/web/src/lib/server/domains/changelog/__tests__/changelog-display-date.test.ts
+++ b/apps/web/src/lib/server/domains/changelog/__tests__/changelog-display-date.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ChangelogId } from '@quackback/ids'
+import { ValidationError } from '@/lib/shared/errors'
+
+const mockEntryFindFirst = vi.fn()
+const mockUpdateSet = vi.fn()
+const mockUpdateWhere = vi.fn()
+const mockChangelogEntryPostsFindMany = vi.fn()
+
+vi.mock('@/lib/server/db', () => ({
+  db: {
+    query: {
+      changelogEntries: {
+        findFirst: (...args: unknown[]) => mockEntryFindFirst(...args),
+      },
+      changelogEntryPosts: {
+        findMany: (...args: unknown[]) => mockChangelogEntryPostsFindMany(...args),
+      },
+      principal: { findFirst: vi.fn().mockResolvedValue(null) },
+      postStatuses: { findFirst: vi.fn().mockResolvedValue(null) },
+    },
+    update: () => ({
+      set: (values: unknown) => {
+        mockUpdateSet(values)
+        return { where: (...args: unknown[]) => mockUpdateWhere(...args) }
+      },
+    }),
+    delete: () => ({ where: vi.fn().mockResolvedValue(undefined) }),
+  },
+  changelogEntries: { id: 'id', publishedAt: 'published_at', deletedAt: 'deleted_at' },
+  changelogEntryPosts: { changelogEntryId: 'changelog_entry_id', postId: 'post_id' },
+  posts: { id: 'posts.id' },
+  principal: { id: 'principal.id' },
+  postStatuses: { id: 'postStatuses.id' },
+  eq: vi.fn(),
+  and: vi.fn(),
+  isNull: vi.fn(),
+  inArray: vi.fn(),
+}))
+
+vi.mock('@/lib/server/content/rehost-images', () => ({
+  rehostExternalImages: vi.fn(async (json: unknown) => json),
+}))
+vi.mock('@/lib/server/events/dispatch', () => ({
+  buildEventActor: vi.fn(() => ({ type: 'user' })),
+  dispatchChangelogPublished: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock('@/lib/server/events/scheduler', () => ({
+  scheduleDispatch: vi.fn(),
+  cancelScheduledDispatch: vi.fn(),
+}))
+
+const ENTRY_ID = 'changelog_01test' as ChangelogId
+const PUBLISHED_AT = new Date('2025-06-01T12:00:00Z')
+
+function baseEntry(overrides: Record<string, unknown> = {}) {
+  return {
+    id: ENTRY_ID,
+    title: 'Release',
+    content: 'Body',
+    contentJson: null,
+    principalId: null,
+    publishedAt: PUBLISHED_AT,
+    displayDate: null,
+    createdAt: new Date('2025-06-01T10:00:00Z'),
+    updatedAt: new Date('2025-06-01T10:00:00Z'),
+    deletedAt: null,
+    viewCount: 0,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockChangelogEntryPostsFindMany.mockResolvedValue([])
+})
+
+describe('displayDate', () => {
+  it('persists displayDate without changing publishedAt', async () => {
+    const { updateChangelog } = await import('../changelog.service')
+    const pastDisplay = new Date('2024-01-15T09:00:00Z')
+
+    mockEntryFindFirst
+      .mockResolvedValueOnce(baseEntry())
+      .mockResolvedValueOnce(baseEntry({ displayDate: pastDisplay }))
+
+    await updateChangelog(ENTRY_ID, { displayDate: pastDisplay })
+
+    expect(mockUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ displayDate: pastDisplay })
+    )
+    const updatePayload = mockUpdateSet.mock.calls[0]![0] as Record<string, unknown>
+    expect(updatePayload).not.toHaveProperty('publishedAt')
+  })
+
+  it('rejects displayDate in the future', async () => {
+    const { updateChangelog } = await import('../changelog.service')
+    mockEntryFindFirst.mockResolvedValueOnce(baseEntry())
+
+    await expect(
+      updateChangelog(ENTRY_ID, { displayDate: new Date(Date.now() + 60_000) })
+    ).rejects.toBeInstanceOf(ValidationError)
+    expect(mockUpdateSet).not.toHaveBeenCalled()
+  })
+
+  it('stores null when displayDate matches publishedAt calendar day', async () => {
+    const { updateChangelog } = await import('../changelog.service')
+    const sameDay = new Date('2025-06-01T18:00:00Z')
+
+    mockEntryFindFirst.mockResolvedValueOnce(baseEntry()).mockResolvedValueOnce(baseEntry())
+
+    await updateChangelog(ENTRY_ID, { displayDate: sameDay })
+
+    expect(mockUpdateSet).toHaveBeenCalledWith(expect.objectContaining({ displayDate: null }))
+  })
+})

--- a/apps/web/src/lib/server/domains/changelog/__tests__/changelog-public-moderation.test.ts
+++ b/apps/web/src/lib/server/domains/changelog/__tests__/changelog-public-moderation.test.ts
@@ -166,9 +166,39 @@ function chainResolving(rows: unknown[]): unknown {
   return chain
 }
 
+function entriesListChain(rows: unknown[]): unknown {
+  const chain: Record<string, unknown> = {}
+  chain.from = () => chain
+  chain.where = () => chain
+  chain.orderBy = () => chain
+  chain.limit = () => Promise.resolve(rows)
+  return chain
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
   mockStatusesFindMany.mockResolvedValue([])
+})
+
+describe('getPublicChangelogById — effective display date', () => {
+  it('returns displayDate override as publishedAt for portal detail view', async () => {
+    const { getPublicChangelogById } = await import('../changelog.public')
+    const displayOverride = new Date('2024-01-15T09:00:00Z')
+    const publishedAt = new Date('2025-06-01T12:00:00Z')
+
+    mockEntryFindFirst.mockResolvedValueOnce({
+      id: 'cl_1' as ChangelogId,
+      title: 'Backdated release',
+      content: 'Body',
+      contentJson: null,
+      publishedAt,
+      displayDate: displayOverride,
+    })
+    mockSelect.mockReturnValueOnce(chainResolving([]))
+
+    const result = await getPublicChangelogById('cl_1' as ChangelogId)
+    expect(result.publishedAt).toEqual(displayOverride)
+  })
 })
 
 describe('getPublicChangelogById — moderation state filter', () => {
@@ -223,22 +253,24 @@ describe('getPublicChangelogById — moderation state filter', () => {
 describe('listPublicChangelogs — moderation state filter', () => {
   it('returns only published linked posts across all entries', async () => {
     const { listPublicChangelogs } = await import('../changelog.public')
-    mockEntryFindMany.mockResolvedValueOnce([
-      {
-        id: 'cl_1' as ChangelogId,
-        title: 'Release 1',
-        content: '',
-        contentJson: null,
-        publishedAt: new Date('2026-01-02'),
-      },
-      {
-        id: 'cl_2' as ChangelogId,
-        title: 'Release 2',
-        content: '',
-        contentJson: null,
-        publishedAt: new Date('2026-01-01'),
-      },
-    ])
+    mockSelect.mockReturnValueOnce(
+      entriesListChain([
+        {
+          id: 'cl_1' as ChangelogId,
+          title: 'Release 1',
+          content: '',
+          contentJson: null,
+          publishedAt: new Date('2026-01-02'),
+        },
+        {
+          id: 'cl_2' as ChangelogId,
+          title: 'Release 2',
+          content: '',
+          contentJson: null,
+          publishedAt: new Date('2026-01-01'),
+        },
+      ])
+    )
     const candidates = [
       candidateRow({ id: 'p_pub_1', moderationState: 'published', changelogEntryId: 'cl_1' }),
       candidateRow({ id: 'p_pen_1', moderationState: 'pending', changelogEntryId: 'cl_1' }),
@@ -297,15 +329,17 @@ describe('public changelog — board audience filter', () => {
 
   it('listPublicChangelogs: hides non-public-audience linked posts across entries', async () => {
     const { listPublicChangelogs } = await import('../changelog.public')
-    mockEntryFindMany.mockResolvedValueOnce([
-      {
-        id: 'cl_1' as ChangelogId,
-        title: 'Release 1',
-        content: '',
-        contentJson: null,
-        publishedAt: new Date('2026-01-02'),
-      },
-    ])
+    mockSelect.mockReturnValueOnce(
+      entriesListChain([
+        {
+          id: 'cl_1' as ChangelogId,
+          title: 'Release 1',
+          content: '',
+          contentJson: null,
+          publishedAt: new Date('2026-01-02'),
+        },
+      ])
+    )
     const candidates = [
       candidateRow({ id: 'p_pub', moderationState: 'published', changelogEntryId: 'cl_1' }),
       candidateRow({

--- a/apps/web/src/lib/server/domains/changelog/__tests__/changelog-soft-delete.test.ts
+++ b/apps/web/src/lib/server/domains/changelog/__tests__/changelog-soft-delete.test.ts
@@ -88,6 +88,17 @@ function selectChainResolving(rows: unknown[]): unknown {
   return chain
 }
 
+// Chainable mock for the entries query: `db.select().from().where().orderBy().limit()`.
+// Resolves with the rows you provide when `.limit()` is awaited.
+function entriesListChain(rows: unknown[]): unknown {
+  const chain: Record<string, unknown> = {}
+  chain.from = () => chain
+  chain.where = () => chain
+  chain.orderBy = () => chain
+  chain.limit = () => Promise.resolve(rows)
+  return chain
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
   mockStatusesFindMany.mockResolvedValue([])
@@ -119,7 +130,7 @@ describe('listPublicChangelogs', () => {
     const { listPublicChangelogs } = await import('../changelog.public')
     const { isNull } = await import('@/lib/server/db')
 
-    mockEntryFindMany.mockResolvedValueOnce([])
+    mockSelect.mockReturnValueOnce(entriesListChain([]))
 
     await listPublicChangelogs({})
 
@@ -134,8 +145,9 @@ describe('listPublicChangelogs', () => {
     // preserves it precisely so pagination has an anchor.
     mockEntryFindFirst.mockResolvedValueOnce({
       publishedAt: new Date('2026-01-01'),
+      displayDate: null,
     })
-    mockEntryFindMany.mockResolvedValueOnce([])
+    mockSelect.mockReturnValueOnce(entriesListChain([]))
 
     await listPublicChangelogs({ cursor: 'cl_cursor' })
 
@@ -148,12 +160,13 @@ describe('listPublicChangelogs', () => {
       )
     expect(cursorEqCalls.length).toBe(1)
 
-    // The pagination filter (lt publishedAt) was applied, so the user
-    // doesn't fall back to the first page.
-    const ltPublishedAtCalls = vi
+    // The pagination filter was applied on the effective display date
+    // (coalesce(display_date, published_at)), so the user doesn't fall
+    // back to the first page.
+    const ltEffectiveDateCalls = vi
       .mocked(lt)
-      .mock.calls.filter((args) => (args[0] as unknown) === changelogEntriesTable.publishedAt)
-    expect(ltPublishedAtCalls.length).toBeGreaterThanOrEqual(1)
+      .mock.calls.filter((args) => (args[0] as { kind?: string })?.kind === 'sql')
+    expect(ltEffectiveDateCalls.length).toBeGreaterThanOrEqual(1)
   })
 })
 

--- a/apps/web/src/lib/server/domains/changelog/changelog.public.ts
+++ b/apps/web/src/lib/server/domains/changelog/changelog.public.ts
@@ -21,6 +21,8 @@ import { NotFoundError } from '@/lib/shared/errors'
 import { computeStatus } from './changelog.service'
 import type { PublicChangelogEntry, PublicChangelogListResult } from './changelog.types'
 
+const effectiveDisplayDate = sql<Date>`coalesce(${changelogEntries.displayDate}, ${changelogEntries.publishedAt})`
+
 /**
  * Predicates that make a changelog entry publicly visible: not soft-deleted
  * and published at or before `now`. Shared by every public read path so the
@@ -47,10 +49,14 @@ export async function getPublicChangelogMetaById(
   const now = new Date()
   const entry = await db.query.changelogEntries.findFirst({
     where: and(eq(changelogEntries.id, id), ...publicChangelogConditions(now)),
-    columns: { id: true, title: true, publishedAt: true },
+    columns: { id: true, title: true, publishedAt: true, displayDate: true },
   })
   if (!entry || !entry.publishedAt) return null
-  return { id: entry.id as ChangelogId, title: entry.title, publishedAt: entry.publishedAt }
+  return {
+    id: entry.id as ChangelogId,
+    title: entry.title,
+    publishedAt: entry.displayDate ?? entry.publishedAt,
+  }
 }
 
 /**
@@ -134,7 +140,7 @@ export async function getPublicChangelogById(id: ChangelogId): Promise<PublicCha
     title: entry.title,
     content: entry.content,
     contentJson: entry.contentJson,
-    publishedAt: entry.publishedAt,
+    publishedAt: entry.displayDate ?? entry.publishedAt,
     linkedPosts: linkedPostRows.map((lp) => ({
       id: lp.postId,
       title: lp.postTitle,
@@ -169,14 +175,17 @@ export async function listPublicChangelogs(params: {
   if (cursor) {
     const cursorEntry = await db.query.changelogEntries.findFirst({
       where: eq(changelogEntries.id, cursor as ChangelogId),
-      columns: { publishedAt: true },
+      columns: { publishedAt: true, displayDate: true },
     })
-    if (cursorEntry?.publishedAt) {
+    const cursorEffective = cursorEntry?.publishedAt
+      ? (cursorEntry.displayDate ?? cursorEntry.publishedAt)
+      : null
+    if (cursorEffective) {
       conditions.push(
         or(
-          lt(changelogEntries.publishedAt, cursorEntry.publishedAt),
+          lt(effectiveDisplayDate, cursorEffective),
           and(
-            eq(changelogEntries.publishedAt, cursorEntry.publishedAt),
+            sql`${effectiveDisplayDate} = ${cursorEffective}`,
             lt(changelogEntries.id, cursor as ChangelogId)
           )
         )!
@@ -185,11 +194,12 @@ export async function listPublicChangelogs(params: {
   }
 
   // Fetch entries
-  const entries = await db.query.changelogEntries.findMany({
-    where: and(...conditions),
-    orderBy: [desc(changelogEntries.publishedAt), desc(changelogEntries.id)],
-    limit: limit + 1,
-  })
+  const entries = await db
+    .select()
+    .from(changelogEntries)
+    .where(and(...conditions))
+    .orderBy(desc(effectiveDisplayDate), desc(changelogEntries.id))
+    .limit(limit + 1)
 
   const hasMore = entries.length > limit
   const items = hasMore ? entries.slice(0, limit) : entries
@@ -256,7 +266,7 @@ export async function listPublicChangelogs(params: {
         title: entry.title,
         content: entry.content,
         contentJson: entry.contentJson,
-        publishedAt: entry.publishedAt!,
+        publishedAt: entry.displayDate ?? entry.publishedAt!,
         linkedPosts: entryLinkedPosts.map((lp) => ({
           id: lp.postId,
           title: lp.postTitle,

--- a/apps/web/src/lib/server/domains/changelog/changelog.query.ts
+++ b/apps/web/src/lib/server/domains/changelog/changelog.query.ts
@@ -155,6 +155,7 @@ export async function listChangelogs(params: ListChangelogParams): Promise<Chang
       contentJson: entry.contentJson,
       principalId: entry.principalId,
       publishedAt: entry.publishedAt,
+      displayDate: entry.displayDate,
       createdAt: entry.createdAt,
       updatedAt: entry.updatedAt,
       author: entry.principalId ? (authorMap.get(entry.principalId) ?? null) : null,

--- a/apps/web/src/lib/server/domains/changelog/changelog.service.ts
+++ b/apps/web/src/lib/server/domains/changelog/changelog.service.ts
@@ -28,7 +28,7 @@ import { buildEventActor, dispatchChangelogPublished } from '@/lib/server/events
 import { scheduleDispatch, cancelScheduledDispatch } from '@/lib/server/events/scheduler'
 import { logger } from '@/lib/server/logger'
 
-const log = logger.child({ component: 'changelog' })
+import { isSameDay } from 'date-fns'
 import type {
   CreateChangelogInput,
   UpdateChangelogInput,
@@ -37,6 +37,8 @@ import type {
   ChangelogAuthor,
   ChangelogLinkedPost,
 } from './changelog.types'
+
+const log = logger.child({ component: 'changelog' })
 
 // ============================================================================
 // Create
@@ -70,6 +72,21 @@ export async function createChangelog(
   // Determine publishedAt based on publish state
   const publishedAt = getPublishedAtFromState(input.publishState)
 
+  if (input.displayDate != null) {
+    if (input.publishState.type !== 'published') {
+      throw new ValidationError(
+        'VALIDATION_ERROR',
+        'Display date can only be set on published changelog entries'
+      )
+    }
+    validateDisplayDate(publishedAt, input.displayDate)
+  }
+
+  const displayDate =
+    input.displayDate != null && input.publishState.type === 'published'
+      ? normalizeDisplayDate(input.displayDate, publishedAt)
+      : null
+
   // Create the changelog entry
   const parsedContentJson = input.contentJson ?? markdownToTiptapJson(content)
   const contentJson = await rehostExternalImages(parsedContentJson, {
@@ -85,6 +102,7 @@ export async function createChangelog(
       contentJson,
       principalId: author.principalId,
       publishedAt,
+      ...(displayDate != null && { displayDate }),
     })
     .returning()
 
@@ -166,6 +184,15 @@ export async function updateChangelog(
       contentType: 'changelog',
       principalId: existing.principalId ?? undefined,
     })
+  }
+
+  if (input.displayDate !== undefined) {
+    validateDisplayDate(existing.publishedAt, input.displayDate)
+    const publishedAtRef =
+      input.publishState !== undefined
+        ? getPublishedAtFromState(input.publishState)
+        : existing.publishedAt
+    updateData.displayDate = normalizeDisplayDate(input.displayDate, publishedAtRef)
   }
 
   // Handle publish state change
@@ -332,6 +359,7 @@ export async function getChangelogById(id: ChangelogId): Promise<ChangelogEntryW
     contentJson: entry.contentJson,
     principalId: entry.principalId,
     publishedAt: entry.publishedAt,
+    displayDate: entry.displayDate,
     createdAt: entry.createdAt,
     updatedAt: entry.updatedAt,
     author,
@@ -388,4 +416,22 @@ export function computeStatus(publishedAt: Date | null): 'draft' | 'scheduled' |
   if (!publishedAt) return 'draft'
   if (publishedAt > new Date()) return 'scheduled'
   return 'published'
+}
+
+function normalizeDisplayDate(displayDate: Date | null, publishedAt: Date | null): Date | null {
+  if (displayDate == null || publishedAt == null) return displayDate
+  return isSameDay(displayDate, publishedAt) ? null : displayDate
+}
+
+function validateDisplayDate(publishedAt: Date | null, displayDate: Date | null): void {
+  const now = new Date()
+  if (!publishedAt || publishedAt > now) {
+    throw new ValidationError(
+      'VALIDATION_ERROR',
+      'Display date can only be set on published changelog entries'
+    )
+  }
+  if (displayDate !== null && displayDate > now) {
+    throw new ValidationError('VALIDATION_ERROR', 'Display date cannot be in the future')
+  }
 }

--- a/apps/web/src/lib/server/domains/changelog/changelog.types.ts
+++ b/apps/web/src/lib/server/domains/changelog/changelog.types.ts
@@ -23,6 +23,7 @@ export interface CreateChangelogInput {
   linkedPostIds?: PostId[]
   /** Publish state */
   publishState: PublishState
+  displayDate?: Date | null
 }
 
 /**
@@ -36,6 +37,7 @@ export interface UpdateChangelogInput {
   linkedPostIds?: PostId[]
   /** Publish state (if changing) */
   publishState?: PublishState
+  displayDate?: Date | null
 }
 
 /**
@@ -64,6 +66,7 @@ export interface ChangelogEntryWithDetails {
   contentJson: TiptapContent | null
   principalId: PrincipalId | null
   publishedAt: Date | null
+  displayDate: Date | null
   createdAt: Date
   updatedAt: Date
   /** Author information - only shown in admin views */

--- a/apps/web/src/lib/server/functions/changelog.ts
+++ b/apps/web/src/lib/server/functions/changelog.ts
@@ -61,6 +61,7 @@ export const createChangelogFn = createServerFn({ method: 'POST' })
           contentJson: data.contentJson ? sanitizeTiptapContent(data.contentJson) : null,
           linkedPostIds: (data.linkedPostIds ?? []) as PostId[],
           publishState: data.publishState as PublishState,
+          ...(data.displayDate !== undefined && { displayDate: data.displayDate }),
         },
         {
           principalId: auth.principal.id,
@@ -73,6 +74,7 @@ export const createChangelogFn = createServerFn({ method: 'POST' })
         createdAt: toIsoString(entry.createdAt),
         updatedAt: toIsoString(entry.updatedAt),
         publishedAt: toIsoStringOrNull(entry.publishedAt),
+        displayDate: toIsoStringOrNull(entry.displayDate),
       }
     } catch (error) {
       log.error({ err: error }, 'create changelog failed')
@@ -96,6 +98,7 @@ export const updateChangelogFn = createServerFn({ method: 'POST' })
         contentJson: data.contentJson ? sanitizeTiptapContent(data.contentJson) : undefined,
         linkedPostIds: data.linkedPostIds as PostId[] | undefined,
         publishState: data.publishState as PublishState | undefined,
+        ...(data.displayDate !== undefined && { displayDate: data.displayDate }),
       })
 
       return {
@@ -103,6 +106,7 @@ export const updateChangelogFn = createServerFn({ method: 'POST' })
         createdAt: toIsoString(entry.createdAt),
         updatedAt: toIsoString(entry.updatedAt),
         publishedAt: toIsoStringOrNull(entry.publishedAt),
+        displayDate: toIsoStringOrNull(entry.displayDate),
       }
     } catch (error) {
       log.error({ err: error }, 'update changelog failed')
@@ -147,6 +151,7 @@ export const getChangelogFn = createServerFn({ method: 'GET' })
         createdAt: toIsoString(entry.createdAt),
         updatedAt: toIsoString(entry.updatedAt),
         publishedAt: toIsoStringOrNull(entry.publishedAt),
+        displayDate: toIsoStringOrNull(entry.displayDate),
       }
     } catch (error) {
       log.error({ err: error }, 'get changelog failed')
@@ -177,6 +182,7 @@ export const listChangelogsFn = createServerFn({ method: 'GET' })
           createdAt: toIsoString(entry.createdAt),
           updatedAt: toIsoString(entry.updatedAt),
           publishedAt: toIsoStringOrNull(entry.publishedAt),
+          displayDate: toIsoStringOrNull(entry.displayDate),
         })),
       }
     } catch (error) {

--- a/apps/web/src/lib/server/mcp/tools.ts
+++ b/apps/web/src/lib/server/mcp/tools.ts
@@ -449,7 +449,14 @@ const updateChangelogSchema = {
     .string()
     .optional()
     .describe(
-      'ISO 8601 datetime to set as publish date (e.g. "2025-03-15T12:00:00Z"). Overrides publish flag. Past dates backdate, future dates schedule, null reverts to draft.'
+      'ISO 8601 datetime for publish/schedule lifecycle (e.g. "2025-03-15T12:00:00Z"). Future dates schedule; past dates publish immediately. For display-only backdating on published entries, use displayDate instead.'
+    ),
+  displayDate: z
+    .string()
+    .nullable()
+    .optional()
+    .describe(
+      'ISO 8601 portal display override for published entries. Null clears the override. Must not be in the future.'
     ),
   linkedPostIds: z
     .array(z.string())
@@ -684,6 +691,7 @@ type UpdateChangelogArgs = {
   content?: string
   publish?: boolean
   publishedAt?: string
+  displayDate?: string | null
   linkedPostIds?: string[]
 }
 
@@ -1247,7 +1255,8 @@ Examples:
 Examples:
 - Update title: update_changelog({ changelogId: "changelog_01abc...", title: "v2.0 Release" })
 - Publish: update_changelog({ changelogId: "changelog_01abc...", publish: true })
-- Backdate: update_changelog({ changelogId: "changelog_01abc...", publishedAt: "2025-03-15T12:00:00Z" })
+- Backdate display: update_changelog({ changelogId: "changelog_01abc...", displayDate: "2025-03-15T12:00:00Z" })
+- Clear display override: update_changelog({ changelogId: "changelog_01abc...", displayDate: null })
 - Link posts: update_changelog({ changelogId: "changelog_01abc...", linkedPostIds: ["post_01a...", "post_01b..."] })${CONTENT_FORMAT_BLOCK}`,
     updateChangelogSchema,
     WRITE,
@@ -1271,6 +1280,9 @@ Examples:
           content: args.content,
           linkedPostIds: args.linkedPostIds as PostId[] | undefined,
           publishState,
+          ...(args.displayDate !== undefined && {
+            displayDate: args.displayDate === null ? null : new Date(args.displayDate),
+          }),
         })
 
         return jsonResult({
@@ -1278,6 +1290,7 @@ Examples:
           title: result.title,
           status: result.status,
           publishedAt: result.publishedAt,
+          displayDate: result.displayDate,
           updatedAt: result.updatedAt,
         })
       } catch (err) {
@@ -2400,6 +2413,7 @@ async function searchChangelogs(args: SearchArgs): Promise<CallToolResult> {
         voteCount: p.voteCount,
       })),
       publishedAt: c.publishedAt,
+      displayDate: c.displayDate,
       createdAt: c.createdAt,
     })),
     nextCursor,
@@ -2521,6 +2535,7 @@ async function getChangelogDetails(changelogId: ChangelogId): Promise<CallToolRe
       status: p.status,
     })),
     publishedAt: entry.publishedAt,
+    displayDate: entry.displayDate,
     createdAt: entry.createdAt,
     updatedAt: entry.updatedAt,
   })

--- a/apps/web/src/lib/shared/schemas/changelog.ts
+++ b/apps/web/src/lib/shared/schemas/changelog.ts
@@ -25,6 +25,7 @@ export const createChangelogSchema = z.object({
   contentJson: tiptapContentSchema.nullable().optional(),
   linkedPostIds: z.array(z.string()).optional(),
   publishState: publishStateSchema,
+  displayDate: z.coerce.date().nullable().optional(),
 })
 
 /**
@@ -37,6 +38,7 @@ export const updateChangelogSchema = z.object({
   contentJson: tiptapContentSchema.nullable().optional(),
   linkedPostIds: z.array(z.string()).optional(),
   publishState: publishStateSchema.optional(),
+  displayDate: z.coerce.date().nullable().optional(),
 })
 
 /**

--- a/apps/web/src/routes/api/v1/changelog/$entryId.ts
+++ b/apps/web/src/routes/api/v1/changelog/$entryId.ts
@@ -21,6 +21,7 @@ const updateChangelogSchema = z.object({
   title: z.string().min(1).max(200).optional(),
   content: z.string().min(1).optional(),
   publishedAt: z.string().datetime().nullable().optional(),
+  displayDate: z.string().datetime().nullable().optional(),
 })
 
 function formatChangelogResponse(entry: {
@@ -28,6 +29,7 @@ function formatChangelogResponse(entry: {
   title: string
   content: string
   publishedAt: Date | null
+  displayDate: Date | null
   createdAt: Date
   updatedAt: Date
 }) {
@@ -36,6 +38,7 @@ function formatChangelogResponse(entry: {
     title: entry.title,
     content: entry.content,
     publishedAt: entry.publishedAt?.toISOString() || null,
+    displayDate: entry.displayDate?.toISOString() || null,
     createdAt: entry.createdAt.toISOString(),
     updatedAt: entry.updatedAt.toISOString(),
   }
@@ -106,6 +109,10 @@ export const Route = createFileRoute('/api/v1/changelog/$entryId')({
             title: parsed.data.title,
             content: parsed.data.content,
             ...(publishState && { publishState }),
+            ...(parsed.data.displayDate !== undefined && {
+              displayDate:
+                parsed.data.displayDate === null ? null : new Date(parsed.data.displayDate),
+            }),
           })
 
           return successResponse(formatChangelogResponse(updated))

--- a/apps/web/src/routes/api/v1/changelog/index.ts
+++ b/apps/web/src/routes/api/v1/changelog/index.ts
@@ -54,6 +54,7 @@ export const Route = createFileRoute('/api/v1/changelog/')({
               title: entry.title,
               content: entry.content,
               publishedAt: entry.publishedAt?.toISOString() || null,
+              displayDate: entry.displayDate?.toISOString() || null,
               createdAt: entry.createdAt.toISOString(),
               updatedAt: entry.updatedAt.toISOString(),
             })),
@@ -114,6 +115,7 @@ export const Route = createFileRoute('/api/v1/changelog/')({
             title: entry.title,
             content: entry.content,
             publishedAt: entry.publishedAt?.toISOString() || null,
+            displayDate: entry.displayDate?.toISOString() || null,
             createdAt: entry.createdAt.toISOString(),
             updatedAt: entry.updatedAt.toISOString(),
           })

--- a/apps/web/src/routes/changelog/feed.ts
+++ b/apps/web/src/routes/changelog/feed.ts
@@ -11,7 +11,7 @@ export const Route = createFileRoute('/changelog/feed')({
       GET: async () => {
         const [
           { config },
-          { db, changelogEntries, and, desc },
+          { db, changelogEntries, and, desc, sql },
           { publicChangelogConditions },
           { getSettingsBrandingData },
           { resolvePortalAccessForRequest },
@@ -22,6 +22,8 @@ export const Route = createFileRoute('/changelog/feed')({
           import('@/lib/server/settings-utils'),
           import('@/lib/server/functions/portal-access'),
         ])
+
+        const effectiveDisplayDate = sql<Date>`coalesce(${changelogEntries.displayDate}, ${changelogEntries.publishedAt})`
 
         const baseUrl = config.baseUrl
 
@@ -34,11 +36,12 @@ export const Route = createFileRoute('/changelog/feed')({
         const access = await resolvePortalAccessForRequest()
 
         const entries = access.granted
-          ? await db.query.changelogEntries.findMany({
-              where: and(...publicChangelogConditions(new Date())),
-              orderBy: [desc(changelogEntries.publishedAt)],
-              limit: 50,
-            })
+          ? await db
+              .select()
+              .from(changelogEntries)
+              .where(and(...publicChangelogConditions(new Date())))
+              .orderBy(desc(effectiveDisplayDate))
+              .limit(50)
           : []
 
         // Per-caller portal-access decisions can't share a public CDN
@@ -61,7 +64,7 @@ export const Route = createFileRoute('/changelog/feed')({
             id: entry.id,
             title: entry.title,
             content: entry.content,
-            publishedAt: entry.publishedAt!,
+            publishedAt: entry.displayDate ?? entry.publishedAt!,
             link: `${baseUrl}/changelog/${entry.id}`,
           })),
         })

--- a/apps/web/src/routes/sitemap[.]xml.ts
+++ b/apps/web/src/routes/sitemap[.]xml.ts
@@ -49,7 +49,7 @@ export const Route = createFileRoute('/sitemap.xml')({
 
 async function collectUrls(baseUrl: string): Promise<SitemapUrl[]> {
   const [
-    { db, changelogEntries, and, desc, eq },
+    { db, changelogEntries, and, desc, eq, sql },
     { publicChangelogConditions },
     { toIsoDateOnly },
   ] = await Promise.all([
@@ -58,6 +58,8 @@ async function collectUrls(baseUrl: string): Promise<SitemapUrl[]> {
     import('@/lib/shared/utils/date'),
   ])
 
+  const effectiveDisplayDate = sql<Date>`coalesce(${changelogEntries.displayDate}, ${changelogEntries.publishedAt})`
+
   const urls: SitemapUrl[] = []
 
   // Static pages
@@ -65,11 +67,11 @@ async function collectUrls(baseUrl: string): Promise<SitemapUrl[]> {
   urls.push({ loc: `${baseUrl}/roadmap` })
   urls.push({ loc: `${baseUrl}/changelog` })
 
-  const entries = await db.query.changelogEntries.findMany({
-    where: and(...publicChangelogConditions(new Date())),
-    orderBy: [desc(changelogEntries.publishedAt)],
-    columns: { id: true, updatedAt: true },
-  })
+  const entries = await db
+    .select({ id: changelogEntries.id, updatedAt: changelogEntries.updatedAt })
+    .from(changelogEntries)
+    .where(and(...publicChangelogConditions(new Date())))
+    .orderBy(desc(effectiveDisplayDate))
 
   for (const entry of entries) {
     urls.push({

--- a/packages/db/drizzle/0119_changelog_display_date.sql
+++ b/packages/db/drizzle/0119_changelog_display_date.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "changelog_entries" ADD COLUMN "display_date" timestamp with time zone;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -834,6 +834,13 @@
       "when": 1783036800000,
       "tag": "0118_identity_provider_consolidate_default_role",
       "breakpoints": true
+    },
+    {
+      "idx": 119,
+      "version": "7",
+      "when": 1783123200000,
+      "tag": "0119_changelog_display_date",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/__tests__/schema.test.ts
+++ b/packages/db/src/__tests__/schema.test.ts
@@ -226,6 +226,7 @@ describe('Schema definitions', () => {
       expect(columns).toContain('title')
       expect(columns).toContain('content')
       expect(columns).toContain('publishedAt')
+      expect(columns).toContain('displayDate')
       expect(columns).toContain('createdAt')
       expect(columns).toContain('updatedAt')
     })

--- a/packages/db/src/schema/changelog.ts
+++ b/packages/db/src/schema/changelog.ts
@@ -18,6 +18,7 @@ export const changelogEntries = pgTable(
       onDelete: 'set null',
     }),
     publishedAt: timestamp('published_at', { withTimezone: true }),
+    displayDate: timestamp('display_date', { withTimezone: true }),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
     // Soft delete support


### PR DESCRIPTION
First off, this is a really great tool and it's solved exactly the problem I have without breaking the bank! Thank you for making it open source and self hostable!

I was migrating all my changelogs from my custom docs page to Quackback and realised that all the dates now show the same day which is a bit annoying, I also realised this is a requested feature from other people too so I decided to help out and build it myself.

This PR adds an optional display date for published changelog entries. The real `publishedAt` stays untouched (scheduling, lifecycle, events). What visitors see on /changelog uses `displayDate` when set, otherwise falls back to `publishedAt`.

## What's changed:

- Database: nullable `display_date` column on `changelog_entries` (migration 0119, no backfill)
- Server: validation (published entries only, can't be in the future); stores `null` when the display date is the same calendar day as `publishedAt` so we don't accumulate pointless overrides
- Public reads: list, detail, embeds, RSS feed, and sitemap all sort/display by the effective date (`COALESCE(display_date, published_at)`)
- Admin UI: date-only picker on published entries (with clear button); works in create and edit flows
- Admin list: shows a "Showing as Jan 15, 2026" hint when an override is active
- API & MCP: `displayDate` exposed on admin GET/PATCH/list; MCP docs clarify that backdating display is `displayDate`, not `publishedAt`
- DateTimePicker: dateOnly, maxDate, and inline clear support (used by the display date field)
- Tests: service validation + normalization, public detail coalescing, schema column check, E2E for admin > portal display

## Test plan:

- [ ]  Publish an entry > set a past display date > confirm list and detail show the override
- [ ]  Clear display date > portal reverts to the publish date
- [ ]  Admin list shows "Showing as …" when override is set
- [ ]  Scheduled publish picker still works (datetime mode unchanged)

## Screenshots:

<details>
<summary>1. Creating a published entry with a display date</summary>

<img width="1159" height="824" alt="image" src="https://github.com/user-attachments/assets/169c55ca-f6a3-4ff8-98d7-e7ebf9f46b2c" />


</details>

<details>
<summary>2. Editing a published entry - display date picker</summary>

<img width="1160" height="823" alt="image" src="https://github.com/user-attachments/assets/7e984eec-cc41-4fff-870a-600f03afbe34" />

</details>

<details>
<summary>3. Admin list - "Showing as …" hint</summary>

<img width="1026" height="145" alt="image" src="https://github.com/user-attachments/assets/a87d94a7-408e-4c92-b878-28dc085b94c4" />

</details>

<details>
<summary>4. Public changelog - effective display date on list</summary>

<img width="1142" height="941" alt="image" src="https://github.com/user-attachments/assets/2c8bd5b3-fb75-46dd-a3ec-60d3b317c86a" />

</details>