### PR TITLE
fix(sentiment): stripCodeFences before JSON.parse (closes #296)

### DIFF
--- a/apps/web/src/lib/server/domains/sentiment/sentiment.service.ts
+++ b/apps/web/src/lib/server/domains/sentiment/sentiment.service.ts
@@ -7,7 +7,7 @@
 
 import { db, postSentiment, posts, eq, and, gte, lte, sql, count, isNull } from '@/lib/server/db'
 import { createId, type PostId } from '@quackback/ids'
-import { getOpenAI } from '@/lib/server/domains/ai/config'
+import { getOpenAI, stripCodeFences } from '@/lib/server/domains/ai/config'
 import { getChatModel } from '@/lib/server/domains/ai/models'
 import { withRetry } from '@/lib/server/domains/ai/retry'
 import { withUsageLogging } from '@/lib/server/domains/ai/usage-log'
@@ -103,7 +103,7 @@ export async function analyzeSentiment(
         totalTokens: r.usage?.total_tokens ?? 0,
       })
     )
-    const parsed = JSON.parse(response.choices[0]?.message?.content || '{}')
+    const parsed = JSON.parse(stripCodeFences(response.choices[0]?.message?.content || '{}'))
 
     if (!isValidSentiment(parsed.sentiment) || typeof parsed.confidence !== 'number') {
       log.error({ model_response_keys: Object.keys(parsed) }, 'invalid sentiment model response')


### PR DESCRIPTION
Closes #296.

`analyzeSentiment` in `sentiment.service.ts` does a bare `JSON.parse` on the chat response, unlike `summary.service.ts:146` and `merge-assessment.service.ts` which both wrap it in `stripCodeFences(...)`. Any provider/model that wraps the `json_object` output in ```` ```json ... ``` ```` fences — even with `response_format: { type: 'json_object' }` — therefore throws `JSON Parse error: Unrecognized token '`'` and sentiment is dropped.

Verified live via OpenRouter: `anthropic/claude-haiku-4.5` and `deepseek/deepseek-chat` fence the output; OpenAI models, `claude-sonnet-4.6`, `google/gemini-3.1-flash-lite`, and `meta-llama/llama-3.3-70b-instruct` return clean JSON.

This is the minimal fix: import the existing `stripCodeFences` helper and apply it before `JSON.parse`, exactly as the sibling summary/merge services already do. One-line behavior change, no new dependency.