### PR TITLE
feat(sso): per-provider profile mapping for non-standard OIDC IdPs

### DIFF
--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-editor.test.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-editor.test.tsx
@@ -91,6 +91,7 @@ function makeProvider(over: Partial<IdentityProvider>): IdentityProvider {
     autoCreateUsers: true,
     autoProvisionRole: 'user',
     attributeMapping: null,
+    profileMapping: null,
     showButton: false,
     detailsChangedAt: null,
     lastSuccessfulTestAt: null,

--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-list.test.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-list.test.tsx
@@ -106,6 +106,7 @@ function makeProvider(over: Partial<IdentityProvider>): IdentityProvider {
     autoCreateUsers: true,
     autoProvisionRole: 'user',
     attributeMapping: null,
+    profileMapping: null,
     showButton: false,
     detailsChangedAt: null,
     lastSuccessfulTestAt: null,

--- a/apps/web/src/lib/server/auth/__tests__/provider-registration.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/provider-registration.test.ts
@@ -1,6 +1,12 @@
-import { describe, it, expect } from 'vitest'
-import { buildGenericOAuthConfigs } from '../build-oauth-configs'
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { buildGenericOAuthConfigs, buildProfileMappingGetUserInfo } from '../build-oauth-configs'
 import { getAllAuthProviders } from '../auth-providers'
+
+/** Unsigned JWT with the given payload — the login path never verifies. */
+function fakeJwt(payload: Record<string, unknown>): string {
+  const b64 = (o: object) => Buffer.from(JSON.stringify(o)).toString('base64url')
+  return `${b64({ alg: 'HS256', typ: 'JWT' })}.${b64(payload)}.sig`
+}
 
 describe('buildGenericOAuthConfigs', () => {
   it('registers one config per enabled provider under its registrationId', async () => {
@@ -68,6 +74,161 @@ describe('buildGenericOAuthConfigs', () => {
       tierAllowsOidc: false,
     })
     expect(cfgs).toHaveLength(0)
+  })
+})
+
+describe('profile mapping (getUserInfo)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('attaches getUserInfo only when the provider has a profileMapping', async () => {
+    const cfgs = await buildGenericOAuthConfigs({
+      providers: [
+        {
+          id: 'idp_plain',
+          registrationId: 'oidc_plain',
+          enabled: true,
+          autoCreateUsers: true,
+          discoveryUrl: 'https://x/.well-known/openid-configuration',
+        },
+        {
+          id: 'idp_eve',
+          registrationId: 'oidc_eve',
+          enabled: true,
+          autoCreateUsers: true,
+          discoveryUrl: 'https://login.eveonline.com/.well-known/openid-configuration',
+          profileMapping: { source: 'accessTokenJwt' },
+        },
+      ] as any,
+      creds: async () => ({ clientId: 'c', clientSecret: 's' }),
+      tierAllowsOidc: true,
+    })
+    expect(cfgs).toHaveLength(2)
+    expect(cfgs.find((c) => c.providerId === 'oidc_plain')?.getUserInfo).toBeUndefined()
+    expect(cfgs.find((c) => c.providerId === 'oidc_eve')?.getUserInfo).toBeTypeOf('function')
+  })
+
+  it('accessTokenJwt: decodes the access token and synthesizes a sanitized fallback email', async () => {
+    const getUserInfo = buildProfileMappingGetUserInfo(
+      { userInfoUrl: null, discoveryUrl: 'https://login.eveonline.com/.well-known/oidc' },
+      { source: 'accessTokenJwt', emailFallback: '{id}@eve.example.com' }
+    )
+    const user = await getUserInfo({
+      accessToken: fakeJwt({
+        sub: 'CHARACTER:EVE:2119123456',
+        name: 'Some Pilot',
+        owner: 'abc123=',
+      }),
+    })
+    expect(user).toMatchObject({
+      id: 'CHARACTER:EVE:2119123456',
+      name: 'Some Pilot',
+      email: 'character.eve.2119123456@eve.example.com',
+      emailVerified: true,
+    })
+    // Raw claims are spread through for mapProfileToUser consumers.
+    expect(user?.owner).toBe('abc123=')
+  })
+
+  it('accessTokenJwt: prefers a real email claim over the fallback', async () => {
+    const getUserInfo = buildProfileMappingGetUserInfo(
+      { userInfoUrl: null, discoveryUrl: null },
+      { source: 'accessTokenJwt', emailFallback: '{id}@sso.example.com' }
+    )
+    const user = await getUserInfo({
+      accessToken: fakeJwt({ sub: 'u1', name: 'N', email: 'real@example.com' }),
+    })
+    expect(user?.email).toBe('real@example.com')
+    // Claim-sourced email is only verified when the IdP says so.
+    expect(user?.emailVerified).toBe(false)
+  })
+
+  it('accessTokenJwt: returns null on a malformed token or missing id claim', async () => {
+    const getUserInfo = buildProfileMappingGetUserInfo(
+      { userInfoUrl: null, discoveryUrl: null },
+      { source: 'accessTokenJwt' }
+    )
+    expect(await getUserInfo({ accessToken: 'not-a-jwt' })).toBeNull()
+    expect(await getUserInfo({})).toBeNull()
+    expect(await getUserInfo({ accessToken: fakeJwt({ name: 'no sub here' }) })).toBeNull()
+  })
+
+  it('accessTokenJwt: omits email when absent and no fallback is configured', async () => {
+    // Better-Auth then reports the accurate email_is_missing error.
+    const getUserInfo = buildProfileMappingGetUserInfo(
+      { userInfoUrl: null, discoveryUrl: null },
+      { source: 'accessTokenJwt' }
+    )
+    const user = await getUserInfo({ accessToken: fakeJwt({ sub: 'u1', name: 'N' }) })
+    expect(user?.id).toBe('u1')
+    expect(user?.email).toBeUndefined()
+  })
+
+  it('userinfo: fetches the row userInfoUrl with the bearer token and maps custom claim paths', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        CharacterID: 2119123456,
+        CharacterName: 'Some Pilot',
+        email_verified: true,
+        contact: { email: 'pilot@example.com' },
+      }),
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const getUserInfo = buildProfileMappingGetUserInfo(
+      { userInfoUrl: 'https://idp.example.com/userinfo', discoveryUrl: null },
+      {
+        source: 'userinfo',
+        idClaim: 'CharacterID',
+        nameClaim: 'CharacterName',
+        emailClaim: 'contact.email',
+      }
+    )
+    const user = await getUserInfo({ accessToken: 'opaque-token' })
+    expect(fetchMock).toHaveBeenCalledWith('https://idp.example.com/userinfo', {
+      headers: { authorization: 'Bearer opaque-token' },
+    })
+    expect(user).toMatchObject({
+      id: '2119123456',
+      name: 'Some Pilot',
+      email: 'pilot@example.com',
+      emailVerified: true,
+    })
+  })
+
+  it('userinfo: resolves the endpoint from discovery once and caches it', async () => {
+    const fetchMock = vi.fn(async (url: string) =>
+      url === 'https://idp.example.com/.well-known/openid-configuration'
+        ? { ok: true, json: async () => ({ userinfo_endpoint: 'https://idp.example.com/me' }) }
+        : { ok: true, json: async () => ({ sub: 'u1', name: 'N', email: 'e@example.com' }) }
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const getUserInfo = buildProfileMappingGetUserInfo(
+      {
+        userInfoUrl: null,
+        discoveryUrl: 'https://idp.example.com/.well-known/openid-configuration',
+      },
+      { source: 'userinfo' }
+    )
+    expect((await getUserInfo({ accessToken: 't1' }))?.id).toBe('u1')
+    expect((await getUserInfo({ accessToken: 't2' }))?.id).toBe('u1')
+    // 1 discovery fetch + 2 userinfo fetches — discovery cached after the first.
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('userinfo: returns null when the userinfo fetch fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, json: async () => ({}) }))
+    )
+    const getUserInfo = buildProfileMappingGetUserInfo(
+      { userInfoUrl: 'https://idp.example.com/userinfo', discoveryUrl: null },
+      { source: 'userinfo' }
+    )
+    expect(await getUserInfo({ accessToken: 't' })).toBeNull()
   })
 })
 

--- a/apps/web/src/lib/server/auth/build-oauth-configs.ts
+++ b/apps/web/src/lib/server/auth/build-oauth-configs.ts
@@ -20,6 +20,7 @@
  */
 
 import type { IdentityProvider } from '@/lib/server/domains/settings/identity-providers.service'
+import type { IdentityProviderProfileMapping } from '@/lib/server/db'
 
 /**
  * Default OIDC scopes requested when a provider has no explicit `scopes`.
@@ -27,6 +28,19 @@ import type { IdentityProvider } from '@/lib/server/domains/settings/identity-pr
  * same scope request production sign-in will make.
  */
 export const DEFAULT_OIDC_SCOPES = ['openid', 'email', 'profile'] as const
+
+/**
+ * Profile shape returned by a custom `getUserInfo`. The mapped identity
+ * fields satisfy Better-Auth's `OAuth2UserInfo`; the raw claims are spread
+ * alongside so `mapProfileToUser` (locale) still sees them.
+ */
+export type MappedUserInfo = {
+  id: string
+  name?: string
+  email?: string
+  image?: string
+  emailVerified: boolean
+} & Record<string, unknown>
 
 /** A single entry in the genericOAuth plugin's `config` array. */
 export interface GenericOAuthConfig {
@@ -39,6 +53,16 @@ export interface GenericOAuthConfig {
   authorizationUrl?: string
   tokenUrl?: string
   scopes?: string[]
+  /**
+   * Custom user-info resolution, attached only when the provider row has a
+   * `profile_mapping`. Replaces Better-Auth's id_token/userinfo default for
+   * IdPs whose claims don't fit it (e.g. EVE Online: no id_token, no email,
+   * identity in the JWT access token).
+   */
+  getUserInfo?: (tokens: {
+    accessToken?: string
+    idToken?: string
+  }) => Promise<MappedUserInfo | null>
   mapProfileToUser?: (profile: unknown) => Record<string, unknown>
   // Force the IdP account picker so admins notice when they're already
   // signed in as a different identity.
@@ -66,6 +90,121 @@ export type ProviderCredentials = {
   clientSecret?: string
   discoveryUrl?: string
 } | null
+
+/** Resolve a dotted claim path (same convention as `attributeMapping.claimPath`). */
+function resolveClaim(claims: Record<string, unknown>, path: string): unknown {
+  // Namespaced claims (e.g. "https://acme.com/roles") contain dots that are
+  // not path separators — prefer an exact key match before splitting.
+  if (path in claims) return claims[path]
+  let current: unknown = claims
+  for (const segment of path.split('.')) {
+    if (current === null || typeof current !== 'object') return undefined
+    current = (current as Record<string, unknown>)[segment]
+  }
+  return current
+}
+
+/** Decode a JWT's payload without verification — mirrors how Better-Auth's
+ *  generic-oauth login path treats id_tokens (bare `decodeJwt`). The token
+ *  was just received first-hand from the IdP's token endpoint over TLS, so
+ *  possession is the trust anchor; there is no third-party token to verify. */
+function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  const parts = token.split('.')
+  if (parts.length !== 3) return null
+  try {
+    const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf-8'))
+    return payload !== null && typeof payload === 'object'
+      ? (payload as Record<string, unknown>)
+      : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Synthesize an address from the `emailFallback` template. The `{id}`
+ * placeholder is sanitized to `[a-z0-9._-]` so a structured id like EVE's
+ * `CHARACTER:EVE:2119…` becomes a valid local part (`character.eve.2119…`).
+ */
+function synthesizeEmail(template: string, id: string): string {
+  const sanitized = id
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '.')
+    .replace(/^\.+|\.+$/g, '')
+  return template.replaceAll('{id}', sanitized)
+}
+
+/**
+ * Build the custom `getUserInfo` for a provider with a `profile_mapping`.
+ *
+ * Claim source is either the JWT access token's payload (`accessTokenJwt`)
+ * or the provider's userinfo endpoint (`userinfo` — the row's `userInfoUrl`,
+ * else resolved from the discovery document once and cached). Identity
+ * fields resolve via the configured claim paths; a missing email falls back
+ * to the `emailFallback` template (such users are marked emailVerified —
+ * there is no real inbox to verify). Returns null (→ Better-Auth's
+ * `user_info_is_missing` redirect) when claims can't be obtained or the id
+ * claim is absent.
+ */
+export function buildProfileMappingGetUserInfo(
+  provider: Pick<IdentityProvider, 'userInfoUrl' | 'discoveryUrl'>,
+  mapping: IdentityProviderProfileMapping
+): NonNullable<GenericOAuthConfig['getUserInfo']> {
+  // Discovery resolution is once-per-auth-instance: the closure lives as
+  // long as the built config, which resetAuth() discards on config change.
+  let cachedUserInfoUrl: string | null = provider.userInfoUrl
+
+  async function fetchClaims(accessToken: string): Promise<Record<string, unknown> | null> {
+    if (!cachedUserInfoUrl && provider.discoveryUrl) {
+      const res = await fetch(provider.discoveryUrl)
+      if (!res.ok) return null
+      const doc = (await res.json()) as { userinfo_endpoint?: unknown }
+      if (typeof doc.userinfo_endpoint !== 'string') return null
+      cachedUserInfoUrl = doc.userinfo_endpoint
+    }
+    if (!cachedUserInfoUrl) return null
+    const res = await fetch(cachedUserInfoUrl, {
+      headers: { authorization: `Bearer ${accessToken}` },
+    })
+    if (!res.ok) return null
+    const claims = (await res.json()) as unknown
+    return claims !== null && typeof claims === 'object'
+      ? (claims as Record<string, unknown>)
+      : null
+  }
+
+  return async (tokens) => {
+    if (!tokens.accessToken) return null
+
+    const claims =
+      mapping.source === 'accessTokenJwt'
+        ? decodeJwtPayload(tokens.accessToken)
+        : await fetchClaims(tokens.accessToken)
+    if (!claims) return null
+
+    const id = resolveClaim(claims, mapping.idClaim ?? 'sub')
+    if (id === undefined || id === null || id === '') return null
+
+    const name = resolveClaim(claims, mapping.nameClaim ?? 'name')
+    const emailClaim = resolveClaim(claims, mapping.emailClaim ?? 'email')
+    let email = typeof emailClaim === 'string' && emailClaim !== '' ? emailClaim : undefined
+    let emailVerified = resolveClaim(claims, 'email_verified') === true
+    if (!email && mapping.emailFallback) {
+      email = synthesizeEmail(mapping.emailFallback, String(id))
+      emailVerified = true
+    }
+
+    // A still-missing email is returned as-is so Better-Auth reports the
+    // accurate `email_is_missing` (not `user_info_is_missing`).
+    return {
+      ...claims,
+      id: String(id),
+      ...(typeof name === 'string' && name !== '' ? { name } : {}),
+      ...(email ? { email } : {}),
+      emailVerified,
+    }
+  }
+}
 
 export interface BuildGenericOAuthConfigsArgs {
   providers: IdentityProvider[]
@@ -139,6 +278,11 @@ export async function buildGenericOAuthConfigs({
       // handleOAuthUserInfo before any user/session is created. Existing
       // users still link via accountLinking.trustedProviders.
       disableSignUp: provider.autoCreateUsers === false,
+      // Custom profile-claim resolution (opt-in via the profile_mapping
+      // column) for IdPs whose user info doesn't fit the OIDC defaults.
+      ...(provider.profileMapping
+        ? { getUserInfo: buildProfileMappingGetUserInfo(provider, provider.profileMapping) }
+        : {}),
       ...(mapProfileToUser ? { mapProfileToUser } : {}),
       ...(buildLoginHintParams ? { authorizationUrlParams: buildLoginHintParams } : {}),
     })

--- a/apps/web/src/lib/server/db.ts
+++ b/apps/web/src/lib/server/db.ts
@@ -275,7 +275,10 @@ export {
 
 // Re-export schema types not covered by @quackback/db/types
 export type { ServiceMetadata } from '@quackback/db'
-export type { IdentityProviderAttributeMapping } from '@quackback/db'
+export type {
+  IdentityProviderAttributeMapping,
+  IdentityProviderProfileMapping,
+} from '@quackback/db'
 
 // Re-export types (for client components that need types without side effects)
 export * from '@quackback/db/types'

--- a/apps/web/src/lib/server/domains/settings/identity-providers.service.ts
+++ b/apps/web/src/lib/server/domains/settings/identity-providers.service.ts
@@ -20,6 +20,7 @@ import {
   identityProvider,
   ssoVerifiedDomain,
   type IdentityProviderAttributeMapping,
+  type IdentityProviderProfileMapping,
 } from '@/lib/server/db'
 import type { IdentityProviderId } from '@quackback/ids'
 import { logger } from '@/lib/server/logger'
@@ -75,6 +76,8 @@ export interface IdentityProvider {
   autoCreateUsers: boolean
   autoProvisionRole: 'admin' | 'member' | 'user' | null
   attributeMapping: IdentityProviderAttributeMapping | null
+  /** Custom profile-claim resolution; null = Better-Auth default user info. */
+  profileMapping: IdentityProviderProfileMapping | null
   showButton: boolean
   /** ISO-8601 UTC; null until a redirect-affecting detail changes. */
   detailsChangedAt: string | null
@@ -111,6 +114,7 @@ export interface UpsertIdentityProviderInput {
   autoCreateUsers?: boolean
   autoProvisionRole?: 'admin' | 'member' | 'user' | null
   attributeMapping?: IdentityProviderAttributeMapping | null
+  profileMapping?: IdentityProviderProfileMapping | null
   showButton?: boolean
 }
 
@@ -175,6 +179,7 @@ function rowToIdentityProvider(
     autoCreateUsers: row.autoCreateUsers,
     autoProvisionRole: row.autoProvisionRole,
     attributeMapping: row.attributeMapping ?? null,
+    profileMapping: row.profileMapping ?? null,
     showButton: row.showButton,
     detailsChangedAt: row.detailsChangedAt ? row.detailsChangedAt.toISOString() : null,
     lastSuccessfulTestAt: row.lastSuccessfulTestAt ? row.lastSuccessfulTestAt.toISOString() : null,
@@ -368,6 +373,7 @@ export async function upsertIdentityProvider(
         if (input.autoCreateUsers !== undefined) patch.autoCreateUsers = input.autoCreateUsers
         if (input.autoProvisionRole !== undefined) patch.autoProvisionRole = input.autoProvisionRole
         if (input.attributeMapping !== undefined) patch.attributeMapping = input.attributeMapping
+        if (input.profileMapping !== undefined) patch.profileMapping = input.profileMapping
         if (input.showButton !== undefined) patch.showButton = input.showButton
 
         // Restamp the freshness baseline when a connection-affecting field
@@ -413,6 +419,7 @@ export async function upsertIdentityProvider(
             autoCreateUsers: input.autoCreateUsers ?? true,
             autoProvisionRole: input.autoProvisionRole ?? null,
             attributeMapping: input.attributeMapping ?? null,
+            profileMapping: input.profileMapping ?? null,
             showButton: input.showButton ?? false,
           })
           .returning()

--- a/apps/web/src/lib/server/functions/sso.ts
+++ b/apps/web/src/lib/server/functions/sso.ts
@@ -160,6 +160,23 @@ const attributeMappingSchema = z.object({
   syncOnEverySignIn: z.boolean().optional(),
 })
 
+/** Profile-claim mapping mirror of `IdentityProviderProfileMapping`. */
+const profileMappingSchema = z.object({
+  source: z.enum(['userinfo', 'accessTokenJwt']).optional(),
+  idClaim: z.string().max(256).optional(),
+  nameClaim: z.string().max(256).optional(),
+  emailClaim: z.string().max(256).optional(),
+  // Must contain exactly one @ so the synthesized value is a plausible
+  // address; {id} substitution is sanitized in build-oauth-configs.
+  emailFallback: z
+    .string()
+    .max(320)
+    .refine((t) => t.split('@').length === 2 && t.split('@')[1].length > 0, {
+      message: 'emailFallback must be an email template like {id}@sso.example.com',
+    })
+    .optional(),
+})
+
 /**
  * Identity-provider registrationIds are restricted to the generated `oidc_`
  * namespace plus the two legacy ids (`sso` / `custom-oidc`). This blocks
@@ -195,6 +212,7 @@ const upsertIdentityProviderInput = z.object({
   autoCreateUsers: z.boolean().optional(),
   autoProvisionRole: idpRole.nullable().optional(),
   attributeMapping: attributeMappingSchema.nullable().optional(),
+  profileMapping: profileMappingSchema.nullable().optional(),
   showButton: z.boolean().optional(),
 })
 

--- a/packages/db/drizzle/0126_identity_provider_profile_mapping.sql
+++ b/packages/db/drizzle/0126_identity_provider_profile_mapping.sql
@@ -1,0 +1,7 @@
+-- Per-provider profile-claim mapping for IdPs whose user info doesn't fit the
+-- OIDC defaults (sub/name/email from the id_token or userinfo endpoint).
+-- Shape: { source?: 'userinfo' | 'accessTokenJwt', idClaim?, nameClaim?,
+-- emailClaim?, emailFallback? } — see IdentityProviderProfileMapping in
+-- packages/db/src/schema/auth.ts. Nullable: NULL keeps Better-Auth's default
+-- user-info resolution, so existing providers are untouched.
+ALTER TABLE "identity_provider" ADD COLUMN "profile_mapping" jsonb;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -883,6 +883,13 @@
       "when": 1783641600000,
       "tag": "0125_conversation_channel_drop_default",
       "breakpoints": true
+    },
+    {
+      "idx": 126,
+      "version": "7",
+      "when": 1783728000000,
+      "tag": "0126_identity_provider_profile_mapping",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -344,6 +344,43 @@ export type IdentityProviderAttributeMapping = {
 }
 
 /**
+ * Per-provider profile-claim mapping for IdPs whose user info doesn't fit
+ * the OIDC defaults (`sub`/`name`/`email` from the id_token or userinfo
+ * endpoint). When set, the auth builder attaches a custom `getUserInfo`
+ * to the provider's generic-oauth config. Declared here (like
+ * `IdentityProviderAttributeMapping`) so the jsonb column is typed
+ * without coupling the db package to the app layer.
+ *
+ * Example: EVE Online SSO returns no id_token and no email; its JWT
+ * access token carries `sub`/`name`, so
+ * `{ source: 'accessTokenJwt', emailFallback: '{id}@eve.example.com' }`
+ * makes sign-in work.
+ */
+export type IdentityProviderProfileMapping = {
+  /**
+   * Where profile claims come from. `userinfo` fetches the provider's
+   * userinfo endpoint (mapping applied on top); `accessTokenJwt` decodes
+   * the JWT access token's payload. Default `userinfo`.
+   */
+  source?: 'userinfo' | 'accessTokenJwt'
+  /** Claim path for the account id. Default `sub`. */
+  idClaim?: string
+  /** Claim path for the display name. Default `name`. */
+  nameClaim?: string
+  /** Claim path for the email. Default `email`. */
+  emailClaim?: string
+  /**
+   * Template used when the email claim is absent, e.g.
+   * `"{id}@sso.example.com"`. `{id}` is the resolved id-claim value
+   * sanitized to `[a-z0-9._-]`. Presence of this field is the opt-in for
+   * synthesized emails; such users are marked emailVerified (there is no
+   * real inbox to verify) and can never receive notifications or magic
+   * links.
+   */
+  emailFallback?: string
+}
+
+/**
  * Identity provider — the single source of truth for an OIDC IdP.
  *
  * Consolidates the two legacy OIDC config models. `id` is the internal
@@ -390,6 +427,8 @@ export const identityProvider = pgTable(
     autoCreateUsers: boolean('auto_create_users').notNull().default(true),
     autoProvisionRole: text('auto_provision_role').$type<'admin' | 'member' | 'user'>(),
     attributeMapping: jsonb('attribute_mapping').$type<IdentityProviderAttributeMapping>(),
+    /** Non-null opts this provider into custom profile-claim resolution. */
+    profileMapping: jsonb('profile_mapping').$type<IdentityProviderProfileMapping>(),
     showButton: boolean('show_button').notNull().default(false),
     /** Bumped when redirect-affecting details change; freshness baseline. */
     detailsChangedAt: timestamp('details_changed_at', { withTimezone: true }),


### PR DESCRIPTION
## Problem

Some OIDC providers can't complete sign-in through the Custom OIDC (generic-oauth) path because their user info doesn't fit Better-Auth's default resolution — id_token claims, or a userinfo endpoint returning `sub`/`name`/`email`.

Concrete motivating case, **EVE Online SSO** (`login.eveonline.com`, [docs](https://developers.eveonline.com/docs/services/sso/)):

- Advertises OIDC discovery but **returns no id_token** at all
- Its userinfo endpoint (`/v2/oauth/verify`) returns PascalCase fields (`CharacterID`, `CharacterName`, …) with **no `sub`/`id`**
- **Never releases an email** — EVE identities don't have one
- The actual identity lives in the **JWT access token**: `sub: "CHARACTER:EVE:<id>"`, `name: "<character name>"`

Result today: authorization + PKCE + token exchange all succeed, then the callback dies with `user_info_is_missing`. (Verified live before writing this patch.)

This is shaped as a **generic per-provider profile mapping**, not an EVE special case — the same mechanism covers any IdP with non-standard claim names, claims nested in objects, or identities without email.

## What this adds

A nullable `identity_provider.profile_mapping` jsonb column:

```ts
interface IdentityProviderProfileMapping {
  /** Where profile claims come from. 'userinfo' (default) = fetch the
   *  userinfo endpoint, mapping applied on top; 'accessTokenJwt' decodes
   *  the JWT access token's payload. */
  source?: 'userinfo' | 'accessTokenJwt'
  idClaim?: string // default 'sub'   — dotted paths supported
  nameClaim?: string // default 'name'
  emailClaim?: string // default 'email'
  /** Template used when the email claim is absent, e.g. "{id}@sso.example.com".
   *  {id} = resolved id claim, sanitized to [a-z0-9._-]. Presence of this
   *  field is the opt-in for synthesized emails; such users are marked
   *  emailVerified (no real inbox exists to verify). */
  emailFallback?: string
}
```

When `profile_mapping` is non-null, `buildGenericOAuthConfigs` attaches a custom `getUserInfo` to that provider's generic-oauth config:

- **`accessTokenJwt`** — decodes the access token's payload (unverified, matching the trust model of the login path's existing bare `decodeJwt` of id_tokens: the token arrives first-hand from the token endpoint over TLS; possession is the trust anchor)
- **`userinfo`** — fetches the row's `userInfoUrl` (or resolves `userinfo_endpoint` from the discovery document once, cached per auth instance) with the bearer token, then maps claims on top

Claim resolution supports dotted paths with an exact-key match preferred first (so namespaced claims like `https://acme.com/email` still work). A missing email with no fallback is returned as-is so Better-Auth reports the accurate `email_is_missing` rather than `user_info_is_missing`. Providers without a mapping are completely untouched — no behavior change.

Composes cleanly with the existing `mapProfileToUser` locale passthrough: raw claims are spread into the returned profile, and Better-Auth falls back to the `getUserInfo` result for `id`/`email`/`name`.

## Example: working EVE Online provider row

```
discovery_url:   https://login.eveonline.com/.well-known/openid-configuration
scopes:          ' '   (single space — EVE auth-only apps reject any scope, including openid)
profile_mapping: {"source": "accessTokenJwt", "emailFallback": "{id}@sso.example.com"}
```

Signs in as the character: user `<Character Name>`, account_id `CHARACTER:EVE:<id>`, email `character.eve.<id>@sso.example.com` (verified, synthesized).

## Files changed

- `packages/db/src/schema/auth.ts` — `IdentityProviderProfileMapping` type + `profile_mapping` jsonb column
- `packages/db/drizzle/0126_identity_provider_profile_mapping.sql` — migration (hand-authored, matching recent migrations' convention)
- `apps/web/src/lib/server/auth/build-oauth-configs.ts` — `getUserInfo` factory (`buildProfileMappingGetUserInfo`), kept pure/no DB imports per the file's philosophy
- `apps/web/src/lib/server/domains/settings/identity-providers.service.ts` — carry `profileMapping` through the interface, list mapping, and upsert (patch semantics preserved)
- `apps/web/src/lib/server/functions/sso.ts` — zod schema for the new field (emailFallback validated as an email-shaped template)
- Tests: 9 new cases in `provider-registration.test.ts` covering attach-only-when-configured, JWT decode + claim mapping, email synthesis + sanitization, real-email preference, malformed-token/missing-id nulls, userinfo fetch with custom claim paths, discovery resolution + caching, and fetch-failure handling

## Verified

- Unit: 12/12 in `provider-registration.test.ts`; monorepo lint 0 errors; typecheck adds no new errors over `main`
- **Live end-to-end**: full docker-compose.prod stack built from this branch; real EVE character login through the portal button → callback `302`, JIT user + `oidc_eve` account + session created, synthesized verified email, no `/api/auth/error` bounce

## Known limitations (called out, not regressions)

1. **Admin "Test sign-in" diagnostic** (`sso-test-handshake.ts`) hard-requires an id_token + JWKS verification, so it will always fail for an `accessTokenJwt` provider. Sign-in itself works; only the *SSO enforcement* unlock is gated on a passing test. Teaching the handshake about profile mapping is a natural follow-up.
2. **Role `attributeMapping`** reads claims from the stored `account.id_token`, so `accessTokenJwt` providers resolve the default role. Follow-up could read the access-token claims when the provider's mapping source says so.
3. **No editor UI yet** — this PR is deliberately backend-only to get agreement on the mechanism first. If the approach lands, a follow-up adds a Scopes field (the column + API already exist but the editor renders no input) and an "Advanced" profile-mapping section to `provider-editor.tsx`. Until then the field is settable via the upsert server function.
4. Synthesized-email users can't receive notifications or magic links (documented on the type; inherent to email-less IdPs).
5. Reproducing the EVE case requires EVE developer credentials, which can't be created without an account that has purchased game time — reviewers may not be able to test against EVE directly. The `userinfo` mapping path is testable with any IdP (or the unit tests' mocked flows), and I'm happy to work together to get the `accessTokenJwt` path verified on your side.

I really like what you're doing with this project, and I'd like to use it with a couple of apps that I build, but requiring an email is a non-starter for my audience. I took this PR-first approach to show a working example of what I'm trying to do, but I'm not super tied to any aspect of it as long as I can get to a point where there's a working "sign in with eve online" option. Happy to contribute UI as well but wanted to get on the same page with the backend options first.
