### PR TITLE
fix(chat): keep inbound reply-to local part within the RFC 5321 limit

### DIFF
--- a/apps/web/src/lib/server/domains/chat/__tests__/chat-email-channel.test.ts
+++ b/apps/web/src/lib/server/domains/chat/__tests__/chat-email-channel.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from 'vitest'
+import type { ConversationId } from '@quackback/ids'
 import {
   isEmailInboundConfigured,
   inboundReplyToAddress,
   conversationIdFromInboundAddress,
+  signConversationId,
 } from '../chat.email-channel'
 
 // 'whsec_' + base64('testsecret') / base64('othersecret').
@@ -11,6 +13,14 @@ const ENV = {
   EMAIL_INBOUND_SIGNING_SECRET: 'whsec_dGVzdHNlY3JldA==',
 }
 const OTHER_ENV = { ...ENV, EMAIL_INBOUND_SIGNING_SECRET: 'whsec_b3RoZXJzZWNyZXQ=' }
+
+// A short stand-in id for the string mechanics, and a real id: the
+// `conversation_` prefix plus a full 26-char TypeID suffix whose full local part
+// used to overflow the RFC 5321 limit; see #293.
+const ID = 'conversation_abc' as ConversationId
+const REAL_ID = 'conversation_01kw8qxn1eeh4t2rek7varh032' as ConversationId
+
+const localPartOf = (address: string) => address.slice(0, address.indexOf('@'))
 
 describe('isEmailInboundConfigured', () => {
   it('is true only when both the inbound domain and signing secret are set', () => {
@@ -28,30 +38,54 @@ describe('isEmailInboundConfigured', () => {
 
 describe('inboundReplyToAddress', () => {
   it('builds a signed plus-addressed reply address', () => {
-    expect(inboundReplyToAddress('conversation_abc', ENV)).toMatch(
-      /^reply\+conversation_abc\.[A-Za-z0-9_-]+@tenaevexeo\.resend\.app$/
+    expect(inboundReplyToAddress(ID, ENV)).toMatch(
+      /^reply\+abc\.[A-Za-z0-9_-]+@tenaevexeo\.resend\.app$/
     )
   })
 
   it('returns null when the inbound domain or signing secret is missing', () => {
-    expect(inboundReplyToAddress('conversation_abc', {})).toBeNull()
-    expect(
-      inboundReplyToAddress('conversation_abc', { EMAIL_INBOUND_DOMAIN: 'tenaevexeo.resend.app' })
-    ).toBeNull()
+    expect(inboundReplyToAddress(ID, {})).toBeNull()
+    expect(inboundReplyToAddress(ID, { EMAIL_INBOUND_DOMAIN: 'tenaevexeo.resend.app' })).toBeNull()
+  })
+
+  // #293: a real 26-char TypeID suffix pushed the local part to 68, over the
+  // RFC 5321 64-char limit, so strict providers (Resend) rejected the send.
+  it('keeps the local part within the RFC 5321 64-char limit for a real id', () => {
+    const addr = inboundReplyToAddress(REAL_ID, ENV)!
+    expect(localPartOf(addr).length).toBeLessThanOrEqual(64)
+  })
+
+  it('embeds the bare TypeID suffix, not the redundant conversation_ prefix', () => {
+    expect(inboundReplyToAddress(REAL_ID, ENV)).toMatch(
+      /^reply\+01kw8qxn1eeh4t2rek7varh032\.[A-Za-z0-9_-]+@tenaevexeo\.resend\.app$/
+    )
   })
 })
 
 describe('conversationIdFromInboundAddress', () => {
   it('round-trips a signed address back to the conversation id', () => {
-    const addr = inboundReplyToAddress('conversation_abc', ENV)!
-    expect(conversationIdFromInboundAddress(addr, ENV)).toBe('conversation_abc')
+    const addr = inboundReplyToAddress(ID, ENV)!
+    expect(conversationIdFromInboundAddress(addr, ENV)).toBe(ID)
     // Tolerant of a display-name wrapper.
-    expect(conversationIdFromInboundAddress(`Support <${addr}>`, ENV)).toBe('conversation_abc')
+    expect(conversationIdFromInboundAddress(`Support <${addr}>`, ENV)).toBe(ID)
+  })
+
+  it('round-trips a real prefixed conversation id', () => {
+    const addr = inboundReplyToAddress(REAL_ID, ENV)!
+    expect(conversationIdFromInboundAddress(addr, ENV)).toBe(REAL_ID)
+  })
+
+  // Reply-tos minted before #293 embedded the full `conversation_<suffix>` id;
+  // the parser must still route them so in-flight emails don't bounce.
+  it('still parses a legacy full-prefix plus-address', () => {
+    const sig = signConversationId(REAL_ID, ENV)
+    const legacy = `reply+${REAL_ID}.${sig}@tenaevexeo.resend.app`
+    expect(conversationIdFromInboundAddress(legacy, ENV)).toBe(REAL_ID)
   })
 
   it('rejects a tampered conversation id whose signature no longer matches', () => {
-    const addr = inboundReplyToAddress('conversation_abc', ENV)!
-    const tampered = addr.replace('conversation_abc', 'conversation_evil')
+    const addr = inboundReplyToAddress(ID, ENV)!
+    const tampered = addr.replace('reply+abc.', 'reply+evil.')
     expect(conversationIdFromInboundAddress(tampered, ENV)).toBeNull()
   })
 
@@ -62,7 +96,7 @@ describe('conversationIdFromInboundAddress', () => {
   })
 
   it('rejects a signature minted with a different secret', () => {
-    const addr = inboundReplyToAddress('conversation_abc', ENV)!
+    const addr = inboundReplyToAddress(ID, ENV)!
     expect(conversationIdFromInboundAddress(addr, OTHER_ENV)).toBeNull()
   })
 

--- a/apps/web/src/lib/server/domains/chat/__tests__/chat-notify.test.ts
+++ b/apps/web/src/lib/server/domains/chat/__tests__/chat-notify.test.ts
@@ -302,9 +302,11 @@ describe('notifyAgentReply', () => {
         agentName: 'Agent',
       })
 
-      // Signed plus-address: reply+<id>.<hmac>@domain (unforgeable conversation id).
+      // Signed plus-address: reply+<id-suffix>.<hmac>@domain (unforgeable; the
+      // `conversation_` prefix is dropped to stay under the 64-char local part).
+      const suffix = conversationId.replace(/^conversation_/, '')
       expect(sendChatMessageEmail.mock.calls[0][0].replyTo).toMatch(
-        new RegExp(`^reply\\+${conversationId}\\.[A-Za-z0-9_-]+@tenaevexeo\\.resend\\.app$`)
+        new RegExp(`^reply\\+${suffix}\\.[A-Za-z0-9_-]+@tenaevexeo\\.resend\\.app$`)
       )
     })
 

--- a/apps/web/src/lib/server/domains/chat/chat.email-channel.ts
+++ b/apps/web/src/lib/server/domains/chat/chat.email-channel.ts
@@ -1,7 +1,7 @@
 /**
  * Inbound email channel config + plus-address routing, kept pure so it's
  * unit-tested directly. The widget's outbound agent-reply emails set a
- * conversation-specific Reply-To (`reply+<conversationId>.<sig>@<inbound-domain>`);
+ * conversation-specific Reply-To (`reply+<id-suffix>.<sig>@<inbound-domain>`);
  * the inbound webhook reads that plus-address back to route a reply into the
  * right conversation. The `<sig>` is an HMAC of the conversation id under the
  * workspace's inbound signing secret, so a third party who receives one of our
@@ -9,17 +9,28 @@
  * messages as another visitor — the webhook signature only proves the provider
  * forwarded the mail, not the SMTP sender's identity. Both are gated on inbound
  * being configured.
+ *
+ * Only the TypeID suffix is embedded, not the full `conversation_<suffix>` id:
+ * the prefix is constant across every conversation, so carrying it would just
+ * burn 13 characters of the RFC 5321 64-char local-part budget for no routing
+ * value. The parser re-attaches it. The HMAC is still taken over the full id.
  */
 import { createHmac, timingSafeEqual } from 'crypto'
+import { ID_PREFIXES, type ConversationId } from '@quackback/ids'
 
 type EnvLike = Record<string, string | undefined>
 
 const INBOUND_DOMAIN_ENV = 'EMAIL_INBOUND_DOMAIN'
 const INBOUND_SECRET_ENV = 'EMAIL_INBOUND_SIGNING_SECRET'
 
-// base64url chars of the HMAC-SHA256 tag embedded in the plus-address. 22 chars
-// is ~132 bits — far beyond what's needed to make the id unforgeable, while
-// keeping the local-part short.
+// `conversation_` — the constant TypeID prefix stripped from the local part on
+// the way out and re-attached on the way in.
+const CONVERSATION_PREFIX = `${ID_PREFIXES.conversation}_`
+
+// base64url chars of the HMAC-SHA256 tag embedded in the plus-address. The
+// local part is `reply+` + a 26-char TypeID suffix + `.` + the tag, so the RFC
+// 5321 64-char limit leaves room for 31; 22 (~132 bits) is far beyond what's
+// needed to make the id unforgeable while staying well clear of the limit (#293).
 const SIG_LEN = 22
 
 /** Decode the `whsec_<base64>` signing secret to raw key bytes, or null. */
@@ -48,19 +59,22 @@ export function signConversationId(
   return createHmac('sha256', key).update(conversationId).digest('base64url').slice(0, SIG_LEN)
 }
 
-/** `reply+<conversationId>.<sig>@<inbound-domain>`, or null when the inbound
- *  domain or signing secret is missing. */
+/** `reply+<id-suffix>.<sig>@<inbound-domain>`, or null when the inbound domain
+ *  or signing secret is missing. The `conversation_` prefix is dropped to keep
+ *  the local part under the RFC 5321 64-char limit (#293). */
 export function inboundReplyToAddress(
-  conversationId: string,
+  conversationId: ConversationId,
   env: EnvLike = process.env
 ): string | null {
   const domain = env[INBOUND_DOMAIN_ENV]
   const sig = signConversationId(conversationId, env)
   if (!domain || !sig) return null
-  return `reply+${conversationId}.${sig}@${domain}`
+  // The `ConversationId` type guarantees the prefix; embed only the bare suffix.
+  const suffix = conversationId.slice(CONVERSATION_PREFIX.length)
+  return `reply+${suffix}.${sig}@${domain}`
 }
 
-/** Extract + verify the conversation id from a `reply+<id>.<sig>@domain`
+/** Extract + verify the conversation id from a `reply+<id-suffix>.<sig>@domain`
  *  recipient. Returns the id only when the signature matches (constant-time);
  *  an unsigned, tampered, or wrong-secret address yields null so a forged
  *  reply-to can't route into someone else's conversation. */
@@ -71,12 +85,17 @@ export function conversationIdFromInboundAddress(
   const match = /reply\+([^@>\s]+)@/i.exec(address)
   if (!match) return null
   const local = match[1]
-  // id and sig are both dot-free (TypeID base32 + base64url), so the last dot
-  // is an unambiguous separator.
+  // suffix and sig are both dot-free (TypeID base32 + base64url), so the last
+  // dot is an unambiguous separator.
   const dot = local.lastIndexOf('.')
   if (dot === -1) return null
-  const id = local.slice(0, dot)
+  const embedded = local.slice(0, dot)
   const provided = local.slice(dot + 1)
+  // Re-attach the prefix. base32 suffixes never contain `_`, so an embedded
+  // value that already starts with `conversation_` is a pre-#293 full id.
+  const id = embedded.startsWith(CONVERSATION_PREFIX)
+    ? embedded
+    : `${CONVERSATION_PREFIX}${embedded}`
   const expected = signConversationId(id, env)
   if (!expected) return null
   const a = Buffer.from(provided)


### PR DESCRIPTION
## Summary

With the inbound chat email channel enabled, agent-reply emails set a conversation-specific Reply-To of the form `reply+<conversationId>.<sig>@<EMAIL_INBOUND_DOMAIN>`. With a full `conversation_<ULID>` id plus the 22-char HMAC, the local part came to 68 characters, over the RFC 5321 64-char local-part limit. Providers that enforce the limit reject the send: on Resend every agent reply failed with a `422 validation_error`, so inbound replies never reached the visitor.

## Fix

Embed only the bare TypeID suffix instead of the full id. The `conversation_` prefix is constant across every conversation and carries no routing information, so dropping it brings the local part to 55 characters (9 to spare). The parser re-attaches the prefix on the way in.

- The HMAC is still computed over the full conversation id, so signature strength is unchanged (still ~132 bits).
- The parser stays tolerant of the old full-id form, so any reply-tos already in flight keep routing.
- `inboundReplyToAddress` now takes a branded `ConversationId`, so the "prefix is always present" precondition is enforced by the compiler rather than assumed.

## Tests

- New regression test pins the local part at `<= 64` chars for a real 26-char TypeID id.
- New tests cover the bare-suffix format, the real-id round trip, and backward-compatible parsing of legacy full-id addresses.
- Full chat email/notify/webhook suite green (71 tests); typecheck and lint clean.

Fixes #293
