### PR TITLE
fix(github): store owner/repo as channelId so webhook registration works

### DIFF
--- a/apps/web/src/components/admin/settings/integrations/github/github-config.tsx
+++ b/apps/web/src/components/admin/settings/integrations/github/github-config.tsx
@@ -86,9 +86,9 @@ export function GitHubConfig({
     updateMutation.mutate({ id: integrationId, enabled: checked })
   }
 
-  const handleRepoChange = (repoId: string) => {
-    setSelectedRepo(repoId)
-    updateMutation.mutate({ id: integrationId, config: { channelId: repoId } })
+  const handleRepoChange = (repoFullName: string) => {
+    setSelectedRepo(repoFullName)
+    updateMutation.mutate({ id: integrationId, config: { channelId: repoFullName } })
   }
 
   const handleEventToggle = (eventId: string, checked: boolean) => {
@@ -158,7 +158,7 @@ export function GitHubConfig({
             </SelectTrigger>
             <SelectContent>
               {repos.map((repo) => (
-                <SelectItem key={repo.id} value={repo.id.toString()}>
+                <SelectItem key={repo.id} value={repo.fullName}>
                   <div className="flex items-center gap-2">
                     <FolderIcon className="h-3.5 w-3.5 text-muted-foreground" />
                     <span>{repo.fullName}</span>


### PR DESCRIPTION
Fixed Github Status sync not working. The repository <SelectItem> used the numeric repo id as its value, so config.channelId was saved as e.g. "123456789" instead of "owner/repo". Webhook registration builds https://api.github.com/repos/${channelId}/hooks, which GitHub then parses as /repos/{owner}/{repo} and returns `404 (documentation_url: repos#update-a-repository)`.

Use repo.fullName ("owner/repo") as the select value so channelId round-trips correctly, matching what the webhook and issue-sync code expect.

