### PR TITLE
chore(release): 0.13.0

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quackback/web",
-  "version": "0.12.4",
+  "version": "0.13.0",
   "private": true,
   "license": "AGPL-3.0",
   "type": "module",


### PR DESCRIPTION
Bumps `apps/web/package.json` to `0.13.0`, the source of truth for the
`__APP_VERSION__` baked into the build at the tagged commit. Cut ahead of the
`v0.13.0` release tag.

Highlights:
- Unified sign-in dialog for portal users and admins, plus multi-provider OIDC SSO with per-domain routing and enforcement (#284)
- Redesigned SSO provider editor: claim/group mapping, autocomplete, ID-token inspection, manual endpoints (#287)
- Settings restricted to admins, with a clearer permission notice
- nodemailer 9.0.1 security update (GHSA-p6gq-j5cr-w38f)

Full notes ship with the v0.13.0 release.
