### PR TITLE
fix(slugs): handle non-Latin and symbol-only names across boards + help-center (#285)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -114,6 +114,7 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tippy.js": "^6.3.7",
+    "transliteration": "^2.6.1",
     "tw-animate-css": "^1.4.0",
     "typeid-js": "^1.2.0",
     "yaml": "^2.8.4",

--- a/apps/web/src/lib/server/domains/boards/__tests__/board-slug-generation.test.ts
+++ b/apps/web/src/lib/server/domains/boards/__tests__/board-slug-generation.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Regression for #285: a board whose name slugifies to an empty string
+ * (CJK scripts, emoji, etc. — slugify strips them) must still get a
+ * non-empty, URL-safe slug. An empty slug violates the column's NOT NULL
+ * UNIQUE constraint in spirit and, downstream, crashes slug-keyed
+ * <Select.Item> components (Radix forbids an empty-string value) and
+ * breaks board routing.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+const hoisted = vi.hoisted(() => ({
+  mockedFindFirst: vi.fn(),
+  mockedSelect: vi.fn(),
+  mockedInsert: vi.fn(),
+  mockedUpdate: vi.fn(),
+}))
+
+vi.mock('@/lib/server/db', async () => {
+  const drizzle = await vi.importActual<typeof import('drizzle-orm')>('drizzle-orm')
+  return {
+    db: {
+      query: {
+        boards: { findFirst: (...a: unknown[]) => hoisted.mockedFindFirst(...a) },
+      },
+      select: hoisted.mockedSelect,
+      insert: hoisted.mockedInsert,
+      update: hoisted.mockedUpdate,
+    },
+    boards: { id: 'id', slug: 'slug', deletedAt: 'deletedAt' },
+    posts: { boardId: 'boardId', deletedAt: 'deletedAt' },
+    webhooks: { boardIds: 'boardIds' },
+    eq: drizzle.eq,
+    and: drizzle.and,
+    isNull: drizzle.isNull,
+    inArray: drizzle.inArray,
+    asc: drizzle.asc,
+    sql: drizzle.sql,
+    DEFAULT_BOARD_ACCESS: {
+      view: 'anonymous',
+      vote: 'anonymous',
+      comment: 'anonymous',
+      submit: 'anonymous',
+      segments: { view: [], vote: [], comment: [], submit: [] },
+      moderation: { anonPosts: 'inherit', signedPosts: 'inherit', comments: 'inherit' },
+    },
+  }
+})
+
+vi.mock('@/lib/server/domains/settings/tier-limits.service', () => ({
+  getTierLimits: vi.fn(),
+}))
+
+import { createBoard, updateBoard } from '../board.service'
+import { getTierLimits } from '@/lib/server/domains/settings/tier-limits.service'
+import { OSS_TIER_LIMITS } from '@/lib/server/domains/settings/tier-limits.types'
+import type { BoardId } from '@quackback/ids'
+
+const BOARD_ID = 'board_01' as unknown as BoardId
+
+const EXISTING_BOARD = {
+  id: BOARD_ID,
+  name: 'Original',
+  slug: 'original',
+  description: null,
+  access: {},
+  settings: {},
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  deletedAt: null,
+}
+
+/** Captures the values passed to db.insert().values() */
+let capturedInsert: Record<string, unknown> = {}
+/** Captures the patch passed to db.update().set() */
+let capturedSet: Record<string, unknown> = {}
+
+beforeEach(() => {
+  capturedInsert = {}
+  capturedSet = {}
+  vi.clearAllMocks()
+
+  hoisted.mockedInsert.mockReturnValue({
+    values: (vals: Record<string, unknown>) => {
+      capturedInsert = vals
+      return { returning: () => Promise.resolve([{ ...EXISTING_BOARD, ...vals }]) }
+    },
+  })
+  hoisted.mockedUpdate.mockReturnValue({
+    set: (patch: Record<string, unknown>) => {
+      capturedSet = patch
+      return {
+        where: () => ({ returning: () => Promise.resolve([{ ...EXISTING_BOARD, ...patch }]) }),
+      }
+    },
+  })
+})
+
+describe('board slug generation for non-Latin names (#285)', () => {
+  describe('createBoard', () => {
+    beforeEach(() => {
+      vi.mocked(getTierLimits).mockResolvedValue(OSS_TIER_LIMITS)
+      hoisted.mockedFindFirst.mockResolvedValue(null) // no slug collision
+    })
+
+    it('transliterates a Chinese name to a pinyin slug', async () => {
+      await expect(createBoard({ name: '反馈' })).resolves.toBeDefined()
+      expect(capturedInsert.slug).toBe('fan-kui')
+    })
+
+    it('still slugifies Latin names normally', async () => {
+      await createBoard({ name: 'Feature Requests' })
+      expect(capturedInsert.slug).toBe('feature-requests')
+    })
+
+    it('falls back to a generic base for emoji-only names', async () => {
+      // Emoji romanize to nothing, so there is no name-derived slug — the
+      // generic fallback keeps the board addressable.
+      await createBoard({ name: '🎉🎉' })
+      expect(capturedInsert.slug).toBe('board')
+    })
+
+    it('disambiguates colliding slugs with a counter suffix', async () => {
+      // A board already owns "jian-yi"; "jian-yi-1" is free.
+      hoisted.mockedFindFirst
+        .mockResolvedValueOnce({ id: 'board_other', slug: 'jian-yi' })
+        .mockResolvedValueOnce(null)
+      await createBoard({ name: '建议' })
+      expect(capturedInsert.slug).toBe('jian-yi-1')
+    })
+  })
+
+  describe('updateBoard', () => {
+    beforeEach(() => {
+      hoisted.mockedFindFirst.mockResolvedValue(EXISTING_BOARD)
+    })
+
+    it('transliterates the slug when renaming a board to a Chinese name', async () => {
+      await updateBoard(BOARD_ID, { name: '反馈' })
+      expect(capturedSet.slug).toBe('fan-kui')
+    })
+
+    it('still auto-updates the slug for Latin renames', async () => {
+      hoisted.mockedFindFirst.mockResolvedValueOnce(EXISTING_BOARD) // load existing
+      hoisted.mockedFindFirst.mockResolvedValueOnce(null) // slug free
+      await updateBoard(BOARD_ID, { name: 'Brand New Name' })
+      expect(capturedSet.slug).toBe('brand-new-name')
+    })
+
+    it('keeps the existing slug when the derived slug is taken by another board', async () => {
+      // existing board owns slug "beta"; "jian-yi" belongs to a different
+      // board, so renaming must NOT steal it — keep "beta".
+      hoisted.mockedFindFirst
+        .mockResolvedValueOnce({ ...EXISTING_BOARD, slug: 'beta' }) // load existing
+        .mockResolvedValueOnce({ id: 'board_other', slug: 'jian-yi' }) // derived slug taken elsewhere
+      await updateBoard(BOARD_ID, { name: '建议' })
+      // No slug write (stays "beta") — and definitely not a duplicate.
+      expect(capturedSet.slug).toBeUndefined()
+    })
+  })
+})

--- a/apps/web/src/lib/server/domains/boards/__tests__/board-slug-generation.test.ts
+++ b/apps/web/src/lib/server/domains/boards/__tests__/board-slug-generation.test.ts
@@ -112,6 +112,14 @@ describe('board slug generation for non-Latin names (#285)', () => {
       expect(capturedInsert.slug).toBe('feature-requests')
     })
 
+    it('rejects an explicit slug that slugifies to nothing', async () => {
+      // The REST schema allows hyphen-only slugs like "---"; an explicit slug
+      // that romanizes to nothing is a caller error, not a fallback case.
+      await expect(createBoard({ name: 'Roadmap', slug: '---' })).rejects.toMatchObject({
+        code: 'VALIDATION_ERROR',
+      })
+    })
+
     it('falls back to a generic base for emoji-only names', async () => {
       // Emoji romanize to nothing, so there is no name-derived slug — the
       // generic fallback keeps the board addressable.

--- a/apps/web/src/lib/server/domains/boards/board.service.ts
+++ b/apps/web/src/lib/server/domains/boards/board.service.ts
@@ -106,8 +106,19 @@ export async function createBoard(input: CreateBoardInput): Promise<Board> {
     },
   })
 
-  // Derive the slug from an explicit value or the name, never empty.
-  const baseSlug = (input.slug ? slugify(input.slug) : slugify(input.name)) || FALLBACK_BOARD_SLUG
+  // Derive the slug. An explicit slug that slugifies to nothing is a caller
+  // error worth rejecting (mirrors updateBoard, and avoids silently turning
+  // e.g. slug "---" into a generic "board"); only a name-derived slug falls
+  // back to a generic base so any-language name can still create a board.
+  let baseSlug: string
+  if (input.slug) {
+    baseSlug = slugify(input.slug)
+    if (!baseSlug) {
+      throw new ValidationError('VALIDATION_ERROR', 'Could not generate valid slug from name')
+    }
+  } else {
+    baseSlug = slugify(input.name) || FALLBACK_BOARD_SLUG
+  }
 
   // Check for slug uniqueness and generate a unique one if needed
   let slug = baseSlug

--- a/apps/web/src/lib/server/domains/boards/board.service.ts
+++ b/apps/web/src/lib/server/domains/boards/board.service.ts
@@ -69,6 +69,12 @@ import { logger } from '@/lib/server/logger'
 
 const log = logger.child({ component: 'boards' })
 
+// Slug base for names that romanize to nothing even after transliteration
+// (emoji- or punctuation-only). The uniqueness loop disambiguates ("board",
+// "board-1", ...). Without it such names yield an empty slug, which breaks
+// the NOT NULL UNIQUE column and crashes slug-keyed <Select.Item> (#285).
+const FALLBACK_BOARD_SLUG = 'board'
+
 /**
  * Create a new board
  */
@@ -100,13 +106,8 @@ export async function createBoard(input: CreateBoardInput): Promise<Board> {
     },
   })
 
-  // Generate or validate slug
-  const baseSlug = input.slug ? slugify(input.slug) : slugify(input.name)
-
-  // Ensure slug is not empty after slugification
-  if (!baseSlug) {
-    throw new ValidationError('VALIDATION_ERROR', 'Could not generate valid slug from name')
-  }
+  // Derive the slug from an explicit value or the name, never empty.
+  const baseSlug = (input.slug ? slugify(input.slug) : slugify(input.name)) || FALLBACK_BOARD_SLUG
 
   // Check for slug uniqueness and generate a unique one if needed
   let slug = baseSlug
@@ -194,8 +195,8 @@ export async function updateBoard(id: BoardId, input: UpdateBoardInput): Promise
       }
     }
   } else if (input.name !== undefined) {
-    // Auto-update slug if name changes but slug is not explicitly provided
-    const newSlug = slugify(input.name)
+    // Auto-update slug when the name changes and no slug was given, never empty.
+    const newSlug = slugify(input.name) || FALLBACK_BOARD_SLUG
     if (newSlug !== existingBoard.slug) {
       const existingWithSlug = await db.query.boards.findFirst({
         where: eq(boards.slug, newSlug),

--- a/apps/web/src/lib/server/domains/help-center/__tests__/help-center-article.service.test.ts
+++ b/apps/web/src/lib/server/domains/help-center/__tests__/help-center-article.service.test.ts
@@ -272,7 +272,11 @@ describe('createArticle', () => {
   })
 
   it('throws ValidationError when authorId is a non-member principal', async () => {
-    mockPrincipalFindFirst.mockResolvedValueOnce({ id: 'principal_portal', role: 'user', type: 'user' })
+    mockPrincipalFindFirst.mockResolvedValueOnce({
+      id: 'principal_portal',
+      role: 'user',
+      type: 'user',
+    })
     await expect(
       createArticle(
         { categoryId: 'category_1', title: 'Title', content: 'Content' },
@@ -283,7 +287,11 @@ describe('createArticle', () => {
   })
 
   it('throws ValidationError when authorId is a service principal', async () => {
-    mockPrincipalFindFirst.mockResolvedValueOnce({ id: 'principal_svc', role: 'admin', type: 'service' })
+    mockPrincipalFindFirst.mockResolvedValueOnce({
+      id: 'principal_svc',
+      role: 'admin',
+      type: 'service',
+    })
     await expect(
       createArticle(
         { categoryId: 'category_1', title: 'Title', content: 'Content' },
@@ -294,21 +302,38 @@ describe('createArticle', () => {
   })
 
   it('accepts a member-role authorId', async () => {
-    mockPrincipalFindFirst.mockResolvedValueOnce({ id: 'principal_member', role: 'member', type: 'user' })
+    mockPrincipalFindFirst.mockResolvedValueOnce({
+      id: 'principal_member',
+      role: 'member',
+      type: 'user',
+    })
     mockCategoryFindFirst.mockResolvedValue({ id: 'category_1', slug: 'cat', name: 'Cat' })
-    mockPrincipalFindFirst.mockResolvedValueOnce({ id: 'principal_member', displayName: 'Jane', avatarUrl: null })
+    mockPrincipalFindFirst.mockResolvedValueOnce({
+      id: 'principal_member',
+      displayName: 'Jane',
+      avatarUrl: null,
+    })
 
     const { db } = await import('@/lib/server/db')
     const chain: Record<string, unknown> = {}
     chain.values = vi.fn(() => chain)
-    chain.returning = vi.fn().mockResolvedValue([{
-      id: 'article_new' as HelpCenterArticleId,
-      slug: 'title', title: 'Title', content: 'Content',
-      contentJson: null, categoryId: 'category_1',
-      principalId: 'principal_member', publishedAt: null,
-      viewCount: 0, helpfulCount: 0, notHelpfulCount: 0,
-      createdAt: new Date(), updatedAt: new Date(),
-    }])
+    chain.returning = vi.fn().mockResolvedValue([
+      {
+        id: 'article_new' as HelpCenterArticleId,
+        slug: 'title',
+        title: 'Title',
+        content: 'Content',
+        contentJson: null,
+        categoryId: 'category_1',
+        principalId: 'principal_member',
+        publishedAt: null,
+        viewCount: 0,
+        helpfulCount: 0,
+        notHelpfulCount: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ])
     vi.mocked(db.insert).mockReturnValueOnce(chain as never)
 
     await expect(
@@ -318,6 +343,65 @@ describe('createArticle', () => {
         'principal_member' as PrincipalId
       )
     ).resolves.toBeDefined()
+  })
+})
+
+describe('createArticle slug generation (#285)', () => {
+  beforeEach(async () => {
+    const { db } = await import('@/lib/server/db')
+    const chain: Record<string, unknown> = {}
+    chain.values = vi.fn((...args: unknown[]) => {
+      insertValuesCalls.push(args)
+      return chain
+    })
+    chain.returning = vi.fn().mockResolvedValue([
+      {
+        id: 'article_new1' as HelpCenterArticleId,
+        slug: 'placeholder',
+        title: 'placeholder',
+        content: 'Content',
+        contentJson: { type: 'doc', content: [] },
+        categoryId: 'category_1',
+        principalId: 'principal_1',
+        publishedAt: null,
+        viewCount: 0,
+        helpfulCount: 0,
+        notHelpfulCount: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ])
+    vi.mocked(db.insert).mockReturnValue(chain as never)
+    mockCategoryFindFirst.mockResolvedValue({
+      id: 'category_1',
+      slug: 'getting-started',
+      name: 'Getting Started',
+    })
+    mockPrincipalFindFirst.mockResolvedValue({
+      id: 'principal_1',
+      displayName: 'Author',
+      avatarUrl: null,
+      type: 'user',
+    })
+  })
+
+  const author = 'principal_1' as PrincipalId
+  const insertedSlug = () => (insertValuesCalls[0][0] as Record<string, unknown>).slug
+
+  it('transliterates a Chinese title to a pinyin slug', async () => {
+    await createArticle({ categoryId: 'category_1', title: '反馈', content: 'c' }, author)
+    expect(insertedSlug()).toBe('fan-kui')
+  })
+
+  it('falls back to a generic slug for an emoji-only title', async () => {
+    await createArticle({ categoryId: 'category_1', title: '🎉🎉', content: 'c' }, author)
+    expect(insertedSlug()).toBe('article')
+  })
+
+  it('appends a counter when the derived slug collides', async () => {
+    mockArticleFindFirst.mockResolvedValueOnce({ id: 'article_other' }).mockResolvedValueOnce(null)
+    await createArticle({ categoryId: 'category_1', title: '反馈', content: 'c' }, author)
+    expect(insertedSlug()).toBe('fan-kui-2')
   })
 })
 
@@ -392,8 +476,17 @@ describe('createArticle with position and description', () => {
     ])
     vi.mocked(db.insert).mockReturnValueOnce(articleInsertChain as never)
 
-    mockCategoryFindFirst.mockResolvedValue({ id: 'category_1', slug: 'getting-started', name: 'Getting Started' })
-    mockPrincipalFindFirst.mockResolvedValue({ id: 'principal_1', displayName: 'Author', avatarUrl: null, type: 'user' })
+    mockCategoryFindFirst.mockResolvedValue({
+      id: 'category_1',
+      slug: 'getting-started',
+      name: 'Getting Started',
+    })
+    mockPrincipalFindFirst.mockResolvedValue({
+      id: 'principal_1',
+      displayName: 'Author',
+      avatarUrl: null,
+      type: 'user',
+    })
 
     const result = await createArticle(
       {
@@ -415,14 +508,22 @@ describe('createArticle with position and description', () => {
 
 describe('updateArticle authorId validation', () => {
   it('throws ValidationError when authorId is a non-member principal', async () => {
-    mockPrincipalFindFirst.mockResolvedValueOnce({ id: 'principal_portal', role: 'user', type: 'user' })
+    mockPrincipalFindFirst.mockResolvedValueOnce({
+      id: 'principal_portal',
+      role: 'user',
+      type: 'user',
+    })
     await expect(
       updateArticle('article_1' as HelpCenterArticleId, {}, 'principal_portal' as PrincipalId)
     ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' })
   })
 
   it('throws ValidationError when authorId is a service principal', async () => {
-    mockPrincipalFindFirst.mockResolvedValueOnce({ id: 'principal_svc', role: 'member', type: 'service' })
+    mockPrincipalFindFirst.mockResolvedValueOnce({
+      id: 'principal_svc',
+      role: 'member',
+      type: 'service',
+    })
     await expect(
       updateArticle('article_1' as HelpCenterArticleId, {}, 'principal_svc' as PrincipalId)
     ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' })
@@ -430,23 +531,40 @@ describe('updateArticle authorId validation', () => {
 
   it('allows re-asserting a former-member as author when they already own the article', async () => {
     mockArticleFindFirst.mockResolvedValueOnce({ id: 'article_1', principalId: 'principal_former' })
-    mockPrincipalFindFirst.mockResolvedValueOnce({ id: 'principal_former', role: 'user', type: 'user' })
+    mockPrincipalFindFirst.mockResolvedValueOnce({
+      id: 'principal_former',
+      role: 'user',
+      type: 'user',
+    })
 
     const { db } = await import('@/lib/server/db')
     const chain: Record<string, unknown> = {}
     chain.set = vi.fn(() => chain)
     chain.where = vi.fn(() => chain)
-    chain.returning = vi.fn().mockResolvedValue([{
-      id: 'article_1' as HelpCenterArticleId,
-      slug: 'test', title: 'Test', content: 'Content',
-      contentJson: null, categoryId: 'category_1',
-      principalId: 'principal_former', publishedAt: null,
-      viewCount: 0, helpfulCount: 0, notHelpfulCount: 0,
-      createdAt: new Date(), updatedAt: new Date(),
-    }])
+    chain.returning = vi.fn().mockResolvedValue([
+      {
+        id: 'article_1' as HelpCenterArticleId,
+        slug: 'test',
+        title: 'Test',
+        content: 'Content',
+        contentJson: null,
+        categoryId: 'category_1',
+        principalId: 'principal_former',
+        publishedAt: null,
+        viewCount: 0,
+        helpfulCount: 0,
+        notHelpfulCount: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ])
     vi.mocked(db.update).mockReturnValueOnce(chain as never)
     mockCategoryFindFirst.mockResolvedValue({ id: 'category_1', slug: 'cat', name: 'Cat' })
-    mockPrincipalFindFirst.mockResolvedValueOnce({ id: 'principal_former', displayName: 'Jane', avatarUrl: null })
+    mockPrincipalFindFirst.mockResolvedValueOnce({
+      id: 'principal_former',
+      displayName: 'Jane',
+      avatarUrl: null,
+    })
 
     await expect(
       updateArticle('article_1' as HelpCenterArticleId, {}, 'principal_former' as PrincipalId)
@@ -454,23 +572,40 @@ describe('updateArticle authorId validation', () => {
   })
 
   it('accepts a member-role authorId in updateArticle', async () => {
-    mockPrincipalFindFirst.mockResolvedValueOnce({ id: 'principal_member', role: 'member', type: 'user' })
+    mockPrincipalFindFirst.mockResolvedValueOnce({
+      id: 'principal_member',
+      role: 'member',
+      type: 'user',
+    })
 
     const { db } = await import('@/lib/server/db')
     const chain: Record<string, unknown> = {}
     chain.set = vi.fn(() => chain)
     chain.where = vi.fn(() => chain)
-    chain.returning = vi.fn().mockResolvedValue([{
-      id: 'article_1' as HelpCenterArticleId,
-      slug: 'test', title: 'Test', content: 'Content',
-      contentJson: null, categoryId: 'category_1',
-      principalId: 'principal_member', publishedAt: null,
-      viewCount: 0, helpfulCount: 0, notHelpfulCount: 0,
-      createdAt: new Date(), updatedAt: new Date(),
-    }])
+    chain.returning = vi.fn().mockResolvedValue([
+      {
+        id: 'article_1' as HelpCenterArticleId,
+        slug: 'test',
+        title: 'Test',
+        content: 'Content',
+        contentJson: null,
+        categoryId: 'category_1',
+        principalId: 'principal_member',
+        publishedAt: null,
+        viewCount: 0,
+        helpfulCount: 0,
+        notHelpfulCount: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ])
     vi.mocked(db.update).mockReturnValueOnce(chain as never)
     mockCategoryFindFirst.mockResolvedValue({ id: 'category_1', slug: 'cat', name: 'Cat' })
-    mockPrincipalFindFirst.mockResolvedValueOnce({ id: 'principal_member', displayName: 'Jane', avatarUrl: null })
+    mockPrincipalFindFirst.mockResolvedValueOnce({
+      id: 'principal_member',
+      displayName: 'Jane',
+      avatarUrl: null,
+    })
 
     await expect(
       updateArticle('article_1' as HelpCenterArticleId, {}, 'principal_member' as PrincipalId)
@@ -609,7 +744,11 @@ describe('restoreArticle', () => {
     const { db } = await import('@/lib/server/db')
     vi.mocked(db.update).mockReturnValueOnce(makeRestoredArticleChain(setCallsCapture) as never)
 
-    mockCategoryFindFirst.mockResolvedValue({ id: 'category_1', slug: 'getting-started', name: 'Getting Started' })
+    mockCategoryFindFirst.mockResolvedValue({
+      id: 'category_1',
+      slug: 'getting-started',
+      name: 'Getting Started',
+    })
     mockPrincipalFindFirst.mockResolvedValue(null)
 
     const result = await restoreArticle('article_1' as HelpCenterArticleId)

--- a/apps/web/src/lib/server/domains/help-center/__tests__/help-center-article.service.test.ts
+++ b/apps/web/src/lib/server/domains/help-center/__tests__/help-center-article.service.test.ts
@@ -405,6 +405,19 @@ describe('createArticle slug generation (#285)', () => {
   })
 })
 
+describe('updateArticle slug generation (#285)', () => {
+  it('falls back to a generic slug when an explicit empty slug is given', async () => {
+    await updateArticle('article_1' as HelpCenterArticleId, { slug: '' })
+    expect((updateSetCalls[0][0] as Record<string, unknown>).slug).toBe('article')
+  })
+
+  it('keeps an explicit slug that only collides with the same article', async () => {
+    mockArticleFindFirst.mockResolvedValueOnce({ id: 'article_1' })
+    await updateArticle('article_1' as HelpCenterArticleId, { slug: 'guide' })
+    expect((updateSetCalls[0][0] as Record<string, unknown>).slug).toBe('guide')
+  })
+})
+
 describe('publishArticle', () => {
   it('sets publishedAt to current date', async () => {
     mockCategoryFindFirst.mockResolvedValue({ id: 'category_1', slug: 'test', name: 'Test' })

--- a/apps/web/src/lib/server/domains/help-center/__tests__/help-center-category.service.test.ts
+++ b/apps/web/src/lib/server/domains/help-center/__tests__/help-center-category.service.test.ts
@@ -432,6 +432,27 @@ describe('createCategory slug generation (#285)', () => {
   })
 })
 
+describe('updateCategory slug generation (#285)', () => {
+  it('falls back to a generic slug when an explicit empty slug is given', async () => {
+    await updateCategory('category_1' as HelpCenterCategoryId, { slug: '' })
+    expect((updateSetCalls[0][0] as Record<string, unknown>).slug).toBe('category')
+  })
+
+  it('disambiguates an explicit slug that collides with another category', async () => {
+    mockCategoryFindFirst
+      .mockResolvedValueOnce({ id: 'category_other' })
+      .mockResolvedValueOnce(null)
+    await updateCategory('category_1' as HelpCenterCategoryId, { slug: 'faq' })
+    expect((updateSetCalls[0][0] as Record<string, unknown>).slug).toBe('faq-2')
+  })
+
+  it('keeps an explicit slug that only collides with the same category', async () => {
+    mockCategoryFindFirst.mockResolvedValueOnce({ id: 'category_1' })
+    await updateCategory('category_1' as HelpCenterCategoryId, { slug: 'faq' })
+    expect((updateSetCalls[0][0] as Record<string, unknown>).slug).toBe('faq')
+  })
+})
+
 describe('deleteCategory', () => {
   it('soft deletes the category', async () => {
     mockCategoryFindMany.mockResolvedValue([{ id: 'category_1', parentId: null }])

--- a/apps/web/src/lib/server/domains/help-center/__tests__/help-center-category.service.test.ts
+++ b/apps/web/src/lib/server/domains/help-center/__tests__/help-center-category.service.test.ts
@@ -412,6 +412,26 @@ describe('createCategory', () => {
   })
 })
 
+describe('createCategory slug generation (#285)', () => {
+  it('transliterates a Chinese name to a pinyin slug', async () => {
+    await createCategory({ name: '反馈' })
+    expect((insertValuesCalls[0][0] as Record<string, unknown>).slug).toBe('fan-kui')
+  })
+
+  it('falls back to a generic slug for an emoji-only name', async () => {
+    await createCategory({ name: '🎉🎉' })
+    expect((insertValuesCalls[0][0] as Record<string, unknown>).slug).toBe('category')
+  })
+
+  it('appends a counter when the derived slug collides', async () => {
+    mockCategoryFindFirst
+      .mockResolvedValueOnce({ id: 'category_other' })
+      .mockResolvedValueOnce(null)
+    await createCategory({ name: '反馈' })
+    expect((insertValuesCalls[0][0] as Record<string, unknown>).slug).toBe('fan-kui-2')
+  })
+})
+
 describe('deleteCategory', () => {
   it('soft deletes the category', async () => {
     mockCategoryFindMany.mockResolvedValue([{ id: 'category_1', parentId: null }])

--- a/apps/web/src/lib/server/domains/help-center/help-center.article.service.ts
+++ b/apps/web/src/lib/server/domains/help-center/help-center.article.service.ts
@@ -119,6 +119,37 @@ export async function getPublicArticleBySlug(slug: string): Promise<HelpCenterAr
   return resolveArticleWithCategory(article)
 }
 
+// Slug base for article titles that romanize to nothing (emoji- or
+// punctuation-only). slugify() transliterates CJK, but still returns ''
+// for those — an empty slug breaks the NOT NULL kb_articles_slug_idx
+// unique index and slug routing. Mirrors FALLBACK_BOARD_SLUG (#285).
+const FALLBACK_ARTICLE_SLUG = 'article'
+
+/**
+ * Build a unique article slug. Falls back to a generic base when the
+ * desired slug is empty, then appends a numeric suffix until free.
+ * `excludeId` skips the row being renamed so it doesn't collide with
+ * itself. The unique index covers all rows (it is not filtered on
+ * deleted_at), so collisions are probed against soft-deleted rows too.
+ */
+async function uniqueArticleSlug(
+  desired: string,
+  excludeId?: HelpCenterArticleId
+): Promise<string> {
+  const base = desired || FALLBACK_ARTICLE_SLUG
+  let candidate = base
+  let counter = 2
+  while (true) {
+    const collision = await db.query.helpCenterArticles.findFirst({
+      where: eq(helpCenterArticles.slug, candidate),
+      columns: { id: true },
+    })
+    if (!collision || (excludeId && collision.id === excludeId)) return candidate
+    candidate = `${base}-${counter}`
+    counter++
+  }
+}
+
 export async function createArticle(
   input: CreateArticleInput,
   principalId: PrincipalId,
@@ -154,7 +185,7 @@ export async function createArticle(
     }
     effectivePrincipalId = principalId
   }
-  const slug = input.slug?.trim() || slugify(title)
+  const slug = await uniqueArticleSlug(input.slug?.trim() || slugify(title))
 
   const parsedContentJson = input.contentJson ?? markdownToTiptapJson(content)
   const contentJson = await rehostExternalImages(parsedContentJson, {

--- a/apps/web/src/lib/server/domains/help-center/help-center.article.service.ts
+++ b/apps/web/src/lib/server/domains/help-center/help-center.article.service.ts
@@ -17,6 +17,7 @@ import { isTeamMember } from '@/lib/shared/roles'
 import { markdownToTiptapJson } from '@/lib/server/markdown-tiptap'
 import { rehostExternalImages } from '@/lib/server/content/rehost-images'
 import { slugify } from '@/lib/shared/utils'
+import { uniqueHelpCenterSlug } from './help-center.slug'
 import type {
   HelpCenterArticleWithCategory,
   CreateArticleInput,
@@ -119,36 +120,15 @@ export async function getPublicArticleBySlug(slug: string): Promise<HelpCenterAr
   return resolveArticleWithCategory(article)
 }
 
-// Slug base for article titles that romanize to nothing (emoji- or
-// punctuation-only). slugify() transliterates CJK, but still returns ''
-// for those — an empty slug breaks the NOT NULL kb_articles_slug_idx
-// unique index and slug routing. Mirrors FALLBACK_BOARD_SLUG (#285).
+// Fallback slug base for article titles that romanize to nothing (see
+// uniqueHelpCenterSlug). 'article', 'article-2', ...
 const FALLBACK_ARTICLE_SLUG = 'article'
 
-/**
- * Build a unique article slug. Falls back to a generic base when the
- * desired slug is empty, then appends a numeric suffix until free.
- * `excludeId` skips the row being renamed so it doesn't collide with
- * itself. The unique index covers all rows (it is not filtered on
- * deleted_at), so collisions are probed against soft-deleted rows too.
- */
-async function uniqueArticleSlug(
-  desired: string,
-  excludeId?: HelpCenterArticleId
-): Promise<string> {
-  const base = desired || FALLBACK_ARTICLE_SLUG
-  let candidate = base
-  let counter = 2
-  while (true) {
-    const collision = await db.query.helpCenterArticles.findFirst({
-      where: eq(helpCenterArticles.slug, candidate),
-      columns: { id: true },
-    })
-    if (!collision || (excludeId && collision.id === excludeId)) return candidate
-    candidate = `${base}-${counter}`
-    counter++
-  }
-}
+const findArticleSlugConflict = (slug: string) =>
+  db.query.helpCenterArticles.findFirst({
+    where: eq(helpCenterArticles.slug, slug),
+    columns: { id: true },
+  })
 
 export async function createArticle(
   input: CreateArticleInput,
@@ -185,7 +165,11 @@ export async function createArticle(
     }
     effectivePrincipalId = principalId
   }
-  const slug = await uniqueArticleSlug(input.slug?.trim() || slugify(title))
+  const slug = await uniqueHelpCenterSlug(
+    input.slug?.trim() || slugify(title),
+    FALLBACK_ARTICLE_SLUG,
+    findArticleSlugConflict
+  )
 
   const parsedContentJson = input.contentJson ?? markdownToTiptapJson(content)
   const contentJson = await rehostExternalImages(parsedContentJson, {
@@ -235,7 +219,13 @@ export async function updateArticle(
   }
   if (input.categoryId !== undefined)
     updateData.categoryId = input.categoryId as HelpCenterCategoryId
-  if (input.slug !== undefined) updateData.slug = input.slug.trim()
+  if (input.slug !== undefined)
+    updateData.slug = await uniqueHelpCenterSlug(
+      input.slug.trim(),
+      FALLBACK_ARTICLE_SLUG,
+      findArticleSlugConflict,
+      id
+    )
   if (input.position !== undefined) updateData.position = input.position
   if (input.description !== undefined) updateData.description = input.description?.trim() || null
   const updated = await db.transaction(async (tx) => {

--- a/apps/web/src/lib/server/domains/help-center/help-center.category.service.ts
+++ b/apps/web/src/lib/server/domains/help-center/help-center.category.service.ts
@@ -13,6 +13,7 @@ import {
 import type { HelpCenterCategoryId } from '@quackback/ids'
 import { NotFoundError, ValidationError } from '@/lib/shared/errors'
 import { slugify } from '@/lib/shared/utils'
+import { uniqueHelpCenterSlug } from './help-center.slug'
 import type {
   HelpCenterCategory,
   HelpCenterCategoryWithCount,
@@ -214,42 +215,25 @@ export async function getPublicCategoryBySlug(slug: string): Promise<HelpCenterC
   return category
 }
 
-// Slug base for category names that romanize to nothing (emoji- or
-// punctuation-only). slugify() transliterates CJK, but still returns ''
-// for those — an empty slug breaks the NOT NULL kb_categories_slug_idx
-// unique index and slug routing. Mirrors FALLBACK_BOARD_SLUG (#285).
+// Fallback slug base for category names that romanize to nothing (see
+// uniqueHelpCenterSlug). 'category', 'category-2', ...
 const FALLBACK_CATEGORY_SLUG = 'category'
 
-/**
- * Build a unique category slug. Falls back to a generic base when the
- * desired slug is empty, then appends a numeric suffix until free.
- * `excludeId` skips the row being renamed so it doesn't collide with
- * itself. The unique index covers all rows (it is not filtered on
- * deleted_at), so collisions are probed against soft-deleted rows too.
- */
-async function uniqueCategorySlug(
-  desired: string,
-  excludeId?: HelpCenterCategoryId
-): Promise<string> {
-  const base = desired || FALLBACK_CATEGORY_SLUG
-  let candidate = base
-  let counter = 2
-  while (true) {
-    const collision = await db.query.helpCenterCategories.findFirst({
-      where: eq(helpCenterCategories.slug, candidate),
-      columns: { id: true },
-    })
-    if (!collision || (excludeId && collision.id === excludeId)) return candidate
-    candidate = `${base}-${counter}`
-    counter++
-  }
-}
+const findCategorySlugConflict = (slug: string) =>
+  db.query.helpCenterCategories.findFirst({
+    where: eq(helpCenterCategories.slug, slug),
+    columns: { id: true },
+  })
 
 export async function createCategory(input: CreateCategoryInput): Promise<HelpCenterCategory> {
   const name = input.name?.trim()
   if (!name) throw new ValidationError('VALIDATION_ERROR', 'Name is required')
 
-  const slug = await uniqueCategorySlug(input.slug?.trim() || slugify(name))
+  const slug = await uniqueHelpCenterSlug(
+    input.slug?.trim() || slugify(name),
+    FALLBACK_CATEGORY_SLUG,
+    findCategorySlugConflict
+  )
 
   if (input.parentId !== undefined && input.parentId !== null) {
     const flat = await db.query.helpCenterCategories.findMany({
@@ -285,7 +269,13 @@ export async function updateCategory(
 ): Promise<HelpCenterCategory> {
   const updateData: Partial<typeof helpCenterCategories.$inferInsert> = { updatedAt: new Date() }
   if (input.name !== undefined) updateData.name = input.name.trim()
-  if (input.slug !== undefined) updateData.slug = input.slug.trim()
+  if (input.slug !== undefined)
+    updateData.slug = await uniqueHelpCenterSlug(
+      input.slug.trim(),
+      FALLBACK_CATEGORY_SLUG,
+      findCategorySlugConflict,
+      id
+    )
   if (input.description !== undefined) updateData.description = input.description?.trim() || null
   if (input.isPublic !== undefined) updateData.isPublic = input.isPublic
   if (input.position !== undefined) updateData.position = input.position

--- a/apps/web/src/lib/server/domains/help-center/help-center.category.service.ts
+++ b/apps/web/src/lib/server/domains/help-center/help-center.category.service.ts
@@ -214,11 +214,42 @@ export async function getPublicCategoryBySlug(slug: string): Promise<HelpCenterC
   return category
 }
 
+// Slug base for category names that romanize to nothing (emoji- or
+// punctuation-only). slugify() transliterates CJK, but still returns ''
+// for those — an empty slug breaks the NOT NULL kb_categories_slug_idx
+// unique index and slug routing. Mirrors FALLBACK_BOARD_SLUG (#285).
+const FALLBACK_CATEGORY_SLUG = 'category'
+
+/**
+ * Build a unique category slug. Falls back to a generic base when the
+ * desired slug is empty, then appends a numeric suffix until free.
+ * `excludeId` skips the row being renamed so it doesn't collide with
+ * itself. The unique index covers all rows (it is not filtered on
+ * deleted_at), so collisions are probed against soft-deleted rows too.
+ */
+async function uniqueCategorySlug(
+  desired: string,
+  excludeId?: HelpCenterCategoryId
+): Promise<string> {
+  const base = desired || FALLBACK_CATEGORY_SLUG
+  let candidate = base
+  let counter = 2
+  while (true) {
+    const collision = await db.query.helpCenterCategories.findFirst({
+      where: eq(helpCenterCategories.slug, candidate),
+      columns: { id: true },
+    })
+    if (!collision || (excludeId && collision.id === excludeId)) return candidate
+    candidate = `${base}-${counter}`
+    counter++
+  }
+}
+
 export async function createCategory(input: CreateCategoryInput): Promise<HelpCenterCategory> {
   const name = input.name?.trim()
   if (!name) throw new ValidationError('VALIDATION_ERROR', 'Name is required')
 
-  const slug = input.slug?.trim() || slugify(name)
+  const slug = await uniqueCategorySlug(input.slug?.trim() || slugify(name))
 
   if (input.parentId !== undefined && input.parentId !== null) {
     const flat = await db.query.helpCenterCategories.findMany({

--- a/apps/web/src/lib/server/domains/help-center/help-center.slug.ts
+++ b/apps/web/src/lib/server/domains/help-center/help-center.slug.ts
@@ -1,0 +1,30 @@
+/**
+ * Build a unique, non-empty slug for a help-center entity.
+ *
+ * Falls back to `fallback` when the desired slug is empty — a name that
+ * romanizes to nothing, e.g. emoji- or punctuation-only (slugify() already
+ * transliterates CJK). An empty slug breaks the NOT NULL unique slug index
+ * and slug routing (#285). Then appends a numeric suffix until `findConflict`
+ * reports the candidate free. `excludeId` skips the row being renamed so a
+ * slug never collides with itself.
+ *
+ * Collisions are probed via the caller's `findConflict` across all rows,
+ * since the kb slug unique indexes are not filtered on deleted_at.
+ */
+export async function uniqueHelpCenterSlug(
+  desired: string,
+  fallback: string,
+  findConflict: (candidate: string) => Promise<{ id: string } | undefined>,
+  excludeId?: string
+): Promise<string> {
+  const base = desired || fallback
+  let candidate = base
+  let counter = 2
+  while (true) {
+    const conflict = await findConflict(candidate)
+    const isSelfCollision = excludeId !== undefined && conflict?.id === excludeId
+    if (!conflict || isSelfCollision) return candidate
+    candidate = `${base}-${counter}`
+    counter++
+  }
+}

--- a/apps/web/src/lib/shared/utils/__tests__/string.test.ts
+++ b/apps/web/src/lib/shared/utils/__tests__/string.test.ts
@@ -246,6 +246,26 @@ describe('slugify', () => {
   it('collapses multiple hyphens', () => {
     expect(slugify('a---b')).toBe('a-b')
   })
+
+  it('transliterates Chinese to pinyin', () => {
+    expect(slugify('反馈')).toBe('fan-kui')
+  })
+
+  it('transliterates mixed Chinese and Latin', () => {
+    expect(slugify('北京 Feature')).toBe('bei-jing-feature')
+  })
+
+  it('transliterates Japanese and Korean', () => {
+    expect(slugify('日本語')).toBe('ri-ben-yu')
+    expect(slugify('한국어')).toBe('hangugeo')
+  })
+
+  it('returns empty string for input that romanizes to nothing', () => {
+    // Emoji- or punctuation-only names have no ASCII form; callers add a
+    // fallback. The slugifier itself stays honest and returns ''.
+    expect(slugify('🎉🎉')).toBe('')
+    expect(slugify('...')).toBe('')
+  })
 })
 
 describe('truncate', () => {

--- a/apps/web/src/lib/shared/utils/string.ts
+++ b/apps/web/src/lib/shared/utils/string.ts
@@ -3,6 +3,7 @@
  */
 
 import slugifyLib from 'slugify'
+import { transliterate } from 'transliteration'
 
 /**
  * Compute initials from a name string.
@@ -71,10 +72,16 @@ export function stripMarkdownPreview(text: string, maxLength = 150): string {
 
 /**
  * Generate a URL-friendly slug from text.
- * Handles non-Latin scripts (Cyrillic, German umlauts, etc.) via transliteration.
+ *
+ * Transliterates to ASCII first so non-Latin scripts survive as readable
+ * romanizations — CJK via pinyin/romaji/romaja (反馈 -> "fan-kui"), plus
+ * Cyrillic, Greek, etc. — then runs the strict slugifier for consistent
+ * casing/separator handling. Returns '' for input that romanizes to nothing
+ * (emoji- or punctuation-only); callers that need a guaranteed-present slug
+ * supply their own fallback.
  */
 export function slugify(text: string): string {
-  return slugifyLib(text, { lower: true, strict: true })
+  return slugifyLib(transliterate(text), { lower: true, strict: true })
 }
 
 /**

--- a/apps/web/src/lib/shared/utils/string.ts
+++ b/apps/web/src/lib/shared/utils/string.ts
@@ -81,6 +81,9 @@ export function stripMarkdownPreview(text: string, maxLength = 150): string {
  * supply their own fallback.
  */
 export function slugify(text: string): string {
+  // Guard nullish input: transliterate() coerces via String(), which would
+  // otherwise turn undefined/null into the literal slug "undefined"/"null".
+  if (!text) return ''
   return slugifyLib(transliterate(text), { lower: true, strict: true })
 }
 

--- a/bun.lock
+++ b/bun.lock
@@ -44,7 +44,7 @@
     },
     "apps/web": {
       "name": "@quackback/web",
-      "version": "0.13.0",
+      "version": "0.12.4",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1032.0",
         "@aws-sdk/s3-request-presigner": "^3.1032.0",
@@ -2541,7 +2541,7 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-openapi": ["zod-openapi@5.4.6", "", { "peerDependencies": { "zod": "^3.25.74 || ^4.0.0" } }, "sha512-P2jsOOBAq/6hCwUsMCjUATZ8szkMsV5VAwZENfyxp2Hc/XPJQpVwAgevWZc65xZauCwWB9LAn7zYeiCJFAEL+A=="],
 
@@ -2557,17 +2557,11 @@
 
     "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
-    "@better-auth/core/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "@better-auth/oauth-provider/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@modelcontextprotocol/sdk/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
-
-    "@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@quackback/import/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
@@ -2689,9 +2683,15 @@
 
     "@tanstack/router-generator/jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
+    "@tanstack/router-generator/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
     "@tanstack/router-plugin/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
+    "@tanstack/router-plugin/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
     "@tanstack/start-plugin-core/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
+
+    "@tanstack/start-plugin-core/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
@@ -2702,8 +2702,6 @@
     "ajv-formats/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "better-auth/kysely": ["kysely@0.29.2", "", {}, "sha512-s6WVJyEZrbm6jhBpiKHsGHyePMrVQKJ85wZCFCr9W4QHv6WTjWIrdvTmO9hDEA3bNK0xkrE2DqrHsXMLWuZpQg=="],
-
-    "better-auth/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "better-call/rou3": ["rou3@0.7.12", "", {}, "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="],
 
@@ -2722,8 +2720,6 @@
     "dotenv-expand/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
     "eslint-plugin-react/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
-
-    "eslint-plugin-react-hooks/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -44,7 +44,7 @@
     },
     "apps/web": {
       "name": "@quackback/web",
-      "version": "0.12.4",
+      "version": "0.13.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1032.0",
         "@aws-sdk/s3-request-presigner": "^3.1032.0",
@@ -142,6 +142,7 @@
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tippy.js": "^6.3.7",
+        "transliteration": "^2.6.1",
         "tw-animate-css": "^1.4.0",
         "typeid-js": "^1.2.0",
         "yaml": "^2.8.4",
@@ -2422,6 +2423,8 @@
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
+    "transliteration": ["transliteration@2.6.1", "", { "bin": { "transliterate": "dist/bin/transliterate", "slugify": "dist/bin/slugify" } }, "sha512-hJ9BhrQAOnNTbpOr1MxsNjZISkn7ppvF5TKUeFmTE1mG4ZPD/XVxF0L0LUoIUCWmQyxH0gJpVtfYLAWf298U9w=="],
+
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
     "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
@@ -2538,7 +2541,7 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zod-openapi": ["zod-openapi@5.4.6", "", { "peerDependencies": { "zod": "^3.25.74 || ^4.0.0" } }, "sha512-P2jsOOBAq/6hCwUsMCjUATZ8szkMsV5VAwZENfyxp2Hc/XPJQpVwAgevWZc65xZauCwWB9LAn7zYeiCJFAEL+A=="],
 
@@ -2554,11 +2557,17 @@
 
     "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
+    "@better-auth/core/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "@better-auth/oauth-provider/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@modelcontextprotocol/sdk/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@quackback/import/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
@@ -2680,15 +2689,9 @@
 
     "@tanstack/router-generator/jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
-    "@tanstack/router-generator/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
-
     "@tanstack/router-plugin/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
-    "@tanstack/router-plugin/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
-
     "@tanstack/start-plugin-core/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
-
-    "@tanstack/start-plugin-core/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
@@ -2699,6 +2702,8 @@
     "ajv-formats/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "better-auth/kysely": ["kysely@0.29.2", "", {}, "sha512-s6WVJyEZrbm6jhBpiKHsGHyePMrVQKJ85wZCFCr9W4QHv6WTjWIrdvTmO9hDEA3bNK0xkrE2DqrHsXMLWuZpQg=="],
+
+    "better-auth/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "better-call/rou3": ["rou3@0.7.12", "", {}, "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="],
 
@@ -2717,6 +2722,8 @@
     "dotenv-expand/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
     "eslint-plugin-react/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "eslint-plugin-react-hooks/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 

--- a/packages/db/drizzle/0121_board_slug_backfill.sql
+++ b/packages/db/drizzle/0121_board_slug_backfill.sql
@@ -1,0 +1,13 @@
+-- Heal boards whose slug was emptied by renaming them to a name that
+-- slugifies to nothing (CJK scripts, emoji, etc.). An empty slug crashes
+-- the slug-keyed board <Select.Item> on the widget settings page and makes
+-- the board unselectable across the admin UI (#285). The service paths are
+-- fixed going forward; this repairs already-broken rows.
+--
+-- The slug column is NOT NULL UNIQUE, so at most one row can hold ''. We
+-- derive the replacement from the (unique) id so it can never collide.
+-- Idempotent: only touches empty slugs.
+
+UPDATE "boards"
+SET "slug" = 'board-' || "id"::text
+WHERE "slug" = '';

--- a/packages/db/drizzle/0122_help_center_slug_backfill.sql
+++ b/packages/db/drizzle/0122_help_center_slug_backfill.sql
@@ -1,0 +1,18 @@
+-- Heal help-center categories/articles whose slug was left empty by the
+-- pre-fix create paths for names that slugified to nothing (CJK before
+-- transliteration, or emoji-/punctuation-only). An empty slug breaks the
+-- NOT NULL unique slug index and the path-param category/article routes
+-- (#285). The service paths are fixed going forward; this repairs already
+-- broken rows.
+--
+-- Each slug index is NOT NULL UNIQUE, so at most one row per table can hold
+-- ''. The replacement is derived from the (unique) id so it cannot collide.
+-- Idempotent: only touches empty slugs.
+
+UPDATE "kb_categories"
+SET "slug" = 'category-' || "id"::text
+WHERE "slug" = '';
+
+UPDATE "kb_articles"
+SET "slug" = 'article-' || "id"::text
+WHERE "slug" = '';

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -855,6 +855,13 @@
       "when": 1783296000000,
       "tag": "0121_board_slug_backfill",
       "breakpoints": true
+    },
+    {
+      "idx": 122,
+      "version": "7",
+      "when": 1783382400000,
+      "tag": "0122_help_center_slug_backfill",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -848,6 +848,13 @@
       "when": 1783209600000,
       "tag": "0120_changelog_notified_at",
       "breakpoints": true
+    },
+    {
+      "idx": 121,
+      "version": "7",
+      "when": 1783296000000,
+      "tag": "0121_board_slug_backfill",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Closes #285.

## Problem

Slugs auto-derived from a user-provided name could become an empty string, because the slugifier dropped every non-Latin character (Chinese, Japanese, Korean) and every emoji/punctuation character. An empty slug breaks `NOT NULL UNIQUE` slug columns and any code that assumes a non-empty slug.

The reported symptom (#285) was on **boards**: a board renamed to a Chinese name got an empty slug, which crashed the default-board `<Select>` on the widget settings page (`A <Select.Item /> must have a value prop that is not an empty string`) and made the board unselectable across the admin UI. A review for the same root cause found the same latent bug in the **help-center** (category + article create), where it surfaces as a 500 on the unique index and broken slug routing rather than a React crash.

## Fix

- **Transliterate before slugifying.** `slugify()` now romanizes to ASCII first (via `transliteration`), so non-Latin scripts survive as readable slugs (`反馈` becomes `fan-kui`, `日本語` becomes `ri-ben-yu`) instead of being stripped to nothing. Existing Latin / Cyrillic / umlaut output is unchanged.
- **Never persist an empty slug.**
  - Boards: create and the rename auto-slug path fall back to a generic, uniqueness-resolved base when a name romanizes to nothing at all (emoji- or punctuation-only).
  - Help-center categories and articles: new `uniqueCategorySlug` / `uniqueArticleSlug` helpers mirror the existing `uniqueSegmentSlug` pattern (empty-fallback + collision loop). This also fixes a pre-existing duplicate-name collision (two same-named articles previously 500'd on the unique index).
- **Backfill migration `0121`.** Heals any board already left with an empty slug by the previous behavior. The `UNIQUE` constraint means at most one such row can exist, and the replacement is derived from the row id so it cannot collide.

## Scope of the review

A read-only audit of every slug-persistence path and every Radix `value`-prop binding confirmed the rest of the app is safe:

- **segments, post statuses, roadmaps, workspace settings** already guard their slugs (segments via `uniqueSegmentSlug`; the others require an explicit non-empty slug).
- **posts, changelog, tags** have no slug column.
- **Select bindings:** only `board.slug` (now safe) bound a slug to a Radix item value. Two Azure DevOps integration selects bind to an external `project.name` / `type.name`, which the external API guarantees non-empty.

## Testing

- New `board-slug-generation.test.ts` and help-center slug cases (transliteration, emoji-only fallback, collision counter, keep-existing-slug on conflict).
- Extended `string.test.ts` with CJK cases; confirmed no regression on the existing Latin / Cyrillic / umlaut expectations.
- `slugify()` is shared, so the boards, posts, help-center, and client-mutation suites were run as well (all green).

## Notes

- The generic fallback is a narrow safety net (only names that romanize to nothing reach it); removing it would reintroduce the empty-slug bug for emoji/punctuation-only names.
- A pre-existing check-then-insert race on slug uniqueness is out of scope; it affects every slug, not just the fallback, and is a separate hardening if ever needed.