### PR TITLE
fix(integrations): merge stored config into outbound hook targets

### DIFF
--- a/apps/web/src/lib/server/events/__tests__/integration-target-coverage.test.ts
+++ b/apps/web/src/lib/server/events/__tests__/integration-target-coverage.test.ts
@@ -33,8 +33,20 @@ vi.mock('@/lib/server/db', () => ({
     select: () => ({ from: () => ({ innerJoin: () => ({ where: () => [] }) }) }),
     query: { webhooks: { findMany: vi.fn().mockResolvedValue([]) } },
   },
-  integrations: { id: 'id', integrationType: 'integrationType', secrets: 'secrets', config: 'config', status: 'status' },
-  integrationEventMappings: { integrationId: 'integrationId', eventType: 'eventType', actionConfig: 'actionConfig', filters: 'filters', enabled: 'enabled' },
+  integrations: {
+    id: 'id',
+    integrationType: 'integrationType',
+    secrets: 'secrets',
+    config: 'config',
+    status: 'status',
+  },
+  integrationEventMappings: {
+    integrationId: 'integrationId',
+    eventType: 'eventType',
+    actionConfig: 'actionConfig',
+    filters: 'filters',
+    enabled: 'enabled',
+  },
   webhooks: { status: 'status', deletedAt: 'deletedAt', $inferSelect: {} },
   eq: vi.fn(),
   and: vi.fn(),
@@ -45,6 +57,12 @@ vi.mock('@/lib/server/db', () => ({
 
 vi.mock('@/lib/server/integrations/encryption', () => ({
   decryptSecrets: vi.fn((s: string) => JSON.parse(s)),
+}))
+vi.mock('@/lib/server/integrations/jira/access-token', () => ({
+  getJiraAccessToken: vi.fn(async (integration: { secrets: unknown }) => {
+    const parsed = JSON.parse(integration.secrets as string) as { accessToken?: string }
+    return parsed.accessToken
+  }),
 }))
 vi.mock('@/lib/server/domains/webhooks/encryption', () => ({
   decryptWebhookSecret: vi.fn((s: string) => s),
@@ -79,7 +97,10 @@ const { listIntegrationTypes, getIntegrationHook } = await import('@/lib/server/
  * Enrichment hooks that store NO channelId at connect time are listed in
  * KNOWN_UNRESOLVED below, not here — do not fabricate a channelId for them.
  */
-const CONNECTED_FIXTURES: Record<string, { integrationConfig?: Record<string, unknown>; actionConfig?: Record<string, unknown> }> = {
+const CONNECTED_FIXTURES: Record<
+  string,
+  { integrationConfig?: Record<string, unknown>; actionConfig?: Record<string, unknown> }
+> = {
   slack: { actionConfig: { channelId: 'C1' } },
   discord: { actionConfig: { channelId: 'C1' } },
   teams: { integrationConfig: { channelId: 'C1' } },

--- a/apps/web/src/lib/server/events/__tests__/targets-cache.test.ts
+++ b/apps/web/src/lib/server/events/__tests__/targets-cache.test.ts
@@ -74,6 +74,13 @@ vi.mock('@/lib/server/integrations/encryption', () => ({
   decryptSecrets: vi.fn((s: string) => JSON.parse(s)),
 }))
 
+vi.mock('@/lib/server/integrations/jira/access-token', () => ({
+  getJiraAccessToken: vi.fn(async (integration: { secrets: unknown }) => {
+    const parsed = JSON.parse(integration.secrets as string) as { accessToken?: string }
+    return parsed.accessToken
+  }),
+}))
+
 vi.mock('@/lib/server/domains/webhooks/encryption', () => ({
   decryptWebhookSecret: vi.fn((s: string) => s),
 }))
@@ -229,6 +236,101 @@ describe('integration mapping caching', () => {
     // Target was returned
     const slackTargets = targets.filter((t) => t.type === 'slack')
     expect(slackTargets).toHaveLength(1)
+  })
+})
+
+describe('integration hook config', () => {
+  function mapping(overrides: Record<string, unknown>) {
+    return {
+      eventType: 'post.created',
+      secrets: JSON.stringify({ accessToken: 'tok' }),
+      actionConfig: { channelId: 'chan' },
+      filters: null,
+      ...overrides,
+    }
+  }
+
+  async function targetsFor(row: Record<string, unknown>) {
+    mockCacheGet.mockResolvedValueOnce([row]).mockResolvedValueOnce([])
+    return getHookTargets(makePostCreatedEvent())
+  }
+
+  it('forwards stored integration config and lets accessToken/rootUrl win', async () => {
+    const [jira] = (
+      await targetsFor(
+        mapping({
+          integrationType: 'jira',
+          integrationConfig: {
+            cloudId: 'cloud-1',
+            siteUrl: 'https://ex.atlassian.net',
+            accessToken: 'stale-from-config',
+            rootUrl: 'https://should-not-use',
+          },
+          actionConfig: { channelId: '10000:10001' },
+        })
+      )
+    ).filter((t) => t.type === 'jira')
+
+    expect(jira.config).toMatchObject({
+      cloudId: 'cloud-1',
+      siteUrl: 'https://ex.atlassian.net',
+      accessToken: 'tok',
+      rootUrl: 'https://test.quackback.io',
+    })
+  })
+
+  it('forwards organizationName, apiKey, and teamId from stored config', async () => {
+    mockCacheGet
+      .mockResolvedValueOnce([
+        mapping({
+          integrationType: 'azure_devops',
+          integrationConfig: { organizationName: 'acme' },
+          actionConfig: { channelId: 'Proj:Task' },
+        }),
+        mapping({
+          integrationType: 'trello',
+          integrationConfig: { apiKey: 'key-1' },
+          actionConfig: { channelId: 'list-1' },
+        }),
+        mapping({
+          integrationType: 'teams',
+          integrationConfig: { teamId: 'team-1' },
+          actionConfig: { channelId: 'ch-1' },
+        }),
+      ])
+      .mockResolvedValueOnce([])
+
+    const targets = await getHookTargets(makePostCreatedEvent())
+    expect(targets.find((t) => t.type === 'azure_devops')?.config).toMatchObject({
+      organizationName: 'acme',
+      accessToken: 'tok',
+    })
+    expect(targets.find((t) => t.type === 'trello')?.config).toMatchObject({ apiKey: 'key-1' })
+    expect(targets.find((t) => t.type === 'teams')?.config).toMatchObject({ teamId: 'team-1' })
+  })
+
+  it('does not put inbound webhook fields on the hook job', async () => {
+    const [jira] = (
+      await targetsFor(
+        mapping({
+          integrationType: 'jira',
+          integrationConfig: {
+            cloudId: 'cloud-1',
+            webhookSecret: 'whsec_should_not_leak',
+            statusMappings: { Done: 'status_1' },
+            statusSyncEnabled: true,
+            externalWebhookId: '99',
+          },
+          actionConfig: { channelId: '10000:10001' },
+        })
+      )
+    ).filter((t) => t.type === 'jira')
+
+    expect(jira.config).toMatchObject({ cloudId: 'cloud-1', accessToken: 'tok' })
+    expect(jira.config).not.toHaveProperty('webhookSecret')
+    expect(jira.config).not.toHaveProperty('statusMappings')
+    expect(jira.config).not.toHaveProperty('statusSyncEnabled')
+    expect(jira.config).not.toHaveProperty('externalWebhookId')
   })
 })
 

--- a/apps/web/src/lib/server/events/targets.ts
+++ b/apps/web/src/lib/server/events/targets.ts
@@ -317,22 +317,29 @@ async function getIntegrationTargets(
     let accessToken: string | undefined
     if (m.secrets) {
       try {
-        if (m.integrationType === 'jira') {
-          accessToken = await getJiraAccessToken({
-            id: m.integrationId,
-            secrets: m.secrets,
-            config: m.integrationConfig,
-          })
-        } else {
-          const secrets = decryptSecrets<{ accessToken?: string }>(m.secrets)
-          accessToken = secrets.accessToken
-        }
+        const secrets = decryptSecrets<{ accessToken?: string }>(m.secrets)
+        accessToken = secrets.accessToken
       } catch (error) {
         log.error(
           { err: error, integration_type: m.integrationType },
           'failed to decrypt integration secrets'
         )
         continue
+      }
+
+      if (m.integrationType === 'jira') {
+        try {
+          accessToken = await getJiraAccessToken({
+            id: m.integrationId,
+            secrets: m.secrets,
+            config: m.integrationConfig,
+          })
+        } catch (error) {
+          log.warn(
+            { err: error, integration_type: m.integrationType },
+            'jira token refresh failed; using cached access token'
+          )
+        }
       }
     }
 

--- a/apps/web/src/lib/server/events/targets.ts
+++ b/apps/web/src/lib/server/events/targets.ts
@@ -21,6 +21,7 @@ import {
 } from '@/lib/server/db'
 import { canViewPost, type Actor } from '@/lib/server/policy'
 import { decryptSecrets } from '@/lib/server/integrations/encryption'
+import { getJiraAccessToken } from '@/lib/server/integrations/jira/access-token'
 import { decryptWebhookSecret } from '@/lib/server/domains/webhooks/encryption'
 import {
   getSubscribersForEvent,
@@ -314,18 +315,42 @@ async function getIntegrationTargets(
     let accessToken: string | undefined
     if (m.secrets) {
       try {
-        const secrets = decryptSecrets<{ accessToken?: string }>(m.secrets)
-        accessToken = secrets.accessToken
+        if (m.integrationType === 'jira') {
+          accessToken = await getJiraAccessToken({
+            secrets: m.secrets,
+            config: m.integrationConfig,
+          })
+        } else {
+          const secrets = decryptSecrets<{ accessToken?: string }>(m.secrets)
+          accessToken = secrets.accessToken
+        }
       } catch (error) {
-        log.error({ err: error, integration_type: m.integrationType }, 'failed to decrypt integration secrets')
+        log.error(
+          { err: error, integration_type: m.integrationType },
+          'failed to decrypt integration secrets'
+        )
         continue
       }
     }
 
+    // Inbound-only fields stay on the integration row; they must not ride
+    // along in hook jobs (webhookSecret especially).
+    const {
+      webhookSecret: _webhookSecret,
+      statusMappings: _statusMappings,
+      statusSyncEnabled: _statusSyncEnabled,
+      externalWebhookId: _externalWebhookId,
+      ...hookConfig
+    } = integrationConfig
+
     targets.push({
       type: m.integrationType,
       target: { channelId },
-      config: { accessToken, rootUrl: context.portalBaseUrl },
+      config: {
+        ...hookConfig,
+        accessToken,
+        rootUrl: context.portalBaseUrl,
+      },
     })
   }
 

--- a/apps/web/src/lib/server/events/targets.ts
+++ b/apps/web/src/lib/server/events/targets.ts
@@ -223,6 +223,7 @@ export async function getHookTargets(event: EventData): Promise<HookTarget[]> {
 }
 
 type CachedIntegrationMapping = {
+  integrationId: string
   eventType: string
   integrationType: string
   secrets: string | null
@@ -240,6 +241,7 @@ async function getCachedIntegrationMappings(): Promise<CachedIntegrationMapping[
 
   const mappings = await db
     .select({
+      integrationId: integrations.id,
       eventType: integrationEventMappings.eventType,
       integrationType: integrations.integrationType,
       secrets: integrations.secrets,
@@ -317,6 +319,7 @@ async function getIntegrationTargets(
       try {
         if (m.integrationType === 'jira') {
           accessToken = await getJiraAccessToken({
+            id: m.integrationId,
             secrets: m.secrets,
             config: m.integrationConfig,
           })

--- a/apps/web/src/lib/server/integrations/azure-devops/__tests__/hook.test.ts
+++ b/apps/web/src/lib/server/integrations/azure-devops/__tests__/hook.test.ts
@@ -68,6 +68,28 @@ describe('azureDevOpsHook', () => {
     expect(createWorkItem).toHaveBeenCalledWith('pat', 'acme', 'Proj', 'Task', expect.any(Object))
   })
 
+  it('maps HTTP 401 to reconnect only when organizationName is present', async () => {
+    vi.mocked(createWorkItem).mockRejectedValue(
+      Object.assign(new Error('Unauthorized'), { status: 401 })
+    )
+
+    const result = await azureDevOpsHook.run(
+      makePostCreatedEvent(),
+      { channelId: 'Proj:Task' },
+      {
+        accessToken: 'pat',
+        organizationName: 'acme',
+        rootUrl: 'https://app.example.com',
+      }
+    )
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Authentication failed. Please reconnect Azure DevOps.',
+      shouldRetry: false,
+    })
+  })
+
   it('skips non post.created events', async () => {
     const event = { type: 'comment.created' } as unknown as EventData
     expect(await azureDevOpsHook.run(event, { channelId: 'Proj:Task' }, {})).toEqual({

--- a/apps/web/src/lib/server/integrations/azure-devops/__tests__/hook.test.ts
+++ b/apps/web/src/lib/server/integrations/azure-devops/__tests__/hook.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { EventData, PostCreatedEvent } from '../../../events/types'
+
+vi.mock('../api', () => ({
+  createWorkItem: vi.fn(),
+}))
+
+import { azureDevOpsHook } from '../hook'
+import { createWorkItem } from '../api'
+
+function makePostCreatedEvent(): PostCreatedEvent {
+  return {
+    id: 'evt-1',
+    type: 'post.created',
+    timestamp: '2025-01-01T00:00:00Z',
+    actor: { type: 'user', userId: 'user_1', email: 'test@test.com' },
+    data: {
+      post: {
+        id: 'post_1',
+        title: 'Bug report',
+        content: '<p>Something broke</p>',
+        boardId: 'board_1',
+        boardSlug: 'bugs',
+        voteCount: 0,
+      },
+    },
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('azureDevOpsHook', () => {
+  it('does not treat a missing organization name as an auth failure', async () => {
+    const result = await azureDevOpsHook.run(
+      makePostCreatedEvent(),
+      { channelId: 'Proj:Task' },
+      { accessToken: 'pat', rootUrl: 'https://app.example.com' }
+    )
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Azure DevOps organization name is missing from integration config',
+      shouldRetry: false,
+    })
+    expect(createWorkItem).not.toHaveBeenCalled()
+  })
+
+  it('creates a work item when organizationName is present', async () => {
+    vi.mocked(createWorkItem).mockResolvedValue({
+      id: 42,
+      url: 'https://dev.azure.com/acme/Proj/_workitems/edit/42',
+    })
+
+    const result = await azureDevOpsHook.run(
+      makePostCreatedEvent(),
+      { channelId: 'Proj:Task' },
+      {
+        accessToken: 'pat',
+        organizationName: 'acme',
+        rootUrl: 'https://app.example.com',
+      }
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.externalId).toBe('42')
+    expect(createWorkItem).toHaveBeenCalledWith('pat', 'acme', 'Proj', 'Task', expect.any(Object))
+  })
+
+  it('skips non post.created events', async () => {
+    const event = { type: 'comment.created' } as unknown as EventData
+    expect(await azureDevOpsHook.run(event, { channelId: 'Proj:Task' }, {})).toEqual({
+      success: true,
+    })
+  })
+})

--- a/apps/web/src/lib/server/integrations/azure-devops/hook.ts
+++ b/apps/web/src/lib/server/integrations/azure-devops/hook.ts
@@ -32,6 +32,21 @@ export const azureDevOpsHook: HookHandler = {
       return { success: true }
     }
 
+    if (!organizationName) {
+      return {
+        success: false,
+        error: 'Azure DevOps organization name is missing from integration config',
+        shouldRetry: false,
+      }
+    }
+    if (!accessToken) {
+      return {
+        success: false,
+        error: 'Azure DevOps access token is missing',
+        shouldRetry: false,
+      }
+    }
+
     const [project, workItemType] = channelId.split(':')
     if (!project || !workItemType) {
       return {

--- a/apps/web/src/lib/server/integrations/jira/__tests__/access-token.test.ts
+++ b/apps/web/src/lib/server/integrations/jira/__tests__/access-token.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const hoisted = vi.hoisted(() => ({
+  decryptSecrets: vi.fn(),
+  encryptSecrets: vi.fn((s: unknown) => JSON.stringify(s)),
+  findFirst: vi.fn(),
+  updateWhere: vi.fn(),
+  eq: vi.fn((col: unknown, val: unknown) => ({ col, val })),
+  refreshJiraToken: vi.fn(),
+  getPlatformCredentials: vi.fn(),
+  cacheDel: vi.fn(),
+}))
+
+vi.mock('../../encryption', () => ({
+  decryptSecrets: (...args: unknown[]) => hoisted.decryptSecrets(...args),
+  encryptSecrets: (...args: unknown[]) => hoisted.encryptSecrets(...args),
+}))
+
+vi.mock('@/lib/server/db', () => ({
+  db: {
+    query: { integrations: { findFirst: (...args: unknown[]) => hoisted.findFirst(...args) } },
+    update: () => ({
+      set: () => ({ where: (...args: unknown[]) => hoisted.updateWhere(...args) }),
+    }),
+  },
+  integrations: { id: 'id', integrationType: 'integrationType' },
+  eq: (...args: unknown[]) => hoisted.eq(...args),
+}))
+
+vi.mock('../oauth', () => ({
+  refreshJiraToken: (...args: unknown[]) => hoisted.refreshJiraToken(...args),
+}))
+
+vi.mock('@/lib/server/domains/platform-credentials/platform-credential.service', () => ({
+  getPlatformCredentials: (...args: unknown[]) => hoisted.getPlatformCredentials(...args),
+}))
+
+vi.mock('@/lib/server/redis', () => ({
+  cacheDel: (...args: unknown[]) => hoisted.cacheDel(...args),
+  CACHE_KEYS: { INTEGRATION_MAPPINGS: 'hooks:integration-mappings' },
+}))
+
+vi.mock('@/lib/server/logger', () => ({
+  logger: { child: () => ({ info: vi.fn(), error: vi.fn(), debug: vi.fn() }) },
+}))
+
+const { getJiraAccessToken } = await import('../access-token')
+
+const ID = 'int_jira1'
+const expired = new Date(Date.now() - 60_000).toISOString()
+const fresh = new Date(Date.now() + 60 * 60_000).toISOString()
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  hoisted.decryptSecrets.mockImplementation((s: string) => JSON.parse(s))
+  hoisted.getPlatformCredentials.mockResolvedValue({ clientId: 'id', clientSecret: 'sec' })
+  hoisted.refreshJiraToken.mockResolvedValue({
+    accessToken: 'new-tok',
+    refreshToken: 'new-rt',
+    expiresIn: 3600,
+  })
+  hoisted.updateWhere.mockResolvedValue(undefined)
+  hoisted.cacheDel.mockResolvedValue(undefined)
+})
+
+describe('getJiraAccessToken', () => {
+  it('returns the current token when it is not expiring', async () => {
+    const token = await getJiraAccessToken({
+      id: ID,
+      secrets: JSON.stringify({ accessToken: 'tok', refreshToken: 'rt' }),
+      config: { tokenExpiresAt: fresh },
+    })
+
+    expect(token).toBe('tok')
+    expect(hoisted.findFirst).not.toHaveBeenCalled()
+    expect(hoisted.refreshJiraToken).not.toHaveBeenCalled()
+  })
+
+  it('does not refresh without a row id', async () => {
+    const token = await getJiraAccessToken({
+      secrets: JSON.stringify({ accessToken: 'tok', refreshToken: 'rt' }),
+      config: { tokenExpiresAt: expired },
+    })
+
+    expect(token).toBe('tok')
+    expect(hoisted.refreshJiraToken).not.toHaveBeenCalled()
+    expect(hoisted.updateWhere).not.toHaveBeenCalled()
+  })
+
+  it('uses an already-rotated row instead of replaying the cached refresh token', async () => {
+    hoisted.findFirst.mockResolvedValue({
+      secrets: JSON.stringify({ accessToken: 'db-tok', refreshToken: 'db-rt' }),
+      config: { cloudId: 'c', tokenExpiresAt: fresh },
+    })
+
+    const token = await getJiraAccessToken({
+      id: ID,
+      secrets: JSON.stringify({ accessToken: 'stale-tok', refreshToken: 'stale-rt' }),
+      config: { tokenExpiresAt: expired },
+    })
+
+    expect(token).toBe('db-tok')
+    expect(hoisted.refreshJiraToken).not.toHaveBeenCalled()
+    expect(hoisted.updateWhere).not.toHaveBeenCalled()
+  })
+
+  it('refreshes by integration id and drops the mappings cache', async () => {
+    hoisted.findFirst.mockResolvedValue({
+      secrets: JSON.stringify({ accessToken: 'stale-tok', refreshToken: 'stale-rt' }),
+      config: { cloudId: 'c', tokenExpiresAt: expired },
+    })
+
+    const token = await getJiraAccessToken({
+      id: ID,
+      secrets: JSON.stringify({ accessToken: 'stale-tok', refreshToken: 'stale-rt' }),
+      config: { tokenExpiresAt: expired },
+    })
+
+    expect(token).toBe('new-tok')
+    expect(hoisted.refreshJiraToken).toHaveBeenCalledWith('stale-rt', {
+      clientId: 'id',
+      clientSecret: 'sec',
+    })
+    expect(hoisted.updateWhere).toHaveBeenCalledWith({ col: 'id', val: ID })
+    expect(hoisted.eq).not.toHaveBeenCalledWith('integrationType', 'jira')
+    expect(hoisted.cacheDel).toHaveBeenCalledWith('hooks:integration-mappings')
+  })
+})

--- a/apps/web/src/lib/server/integrations/jira/__tests__/access-token.test.ts
+++ b/apps/web/src/lib/server/integrations/jira/__tests__/access-token.test.ts
@@ -59,7 +59,7 @@ vi.mock('@/lib/server/redis', () => ({
 }))
 
 vi.mock('@/lib/server/logger', () => ({
-  logger: { child: () => ({ info: vi.fn(), error: vi.fn(), debug: vi.fn() }) },
+  logger: { child: () => ({ info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() }) },
 }))
 
 const { getJiraAccessToken } = await import('../access-token')
@@ -149,6 +149,26 @@ describe('getJiraAccessToken', () => {
     expect(hoisted.updateWhere).toHaveBeenCalledWith({ col: 'id', val: ID })
     expect(hoisted.eq).not.toHaveBeenCalledWith('integrationType', 'jira')
     expect(hoisted.cacheDel).toHaveBeenCalledWith('hooks:integration-mappings')
+  })
+
+  it('returns the cached token when refresh throws so the hook is still enqueued', async () => {
+    hoisted.lockedRows.mockResolvedValue([
+      {
+        secrets: JSON.stringify({ accessToken: 'stale-tok', refreshToken: 'stale-rt' }),
+        config: { cloudId: 'c', tokenExpiresAt: expired },
+      },
+    ])
+    hoisted.refreshJiraToken.mockRejectedValue(new Error('Atlassian 503'))
+
+    await expect(
+      getJiraAccessToken({
+        id: ID,
+        secrets: JSON.stringify({ accessToken: 'stale-tok', refreshToken: 'stale-rt' }),
+        config: { tokenExpiresAt: expired },
+      })
+    ).resolves.toBe('stale-tok')
+    expect(hoisted.updateWhere).not.toHaveBeenCalled()
+    expect(hoisted.cacheDel).not.toHaveBeenCalled()
   })
 
   it('still returns the rotated token if dropping the mappings cache fails', async () => {

--- a/apps/web/src/lib/server/integrations/jira/__tests__/access-token.test.ts
+++ b/apps/web/src/lib/server/integrations/jira/__tests__/access-token.test.ts
@@ -3,7 +3,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 const hoisted = vi.hoisted(() => ({
   decryptSecrets: vi.fn(),
   encryptSecrets: vi.fn((s: unknown) => JSON.stringify(s)),
-  findFirst: vi.fn(),
+  lockedRows: vi.fn(),
+  forUpdate: vi.fn(),
   updateWhere: vi.fn(),
   eq: vi.fn((col: unknown, val: unknown) => ({ col, val })),
   refreshJiraToken: vi.fn(),
@@ -16,16 +17,33 @@ vi.mock('../../encryption', () => ({
   encryptSecrets: (...args: unknown[]) => hoisted.encryptSecrets(...args),
 }))
 
-vi.mock('@/lib/server/db', () => ({
-  db: {
-    query: { integrations: { findFirst: (...args: unknown[]) => hoisted.findFirst(...args) } },
+vi.mock('@/lib/server/db', () => {
+  const tx = {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          for: (mode: string) => {
+            hoisted.forUpdate(mode)
+            return hoisted.lockedRows()
+          },
+        }),
+      }),
+    }),
     update: () => ({
       set: () => ({ where: (...args: unknown[]) => hoisted.updateWhere(...args) }),
     }),
-  },
-  integrations: { id: 'id', integrationType: 'integrationType' },
-  eq: (...args: unknown[]) => hoisted.eq(...args),
-}))
+  }
+  return {
+    db: { transaction: async (fn: (t: typeof tx) => unknown) => fn(tx) },
+    integrations: {
+      id: 'id',
+      integrationType: 'integrationType',
+      secrets: 'secrets',
+      config: 'config',
+    },
+    eq: (...args: unknown[]) => hoisted.eq(...args),
+  }
+})
 
 vi.mock('../oauth', () => ({
   refreshJiraToken: (...args: unknown[]) => hoisted.refreshJiraToken(...args),
@@ -72,7 +90,7 @@ describe('getJiraAccessToken', () => {
     })
 
     expect(token).toBe('tok')
-    expect(hoisted.findFirst).not.toHaveBeenCalled()
+    expect(hoisted.forUpdate).not.toHaveBeenCalled()
     expect(hoisted.refreshJiraToken).not.toHaveBeenCalled()
   })
 
@@ -87,11 +105,13 @@ describe('getJiraAccessToken', () => {
     expect(hoisted.updateWhere).not.toHaveBeenCalled()
   })
 
-  it('uses an already-rotated row instead of replaying the cached refresh token', async () => {
-    hoisted.findFirst.mockResolvedValue({
-      secrets: JSON.stringify({ accessToken: 'db-tok', refreshToken: 'db-rt' }),
-      config: { cloudId: 'c', tokenExpiresAt: fresh },
-    })
+  it('uses a locked already-rotated row instead of replaying the cached refresh token', async () => {
+    hoisted.lockedRows.mockResolvedValue([
+      {
+        secrets: JSON.stringify({ accessToken: 'db-tok', refreshToken: 'db-rt' }),
+        config: { cloudId: 'c', tokenExpiresAt: fresh },
+      },
+    ])
 
     const token = await getJiraAccessToken({
       id: ID,
@@ -100,15 +120,18 @@ describe('getJiraAccessToken', () => {
     })
 
     expect(token).toBe('db-tok')
+    expect(hoisted.forUpdate).toHaveBeenCalledWith('update')
     expect(hoisted.refreshJiraToken).not.toHaveBeenCalled()
     expect(hoisted.updateWhere).not.toHaveBeenCalled()
   })
 
-  it('refreshes by integration id and drops the mappings cache', async () => {
-    hoisted.findFirst.mockResolvedValue({
-      secrets: JSON.stringify({ accessToken: 'stale-tok', refreshToken: 'stale-rt' }),
-      config: { cloudId: 'c', tokenExpiresAt: expired },
-    })
+  it('refreshes under a row lock, by integration id, and drops the mappings cache', async () => {
+    hoisted.lockedRows.mockResolvedValue([
+      {
+        secrets: JSON.stringify({ accessToken: 'stale-tok', refreshToken: 'stale-rt' }),
+        config: { cloudId: 'c', tokenExpiresAt: expired },
+      },
+    ])
 
     const token = await getJiraAccessToken({
       id: ID,
@@ -117,6 +140,7 @@ describe('getJiraAccessToken', () => {
     })
 
     expect(token).toBe('new-tok')
+    expect(hoisted.forUpdate).toHaveBeenCalledWith('update')
     expect(hoisted.refreshJiraToken).toHaveBeenCalledWith('stale-rt', {
       clientId: 'id',
       clientSecret: 'sec',

--- a/apps/web/src/lib/server/integrations/jira/__tests__/access-token.test.ts
+++ b/apps/web/src/lib/server/integrations/jira/__tests__/access-token.test.ts
@@ -123,6 +123,7 @@ describe('getJiraAccessToken', () => {
     expect(hoisted.forUpdate).toHaveBeenCalledWith('update')
     expect(hoisted.refreshJiraToken).not.toHaveBeenCalled()
     expect(hoisted.updateWhere).not.toHaveBeenCalled()
+    expect(hoisted.cacheDel).not.toHaveBeenCalled()
   })
 
   it('refreshes under a row lock, by integration id, and drops the mappings cache', async () => {
@@ -148,5 +149,24 @@ describe('getJiraAccessToken', () => {
     expect(hoisted.updateWhere).toHaveBeenCalledWith({ col: 'id', val: ID })
     expect(hoisted.eq).not.toHaveBeenCalledWith('integrationType', 'jira')
     expect(hoisted.cacheDel).toHaveBeenCalledWith('hooks:integration-mappings')
+  })
+
+  it('still returns the rotated token if dropping the mappings cache fails', async () => {
+    hoisted.lockedRows.mockResolvedValue([
+      {
+        secrets: JSON.stringify({ accessToken: 'stale-tok', refreshToken: 'stale-rt' }),
+        config: { cloudId: 'c', tokenExpiresAt: expired },
+      },
+    ])
+    hoisted.cacheDel.mockRejectedValue(new Error('redis down'))
+
+    await expect(
+      getJiraAccessToken({
+        id: ID,
+        secrets: JSON.stringify({ accessToken: 'stale-tok', refreshToken: 'stale-rt' }),
+        config: { tokenExpiresAt: expired },
+      })
+    ).resolves.toBe('new-tok')
+    expect(hoisted.updateWhere).toHaveBeenCalled()
   })
 })

--- a/apps/web/src/lib/server/integrations/jira/__tests__/access-token.test.ts
+++ b/apps/web/src/lib/server/integrations/jira/__tests__/access-token.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const hoisted = vi.hoisted(() => ({
   decryptSecrets: vi.fn(),
-  encryptSecrets: vi.fn((s: unknown) => JSON.stringify(s)),
+  encryptSecrets: vi.fn((...args: unknown[]) => JSON.stringify(args[0])),
   lockedRows: vi.fn(),
   forUpdate: vi.fn(),
   updateWhere: vi.fn(),
-  eq: vi.fn((col: unknown, val: unknown) => ({ col, val })),
+  eq: vi.fn((...args: unknown[]) => ({ col: args[0], val: args[1] })),
   refreshJiraToken: vi.fn(),
   getPlatformCredentials: vi.fn(),
   cacheDel: vi.fn(),

--- a/apps/web/src/lib/server/integrations/jira/__tests__/hook.test.ts
+++ b/apps/web/src/lib/server/integrations/jira/__tests__/hook.test.ts
@@ -108,6 +108,45 @@ describe('jiraHook', () => {
     expect(body.fields.issuetype).toEqual({ id: '999' })
   })
 
+  it('maps HTTP 401 to reconnect only when cloudId and token are present', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: async () => ({}),
+        text: async () => 'Unauthorized',
+      })
+    )
+
+    const result = await jiraHook.run(
+      makePostCreatedEvent(),
+      { channelId: '10000:10001' },
+      { accessToken: 'tok', cloudId: 'cloud-1', rootUrl: 'https://app.example.com' }
+    )
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Authentication failed. Please reconnect Jira.',
+      shouldRetry: false,
+    })
+  })
+
+  it('refuses to call Jira when the access token is missing', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await jiraHook.run(
+      makePostCreatedEvent(),
+      { channelId: '10000:10001' },
+      { cloudId: 'cloud-1', rootUrl: 'https://app.example.com' }
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/access token/i)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('skips non post.created events', async () => {
     const event = { type: 'post.status_changed' } as unknown as EventData
     expect(await jiraHook.run(event, { channelId: '10000' }, { cloudId: 'c' })).toEqual({

--- a/apps/web/src/lib/server/integrations/jira/__tests__/hook.test.ts
+++ b/apps/web/src/lib/server/integrations/jira/__tests__/hook.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { EventData, PostCreatedEvent } from '../../../events/types'
+import { jiraHook, parseJiraChannelId } from '../hook'
+
+function makePostCreatedEvent(): PostCreatedEvent {
+  return {
+    id: 'evt-1',
+    type: 'post.created',
+    timestamp: '2025-01-01T00:00:00Z',
+    actor: { type: 'user', userId: 'user_1', email: 'test@test.com' },
+    data: {
+      post: {
+        id: 'post_1',
+        title: 'Bug report',
+        content: '<p>Something broke</p>',
+        boardId: 'board_1',
+        boardSlug: 'bugs',
+        voteCount: 0,
+      },
+    },
+  }
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('parseJiraChannelId', () => {
+  it('splits the settings composite', () => {
+    expect(parseJiraChannelId('10000:10001')).toEqual({
+      projectId: '10000',
+      issueTypeId: '10001',
+    })
+  })
+
+  it('accepts a bare project id', () => {
+    expect(parseJiraChannelId('10000')).toEqual({ projectId: '10000' })
+  })
+})
+
+describe('jiraHook', () => {
+  it('refuses to call Jira when cloudId is missing', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await jiraHook.run(
+      makePostCreatedEvent(),
+      { channelId: '10000:10001' },
+      { accessToken: 'tok', rootUrl: 'https://app.example.com' }
+    )
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Jira cloud ID is missing from integration config',
+      shouldRetry: false,
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('posts to the cloud id and splits a composite channel id', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({ key: 'PROJ-1' }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await jiraHook.run(
+      makePostCreatedEvent(),
+      { channelId: '10000:10001' },
+      {
+        accessToken: 'tok',
+        cloudId: 'cloud-1',
+        rootUrl: 'https://app.example.com',
+      }
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.externalId).toBe('PROJ-1')
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://api.atlassian.com/ex/jira/cloud-1/rest/api/3/issue'
+    )
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(body.fields.project).toEqual({ id: '10000' })
+    expect(body.fields.issuetype).toEqual({ id: '10001' })
+  })
+
+  it('prefers issueTypeId from config over the channel composite', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({ key: 'PROJ-2' }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await jiraHook.run(
+      makePostCreatedEvent(),
+      { channelId: '10000:10001' },
+      {
+        accessToken: 'tok',
+        cloudId: 'cloud-1',
+        issueTypeId: '999',
+        rootUrl: 'https://app.example.com',
+      }
+    )
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(body.fields.issuetype).toEqual({ id: '999' })
+  })
+
+  it('skips non post.created events', async () => {
+    const event = { type: 'post.status_changed' } as unknown as EventData
+    expect(await jiraHook.run(event, { channelId: '10000' }, { cloudId: 'c' })).toEqual({
+      success: true,
+    })
+  })
+})

--- a/apps/web/src/lib/server/integrations/jira/access-token.ts
+++ b/apps/web/src/lib/server/integrations/jira/access-token.ts
@@ -22,8 +22,8 @@ function isExpiredOrExpiring(tokenExpiresAt: string | undefined): boolean {
  * Returns the current access token.
  *
  * Mappings are cached for 5 minutes, and Atlassian rotates refresh tokens.
- * When a refresh is needed we re-read the row so a prior event's rotation
- * is not replayed, then persist by integration id (never by type).
+ * A refresh takes a row lock so two events cannot rotate the same token.
+ * Persist by integration id (never by type).
  */
 export async function getJiraAccessToken(integration: {
   id?: string
@@ -32,59 +32,68 @@ export async function getJiraAccessToken(integration: {
 }): Promise<string> {
   const { decryptSecrets } = await import('../encryption')
 
-  let secrets = decryptSecrets<{ accessToken: string; refreshToken?: string }>(
+  const cachedSecrets = decryptSecrets<{ accessToken: string; refreshToken?: string }>(
     integration.secrets as string
   )
-  let cfg = (integration.config ?? {}) as JiraTokenConfig
+  const cachedCfg = (integration.config ?? {}) as JiraTokenConfig
 
-  if (!secrets.refreshToken || !isExpiredOrExpiring(cfg.tokenExpiresAt)) {
-    return secrets.accessToken
+  if (!cachedSecrets.refreshToken || !isExpiredOrExpiring(cachedCfg.tokenExpiresAt)) {
+    return cachedSecrets.accessToken
   }
 
   // No row id (stale cache shape): do not refresh — we cannot persist safely.
   if (!integration.id) {
-    return secrets.accessToken
+    return cachedSecrets.accessToken
   }
 
   const { db, integrations, eq } = await import('@/lib/server/db')
-  const row = await db.query.integrations.findFirst({
-    where: eq(integrations.id, integration.id),
-    columns: { secrets: true, config: true },
-  })
-  if (row?.secrets) {
-    secrets = decryptSecrets<{ accessToken: string; refreshToken?: string }>(row.secrets as string)
-    cfg = (row.config ?? {}) as JiraTokenConfig
-    if (!secrets.refreshToken || !isExpiredOrExpiring(cfg.tokenExpiresAt)) {
-      return secrets.accessToken
+
+  return db.transaction(async (tx) => {
+    const [row] = await tx
+      .select({ secrets: integrations.secrets, config: integrations.config })
+      .from(integrations)
+      .where(eq(integrations.id, integration.id))
+      .for('update')
+
+    let secrets = cachedSecrets
+    let cfg = cachedCfg
+    if (row?.secrets) {
+      secrets = decryptSecrets<{ accessToken: string; refreshToken?: string }>(
+        row.secrets as string
+      )
+      cfg = (row.config ?? {}) as JiraTokenConfig
+      if (!secrets.refreshToken || !isExpiredOrExpiring(cfg.tokenExpiresAt)) {
+        return secrets.accessToken
+      }
     }
-  }
 
-  const { logger } = await import('@/lib/server/logger')
-  const log = logger.child({ component: 'jira' })
-  log.info({ integration_id: integration.id }, 'access token expired, refreshing')
+    const { logger } = await import('@/lib/server/logger')
+    const log = logger.child({ component: 'jira' })
+    log.info({ integration_id: integration.id }, 'access token expired, refreshing')
 
-  const { refreshJiraToken } = await import('./oauth')
-  const { getPlatformCredentials } =
-    await import('@/lib/server/domains/platform-credentials/platform-credential.service')
-  const { encryptSecrets } = await import('../encryption')
-  const credentials = await getPlatformCredentials('jira')
-  const refreshed = await refreshJiraToken(secrets.refreshToken, credentials ?? undefined)
+    const { refreshJiraToken } = await import('./oauth')
+    const { getPlatformCredentials } =
+      await import('@/lib/server/domains/platform-credentials/platform-credential.service')
+    const { encryptSecrets } = await import('../encryption')
+    const credentials = await getPlatformCredentials('jira')
+    const refreshed = await refreshJiraToken(secrets.refreshToken, credentials ?? undefined)
 
-  const newExpiry = new Date(Date.now() + refreshed.expiresIn * 1000).toISOString()
-  await db
-    .update(integrations)
-    .set({
-      secrets: encryptSecrets({
-        accessToken: refreshed.accessToken,
-        refreshToken: refreshed.refreshToken,
-      }),
-      config: { ...cfg, tokenExpiresAt: newExpiry },
-      updatedAt: new Date(),
-    })
-    .where(eq(integrations.id, integration.id))
+    const newExpiry = new Date(Date.now() + refreshed.expiresIn * 1000).toISOString()
+    await tx
+      .update(integrations)
+      .set({
+        secrets: encryptSecrets({
+          accessToken: refreshed.accessToken,
+          refreshToken: refreshed.refreshToken,
+        }),
+        config: { ...cfg, tokenExpiresAt: newExpiry },
+        updatedAt: new Date(),
+      })
+      .where(eq(integrations.id, integration.id))
 
-  const { cacheDel, CACHE_KEYS } = await import('@/lib/server/redis')
-  await cacheDel(CACHE_KEYS.INTEGRATION_MAPPINGS)
+    const { cacheDel, CACHE_KEYS } = await import('@/lib/server/redis')
+    await cacheDel(CACHE_KEYS.INTEGRATION_MAPPINGS)
 
-  return refreshed.accessToken
+    return refreshed.accessToken
+  })
 }

--- a/apps/web/src/lib/server/integrations/jira/access-token.ts
+++ b/apps/web/src/lib/server/integrations/jira/access-token.ts
@@ -1,0 +1,60 @@
+/**
+ * Jira access-token refresh. Plain server module (not a serverFn file) so the
+ * events worker can call it without tripping TanStack Start import protection.
+ */
+
+export interface JiraTokenConfig {
+  cloudId?: string
+  siteUrl?: string
+  workspaceName?: string
+  tokenExpiresAt?: string
+}
+
+/**
+ * Refresh the Jira token if expired or about to expire (within 5 minutes).
+ * Returns the current access token.
+ */
+export async function getJiraAccessToken(integration: {
+  secrets: unknown
+  config: unknown
+}): Promise<string> {
+  const { decryptSecrets, encryptSecrets } = await import('../encryption')
+  const { db, integrations, eq } = await import('@/lib/server/db')
+  const { logger } = await import('@/lib/server/logger')
+  const log = logger.child({ component: 'jira' })
+
+  const secrets = decryptSecrets<{ accessToken: string; refreshToken?: string }>(
+    integration.secrets as string
+  )
+  const cfg = (integration.config ?? {}) as JiraTokenConfig
+
+  if (secrets.refreshToken && cfg.tokenExpiresAt) {
+    const expiresAt = new Date(cfg.tokenExpiresAt).getTime()
+    const bufferMs = 5 * 60 * 1000
+    if (Date.now() >= expiresAt - bufferMs) {
+      log.info('access token expired, refreshing')
+      const { refreshJiraToken } = await import('./oauth')
+      const { getPlatformCredentials } =
+        await import('@/lib/server/domains/platform-credentials/platform-credential.service')
+      const credentials = await getPlatformCredentials('jira')
+      const refreshed = await refreshJiraToken(secrets.refreshToken, credentials ?? undefined)
+
+      const newExpiry = new Date(Date.now() + refreshed.expiresIn * 1000).toISOString()
+      await db
+        .update(integrations)
+        .set({
+          secrets: encryptSecrets({
+            accessToken: refreshed.accessToken,
+            refreshToken: refreshed.refreshToken,
+          }),
+          config: { ...cfg, tokenExpiresAt: newExpiry },
+          updatedAt: new Date(),
+        })
+        .where(eq(integrations.integrationType, 'jira'))
+
+      return refreshed.accessToken
+    }
+  }
+
+  return secrets.accessToken
+}

--- a/apps/web/src/lib/server/integrations/jira/access-token.ts
+++ b/apps/web/src/lib/server/integrations/jira/access-token.ts
@@ -81,28 +81,36 @@ export async function getJiraAccessToken(integration: {
     const log = logger.child({ component: 'jira' })
     log.info({ integration_id: rowId }, 'access token expired, refreshing')
 
-    const { refreshJiraToken } = await import('./oauth')
-    const { getPlatformCredentials } =
-      await import('@/lib/server/domains/platform-credentials/platform-credential.service')
-    const { encryptSecrets } = await import('../encryption')
-    const credentials = await getPlatformCredentials('jira')
-    const refreshed = await refreshJiraToken(refreshToken, credentials ?? undefined)
+    try {
+      const { refreshJiraToken } = await import('./oauth')
+      const { getPlatformCredentials } =
+        await import('@/lib/server/domains/platform-credentials/platform-credential.service')
+      const { encryptSecrets } = await import('../encryption')
+      const credentials = await getPlatformCredentials('jira')
+      const refreshed = await refreshJiraToken(refreshToken, credentials ?? undefined)
 
-    const newExpiry = new Date(Date.now() + refreshed.expiresIn * 1000).toISOString()
-    await tx
-      .update(integrations)
-      .set({
-        secrets: encryptSecrets({
-          accessToken: refreshed.accessToken,
-          refreshToken: refreshed.refreshToken,
-        }),
-        config: { ...cfg, tokenExpiresAt: newExpiry },
-        updatedAt: new Date(),
-      })
-      .where(eq(integrations.id, rowId))
+      const newExpiry = new Date(Date.now() + refreshed.expiresIn * 1000).toISOString()
+      await tx
+        .update(integrations)
+        .set({
+          secrets: encryptSecrets({
+            accessToken: refreshed.accessToken,
+            refreshToken: refreshed.refreshToken,
+          }),
+          config: { ...cfg, tokenExpiresAt: newExpiry },
+          updatedAt: new Date(),
+        })
+        .where(eq(integrations.id, rowId))
 
-    didRefresh = true
-    return refreshed.accessToken
+      didRefresh = true
+      return refreshed.accessToken
+    } catch (error) {
+      log.warn(
+        { err: error, integration_id: rowId },
+        'jira token refresh failed; using cached access token'
+      )
+      return secrets.accessToken
+    }
   })
 
   // After commit: Atlassian has already rotated the refresh token. A Redis

--- a/apps/web/src/lib/server/integrations/jira/access-token.ts
+++ b/apps/web/src/lib/server/integrations/jira/access-token.ts
@@ -48,7 +48,8 @@ export async function getJiraAccessToken(integration: {
 
   const { db, integrations, eq } = await import('@/lib/server/db')
 
-  return db.transaction(async (tx) => {
+  let didRefresh = false
+  const token = await db.transaction(async (tx) => {
     const [row] = await tx
       .select({ secrets: integrations.secrets, config: integrations.config })
       .from(integrations)
@@ -91,9 +92,16 @@ export async function getJiraAccessToken(integration: {
       })
       .where(eq(integrations.id, integration.id))
 
-    const { cacheDel, CACHE_KEYS } = await import('@/lib/server/redis')
-    await cacheDel(CACHE_KEYS.INTEGRATION_MAPPINGS)
-
+    didRefresh = true
     return refreshed.accessToken
   })
+
+  // After commit: Atlassian has already rotated the refresh token. A Redis
+  // failure must not roll back the persisted tokens.
+  if (didRefresh) {
+    const { cacheDel, CACHE_KEYS } = await import('@/lib/server/redis')
+    await cacheDel(CACHE_KEYS.INTEGRATION_MAPPINGS).catch(() => undefined)
+  }
+
+  return token
 }

--- a/apps/web/src/lib/server/integrations/jira/access-token.ts
+++ b/apps/web/src/lib/server/integrations/jira/access-token.ts
@@ -3,6 +3,8 @@
  * events worker can call it without tripping TanStack Start import protection.
  */
 
+import type { IntegrationId } from '@quackback/ids'
+
 export interface JiraTokenConfig {
   cloudId?: string
   siteUrl?: string
@@ -42,18 +44,20 @@ export async function getJiraAccessToken(integration: {
   }
 
   // No row id (stale cache shape): do not refresh — we cannot persist safely.
-  if (!integration.id) {
+  const integrationId = integration.id
+  if (!integrationId) {
     return cachedSecrets.accessToken
   }
 
   const { db, integrations, eq } = await import('@/lib/server/db')
+  const rowId = integrationId as IntegrationId
 
   let didRefresh = false
   const token = await db.transaction(async (tx) => {
     const [row] = await tx
       .select({ secrets: integrations.secrets, config: integrations.config })
       .from(integrations)
-      .where(eq(integrations.id, integration.id))
+      .where(eq(integrations.id, rowId))
       .for('update')
 
     let secrets = cachedSecrets
@@ -68,16 +72,21 @@ export async function getJiraAccessToken(integration: {
       }
     }
 
+    const refreshToken = secrets.refreshToken
+    if (!refreshToken) {
+      return secrets.accessToken
+    }
+
     const { logger } = await import('@/lib/server/logger')
     const log = logger.child({ component: 'jira' })
-    log.info({ integration_id: integration.id }, 'access token expired, refreshing')
+    log.info({ integration_id: rowId }, 'access token expired, refreshing')
 
     const { refreshJiraToken } = await import('./oauth')
     const { getPlatformCredentials } =
       await import('@/lib/server/domains/platform-credentials/platform-credential.service')
     const { encryptSecrets } = await import('../encryption')
     const credentials = await getPlatformCredentials('jira')
-    const refreshed = await refreshJiraToken(secrets.refreshToken, credentials ?? undefined)
+    const refreshed = await refreshJiraToken(refreshToken, credentials ?? undefined)
 
     const newExpiry = new Date(Date.now() + refreshed.expiresIn * 1000).toISOString()
     await tx
@@ -90,7 +99,7 @@ export async function getJiraAccessToken(integration: {
         config: { ...cfg, tokenExpiresAt: newExpiry },
         updatedAt: new Date(),
       })
-      .where(eq(integrations.id, integration.id))
+      .where(eq(integrations.id, rowId))
 
     didRefresh = true
     return refreshed.accessToken

--- a/apps/web/src/lib/server/integrations/jira/access-token.ts
+++ b/apps/web/src/lib/server/integrations/jira/access-token.ts
@@ -10,51 +10,81 @@ export interface JiraTokenConfig {
   tokenExpiresAt?: string
 }
 
+const REFRESH_BUFFER_MS = 5 * 60 * 1000
+
+function isExpiredOrExpiring(tokenExpiresAt: string | undefined): boolean {
+  if (!tokenExpiresAt) return false
+  return Date.now() >= new Date(tokenExpiresAt).getTime() - REFRESH_BUFFER_MS
+}
+
 /**
  * Refresh the Jira token if expired or about to expire (within 5 minutes).
  * Returns the current access token.
+ *
+ * Mappings are cached for 5 minutes, and Atlassian rotates refresh tokens.
+ * When a refresh is needed we re-read the row so a prior event's rotation
+ * is not replayed, then persist by integration id (never by type).
  */
 export async function getJiraAccessToken(integration: {
+  id?: string
   secrets: unknown
   config: unknown
 }): Promise<string> {
-  const { decryptSecrets, encryptSecrets } = await import('../encryption')
-  const { db, integrations, eq } = await import('@/lib/server/db')
-  const { logger } = await import('@/lib/server/logger')
-  const log = logger.child({ component: 'jira' })
+  const { decryptSecrets } = await import('../encryption')
 
-  const secrets = decryptSecrets<{ accessToken: string; refreshToken?: string }>(
+  let secrets = decryptSecrets<{ accessToken: string; refreshToken?: string }>(
     integration.secrets as string
   )
-  const cfg = (integration.config ?? {}) as JiraTokenConfig
+  let cfg = (integration.config ?? {}) as JiraTokenConfig
 
-  if (secrets.refreshToken && cfg.tokenExpiresAt) {
-    const expiresAt = new Date(cfg.tokenExpiresAt).getTime()
-    const bufferMs = 5 * 60 * 1000
-    if (Date.now() >= expiresAt - bufferMs) {
-      log.info('access token expired, refreshing')
-      const { refreshJiraToken } = await import('./oauth')
-      const { getPlatformCredentials } =
-        await import('@/lib/server/domains/platform-credentials/platform-credential.service')
-      const credentials = await getPlatformCredentials('jira')
-      const refreshed = await refreshJiraToken(secrets.refreshToken, credentials ?? undefined)
+  if (!secrets.refreshToken || !isExpiredOrExpiring(cfg.tokenExpiresAt)) {
+    return secrets.accessToken
+  }
 
-      const newExpiry = new Date(Date.now() + refreshed.expiresIn * 1000).toISOString()
-      await db
-        .update(integrations)
-        .set({
-          secrets: encryptSecrets({
-            accessToken: refreshed.accessToken,
-            refreshToken: refreshed.refreshToken,
-          }),
-          config: { ...cfg, tokenExpiresAt: newExpiry },
-          updatedAt: new Date(),
-        })
-        .where(eq(integrations.integrationType, 'jira'))
+  // No row id (stale cache shape): do not refresh — we cannot persist safely.
+  if (!integration.id) {
+    return secrets.accessToken
+  }
 
-      return refreshed.accessToken
+  const { db, integrations, eq } = await import('@/lib/server/db')
+  const row = await db.query.integrations.findFirst({
+    where: eq(integrations.id, integration.id),
+    columns: { secrets: true, config: true },
+  })
+  if (row?.secrets) {
+    secrets = decryptSecrets<{ accessToken: string; refreshToken?: string }>(row.secrets as string)
+    cfg = (row.config ?? {}) as JiraTokenConfig
+    if (!secrets.refreshToken || !isExpiredOrExpiring(cfg.tokenExpiresAt)) {
+      return secrets.accessToken
     }
   }
 
-  return secrets.accessToken
+  const { logger } = await import('@/lib/server/logger')
+  const log = logger.child({ component: 'jira' })
+  log.info({ integration_id: integration.id }, 'access token expired, refreshing')
+
+  const { refreshJiraToken } = await import('./oauth')
+  const { getPlatformCredentials } =
+    await import('@/lib/server/domains/platform-credentials/platform-credential.service')
+  const { encryptSecrets } = await import('../encryption')
+  const credentials = await getPlatformCredentials('jira')
+  const refreshed = await refreshJiraToken(secrets.refreshToken, credentials ?? undefined)
+
+  const newExpiry = new Date(Date.now() + refreshed.expiresIn * 1000).toISOString()
+  await db
+    .update(integrations)
+    .set({
+      secrets: encryptSecrets({
+        accessToken: refreshed.accessToken,
+        refreshToken: refreshed.refreshToken,
+      }),
+      config: { ...cfg, tokenExpiresAt: newExpiry },
+      updatedAt: new Date(),
+    })
+    .where(eq(integrations.id, integration.id))
+
+  const { cacheDel, CACHE_KEYS } = await import('@/lib/server/redis')
+  await cacheDel(CACHE_KEYS.INTEGRATION_MAPPINGS)
+
+  return refreshed.accessToken
 }

--- a/apps/web/src/lib/server/integrations/jira/functions.ts
+++ b/apps/web/src/lib/server/integrations/jira/functions.ts
@@ -4,6 +4,7 @@
 import { createServerFn } from '@tanstack/react-start'
 import { z } from 'zod'
 import type { PrincipalId } from '@quackback/ids'
+import { getJiraAccessToken, type JiraTokenConfig } from './access-token'
 
 export interface JiraOAuthState {
   type: 'jira_oauth'
@@ -26,12 +27,7 @@ export interface JiraIssueType {
   subtask: boolean
 }
 
-interface JiraIntegrationConfig {
-  cloudId?: string
-  siteUrl?: string
-  workspaceName?: string
-  tokenExpiresAt?: string
-}
+type JiraIntegrationConfig = JiraTokenConfig
 
 export const getJiraConnectUrl = createServerFn({ method: 'GET' }).handler(
   async (): Promise<string> => {
@@ -62,49 +58,6 @@ export const getJiraConnectUrl = createServerFn({ method: 'GET' }).handler(
     return `/oauth/jira/connect?state=${encodeURIComponent(state)}`
   }
 )
-
-/** Refresh Jira token if expired or about to expire (within 5 minutes). Returns current access token. */
-async function getJiraAccessToken(integration: { secrets: unknown; config: unknown }) {
-  const { decryptSecrets, encryptSecrets } = await import('../encryption')
-  const { db, integrations, eq } = await import('@/lib/server/db')
-  const { logger } = await import('@/lib/server/logger')
-  const log = logger.child({ component: 'jira' })
-
-  const secrets = decryptSecrets<{ accessToken: string; refreshToken?: string }>(
-    integration.secrets as string
-  )
-  const cfg = (integration.config ?? {}) as JiraIntegrationConfig
-
-  if (secrets.refreshToken && cfg.tokenExpiresAt) {
-    const expiresAt = new Date(cfg.tokenExpiresAt).getTime()
-    const bufferMs = 5 * 60 * 1000
-    if (Date.now() >= expiresAt - bufferMs) {
-      log.info('access token expired, refreshing')
-      const { refreshJiraToken } = await import('./oauth')
-      const { getPlatformCredentials } =
-        await import('@/lib/server/domains/platform-credentials/platform-credential.service')
-      const credentials = await getPlatformCredentials('jira')
-      const refreshed = await refreshJiraToken(secrets.refreshToken, credentials ?? undefined)
-
-      const newExpiry = new Date(Date.now() + refreshed.expiresIn * 1000).toISOString()
-      await db
-        .update(integrations)
-        .set({
-          secrets: encryptSecrets({
-            accessToken: refreshed.accessToken,
-            refreshToken: refreshed.refreshToken,
-          }),
-          config: { ...cfg, tokenExpiresAt: newExpiry },
-          updatedAt: new Date(),
-        })
-        .where(eq(integrations.integrationType, 'jira'))
-
-      return refreshed.accessToken
-    }
-  }
-
-  return secrets.accessToken
-}
 
 export const fetchJiraProjectsFn = createServerFn({ method: 'GET' }).handler(
   async (): Promise<JiraProject[]> => {

--- a/apps/web/src/lib/server/integrations/jira/hook.ts
+++ b/apps/web/src/lib/server/integrations/jira/hook.ts
@@ -12,7 +12,19 @@ import { logger } from '@/lib/server/logger'
 const log = logger.child({ component: 'jira' })
 
 export interface JiraTarget {
-  channelId: string // projectId is stored as channelId for consistency
+  channelId: string
+}
+
+/** Settings stores `projectId:issueTypeId`; a bare project id is still accepted. */
+export function parseJiraChannelId(channelId: string): {
+  projectId: string
+  issueTypeId?: string
+} {
+  const sep = channelId.indexOf(':')
+  if (sep === -1) return { projectId: channelId }
+  const projectId = channelId.slice(0, sep)
+  const issueTypeId = channelId.slice(sep + 1)
+  return { projectId, ...(issueTypeId ? { issueTypeId } : {}) }
 }
 
 export interface JiraConfig {
@@ -52,13 +64,31 @@ async function jiraApi(
 
 export const jiraHook: HookHandler = {
   async run(event: EventData, target: unknown, config: unknown): Promise<HookResult> {
-    const { channelId: projectId } = target as JiraTarget
+    const { channelId } = target as JiraTarget
     const { accessToken, cloudId, siteUrl, issueTypeId, rootUrl } = config as JiraConfig
 
-    // Only create issues for new feedback
     if (event.type !== 'post.created') {
       return { success: true }
     }
+
+    if (!cloudId) {
+      return {
+        success: false,
+        error: 'Jira cloud ID is missing from integration config',
+        shouldRetry: false,
+      }
+    }
+    if (!accessToken) {
+      return {
+        success: false,
+        error: 'Jira access token is missing',
+        shouldRetry: false,
+      }
+    }
+
+    const parsed = parseJiraChannelId(channelId)
+    const projectId = parsed.projectId
+    const resolvedIssueTypeId = issueTypeId || parsed.issueTypeId
 
     log.debug({ event_type: event.type, project_id: projectId }, 'creating issue')
 
@@ -69,7 +99,7 @@ export const jiraHook: HookHandler = {
         project: { id: projectId },
         summary: title,
         description,
-        ...(issueTypeId ? { issuetype: { id: issueTypeId } } : {}),
+        ...(resolvedIssueTypeId ? { issuetype: { id: resolvedIssueTypeId } } : {}),
       },
     }
 

--- a/apps/web/src/lib/server/integrations/jira/oauth.ts
+++ b/apps/web/src/lib/server/integrations/jira/oauth.ts
@@ -135,6 +135,7 @@ export async function refreshJiraToken(
       client_secret: clientSecret,
       refresh_token: refreshToken,
     }),
+    signal: AbortSignal.timeout(10_000),
   })
 
   if (!response.ok) {


### PR DESCRIPTION
## Summary
Outbound integration hooks were built as `{ accessToken, rootUrl }` and dropped the stored integration config. Settings UI still worked (it reads the DB row); create-issue automations posted to `ex/jira/undefined` / `dev.azure.com/undefined` and failed permanently with a green admin UI.

- Spread stored config into hook jobs (strip inbound-only fields so `webhookSecret` never enters the queue)
- Split Jira `projectId:issueTypeId` channel ids
- Move Jira token refresh to a plain server module and use it on the events path
- Return a typed missing-config error instead of “please reconnect”

Closes #353
Closes #350

Also unblocks Trello card-create (`apiKey`) and Teams (`teamId`) once those integrations are connected.

## Test plan
- [x] Unit: hook config merge + inbound fields stripped
- [x] Unit: Jira hook splits channel id / refuses missing cloudId
- [x] Unit: Azure DevOps hook refuses missing organizationName (does not call the API)
- [ ] Connect Jira, submit feedback → issue created in the selected project
- [ ] Connect Azure DevOps with a valid PAT, submit feedback → work item created
- [x] Existing Slack/Discord mappings still fire (they only need accessToken + channelId)

Verified locally: 51 vitest cases (hook merge, Jira/Azure refuse-missing-config, Slack/Discord channelId resolution). Live Jira/ADO create-issue not run.