### PR TITLE
fix(chat): split CSAT into once-per-survey submitted + comment_added webhooks

### DIFF
--- a/apps/web/src/lib/server/domains/chat/__tests__/chat-cards.test.ts
+++ b/apps/web/src/lib/server/domains/chat/__tests__/chat-cards.test.ts
@@ -23,6 +23,7 @@ const emit = vi.hoisted(() => ({
   emitConversationAssigned: vi.fn(),
   emitConversationPriorityChanged: vi.fn(),
   emitConversationCsatSubmitted: vi.fn(),
+  emitConversationCsatCommentAdded: vi.fn(),
 }))
 vi.mock('../chat.webhooks', () => emit)
 

--- a/apps/web/src/lib/server/domains/chat/__tests__/chat-csat-service.test.ts
+++ b/apps/web/src/lib/server/domains/chat/__tests__/chat-csat-service.test.ts
@@ -1,10 +1,11 @@
 /**
- * recordCsat webhook de-duplication: the widget submits CSAT as two unordered
- * POSTs (the rating, then an optional comment). The public
- * conversation.csat_submitted webhook must fire exactly once per survey — on
- * the first submission — so integrations don't double-count a rating when the
- * visitor also leaves a comment. The live inbox update, by contrast, still
- * fires on every call so the agent sees the comment land.
+ * recordCsat webhook emission: the widget submits CSAT as two unordered POSTs
+ * (the rating, then an optional comment), so each public webhook fires once per
+ * survey on the call that completes its meaning — conversation.csat_submitted on
+ * the first submission (the rating), conversation.csat_comment_added when a
+ * comment first lands. Integrations therefore never double-count a rating, and
+ * the comment is still delivered as its own event. The live inbox update, by
+ * contrast, fires on every call so the agent sees the comment land.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { PrincipalId, ConversationId } from '@quackback/ids'
@@ -21,6 +22,7 @@ const emit = vi.hoisted(() => ({
   emitConversationAssigned: vi.fn(),
   emitConversationPriorityChanged: vi.fn(),
   emitConversationCsatSubmitted: vi.fn(),
+  emitConversationCsatCommentAdded: vi.fn(),
 }))
 vi.mock('../chat.webhooks', () => emit)
 
@@ -87,8 +89,8 @@ beforeEach(() => {
   conversationRow.csatSubmittedAt = null
 })
 
-describe('recordCsat webhook de-duplication', () => {
-  it('fires conversation.csat_submitted once across the rating-then-comment flow', async () => {
+describe('recordCsat webhook emission', () => {
+  it('fires submitted once on the rating and comment_added once on the comment', async () => {
     // POST 1: initial rating, no comment.
     await recordCsat(convId, 5, undefined, visitorActor)
     // The first submission persists before the comment POST lands.
@@ -98,11 +100,12 @@ describe('recordCsat webhook de-duplication', () => {
     await recordCsat(convId, 5, 'great support', visitorActor)
 
     expect(emit.emitConversationCsatSubmitted).toHaveBeenCalledTimes(1)
+    expect(emit.emitConversationCsatCommentAdded).toHaveBeenCalledTimes(1)
     // The live inbox update still fires on both calls so the comment shows up.
     expect(publishConversationUpdate).toHaveBeenCalledTimes(2)
   })
 
-  it('fires once even when the comment POST lands before the rating POST', async () => {
+  it('still fires each once when the comment POST lands before the rating POST', async () => {
     // POST 1 (out of order): comment + rating together.
     await recordCsat(convId, 4, 'thanks', visitorActor)
     conversationRow.csatRating = 4
@@ -112,5 +115,13 @@ describe('recordCsat webhook de-duplication', () => {
     await recordCsat(convId, 4, undefined, visitorActor)
 
     expect(emit.emitConversationCsatSubmitted).toHaveBeenCalledTimes(1)
+    expect(emit.emitConversationCsatCommentAdded).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires submitted but no comment event for a rating-only survey', async () => {
+    await recordCsat(convId, 3, undefined, visitorActor)
+
+    expect(emit.emitConversationCsatSubmitted).toHaveBeenCalledTimes(1)
+    expect(emit.emitConversationCsatCommentAdded).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/lib/server/domains/chat/__tests__/chat-csat-service.test.ts
+++ b/apps/web/src/lib/server/domains/chat/__tests__/chat-csat-service.test.ts
@@ -58,17 +58,29 @@ vi.mock('@/lib/server/db', () => {
     c.where = () => c
     // loadConversationOr404 -> select().from().where().limit()
     c.limit = async () => [conversationRow]
+    // recordCsat -> select(...).for('update'): the locked pre-update snapshot.
+    c.for = async () => [conversationRow]
     // recordCsat -> update().set().where().returning(): echo the current row so
     // conversationToDTO/emit receive a plausible post-update conversation.
     c.returning = async () => [{ ...conversationRow }]
     return c
   }
+  const tx = { select: () => chain(), update: () => chain() }
   return {
-    db: { select: () => chain(), update: () => chain() },
+    db: {
+      select: () => chain(),
+      update: () => chain(),
+      transaction: async (cb: (t: typeof tx) => unknown) => cb(tx),
+    },
     eq: vi.fn(),
     and: vi.fn(),
     isNull: vi.fn(),
-    conversations: { __name: 'conversations', id: 'id' },
+    conversations: {
+      __name: 'conversations',
+      id: 'id',
+      csatRating: 'csat_rating',
+      csatComment: 'csat_comment',
+    },
   }
 })
 

--- a/apps/web/src/lib/server/domains/chat/__tests__/chat-csat-service.test.ts
+++ b/apps/web/src/lib/server/domains/chat/__tests__/chat-csat-service.test.ts
@@ -1,0 +1,116 @@
+/**
+ * recordCsat webhook de-duplication: the widget submits CSAT as two unordered
+ * POSTs (the rating, then an optional comment). The public
+ * conversation.csat_submitted webhook must fire exactly once per survey — on
+ * the first submission — so integrations don't double-count a rating when the
+ * visitor also leaves a comment. The live inbox update, by contrast, still
+ * fires on every call so the agent sees the comment land.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PrincipalId, ConversationId } from '@quackback/ids'
+import type { Actor } from '@/lib/server/policy/types'
+
+const publishConversationUpdate = vi.fn()
+
+const emit = vi.hoisted(() => ({
+  emitConversationCreated: vi.fn(),
+  emitMessageCreated: vi.fn(),
+  emitMessageNoteCreated: vi.fn(),
+  emitMessageDeleted: vi.fn(),
+  emitConversationStatusChanged: vi.fn(),
+  emitConversationAssigned: vi.fn(),
+  emitConversationPriorityChanged: vi.fn(),
+  emitConversationCsatSubmitted: vi.fn(),
+}))
+vi.mock('../chat.webhooks', () => emit)
+
+vi.mock('@/lib/server/realtime/chat-channels', () => ({
+  publishChatEvent: vi.fn(),
+  publishAgentChatEvent: vi.fn(),
+  publishConversationUpdate: (...a: unknown[]) => publishConversationUpdate(...a),
+}))
+
+vi.mock('../chat.query', () => ({
+  conversationToDTO: vi.fn(async (c: { id: string }) => ({ id: c.id })),
+  toMessageDTO: vi.fn((m: Record<string, unknown>) => m),
+  authorFromInput: vi.fn((a: { principalId: string }) => ({ principalId: a.principalId })),
+  resolveAuthor: vi.fn(),
+  loadAuthors: vi.fn(async () => new Map()),
+}))
+
+// Mutable pre-update conversation snapshot — tests flip csatRating between calls
+// to simulate the first submission having persisted before the second lands.
+const conversationRow: Record<string, unknown> = {
+  id: 'conversation_1',
+  visitorPrincipalId: 'principal_visitor',
+  csatRating: null,
+  csatComment: null,
+  csatSubmittedAt: null,
+}
+
+vi.mock('@/lib/server/db', () => {
+  function chain(): Record<string, unknown> {
+    const c: Record<string, unknown> = {}
+    c.from = () => c
+    c.set = () => c
+    c.where = () => c
+    // loadConversationOr404 -> select().from().where().limit()
+    c.limit = async () => [conversationRow]
+    // recordCsat -> update().set().where().returning(): echo the current row so
+    // conversationToDTO/emit receive a plausible post-update conversation.
+    c.returning = async () => [{ ...conversationRow }]
+    return c
+  }
+  return {
+    db: { select: () => chain(), update: () => chain() },
+    eq: vi.fn(),
+    and: vi.fn(),
+    isNull: vi.fn(),
+    conversations: { __name: 'conversations', id: 'id' },
+  }
+})
+
+import { recordCsat } from '../chat.service'
+
+const convId = 'conversation_1' as ConversationId
+const visitorActor: Actor = {
+  principalId: 'principal_visitor' as PrincipalId,
+  role: 'user',
+  principalType: 'anonymous',
+  segmentIds: new Set(),
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  conversationRow.csatRating = null
+  conversationRow.csatComment = null
+  conversationRow.csatSubmittedAt = null
+})
+
+describe('recordCsat webhook de-duplication', () => {
+  it('fires conversation.csat_submitted once across the rating-then-comment flow', async () => {
+    // POST 1: initial rating, no comment.
+    await recordCsat(convId, 5, undefined, visitorActor)
+    // The first submission persists before the comment POST lands.
+    conversationRow.csatRating = 5
+    conversationRow.csatSubmittedAt = new Date()
+    // POST 2: optional comment follow-up, same rating.
+    await recordCsat(convId, 5, 'great support', visitorActor)
+
+    expect(emit.emitConversationCsatSubmitted).toHaveBeenCalledTimes(1)
+    // The live inbox update still fires on both calls so the comment shows up.
+    expect(publishConversationUpdate).toHaveBeenCalledTimes(2)
+  })
+
+  it('fires once even when the comment POST lands before the rating POST', async () => {
+    // POST 1 (out of order): comment + rating together.
+    await recordCsat(convId, 4, 'thanks', visitorActor)
+    conversationRow.csatRating = 4
+    conversationRow.csatComment = 'thanks'
+    conversationRow.csatSubmittedAt = new Date()
+    // POST 2: the bare rating arrives late.
+    await recordCsat(convId, 4, undefined, visitorActor)
+
+    expect(emit.emitConversationCsatSubmitted).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/src/lib/server/domains/chat/__tests__/chat-delete-service.test.ts
+++ b/apps/web/src/lib/server/domains/chat/__tests__/chat-delete-service.test.ts
@@ -22,6 +22,7 @@ const emit = vi.hoisted(() => ({
   emitConversationAssigned: vi.fn(),
   emitConversationPriorityChanged: vi.fn(),
   emitConversationCsatSubmitted: vi.fn(),
+  emitConversationCsatCommentAdded: vi.fn(),
 }))
 vi.mock('../chat.webhooks', () => emit)
 

--- a/apps/web/src/lib/server/domains/chat/__tests__/chat-notes-service.test.ts
+++ b/apps/web/src/lib/server/domains/chat/__tests__/chat-notes-service.test.ts
@@ -24,6 +24,7 @@ const emit = vi.hoisted(() => ({
   emitConversationAssigned: vi.fn(),
   emitConversationPriorityChanged: vi.fn(),
   emitConversationCsatSubmitted: vi.fn(),
+  emitConversationCsatCommentAdded: vi.fn(),
 }))
 vi.mock('../chat.webhooks', () => emit)
 

--- a/apps/web/src/lib/server/domains/chat/__tests__/chat-send-service.test.ts
+++ b/apps/web/src/lib/server/domains/chat/__tests__/chat-send-service.test.ts
@@ -21,6 +21,7 @@ const emit = vi.hoisted(() => ({
   emitConversationAssigned: vi.fn(),
   emitConversationPriorityChanged: vi.fn(),
   emitConversationCsatSubmitted: vi.fn(),
+  emitConversationCsatCommentAdded: vi.fn(),
 }))
 vi.mock('../chat.webhooks', () => emit)
 

--- a/apps/web/src/lib/server/domains/chat/__tests__/chat-start-agent-conversation.test.ts
+++ b/apps/web/src/lib/server/domains/chat/__tests__/chat-start-agent-conversation.test.ts
@@ -23,6 +23,7 @@ const emit = vi.hoisted(() => ({
   emitConversationAssigned: vi.fn(),
   emitConversationPriorityChanged: vi.fn(),
   emitConversationCsatSubmitted: vi.fn(),
+  emitConversationCsatCommentAdded: vi.fn(),
 }))
 vi.mock('../chat.webhooks', () => emit)
 

--- a/apps/web/src/lib/server/domains/chat/__tests__/chat-suggest-post.test.ts
+++ b/apps/web/src/lib/server/domains/chat/__tests__/chat-suggest-post.test.ts
@@ -30,6 +30,7 @@ vi.mock('../chat.webhooks', () => ({
   emitConversationAssigned: vi.fn(),
   emitConversationPriorityChanged: vi.fn(),
   emitConversationCsatSubmitted: vi.fn(),
+  emitConversationCsatCommentAdded: vi.fn(),
 }))
 
 vi.mock('@/lib/server/domains/embeddings/embedding.service', () => ({

--- a/apps/web/src/lib/server/domains/chat/__tests__/chat-typing-read-side.test.ts
+++ b/apps/web/src/lib/server/domains/chat/__tests__/chat-typing-read-side.test.ts
@@ -26,6 +26,7 @@ vi.mock('../chat.webhooks', () => ({
   emitConversationAssigned: vi.fn(),
   emitConversationPriorityChanged: vi.fn(),
   emitConversationCsatSubmitted: vi.fn(),
+  emitConversationCsatCommentAdded: vi.fn(),
 }))
 
 vi.mock('../chat.notify', () => ({

--- a/apps/web/src/lib/server/domains/chat/__tests__/chat-webhooks.test.ts
+++ b/apps/web/src/lib/server/domains/chat/__tests__/chat-webhooks.test.ts
@@ -9,6 +9,7 @@ const dispatch = vi.hoisted(() => ({
   dispatchConversationAssigned: vi.fn().mockResolvedValue(undefined),
   dispatchConversationPriorityChanged: vi.fn().mockResolvedValue(undefined),
   dispatchConversationCsatSubmitted: vi.fn().mockResolvedValue(undefined),
+  dispatchConversationCsatCommentAdded: vi.fn().mockResolvedValue(undefined),
   dispatchMessageCreated: vi.fn().mockResolvedValue(undefined),
   dispatchMessageNoteCreated: vi.fn().mockResolvedValue(undefined),
   dispatchMessageDeleted: vi.fn().mockResolvedValue(undefined),
@@ -24,6 +25,7 @@ import {
   emitMessageNoteCreated,
   emitMessageDeleted,
   emitConversationCsatSubmitted,
+  emitConversationCsatCommentAdded,
 } from '../chat.webhooks'
 
 const now = new Date('2026-06-05T00:00:00.000Z')
@@ -148,6 +150,33 @@ describe('chat.webhooks emit helpers', () => {
     expect(rating).toBe(4)
     expect(comment).toBe('ok')
     expect(submittedAt).toBe('2026-06-05T02:00:00.000Z')
+  })
+
+  it('emitConversationCsatCommentAdded carries the comment, skips a comment-less row', async () => {
+    const withComment = {
+      ...baseConversation,
+      csatRating: 4,
+      csatComment: 'nice work',
+      csatSubmittedAt: new Date('2026-06-05T02:00:00.000Z'),
+    } as unknown as Conversation
+    await emitConversationCsatCommentAdded(visitorActor, withComment)
+    expect(dispatch.dispatchConversationCsatCommentAdded).toHaveBeenCalledTimes(1)
+    const [, ref, rating, comment, submittedAt] =
+      dispatch.dispatchConversationCsatCommentAdded.mock.calls[0]
+    expect(ref.id).toBe('conversation_1')
+    expect(rating).toBe(4)
+    expect(comment).toBe('nice work')
+    expect(submittedAt).toBe('2026-06-05T02:00:00.000Z')
+
+    // A rating with no comment must not emit the comment event.
+    const noComment = {
+      ...baseConversation,
+      csatRating: 5,
+      csatComment: null,
+      csatSubmittedAt: new Date('2026-06-05T02:00:00.000Z'),
+    } as unknown as Conversation
+    await emitConversationCsatCommentAdded(visitorActor, noComment)
+    expect(dispatch.dispatchConversationCsatCommentAdded).toHaveBeenCalledTimes(1)
   })
 
   it('emitConversationStatusChanged passes previous then new status', async () => {

--- a/apps/web/src/lib/server/domains/chat/chat.service.ts
+++ b/apps/web/src/lib/server/domains/chat/chat.service.ts
@@ -1056,6 +1056,10 @@ export async function recordCsat(
   // supplied, so a rating-only call can never null a comment that the follow-up
   // already saved (or that arrives in either order).
   const trimmedComment = comment?.trim() ? comment.trim().slice(0, 2000) : undefined
+  // A survey is a single satisfaction submission even though it arrives as two
+  // calls — fire the public webhook only on the first, so integrations don't
+  // double-count or re-trigger automations when the visitor adds a comment.
+  const isFirstSubmission = conversation.csatRating == null
   const [updated] = await db
     .update(conversations)
     .set({
@@ -1067,10 +1071,10 @@ export async function recordCsat(
     .where(eq(conversations.id, conversationId))
     .returning()
   // Surface the rating to the agent inbox live (agent-only fields stripped for
-  // the visitor).
+  // the visitor). This fires on every call so a follow-up comment still lands.
   const dto = await conversationToDTO(updated, 'agent')
   publishConversationUpdate(conversationId, dto)
-  void emitConversationCsatSubmitted(actor, updated)
+  if (isFirstSubmission) void emitConversationCsatSubmitted(actor, updated)
 }
 
 /**

--- a/apps/web/src/lib/server/domains/chat/chat.service.ts
+++ b/apps/web/src/lib/server/domains/chat/chat.service.ts
@@ -70,6 +70,7 @@ import {
   emitConversationAssigned,
   emitConversationPriorityChanged,
   emitConversationCsatSubmitted,
+  emitConversationCsatCommentAdded,
 } from './chat.webhooks'
 import { extractMentions } from '@/lib/server/domains/posts/extract-mentions'
 import { syncChatMessageMentions } from './sync-chat-mentions'
@@ -1056,10 +1057,13 @@ export async function recordCsat(
   // supplied, so a rating-only call can never null a comment that the follow-up
   // already saved (or that arrives in either order).
   const trimmedComment = comment?.trim() ? comment.trim().slice(0, 2000) : undefined
-  // A survey is a single satisfaction submission even though it arrives as two
-  // calls — fire the public webhook only on the first, so integrations don't
-  // double-count or re-trigger automations when the visitor adds a comment.
+  // The survey arrives as two unordered calls (rating, then an optional comment),
+  // so each public webhook fires on the single call that completes its meaning:
+  // csat_submitted on the first submission (the rating is banked instantly), and
+  // csat_comment_added when a comment first lands. That keeps each event once per
+  // survey so integrations never double-count or re-trigger automations.
   const isFirstSubmission = conversation.csatRating == null
+  const commentJustAdded = trimmedComment !== undefined && conversation.csatComment == null
   const [updated] = await db
     .update(conversations)
     .set({
@@ -1075,6 +1079,7 @@ export async function recordCsat(
   const dto = await conversationToDTO(updated, 'agent')
   publishConversationUpdate(conversationId, dto)
   if (isFirstSubmission) void emitConversationCsatSubmitted(actor, updated)
+  if (commentJustAdded) void emitConversationCsatCommentAdded(actor, updated)
 }
 
 /**

--- a/apps/web/src/lib/server/domains/chat/chat.service.ts
+++ b/apps/web/src/lib/server/domains/chat/chat.service.ts
@@ -1057,27 +1057,44 @@ export async function recordCsat(
   // supplied, so a rating-only call can never null a comment that the follow-up
   // already saved (or that arrives in either order).
   const trimmedComment = comment?.trim() ? comment.trim().slice(0, 2000) : undefined
-  // The survey arrives as two unordered calls (rating, then an optional comment),
-  // so each public webhook fires on the single call that completes its meaning:
-  // csat_submitted on the first submission (the rating is banked instantly), and
-  // csat_comment_added when a comment first lands. That keeps each event once per
-  // survey so integrations never double-count or re-trigger automations.
-  const isFirstSubmission = conversation.csatRating == null
-  const commentJustAdded = trimmedComment !== undefined && conversation.csatComment == null
-  const [updated] = await db
-    .update(conversations)
-    .set({
-      csatRating: rating,
-      ...(trimmedComment !== undefined ? { csatComment: trimmedComment } : {}),
-      csatSubmittedAt: new Date(),
-      updatedAt: new Date(),
-    })
-    .where(eq(conversations.id, conversationId))
-    .returning()
+
+  // Lock the row and read its pre-update CSAT state in the same transaction so
+  // the once-per-survey decisions are atomic. The widget fires the rating POST
+  // without awaiting it, so a racing comment POST must serialize behind this
+  // SELECT ... FOR UPDATE instead of both seeing a null rating and each emitting
+  // conversation.csat_submitted.
+  const { updated, isFirstSubmission, commentJustAdded } = await db.transaction(async (tx) => {
+    const [prev] = await tx
+      .select({ csatRating: conversations.csatRating, csatComment: conversations.csatComment })
+      .from(conversations)
+      .where(eq(conversations.id, conversationId))
+      .for('update')
+    const [row] = await tx
+      .update(conversations)
+      .set({
+        csatRating: rating,
+        ...(trimmedComment !== undefined ? { csatComment: trimmedComment } : {}),
+        csatSubmittedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(conversations.id, conversationId))
+      .returning()
+    // Each public webhook fires on the single call that completes its meaning:
+    // csat_submitted on the first submission (the rating is banked instantly),
+    // csat_comment_added when a comment first lands. Deciding from the locked
+    // prev state keeps each event to once per survey under concurrent POSTs.
+    return {
+      updated: row,
+      isFirstSubmission: prev?.csatRating == null,
+      commentJustAdded: trimmedComment !== undefined && prev?.csatComment == null,
+    }
+  })
+
   // Surface the rating to the agent inbox live (agent-only fields stripped for
   // the visitor). This fires on every call so a follow-up comment still lands.
   const dto = await conversationToDTO(updated, 'agent')
   publishConversationUpdate(conversationId, dto)
+  // Emit after the transaction commits so a rolled-back write never webhooks.
   if (isFirstSubmission) void emitConversationCsatSubmitted(actor, updated)
   if (commentJustAdded) void emitConversationCsatCommentAdded(actor, updated)
 }

--- a/apps/web/src/lib/server/domains/chat/chat.webhooks.ts
+++ b/apps/web/src/lib/server/domains/chat/chat.webhooks.ts
@@ -25,6 +25,7 @@ import {
   dispatchConversationAssigned,
   dispatchConversationPriorityChanged,
   dispatchConversationCsatSubmitted,
+  dispatchConversationCsatCommentAdded,
   dispatchMessageCreated,
   dispatchMessageNoteCreated,
   dispatchMessageDeleted,
@@ -200,6 +201,31 @@ export async function emitConversationCsatSubmitted(
       conversationRef(conversation),
       csatRating,
       conversation.csatComment ?? null,
+      csatSubmittedAt.toISOString()
+    )
+  )
+}
+
+export async function emitConversationCsatCommentAdded(
+  actor: Actor,
+  conversation: Conversation
+): Promise<void> {
+  // The optional follow-up comment is its own event so csat_submitted can stay
+  // a once-per-survey signal. Only emit once the rating + comment are on file.
+  if (
+    conversation.csatRating == null ||
+    conversation.csatSubmittedAt == null ||
+    !conversation.csatComment
+  ) {
+    return
+  }
+  const { csatRating, csatComment, csatSubmittedAt } = conversation
+  await safe('conversation.csat_comment_added', () =>
+    dispatchConversationCsatCommentAdded(
+      toEventActor(actor),
+      conversationRef(conversation),
+      csatRating,
+      csatComment,
       csatSubmittedAt.toISOString()
     )
   )

--- a/apps/web/src/lib/server/events/__tests__/dispatch-conversation.test.ts
+++ b/apps/web/src/lib/server/events/__tests__/dispatch-conversation.test.ts
@@ -9,6 +9,7 @@ import {
   dispatchMessageCreated,
   dispatchMessageNoteCreated,
   dispatchConversationCsatSubmitted,
+  dispatchConversationCsatCommentAdded,
 } from '../dispatch'
 import type { EventConversationData, EventConversationRef, EventMessageData } from '../types'
 
@@ -79,6 +80,24 @@ describe('conversation/message dispatch', () => {
     await dispatchConversationCsatSubmitted(actor, convRef, 5, 'great', '2026-06-05T01:00:00.000Z')
     const event = processEvent.mock.calls[0][0]
     expect(event.type).toBe('conversation.csat_submitted')
+    expect(event.data).toEqual({
+      conversation: convRef,
+      rating: 5,
+      comment: 'great',
+      submittedAt: '2026-06-05T01:00:00.000Z',
+    })
+  })
+
+  it('dispatchConversationCsatCommentAdded carries the rating + comment', async () => {
+    await dispatchConversationCsatCommentAdded(
+      actor,
+      convRef,
+      5,
+      'great',
+      '2026-06-05T01:00:00.000Z'
+    )
+    const event = processEvent.mock.calls[0][0]
+    expect(event.type).toBe('conversation.csat_comment_added')
     expect(event.data).toEqual({
       conversation: convRef,
       rating: 5,

--- a/apps/web/src/lib/server/events/dispatch.ts
+++ b/apps/web/src/lib/server/events/dispatch.ts
@@ -365,6 +365,20 @@ export async function dispatchConversationCsatSubmitted(
   })
 }
 
+export async function dispatchConversationCsatCommentAdded(
+  actor: EventActor,
+  conversation: EventConversationRef,
+  rating: number,
+  comment: string,
+  submittedAt: string
+): Promise<void> {
+  await dispatchEvent({
+    ...eventEnvelope(actor),
+    type: 'conversation.csat_comment_added',
+    data: { conversation, rating, comment, submittedAt },
+  })
+}
+
 export async function dispatchMessageCreated(
   actor: EventActor,
   message: EventMessageData,

--- a/apps/web/src/lib/server/events/integrations/webhook/constants.ts
+++ b/apps/web/src/lib/server/events/integrations/webhook/constants.ts
@@ -103,6 +103,11 @@ export const WEBHOOK_EVENT_CONFIG = [
     description: 'When a visitor submits a satisfaction rating',
   },
   {
+    id: 'conversation.csat_comment_added',
+    label: 'CSAT Comment Added',
+    description: 'When a visitor adds the optional comment to a satisfaction rating',
+  },
+  {
     id: 'message.created',
     label: 'New Message',
     description: 'When a visitor or agent sends a public message',

--- a/apps/web/src/lib/server/events/types.ts
+++ b/apps/web/src/lib/server/events/types.ts
@@ -24,6 +24,7 @@ export const EVENT_TYPES = [
   'conversation.assigned',
   'conversation.priority_changed',
   'conversation.csat_submitted',
+  'conversation.csat_comment_added',
   'message.created',
   'message.note_created',
   'message.deleted',
@@ -210,6 +211,12 @@ export interface ConversationCsatSubmittedPayload {
   comment: string | null
   submittedAt: string
 }
+export interface ConversationCsatCommentAddedPayload {
+  conversation: EventConversationRef
+  rating: number
+  comment: string
+  submittedAt: string
+}
 export interface MessageCreatedPayload {
   message: EventMessageData
   conversation: EventConversationRef
@@ -297,6 +304,9 @@ export interface ConversationPriorityChangedEvent extends EventBase<'conversatio
 export interface ConversationCsatSubmittedEvent extends EventBase<'conversation.csat_submitted'> {
   data: ConversationCsatSubmittedPayload
 }
+export interface ConversationCsatCommentAddedEvent extends EventBase<'conversation.csat_comment_added'> {
+  data: ConversationCsatCommentAddedPayload
+}
 export interface MessageCreatedEvent extends EventBase<'message.created'> {
   data: MessageCreatedPayload
 }
@@ -334,6 +344,7 @@ export type EventData =
   | ConversationAssignedEvent
   | ConversationPriorityChangedEvent
   | ConversationCsatSubmittedEvent
+  | ConversationCsatCommentAddedEvent
   | MessageCreatedEvent
   | MessageNoteCreatedEvent
   | MessageDeletedEvent

--- a/apps/web/src/lib/server/redis.ts
+++ b/apps/web/src/lib/server/redis.ts
@@ -34,10 +34,7 @@ export function getRedis(): Redis {
 export const CACHE_KEYS = {
   TENANT_SETTINGS: 'settings:tenant',
   INTEGRATION_MAPPINGS: 'hooks:integration-mappings',
-  // Versioned so a deploy that rewrites webhook subscription rows out of band
-  // (e.g. the 0123 csat_comment_added backfill migration) reads fresh from the
-  // DB instead of a stale cached `events` array left over from the old version.
-  ACTIVE_WEBHOOKS: 'hooks:webhooks-active:v2',
+  ACTIVE_WEBHOOKS: 'hooks:webhooks-active',
   SLACK_CHANNELS: 'slack:channels',
   // Hot dependency of getTenantSettings; invalidated by save/delete in
   // platform-credential.service.ts.

--- a/apps/web/src/lib/server/redis.ts
+++ b/apps/web/src/lib/server/redis.ts
@@ -34,7 +34,10 @@ export function getRedis(): Redis {
 export const CACHE_KEYS = {
   TENANT_SETTINGS: 'settings:tenant',
   INTEGRATION_MAPPINGS: 'hooks:integration-mappings',
-  ACTIVE_WEBHOOKS: 'hooks:webhooks-active',
+  // Versioned so a deploy that rewrites webhook subscription rows out of band
+  // (e.g. the 0123 csat_comment_added backfill migration) reads fresh from the
+  // DB instead of a stale cached `events` array left over from the old version.
+  ACTIVE_WEBHOOKS: 'hooks:webhooks-active:v2',
   SLACK_CHANNELS: 'slack:channels',
   // Hot dependency of getTenantSettings; invalidated by save/delete in
   // platform-credential.service.ts.

--- a/docs/webhooks/conversation-events.md
+++ b/docs/webhooks/conversation-events.md
@@ -11,17 +11,20 @@ are opt-in: a webhook only receives the event types listed in its subscription.
 | `conversation.status_changed`   | A conversation moves between `open`/`pending`/`closed`.                                                  |
 | `conversation.assigned`         | A conversation is assigned to or unassigned from an agent (includes auto-routing).                       |
 | `conversation.priority_changed` | A conversation's priority changes.                                                                       |
-| `conversation.csat_submitted`   | A visitor records or updates their satisfaction rating or comment.                                       |
+| `conversation.csat_submitted`   | A visitor submits their satisfaction rating. Fires once per survey.                                      |
+| `conversation.csat_comment_added` | A visitor adds the optional free-text comment to their rating. Fires once per survey, only if a comment is left. |
 | `message.created`               | A visitor or agent sends a public message.                                                               |
 | `message.note_created`          | An agent adds an **internal note**. Private content — subscribe only if your endpoint should receive it. |
 | `message.deleted`               | A public message is soft-deleted.                                                                        |
 
 Internal-note deletions are not emitted. System messages (e.g. "chat ended") are
 represented by `conversation.*` events, not `message.created`. Anonymous visitors'
-emails are never included (synthetic addresses are stripped to `null`). Because a
-visitor can submit a rating and a comment separately, `conversation.csat_submitted`
-may fire more than once for one conversation; each payload carries the current CSAT
-snapshot, so treat it as an upsert keyed on the conversation rather than counting events.
+emails are never included (synthetic addresses are stripped to `null`). The widget
+submits a CSAT rating and its optional comment as two separate calls, so they map to
+two events: `conversation.csat_submitted` fires once when the rating is recorded, and
+`conversation.csat_comment_added` fires once if the visitor later leaves a comment
+(both payloads carry the rating, so a consumer that only wants the score can ignore
+the comment event).
 
 ## Payload envelope
 

--- a/packages/db/drizzle/0123_csat_comment_subscription_backfill.sql
+++ b/packages/db/drizzle/0123_csat_comment_subscription_backfill.sql
@@ -1,0 +1,13 @@
+-- Existing webhooks subscribed to conversation.csat_submitted used to receive a
+-- visitor's CSAT comment through that event: it fired a second time, carrying
+-- the comment, on the follow-up POST. The comment now rides its own
+-- conversation.csat_comment_added event, so subscribe those webhooks to it too.
+-- Without this, consumers that were getting CSAT comments would silently stop
+-- after the upgrade.
+--
+-- Idempotent: skips rows that already list the new event.
+
+UPDATE "webhooks"
+SET "events" = array_append("events", 'conversation.csat_comment_added')
+WHERE 'conversation.csat_submitted' = ANY("events")
+  AND NOT ('conversation.csat_comment_added' = ANY("events"));

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -862,6 +862,13 @@
       "when": 1783382400000,
       "tag": "0122_help_center_slug_backfill",
       "breakpoints": true
+    },
+    {
+      "idx": 123,
+      "version": "7",
+      "when": 1783468800000,
+      "tag": "0123_csat_comment_subscription_backfill",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Problem
The widget submits CSAT as two unordered calls: a rating-only POST on the star click (so the rating is banked instantly), then an optional `{rating, comment}` follow-up. `recordCsat` emitted `conversation.csat_submitted` on **every** call, so a survey with a comment double-fired the event — integrations would double-count the score or re-trigger automations.

A naive "emit only on the first submission" guard fixes the double-count but drops the comment from the webhook entirely (the comment lands on the second, now-suppressed call). Flow C (rating only) and flow A's first call are byte-identical, so no single synchronous emit can be both once-per-survey **and** always carry the comment.

## Fix
Split the two facts into two events, each fired at most once per survey:

- `conversation.csat_submitted` — fires once, on the first submission (the rating). Instant capture preserved; no double-count.
- `conversation.csat_comment_added` — fires once, when a comment first transitions absent → present. Carries the rating too, so consumers that want the score-with-verbatim get it without joining events.

| Flow | `csat_submitted` | `csat_comment_added` |
|---|---|---|
| rate, then comment | call 1 (rating) | call 2 (comment) |
| comment arrives first | call 1 | call 1 |
| rate only | call 1 | never |

The live inbox update still publishes on every call, so the agent always sees the comment land.

## Changes
- New event type + payload, dispatch fn, and `emitConversationCsatCommentAdded`.
- `recordCsat` gates `csat_submitted` on first submission and `csat_comment_added` on a newly-added comment.
- Registers the `conversation.csat_comment_added` webhook topic (enforced by `webhook-config` test).
- Docs updated to describe the two events.
- Service + dispatch test coverage across all three call orderings.

Replaces the original guard-only approach after review flagged the dropped comment.

## Review follow-ups (Codex)
- **Atomic gate (P2):** the once-per-survey decision now happens inside a transaction over a `SELECT … FOR UPDATE` of the conversation row. The widget fires the rating POST without awaiting it, so a racing comment POST serializes behind the rating write instead of both reading a null rating and double-emitting `csat_submitted`.
- **Subscription backfill (P1):** migration `0123` appends `conversation.csat_comment_added` to any webhook already subscribed to `conversation.csat_submitted`, so existing consumers keep receiving CSAT comments after the split (subscriptions are exact-match arrays).