### PR TITLE
fix(auth): drop ignored magicLink allowedAttempts option

### DIFF
--- a/apps/web/src/lib/server/auth/index.ts
+++ b/apps/web/src/lib/server/auth/index.ts
@@ -377,8 +377,6 @@ async function createAuth() {
         // pushes their verification row out to 7 days post-mint.
         expiresIn: 60 * 10,
         disableSignUp: false,
-        // Outlook Safe Links / Slack unfurl can consume tokens before the user clicks.
-        allowedAttempts: 3,
       }),
 
       emailOTP({


### PR DESCRIPTION
## What

Removes the `allowedAttempts: 3` option from the magic-link plugin config.

## Why

better-auth consumes magic-link tokens atomically on the first verification call, so `allowedAttempts` has no effect for any value other than `1` (GHSA-hc7v-rggr-4hvx). The library now emits a startup warning for any non-default value.

The option's original intent (per the comment it carried) was to tolerate Outlook Safe Links / Slack unfurl prefetching the link and burning the token before the human clicks. That concern is already handled elsewhere: the email links to the `/verify-magic-link` interstitial, which only calls the token-consuming verify endpoint from a client-side `useEffect`. Non-browser scanners don't execute JS, so they never consume the token. See `apps/web/src/routes/verify-magic-link.tsx`.

So the option was both non-functional (per the GHSA) and redundant with the interstitial. Dropping it is behaviour-preserving and silences the warning.