### PR TITLE
fix(theme): commit resolved theme to SSR <html> to stop dark-mode white flash

### DIFF
--- a/apps/web/src/lib/server/functions/bootstrap.ts
+++ b/apps/web/src/lib/server/functions/bootstrap.ts
@@ -1,5 +1,5 @@
 import { createServerFn, createServerOnlyFn } from '@tanstack/react-start'
-import { getThemeCookie, type Theme } from '@/lib/shared/theme'
+import { getThemeCookie, parsePrefersColorScheme, type Theme } from '@/lib/shared/theme'
 import { resolveLocale, type SupportedLocale } from '@/lib/shared/i18n'
 import type { Session, PrincipalType } from '@/lib/server/auth/session'
 import type { TenantSettings } from '@/lib/server/domains/settings'
@@ -14,6 +14,11 @@ export interface BootstrapData {
   settings: TenantSettings | null
   userRole: 'admin' | 'member' | 'user' | null
   themeCookie: Theme
+  /** OS color-scheme preference from the `Sec-CH-Prefers-Color-Scheme` client
+   *  hint, used by the root document to resolve a `system` theme during SSR so
+   *  even first-time `system` visitors don't flash. null when the browser
+   *  didn't send the hint (e.g. Firefox/Safari, or before it's advertised). */
+  prefersColorScheme: 'light' | 'dark' | null
   /** Dot-paths managed by `/etc/quackback/config.yaml`. The matching
    *  in-app form controls render disabled when the path appears here.
    *  Empty list = nothing locked. */
@@ -114,13 +119,17 @@ async function getSessionAndRole(): Promise<{
 let _initialized = false
 
 const getBootstrapDataInternal = createServerOnlyFn(async (): Promise<BootstrapData> => {
-  const [{ getTenantSettings }, { getRegisteredAuthProviders }, { config }, { getRequestHeaders }] =
-    await Promise.all([
-      import('@/lib/server/domains/settings/settings.service'),
-      import('@/lib/server/auth/registered-providers'),
-      import('@/lib/server/config'),
-      import('@tanstack/react-start/server'),
-    ])
+  const [
+    { getTenantSettings },
+    { getRegisteredAuthProviders },
+    { config },
+    { getRequestHeaders, setResponseHeader },
+  ] = await Promise.all([
+    import('@/lib/server/domains/settings/settings.service'),
+    import('@/lib/server/auth/registered-providers'),
+    import('@/lib/server/config'),
+    import('@tanstack/react-start/server'),
+  ])
 
   // Single principal read returns both session.principalType + userRole;
   // run in parallel with the settings fetch.
@@ -149,12 +158,25 @@ const getBootstrapDataInternal = createServerOnlyFn(async (): Promise<BootstrapD
   const themeCookie = getThemeCookie(headers.get('cookie') ?? null)
   const acceptLanguageLocale = resolveLocale(headers.get('accept-language'))
 
+  // Advertise the prefers-color-scheme client hint so the browser tells us the
+  // OS preference. Critical-CH makes Chromium retry the very first navigation
+  // with the hint attached, so even a first-time `system` visitor gets the
+  // right theme server-rendered (one extra request, once per origin). Browsers
+  // that don't support it (Firefox/Safari) ignore it and fall back to the
+  // `color-scheme: light dark` canvas. Vary stops a shared cache from handing a
+  // dark-resolved document to a light-mode client.
+  setResponseHeader('Accept-CH', 'Sec-CH-Prefers-Color-Scheme')
+  setResponseHeader('Critical-CH', 'Sec-CH-Prefers-Color-Scheme')
+  setResponseHeader('Vary', 'Sec-CH-Prefers-Color-Scheme')
+  const prefersColorScheme = parsePrefersColorScheme(headers.get('sec-ch-prefers-color-scheme'))
+
   return {
     baseUrl: config.baseUrl,
     session,
     settings,
     userRole,
     themeCookie,
+    prefersColorScheme,
     managedFieldPaths: settings?.managedFieldPaths ?? [],
     registeredAuthProviders,
     acceptLanguageLocale,

--- a/apps/web/src/lib/shared/theme/__tests__/document-theme.test.ts
+++ b/apps/web/src/lib/shared/theme/__tests__/document-theme.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { resolveDocumentTheme } from '../index'
+import { resolveDocumentTheme, parsePrefersColorScheme } from '../index'
 
 // resolveDocumentTheme decides what `class` and `color-scheme` the server puts
 // on <html> so the very first paint already matches the chosen theme. Without
@@ -19,13 +19,56 @@ describe('resolveDocumentTheme', () => {
     expect(resolveDocumentTheme('light')).toEqual({ className: 'light', colorScheme: 'light' })
   })
 
-  it('defers the class but lets the OS pick the canvas for system theme', () => {
-    // The resolved value is unknowable server-side, so we leave the class off
-    // (the inline script adds it) but advertise `light dark` so the browser
-    // paints the canvas from the OS preference instead of defaulting to white.
+  it('defers the class but lets the OS pick the canvas for system theme without a hint', () => {
+    // With no client hint the resolved value is unknowable server-side, so we
+    // leave the class off (the inline script adds it) but advertise `light
+    // dark` so the browser paints the canvas from the OS preference instead of
+    // defaulting to white.
     expect(resolveDocumentTheme('system')).toEqual({
       className: undefined,
       colorScheme: 'light dark',
     })
+  })
+
+  it('resolves system to dark when the client hint says dark', () => {
+    // Sec-CH-Prefers-Color-Scheme: dark lets the server render the real class
+    // and canvas, so even a system user gets a fully server-rendered theme.
+    expect(resolveDocumentTheme('system', 'dark')).toEqual({
+      className: 'dark',
+      colorScheme: 'dark',
+    })
+  })
+
+  it('resolves system to light when the client hint says light', () => {
+    expect(resolveDocumentTheme('system', 'light')).toEqual({
+      className: 'light',
+      colorScheme: 'light',
+    })
+  })
+
+  it('ignores the system hint for an explicit theme', () => {
+    // An explicit cookie/forced theme always wins; a stale hint never overrides it.
+    expect(resolveDocumentTheme('dark', 'light')).toEqual({
+      className: 'dark',
+      colorScheme: 'dark',
+    })
+  })
+})
+
+describe('parsePrefersColorScheme', () => {
+  it('parses the dark and light tokens', () => {
+    expect(parsePrefersColorScheme('dark')).toBe('dark')
+    expect(parsePrefersColorScheme('light')).toBe('light')
+  })
+
+  it('tolerates surrounding whitespace, quotes, and casing', () => {
+    expect(parsePrefersColorScheme(' "Dark" ')).toBe('dark')
+  })
+
+  it('returns null when the hint is absent or unrecognized', () => {
+    expect(parsePrefersColorScheme(null)).toBeNull()
+    expect(parsePrefersColorScheme(undefined)).toBeNull()
+    expect(parsePrefersColorScheme('')).toBeNull()
+    expect(parsePrefersColorScheme('no-preference')).toBeNull()
   })
 })

--- a/apps/web/src/lib/shared/theme/__tests__/document-theme.test.ts
+++ b/apps/web/src/lib/shared/theme/__tests__/document-theme.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { resolveDocumentTheme } from '../index'
+
+// resolveDocumentTheme decides what `class` and `color-scheme` the server puts
+// on <html> so the very first paint already matches the chosen theme. Without
+// it the browser shows its default (light) canvas during load and we get a
+// white flash before next-themes' inline script swaps in the dark class.
+describe('resolveDocumentTheme', () => {
+  it('renders the dark class and a dark UA canvas for an explicit dark theme', () => {
+    // The server knows the answer (forced-dark portal, or a `theme=dark`
+    // cookie), so it must commit to it — color-scheme:dark stops the white
+    // canvas even on a light-mode OS.
+    expect(resolveDocumentTheme('dark')).toEqual({ className: 'dark', colorScheme: 'dark' })
+  })
+
+  it('renders the light class and a light UA canvas for an explicit light theme', () => {
+    // Mirrors what next-themes adds client-side (the `light` class) so the
+    // class never flips on hydration.
+    expect(resolveDocumentTheme('light')).toEqual({ className: 'light', colorScheme: 'light' })
+  })
+
+  it('defers the class but lets the OS pick the canvas for system theme', () => {
+    // The resolved value is unknowable server-side, so we leave the class off
+    // (the inline script adds it) but advertise `light dark` so the browser
+    // paints the canvas from the OS preference instead of defaulting to white.
+    expect(resolveDocumentTheme('system')).toEqual({
+      className: undefined,
+      colorScheme: 'light dark',
+    })
+  })
+})

--- a/apps/web/src/lib/shared/theme/index.ts
+++ b/apps/web/src/lib/shared/theme/index.ts
@@ -27,22 +27,40 @@ export function setThemeCookie(themeValue: Theme): void {
 }
 
 /**
+ * Parse a `Sec-CH-Prefers-Color-Scheme` request header. The browser sends this
+ * (after we advertise `Accept-CH`) as the structured-field token `light` or
+ * `dark`, telling the server the OS preference so `system` can be resolved
+ * during SSR. Returns null when absent or unrecognized.
+ */
+export function parsePrefersColorScheme(value: string | null | undefined): 'light' | 'dark' | null {
+  if (!value) return null
+  const token = value.trim().replace(/^"|"$/g, '').toLowerCase()
+  return token === 'dark' || token === 'light' ? token : null
+}
+
+/**
  * Resolve the `class` and `color-scheme` to put on the SSR-rendered <html> so
  * the first paint already matches the chosen theme. Skipping this leaves the
  * browser painting its default (light) canvas during load — a white flash
  * before next-themes' inline script swaps in the dark class.
  *
  * For an explicit theme we commit to it (e.g. color-scheme:dark keeps the
- * canvas dark even on a light-mode OS). `system` can't be resolved server-side,
- * so we leave the class off (the inline script adds it) and let `light dark`
- * tell the browser to take the canvas from the OS preference.
+ * canvas dark even on a light-mode OS). `system` is resolved from the OS
+ * preference when the browser sent the `Sec-CH-Prefers-Color-Scheme` hint;
+ * without it (Firefox/Safari, or the first request before the hint is known)
+ * we leave the class off (the inline script adds it) and let `light dark` tell
+ * the browser to take the canvas from the OS preference.
  */
-export function resolveDocumentTheme(theme: Theme): {
+export function resolveDocumentTheme(
+  theme: Theme,
+  systemPreference?: 'light' | 'dark' | null
+): {
   className: string | undefined
   colorScheme: 'light' | 'dark' | 'light dark'
 } {
-  if (theme === 'dark') return { className: 'dark', colorScheme: 'dark' }
-  if (theme === 'light') return { className: 'light', colorScheme: 'light' }
+  const resolved = theme === 'system' ? systemPreference : theme
+  if (resolved === 'dark') return { className: 'dark', colorScheme: 'dark' }
+  if (resolved === 'light') return { className: 'light', colorScheme: 'light' }
   return { className: undefined, colorScheme: 'light dark' }
 }
 

--- a/apps/web/src/lib/shared/theme/index.ts
+++ b/apps/web/src/lib/shared/theme/index.ts
@@ -26,6 +26,26 @@ export function setThemeCookie(themeValue: Theme): void {
   document.cookie = `${THEME_COOKIE_NAME}=${themeValue};path=/;max-age=31536000;samesite=lax`
 }
 
+/**
+ * Resolve the `class` and `color-scheme` to put on the SSR-rendered <html> so
+ * the first paint already matches the chosen theme. Skipping this leaves the
+ * browser painting its default (light) canvas during load — a white flash
+ * before next-themes' inline script swaps in the dark class.
+ *
+ * For an explicit theme we commit to it (e.g. color-scheme:dark keeps the
+ * canvas dark even on a light-mode OS). `system` can't be resolved server-side,
+ * so we leave the class off (the inline script adds it) and let `light dark`
+ * tell the browser to take the canvas from the OS preference.
+ */
+export function resolveDocumentTheme(theme: Theme): {
+  className: string | undefined
+  colorScheme: 'light' | 'dark' | 'light dark'
+} {
+  if (theme === 'dark') return { className: 'dark', colorScheme: 'dark' }
+  if (theme === 'light') return { className: 'light', colorScheme: 'light' }
+  return { className: undefined, colorScheme: 'light dark' }
+}
+
 // ============================================================================
 // Theme Types & Utilities
 // ============================================================================

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -29,6 +29,7 @@ export interface RouterContext {
   settings?: TenantSettings | null
   userRole?: 'admin' | 'member' | 'user' | null
   themeCookie?: BootstrapData['themeCookie']
+  prefersColorScheme?: BootstrapData['prefersColorScheme']
   managedFieldPaths?: string[]
   registeredAuthProviders?: string[]
   acceptLanguageLocale?: SupportedLocale
@@ -59,6 +60,7 @@ export const Route = createRootRouteWithContext<RouterContext>()({
       settings,
       userRole,
       themeCookie,
+      prefersColorScheme,
       managedFieldPaths,
       registeredAuthProviders,
       acceptLanguageLocale,
@@ -107,6 +109,7 @@ export const Route = createRootRouteWithContext<RouterContext>()({
       settings: redactedSettings,
       userRole,
       themeCookie,
+      prefersColorScheme,
       managedFieldPaths,
       registeredAuthProviders,
       acceptLanguageLocale,
@@ -211,7 +214,8 @@ class SafeRootDocument extends Component<{ children: ReactNode }, { hasError: bo
 const NON_PORTAL_PREFIXES = ['/admin', '/onboarding', '/api', '/complete-signup']
 
 function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
-  const { settings, themeCookie, acceptLanguageLocale } = Route.useRouteContext()
+  const { settings, themeCookie, prefersColorScheme, acceptLanguageLocale } =
+    Route.useRouteContext()
   const pathname = useRouterState({ select: (s) => s.location.pathname })
   // structuralSharing keeps the array reference stable across store updates that
   // don't change the matched routes, so RootDocument doesn't re-render every tick.
@@ -239,7 +243,12 @@ function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
   // ...but the script can't color the very first canvas the browser paints
   // during load, so when the theme is known we also commit the class and
   // color-scheme on the SSR <html> — otherwise dark users get a white flash.
-  const { className: themeClass, colorScheme } = resolveDocumentTheme(defaultTheme)
+  // `system` is resolved from the Sec-CH-Prefers-Color-Scheme hint when the
+  // browser sent it, so even system users get a fully server-rendered theme.
+  const { className: themeClass, colorScheme } = resolveDocumentTheme(
+    defaultTheme,
+    prefersColorScheme
+  )
 
   // Advertise the rendered language on the document during SSR so non-English
   // visitors don't get an English `<html lang>` (and so RTL locales aren't laid
@@ -252,9 +261,10 @@ function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
   const { lang, dir } = htmlLangDir(documentLocale(routeIds, resolvedLocale))
 
   // suppressHydrationWarning stays: next-themes' inline script sets the theme
-  // class on <html> before React hydrates, and for `system` the server can't
-  // know the OS preference, so the SSR markup and the hydrated DOM differ by
-  // design. This silences that one expected mismatch (one element, one level).
+  // class on <html> before React hydrates, and for `system` without the client
+  // hint (Firefox/Safari) the server can't know the OS preference, so the SSR
+  // markup and the hydrated DOM differ by design. This silences that one
+  // expected mismatch (one element, one level).
   return (
     <html
       lang={lang}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -251,6 +251,10 @@ function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
   const resolvedLocale = widgetOverride ?? acceptLanguageLocale ?? DEFAULT_LOCALE
   const { lang, dir } = htmlLangDir(documentLocale(routeIds, resolvedLocale))
 
+  // suppressHydrationWarning stays: next-themes' inline script sets the theme
+  // class on <html> before React hydrates, and for `system` the server can't
+  // know the OS preference, so the SSR markup and the hydrated DOM differ by
+  // design. This silences that one expected mismatch (one element, one level).
   return (
     <html
       lang={lang}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -15,6 +15,7 @@ import { getBootstrapData, type BootstrapData } from '@/lib/server/functions/boo
 import type { TenantSettings } from '@/lib/shared/types/settings'
 import { redactSettingsForClient } from '@/lib/shared/redact-portal-config'
 import { ThemeProvider } from '@/components/theme-provider'
+import { resolveDocumentTheme } from '@/lib/shared/theme'
 import { Toaster } from '@/components/ui/sonner'
 import { DefaultErrorPage } from '@/components/shared/error-page'
 import { OttHandler } from '@/components/shared/ott-handler'
@@ -171,8 +172,12 @@ function RootComponent() {
  * (e.g. when the error occurred during beforeLoad).
  */
 function MinimalDocument({ children }: Readonly<{ children: ReactNode }>) {
+  // No route context here, so the theme is unknown — fall back to the same
+  // OS-driven canvas the helper uses for `system`, so the error page doesn't
+  // white-flash either.
+  const { colorScheme } = resolveDocumentTheme('system')
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" style={{ colorScheme }} suppressHydrationWarning>
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -231,6 +236,11 @@ function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
   // We pass the resolved default so the script knows what to apply.
   const defaultTheme = forcedTheme ?? themeCookie ?? 'system'
 
+  // ...but the script can't color the very first canvas the browser paints
+  // during load, so when the theme is known we also commit the class and
+  // color-scheme on the SSR <html> — otherwise dark users get a white flash.
+  const { className: themeClass, colorScheme } = resolveDocumentTheme(defaultTheme)
+
   // Advertise the rendered language on the document during SSR so non-English
   // visitors don't get an English `<html lang>` (and so RTL locales aren't laid
   // out LTR until hydration). Decided from the matched route IDs so only
@@ -242,7 +252,13 @@ function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
   const { lang, dir } = htmlLangDir(documentLocale(routeIds, resolvedLocale))
 
   return (
-    <html lang={lang} dir={dir} suppressHydrationWarning>
+    <html
+      lang={lang}
+      dir={dir}
+      className={themeClass}
+      style={{ colorScheme }}
+      suppressHydrationWarning
+    >
       <head>
         <HeadContent />
       </head>


### PR DESCRIPTION
The server already resolves the theme (a forced portal theme or the `theme` cookie) but rendered `<html>` with no class and no color-scheme. The browser painted its default light canvas during load, so dark-mode users saw a white flash before next-themes' inline script applied the dark class.

## SSR-render the resolved theme
Render the class and color-scheme straight onto the SSR `<html>` via a new `resolveDocumentTheme()` helper:

- Explicit `dark` / `light`: commit to the class and `color-scheme` (so `color-scheme: dark` keeps the canvas dark even on a light-mode OS).
- The error fallback (`MinimalDocument`) gets the same `color-scheme` so it no longer flashes either.

## Resolve `system` server-side via a client hint
The server can't read `prefers-color-scheme`, so `system` previously fell back to `color-scheme: light dark` (correct canvas, but the class only arrived via the inline script after first paint). We now advertise the `Sec-CH-Prefers-Color-Scheme` client hint (`Accept-CH` + `Critical-CH`):

- `Critical-CH` makes Chromium retry the first navigation with the hint attached, so even a first-time `system` visitor gets a fully server-rendered theme.
- The bootstrap loader reads the hint and threads it through the root context; `resolveDocumentTheme()` resolves `system` to the reported value.
- Browsers that don't send the hint (Firefox/Safari) keep the existing `color-scheme: light dark` behavior, no regression.
- `Vary: Sec-CH-Prefers-Color-Scheme` stops a shared cache from serving a dark-resolved document to a light-mode client.

`suppressHydrationWarning` stays on `<html>`: next-themes' inline script still mutates the class before hydration (and `system` on non-hint browsers is class-less server-side by design). A code comment documents why.

Adds unit tests for `resolveDocumentTheme()` (including hint resolution) and `parsePrefersColorScheme()`.