### PR TITLE
fix(auth): use prompt=login instead of select_account for OIDC sign-in

### DIFF
--- a/apps/web/src/lib/server/auth/__tests__/provider-registration.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/provider-registration.test.ts
@@ -23,6 +23,23 @@ describe('buildGenericOAuthConfigs', () => {
     expect(cfgs[0].disableSignUp).toBe(false)
   })
 
+  it('requests the broadly-supported prompt=login, not the OIDC-optional select_account', async () => {
+    const cfgs = await buildGenericOAuthConfigs({
+      providers: [
+        {
+          id: 'idp_abc',
+          registrationId: 'sso',
+          enabled: true,
+          autoCreateUsers: true,
+          discoveryUrl: 'https://x/.well-known/openid-configuration',
+        },
+      ] as any,
+      creds: async () => ({ clientId: 'c', clientSecret: 's' }),
+      tierAllowsOidc: true,
+    })
+    expect(cfgs[0].prompt).toBe('login')
+  })
+
   it('skips disabled providers and providers without credentials', async () => {
     const cfgs = await buildGenericOAuthConfigs({
       providers: [

--- a/apps/web/src/lib/server/auth/build-oauth-configs.ts
+++ b/apps/web/src/lib/server/auth/build-oauth-configs.ts
@@ -132,7 +132,7 @@ export async function buildGenericOAuthConfigs({
       pkce: true,
       // Force the account picker so an admin typing a specific email isn't
       // silently signed in as whoever the IdP already has a session for.
-      prompt: 'select_account',
+      prompt: 'login',
       // Better-Auth's JIT block. When false, the OAuth callback aborts in
       // handleOAuthUserInfo before any user/session is created. Existing
       // users still link via accountLinking.trustedProviders.


### PR DESCRIPTION
Fixes: https://github.com/QuackbackIO/quackback/issues/346

## Summary
Custom OIDC sign-in fails for identity providers that don't implement the optional prompt=select_account value. buildGenericOAuthConfigs hardcodes prompt: 'select_account' for every provider, so the authorization request is rejected before authentication and the user is bounced back to /?error=invalid_request.

## Reproduction
Configure a Custom OIDC provider backed by Clerk (https://<tenant>/.well-known/openid-configuration).
Run Test sign-in — succeeds.
Attempt a normal sign-in via the provider button / verified-domain routing — fails and redirects to:
/?error=invalid_request&error_description=...Used+unknown+value+'[select_account]'+for+prom

## Root cause
apps/web/src/lib/server/auth/build-oauth-configs.ts sends prompt: 'select_account' on every generic-OAuth config. select_account is optional per [OIDC Core §3.1.2.1](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest); providers that don't support it (Clerk, and others) return invalid_request rather than ignoring it.

This also explains why Test sign-in passes but real sign-in fails: the SSO test flow in apps/web/src/lib/server/functions/sso-test.ts already uses prompt: 'login', so the test never exercised the value production actually sends.

## Fix
Send prompt: 'login' in production, matching the SSO test flow. login is broadly supported (Clerk, Okta, Auth0, Entra, Google, Keycloak) and preserves the original intent — forcing re-authentication so an admin isn't silently signed in under an existing IdP session. It also removes the test/production divergence, so a passing SSO test now exercises the same prompt production uses.