### PR TITLE
fix(widget): show comment form after verified identity

### DIFF
--- a/apps/web/src/components/widget/__tests__/widget-comment-form-visibility.test.ts
+++ b/apps/web/src/components/widget/__tests__/widget-comment-form-visibility.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { shouldShowWidgetCommentForm } from '../widget-post-detail'
+
+describe('shouldShowWidgetCommentForm', () => {
+  it('shows the editor for an identified user when verified identity is required', () => {
+    expect(
+      shouldShowWidgetCommentForm({
+        isCommentsLocked: false,
+        commentNoAccess: false,
+        hmacRequired: true,
+        isIdentified: true,
+      })
+    ).toBe(true)
+  })
+
+  it('keeps anonymous visitors read-only when verified identity is required', () => {
+    expect(
+      shouldShowWidgetCommentForm({
+        isCommentsLocked: false,
+        commentNoAccess: false,
+        hmacRequired: true,
+        isIdentified: false,
+      })
+    ).toBe(false)
+  })
+
+  it('does not show the editor when comments are locked or access is denied', () => {
+    expect(
+      shouldShowWidgetCommentForm({
+        isCommentsLocked: true,
+        commentNoAccess: false,
+        hmacRequired: false,
+        isIdentified: true,
+      })
+    ).toBe(false)
+    expect(
+      shouldShowWidgetCommentForm({
+        isCommentsLocked: false,
+        commentNoAccess: true,
+        hmacRequired: false,
+        isIdentified: true,
+      })
+    ).toBe(false)
+  })
+})

--- a/apps/web/src/components/widget/widget-post-detail.tsx
+++ b/apps/web/src/components/widget/widget-post-detail.tsx
@@ -31,6 +31,24 @@ interface WidgetPostDetailProps {
   statuses: StatusInfo[]
 }
 
+/**
+ * Verified-identity mode blocks anonymous email capture, but it must not hide
+ * the editor after the host has successfully identified the visitor.
+ */
+export function shouldShowWidgetCommentForm({
+  isCommentsLocked,
+  commentNoAccess,
+  hmacRequired,
+  isIdentified,
+}: {
+  isCommentsLocked: boolean
+  commentNoAccess: boolean
+  hmacRequired: boolean
+  isIdentified: boolean
+}): boolean {
+  return !isCommentsLocked && !commentNoAccess && (!hmacRequired || isIdentified)
+}
+
 export function WidgetPostDetail({ postId, statuses }: WidgetPostDetailProps) {
   const intl = useIntl()
   const {
@@ -284,7 +302,12 @@ export function WidgetPostDetail({ postId, statuses }: WidgetPostDetailProps) {
 
           {/* Root comment form — unified: textarea + email (when anonymous) + single Post.
               For an anonymous viewer the email field escalates them to a real user. */}
-          {!post.isCommentsLocked && !commentNoAccess && !hmacRequired && (
+          {shouldShowWidgetCommentForm({
+            isCommentsLocked: post.isCommentsLocked,
+            commentNoAccess,
+            hmacRequired,
+            isIdentified,
+          }) && (
             <WidgetCommentForm
               isIdentified={isIdentified}
               user={user}


### PR DESCRIPTION
## Summary

Show the widget comment form for users who have already been identified by a host application when `hmacRequired` is enabled.

## Root cause

The existing condition requires `!hmacRequired` unconditionally. That correctly hides anonymous email capture in verified-identity mode, but it also hides the editor after a signed `ssoToken` has successfully identified the user.

## Behavior

- verified identity required + identified user: comment form shown
- verified identity required + anonymous visitor: remains read-only
- comments locked or board access denied: form remains hidden

## Verification

Adds focused regression coverage for all three cases. The patch is based on v0.13.1 and applies cleanly to current `main`.
