### PR TITLE
fix(theme): vary the SSR document on Cookie and Accept-Language

### DIFF
--- a/apps/web/src/lib/server/functions/bootstrap.ts
+++ b/apps/web/src/lib/server/functions/bootstrap.ts
@@ -163,11 +163,15 @@ const getBootstrapDataInternal = createServerOnlyFn(async (): Promise<BootstrapD
   // with the hint attached, so even a first-time `system` visitor gets the
   // right theme server-rendered (one extra request, once per origin). Browsers
   // that don't support it (Firefox/Safari) ignore it and fall back to the
-  // `color-scheme: light dark` canvas. Vary stops a shared cache from handing a
-  // dark-resolved document to a light-mode client.
+  // `color-scheme: light dark` canvas.
   setResponseHeader('Accept-CH', 'Sec-CH-Prefers-Color-Scheme')
   setResponseHeader('Critical-CH', 'Sec-CH-Prefers-Color-Scheme')
-  setResponseHeader('Vary', 'Sec-CH-Prefers-Color-Scheme')
+  // This document is keyed on every input we render into it: the `theme` cookie
+  // (and the session/role embedded in the dehydrated context), Accept-Language
+  // for `<html lang>`/`dir`, and the color-scheme hint. List them all so a
+  // shared cache can never serve e.g. a dark-cookie document to a no-cookie
+  // visitor that happens to share the same hint.
+  setResponseHeader('Vary', 'Cookie, Accept-Language, Sec-CH-Prefers-Color-Scheme')
   const prefersColorScheme = parsePrefersColorScheme(headers.get('sec-ch-prefers-color-scheme'))
 
   return {


### PR DESCRIPTION
Follow-up to #297, addressing the Codex review (P2).

#297 added `Vary: Sec-CH-Prefers-Color-Scheme` to the bootstrap/document response. But that response also renders the `theme` cookie into the `<html>` class/color-scheme (and embeds the session/role in the dehydrated context), and resolves `Accept-Language` into `<html lang>`/`dir`. Listing only the client hint in `Vary` would let a shared cache serve, say, a dark-cookie document to a no-cookie visitor that happens to send the same hint.

List every input the document is keyed on:

```
Vary: Cookie, Accept-Language, Sec-CH-Prefers-Color-Scheme
```

`Cookie` covers both the theme cookie and the per-user session, so an authenticated or themed document can't bleed across visitors via a shared cache.