### PR TITLE
feat(slack): notify on support conversations and visitor messages

### DIFF
--- a/apps/web/src/components/admin/settings/integrations/slack/slack-config.tsx
+++ b/apps/web/src/components/admin/settings/integrations/slack/slack-config.tsx
@@ -90,6 +90,18 @@ const SLACK_EVENT_CONFIG = [
     shortLabel: 'Changelog',
     description: 'When a changelog entry is published',
   },
+  {
+    id: 'conversation.created' as const,
+    label: 'New support conversation',
+    shortLabel: 'Conversation',
+    description: 'When a visitor starts a support conversation',
+  },
+  {
+    id: 'message.created' as const,
+    label: 'New support message',
+    shortLabel: 'Support msg',
+    description: 'When a visitor sends a support message (agent replies are not sent)',
+  },
 ]
 
 // ============================================

--- a/apps/web/src/lib/server/integrations/slack/__tests__/message.test.ts
+++ b/apps/web/src/lib/server/integrations/slack/__tests__/message.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for Slack message building — support-conversation events.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { buildSlackMessage } from '../message'
+import type { EventData } from '../../../events/types'
+
+const ROOT_URL = 'https://feedback.example.com'
+
+const envelope = {
+  id: 'evt_1',
+  occurredAt: '2026-07-21T12:00:00.000Z',
+  actor: { type: 'user' as const, id: 'principal_1', name: 'Test User' },
+}
+
+const conversationRef = {
+  id: 'conv_123',
+  status: 'open' as const,
+  channel: 'messenger' as const,
+  priority: 'none' as const,
+}
+
+function conversationCreatedEvent(overrides: Record<string, unknown> = {}): EventData {
+  return {
+    ...envelope,
+    type: 'conversation.created',
+    data: {
+      conversation: {
+        ...conversationRef,
+        subject: 'Cannot log in <on> my tablet',
+        visitorPrincipalId: 'principal_2',
+        visitorEmail: 'vera@example.com',
+        assignedAgentPrincipalId: null,
+        createdAt: '2026-07-21T12:00:00.000Z',
+        lastMessageAt: '2026-07-21T12:00:00.000Z',
+        resolvedAt: null,
+        ...overrides,
+      },
+    },
+  } as EventData
+}
+
+function messageCreatedEvent(
+  senderType: 'visitor' | 'agent',
+  content = '<p>Hello, I need help & <b>advice</b></p>'
+): EventData {
+  return {
+    ...envelope,
+    type: 'message.created',
+    data: {
+      message: {
+        id: 'msg_1',
+        conversationId: 'conv_123',
+        senderType,
+        authorPrincipalId: 'principal_2',
+        authorName: 'Vera',
+        authorEmail: 'vera@example.com',
+        content,
+        createdAt: '2026-07-21T12:00:00.000Z',
+      },
+      conversation: conversationRef,
+    },
+  } as EventData
+}
+
+describe('buildSlackMessage — conversation.created', () => {
+  it('renders visitor, subject and an inbox deep-link', () => {
+    const msg = buildSlackMessage(conversationCreatedEvent(), ROOT_URL)
+    expect(msg).not.toBeNull()
+    const flat = JSON.stringify(msg)
+    expect(msg?.text).toContain('vera@example.com')
+    expect(flat).toContain(`${ROOT_URL}/admin/inbox?c=conv_123`)
+    // subject is mrkdwn-escaped
+    expect(flat).toContain('Cannot log in &lt;on&gt; my tablet')
+  })
+
+  it('falls back for anonymous visitors and missing subjects', () => {
+    const msg = buildSlackMessage(
+      conversationCreatedEvent({ subject: null, visitorEmail: null }),
+      ROOT_URL
+    )
+    expect(msg).not.toBeNull()
+    expect(msg?.text.toLowerCase()).toContain('anonymous')
+  })
+})
+
+describe('buildSlackMessage — message.created', () => {
+  it('renders a visitor message with escaped content and an inbox deep-link', () => {
+    const msg = buildSlackMessage(messageCreatedEvent('visitor'), ROOT_URL)
+    expect(msg).not.toBeNull()
+    const flat = JSON.stringify(msg)
+    expect(msg?.text).toContain('Vera')
+    expect(flat).toContain(`${ROOT_URL}/admin/inbox?c=conv_123`)
+    // content is HTML: tags stripped, then mrkdwn-escaped
+    expect(flat).toContain('Hello, I need help &amp; advice')
+    expect(flat).not.toContain('<b>')
+  })
+
+  it('returns null for agent messages so replies never notify', () => {
+    expect(buildSlackMessage(messageCreatedEvent('agent'), ROOT_URL)).toBeNull()
+  })
+})
+
+describe('buildSlackMessage — existing events keep working', () => {
+  it('still returns a generic message for unhandled event types', () => {
+    const msg = buildSlackMessage(
+      { ...envelope, type: 'post.unmerged', data: {} } as unknown as EventData,
+      ROOT_URL
+    )
+    expect(msg).not.toBeNull()
+  })
+})

--- a/apps/web/src/lib/server/integrations/slack/hook.ts
+++ b/apps/web/src/lib/server/integrations/slack/hook.ts
@@ -103,8 +103,13 @@ export const slackHook: HookHandler = {
 
     log.debug({ event_type: event.type, channel_id: channelId }, 'processing hook event')
 
-    const client = new WebClient(accessToken)
     const message = buildSlackMessage(event, rootUrl)
+    if (!message) {
+      log.debug({ event_type: event.type }, 'event produces no slack message, skipping')
+      return { success: true }
+    }
+
+    const client = new WebClient(accessToken)
 
     try {
       const result = await postMessage(client, channelId, message)

--- a/apps/web/src/lib/server/integrations/slack/message.ts
+++ b/apps/web/src/lib/server/integrations/slack/message.ts
@@ -37,10 +37,12 @@ function quoteText(text: string): string {
 
 /**
  * Build a Slack message for an event.
+ * Returns null when the event should not produce a Slack message
+ * (e.g. agent-sent support messages — notifying on your own replies is noise).
  * @param event - The event data
  * @param rootUrl - Portal base URL for constructing post links
  */
-export function buildSlackMessage(event: EventData, rootUrl: string): SlackMessage {
+export function buildSlackMessage(event: EventData, rootUrl: string): SlackMessage | null {
   switch (event.type) {
     case 'post.created': {
       const { post } = event.data
@@ -225,6 +227,67 @@ export function buildSlackMessage(event: EventData, rootUrl: string): SlackMessa
             text: {
               type: 'mrkdwn',
               text: `> *<${changelogUrl}|${escapeSlackMrkdwn(changelog.title)}>*\n${quoteText(escapeSlackMrkdwn(content))}`,
+            },
+          },
+        ],
+      }
+    }
+
+    case 'conversation.created': {
+      const { conversation } = event.data
+      const inboxUrl = `${rootUrl}/admin/inbox?c=${conversation.id}`
+      const visitor = conversation.visitorEmail || 'Anonymous visitor'
+      const subject = conversation.subject?.trim() || 'New conversation'
+
+      return {
+        text: `New support conversation from ${visitor}`,
+        blocks: [
+          {
+            type: 'context',
+            elements: [
+              {
+                type: 'mrkdwn',
+                text: `🛟 New support conversation from *${escapeSlackMrkdwn(visitor)}* via ${conversation.channel}`,
+              },
+            ],
+          },
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: `> *<${inboxUrl}|${escapeSlackMrkdwn(subject)}>*`,
+            },
+          },
+        ],
+      }
+    }
+
+    case 'message.created': {
+      const { message, conversation } = event.data
+      // Agent replies would notify the team about its own messages — skip them.
+      if (message.senderType !== 'visitor') return null
+
+      const inboxUrl = `${rootUrl}/admin/inbox?c=${conversation.id}`
+      const author = message.authorName || message.authorEmail || 'Visitor'
+      const content = truncate(stripHtml(message.content), 300)
+
+      return {
+        text: `New support message from ${author}`,
+        blocks: [
+          {
+            type: 'context',
+            elements: [
+              {
+                type: 'mrkdwn',
+                text: `💬 New support message from *${escapeSlackMrkdwn(author)}*`,
+              },
+            ],
+          },
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: `> *<${inboxUrl}|Open in inbox>*\n${quoteText(escapeSlackMrkdwn(content))}`,
             },
           },
         ],


### PR DESCRIPTION
## What

The Slack integration currently offers four notification types (new post, status change, comment, changelog), but nothing for the support inbox — teams get no Slack ping when a visitor starts a conversation or replies. The event bus already dispatches `conversation.created` and `message.created` (the generic webhook integration exposes them), so this teaches the Slack integration about them:

- **Admin UI**: two new per-channel toggles in the Slack notification routing — *New support conversation* and *New support message* (`SLACK_EVENT_CONFIG`).
- **Renderer**: Block Kit cards for both, matching the existing style, with a deep link to `/admin/inbox?c=<conversationId>`. Visitor name/email fall back to "Anonymous visitor"; content is `stripHtml` + mrkdwn-escaped + truncated like `comment.created`.
- **Agent filter**: `message.created` fires for both directions, so agent-sent messages return `null` from `buildSlackMessage` — a team's own replies never notify. `slackHook` treats a null message as a successful no-op (`buildSlackMessage` signature is now `SlackMessage | null`).

## Testing

- New `__tests__/message.test.ts`: renders both events (escaping, inbox deep link, anonymous/missing-subject fallbacks), agent messages return null, unhandled event types still fall through to the generic text.
- `bun run test apps/web/src/lib/server/integrations/slack/` — 21/21 passing; changed files are eslint-clean.

No schema or server-function changes — event-mapping storage already accepts arbitrary event types.