### PR TITLE
chore(release): 0.13.2

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quackback/web",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "private": true,
   "license": "AGPL-3.0",
   "type": "module",


### PR DESCRIPTION
Bump `apps/web/package.json` to 0.13.2 (source of truth for `__APP_VERSION__`).

Cuts the 0.13.2 release. Tagging `v0.13.2` after this merges builds and publishes the image and attaches the OpenAPI spec.