### PR TITLE
fix(api): keep images when a post also contains emoji nodes

### DIFF
--- a/apps/web/src/lib/server/__tests__/markdown-tiptap.test.ts
+++ b/apps/web/src/lib/server/__tests__/markdown-tiptap.test.ts
@@ -236,6 +236,53 @@ describe('contentJsonToMarkdown', () => {
     expect(result).toContain('![S](https://cdn.example.com/s.png)')
   })
 
+  test('keeps emoji (as the Unicode character) when restoring an image', () => {
+    // The reported bug: a post written with the `:` emoji picker made the whole
+    // document non-reserializable, so the API fell back to stored markdown —
+    // which has the shortcodes but not the images. Both must survive.
+    const doc = {
+      type: 'doc' as const,
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'We shipped it ' },
+            { type: 'emoji', attrs: { name: 'tada' } },
+          ],
+        },
+        { type: 'image', attrs: { src: 'https://cdn.example.com/s.png', alt: 'S', title: null } },
+      ],
+    }
+    const result = contentJsonToMarkdown(doc, 'We shipped it :tada:')
+    expect(result).toContain('We shipped it 🎉')
+    expect(result).not.toContain(':tada:')
+    expect(result).toContain('![S](https://cdn.example.com/s.png)')
+  })
+
+  test('prefers an emoji node’s stored character over the shortcode table', () => {
+    const doc = {
+      type: 'doc' as const,
+      content: [
+        { type: 'paragraph', content: [{ type: 'emoji', attrs: { name: 'tada', emoji: '🎊' } }] },
+        { type: 'image', attrs: { src: 'https://cdn.example.com/s.png', alt: 'S', title: null } },
+      ],
+    }
+    expect(contentJsonToMarkdown(doc, 'stored')).toContain('🎊')
+  })
+
+  test('keeps a custom emoji as its shortcode when it has no Unicode character', () => {
+    // Workspace-uploaded emoji are image-backed and have no character to emit;
+    // `:name:` is what the editor round-trips them as.
+    const doc = {
+      type: 'doc' as const,
+      content: [
+        { type: 'paragraph', content: [{ type: 'emoji', attrs: { name: 'quackback_logo' } }] },
+        { type: 'image', attrs: { src: 'https://cdn.example.com/s.png', alt: 'S', title: null } },
+      ],
+    }
+    expect(contentJsonToMarkdown(doc, 'stored')).toContain(':quackback_logo:')
+  })
+
   test('keeps stored markdown when an image coexists with an unsupported node', () => {
     // A youtube embed has no server renderer; re-serializing would drop it, so
     // the whole document keeps its stored markdown (image not re-derived) rather

--- a/apps/web/src/lib/server/markdown-tiptap.ts
+++ b/apps/web/src/lib/server/markdown-tiptap.ts
@@ -12,6 +12,7 @@ import StarterKit from '@tiptap/starter-kit'
 import Link from '@tiptap/extension-link'
 import Underline from '@tiptap/extension-underline'
 import Image from '@tiptap/extension-image'
+import { emojis as defaultEmojis } from '@tiptap/extension-emoji'
 import TaskList from '@tiptap/extension-task-list'
 import TaskItem from '@tiptap/extension-task-item'
 import { Table } from '@tiptap/extension-table'
@@ -81,11 +82,11 @@ const IMAGE_NODE_TYPES = new Set(['image', 'resizableImage'])
 
 /**
  * Node types this module can faithfully turn into markdown: the server
- * manager's own nodes (see SERVER_EXTENSIONS) plus the two we normalize below
- * (`resizableImage` -> `image`, `mention` -> text). Anything else — `youtube`,
- * `quackbackEmbed`, `emoji`, future custom nodes — would be silently dropped by
- * the narrower server manager, so a document containing one keeps its stored
- * markdown (which the client serialized with full coverage) instead.
+ * manager's own nodes (see SERVER_EXTENSIONS) plus the three we normalize below
+ * (`resizableImage` -> `image`, `mention` -> text, `emoji` -> text). Anything
+ * else — `youtube`, `quackbackEmbed`, future custom nodes — would be silently
+ * dropped by the narrower server manager, so a document containing one keeps
+ * its stored markdown (which the client serialized with full coverage) instead.
  */
 const RESERIALIZABLE_NODE_TYPES = new Set([
   'doc',
@@ -108,6 +109,7 @@ const RESERIALIZABLE_NODE_TYPES = new Set([
   'image',
   'resizableImage',
   'mention',
+  'emoji',
 ])
 
 /**
@@ -165,9 +167,10 @@ function isReserializable(node: JSONContent): boolean {
 
 /**
  * Rewrite the editor's custom nodes into ones @tiptap/markdown can serialize:
- * `resizableImage` -> `image` (shares src/alt but has no markdown spec) and
- * `mention` -> the `@label` text the directive would otherwise hide. Only
- * called once {@link isReserializable} has cleared the tree.
+ * `resizableImage` -> `image` (shares src/alt but has no markdown spec),
+ * `mention` -> the `@label` text the directive would otherwise hide, and
+ * `emoji` -> its Unicode character. Only called once {@link isReserializable}
+ * has cleared the tree.
  */
 function normalizeForMarkdown(node: JSONContent): JSONContent {
   if (node.type === 'mention') {
@@ -175,9 +178,27 @@ function normalizeForMarkdown(node: JSONContent): JSONContent {
     const label = (attrs.label as string) || (attrs.id as string) || 'mention'
     return { type: 'text', text: `@${label}` }
   }
+  if (node.type === 'emoji') {
+    return { type: 'text', text: emojiNodeToText(node) }
+  }
   const next = node.type === 'resizableImage' ? { ...node, type: 'image' } : node
   if (!Array.isArray(next.content)) return next
   return { ...next, content: next.content.map(normalizeForMarkdown) }
+}
+
+/**
+ * The text an `emoji` node serializes to. `@tiptap/extension-emoji` persists
+ * `{ name }` and only sometimes the character itself, so fall back to the
+ * shortcode table, and to `:name:` for a custom emoji that has no Unicode
+ * equivalent — the same text the editor round-trips it as.
+ */
+function emojiNodeToText(node: JSONContent): string {
+  const attrs = node.attrs ?? {}
+  const stored = attrs.emoji
+  if (typeof stored === 'string' && stored) return stored
+  const name = typeof attrs.name === 'string' ? attrs.name : ''
+  if (!name) return ''
+  return defaultEmojis.find((e) => e.emoji && e.shortcodes.includes(name))?.emoji ?? `:${name}:`
 }
 
 /**


### PR DESCRIPTION
### Problem

`contentJsonToMarkdown()` only re-serializes `contentJson` when **every** node is in
`RESERIALIZABLE_NODE_TYPES`. `emoji` was not in that set, so any post written with the `:` emoji
picker fell back to the stored `content` column — which is precisely the column that loses images
(the bug #317 fixed for everything else).

So a changelog entry containing *both* a screenshot and an emoji comes back from
`GET /api/v1/changelog` (and the MCP tools) with **no images at all**, and with raw `:tada:`
shortcodes instead of the emoji. Mixing an image and an emoji in one post is common in changelogs,
so this quietly undoes #317 for a large share of real entries.

Reproduce: write a changelog entry in the editor with an uploaded image and one picker emoji,
publish it, then `GET /api/v1/changelog?published=true` — the markdown has neither the image nor
the emoji character.

### Fix

Teach `normalizeForMarkdown()` about the node rather than excluding the whole document:

- `emoji` joins `RESERIALIZABLE_NODE_TYPES`
- an `emoji` node becomes a text node holding its Unicode character — `attrs.emoji` when the editor
  stored it, else the `@tiptap/extension-emoji` shortcode table (the same lookup order
  `rich-text-editor.tsx` already uses for HTML)
- image-backed **custom** emoji have no character, so they keep `:name:` — the text the editor
  round-trips them as

Images now survive alongside emoji, and emoji read as emoji in markdown consumers.

### Tests

Three cases added to `markdown-tiptap.test.ts` (40 pass):

- an image + `:tada:` emoji doc → keeps `![S](…)` **and** renders `🎉`, no leftover shortcode
- `attrs.emoji` wins over the shortcode table
- a custom emoji with no Unicode character stays `:quackback_logo:`

`bun run test apps/web/src/lib/server/__tests__/markdown-tiptap.test.ts` — 40/40.
Lint clean on both files. Repo-wide `typecheck` is red on `main` at 513 errors both with and
without this change (pre-existing, unrelated to these files).
