### PR TITLE
fix(jira): register status-sync with supported JQL and verify bearer JWT

### DIFF
--- a/apps/web/src/lib/server/functions/status-sync.ts
+++ b/apps/web/src/lib/server/functions/status-sync.ts
@@ -98,7 +98,14 @@ export const enableStatusSyncFn = createServerFn({ method: 'POST' })
                 await import('@/lib/server/integrations/jira/webhook-registration')
               const cloudId = config.cloudId as string
               if (!cloudId) throw new Error('No Jira Cloud ID configured')
-              const result = await registerJiraWebhook(accessToken, cloudId, callbackUrl, secret)
+              const projectRef = String(config.channelId ?? '').split(':')[0]
+              if (!projectRef) throw new Error('No Jira project configured')
+              const result = await registerJiraWebhook(
+                accessToken,
+                cloudId,
+                callbackUrl,
+                projectRef
+              )
               externalWebhookId = result.webhookId
               break
             }

--- a/apps/web/src/lib/server/integrations/jira/__tests__/inbound.test.ts
+++ b/apps/web/src/lib/server/integrations/jira/__tests__/inbound.test.ts
@@ -57,8 +57,8 @@ describe('jiraInboundHandler.verifySignature', () => {
     expect(await jiraInboundHandler.verifySignature(request, '', '')).toBe(true)
   })
 
-  it('rejects an expired JWT', async () => {
-    const token = bearerJwt(SECRET, { exp: Math.floor(Date.now() / 1000) - 30 })
+  it('rejects an expired JWT beyond clock skew', async () => {
+    const token = bearerJwt(SECRET, { exp: Math.floor(Date.now() / 1000) - 120 })
     const request = new Request('https://app.example.com/hook', {
       headers: { Authorization: `Bearer ${token}` },
     })
@@ -67,7 +67,7 @@ describe('jiraInboundHandler.verifySignature', () => {
     expect((result as Response).status).toBe(401)
   })
 
-  it('rejects a JWT with no exp claim', async () => {
+  it('accepts a JWT with no exp claim when the signature is valid', async () => {
     const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url')
     const payload = Buffer.from(JSON.stringify({ iss: 'jira' })).toString('base64url')
     const data = `${header}.${payload}`
@@ -75,9 +75,7 @@ describe('jiraInboundHandler.verifySignature', () => {
     const request = new Request('https://app.example.com/hook', {
       headers: { Authorization: `Bearer ${data}.${signature}` },
     })
-    const result = await jiraInboundHandler.verifySignature(request, '', '')
-    expect(result).toBeInstanceOf(Response)
-    expect((result as Response).status).toBe(401)
+    expect(await jiraInboundHandler.verifySignature(request, '', '')).toBe(true)
   })
 })
 

--- a/apps/web/src/lib/server/integrations/jira/__tests__/inbound.test.ts
+++ b/apps/web/src/lib/server/integrations/jira/__tests__/inbound.test.ts
@@ -1,0 +1,57 @@
+import { createHmac } from 'crypto'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { jiraInboundHandler } from '../inbound'
+
+const SECRET = 'jira-client-secret'
+
+vi.mock('@/lib/server/domains/platform-credentials/platform-credential.service', () => ({
+  getPlatformCredentials: vi.fn(async () => ({ clientSecret: SECRET })),
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+function bearerJwt(secret = SECRET) {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url')
+  const payload = Buffer.from(JSON.stringify({ iss: 'jira' })).toString('base64url')
+  const data = `${header}.${payload}`
+  const signature = createHmac('sha256', secret).update(data).digest('base64url')
+  return `${data}.${signature}`
+}
+
+describe('jiraInboundHandler.verifySignature', () => {
+  it('accepts a bearer JWT signed with the Jira client secret', async () => {
+    const token = bearerJwt()
+    const request = new Request('https://app.example.com/hook', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    expect(await jiraInboundHandler.verifySignature(request, '', '')).toBe(true)
+  })
+
+  it('rejects a missing bearer token', async () => {
+    const request = new Request('https://app.example.com/hook')
+    const result = await jiraInboundHandler.verifySignature(request, '', '')
+    expect(result).toBeInstanceOf(Response)
+    expect((result as Response).status).toBe(401)
+  })
+
+  it('rejects a JWT signed with the wrong secret', async () => {
+    const token = bearerJwt('other-secret')
+    const request = new Request('https://app.example.com/hook', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    const result = await jiraInboundHandler.verifySignature(request, '', '')
+    expect(result).toBeInstanceOf(Response)
+    expect((result as Response).status).toBe(401)
+  })
+
+  it('does not require X-Hub-Signature', async () => {
+    const token = bearerJwt()
+    const request = new Request('https://app.example.com/hook', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    expect(request.headers.get('X-Hub-Signature')).toBeNull()
+    expect(await jiraInboundHandler.verifySignature(request, '', '')).toBe(true)
+  })
+})

--- a/apps/web/src/lib/server/integrations/jira/__tests__/inbound.test.ts
+++ b/apps/web/src/lib/server/integrations/jira/__tests__/inbound.test.ts
@@ -88,7 +88,9 @@ describe('jiraInboundHandler.parseStatusChange', () => {
         webhookEvent: 'jira:issue_updated',
         issue: { key: 'PROJ-12' },
         changelog: { items: [{ field: 'assignee' }, { field: 'status', toString: 'Done' }] },
-      })
+      }),
+      {},
+      {}
     )
     expect(result).toEqual({
       externalId: 'PROJ-12',
@@ -103,7 +105,9 @@ describe('jiraInboundHandler.parseStatusChange', () => {
         webhookEvent: 'jira:issue_updated',
         issue: { key: 'PROJ-12' },
         changelog: { items: [{ field: 'summary', toString: 'new title' }] },
-      })
+      }),
+      {},
+      {}
     )
     expect(result).toBeNull()
   })
@@ -114,7 +118,9 @@ describe('jiraInboundHandler.parseStatusChange', () => {
         webhookEvent: 'jira:issue_created',
         issue: { key: 'PROJ-12' },
         changelog: { items: [{ field: 'status', toString: 'To Do' }] },
-      })
+      }),
+      {},
+      {}
     )
     expect(result).toBeNull()
   })

--- a/apps/web/src/lib/server/integrations/jira/__tests__/inbound.test.ts
+++ b/apps/web/src/lib/server/integrations/jira/__tests__/inbound.test.ts
@@ -12,9 +12,11 @@ beforeEach(() => {
   vi.clearAllMocks()
 })
 
-function bearerJwt(secret = SECRET) {
+function bearerJwt(secret = SECRET, claims: Record<string, unknown> = {}) {
   const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url')
-  const payload = Buffer.from(JSON.stringify({ iss: 'jira' })).toString('base64url')
+  const payload = Buffer.from(
+    JSON.stringify({ iss: 'jira', exp: Math.floor(Date.now() / 1000) + 3600, ...claims })
+  ).toString('base64url')
   const data = `${header}.${payload}`
   const signature = createHmac('sha256', secret).update(data).digest('base64url')
   return `${data}.${signature}`
@@ -53,5 +55,28 @@ describe('jiraInboundHandler.verifySignature', () => {
     })
     expect(request.headers.get('X-Hub-Signature')).toBeNull()
     expect(await jiraInboundHandler.verifySignature(request, '', '')).toBe(true)
+  })
+
+  it('rejects an expired JWT', async () => {
+    const token = bearerJwt(SECRET, { exp: Math.floor(Date.now() / 1000) - 30 })
+    const request = new Request('https://app.example.com/hook', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    const result = await jiraInboundHandler.verifySignature(request, '', '')
+    expect(result).toBeInstanceOf(Response)
+    expect((result as Response).status).toBe(401)
+  })
+
+  it('rejects a JWT with no exp claim', async () => {
+    const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url')
+    const payload = Buffer.from(JSON.stringify({ iss: 'jira' })).toString('base64url')
+    const data = `${header}.${payload}`
+    const signature = createHmac('sha256', SECRET).update(data).digest('base64url')
+    const request = new Request('https://app.example.com/hook', {
+      headers: { Authorization: `Bearer ${data}.${signature}` },
+    })
+    const result = await jiraInboundHandler.verifySignature(request, '', '')
+    expect(result).toBeInstanceOf(Response)
+    expect((result as Response).status).toBe(401)
   })
 })

--- a/apps/web/src/lib/server/integrations/jira/__tests__/inbound.test.ts
+++ b/apps/web/src/lib/server/integrations/jira/__tests__/inbound.test.ts
@@ -80,3 +80,42 @@ describe('jiraInboundHandler.verifySignature', () => {
     expect((result as Response).status).toBe(401)
   })
 })
+
+describe('jiraInboundHandler.parseStatusChange', () => {
+  it('extracts a status change from jira:issue_updated', async () => {
+    const result = await jiraInboundHandler.parseStatusChange(
+      JSON.stringify({
+        webhookEvent: 'jira:issue_updated',
+        issue: { key: 'PROJ-12' },
+        changelog: { items: [{ field: 'assignee' }, { field: 'status', toString: 'Done' }] },
+      })
+    )
+    expect(result).toEqual({
+      externalId: 'PROJ-12',
+      externalStatus: 'Done',
+      eventType: 'jira:issue_updated',
+    })
+  })
+
+  it('ignores updates that are not a status change', async () => {
+    const result = await jiraInboundHandler.parseStatusChange(
+      JSON.stringify({
+        webhookEvent: 'jira:issue_updated',
+        issue: { key: 'PROJ-12' },
+        changelog: { items: [{ field: 'summary', toString: 'new title' }] },
+      })
+    )
+    expect(result).toBeNull()
+  })
+
+  it('ignores non-update events', async () => {
+    const result = await jiraInboundHandler.parseStatusChange(
+      JSON.stringify({
+        webhookEvent: 'jira:issue_created',
+        issue: { key: 'PROJ-12' },
+        changelog: { items: [{ field: 'status', toString: 'To Do' }] },
+      })
+    )
+    expect(result).toBeNull()
+  })
+})

--- a/apps/web/src/lib/server/integrations/jira/__tests__/webhook-registration.test.ts
+++ b/apps/web/src/lib/server/integrations/jira/__tests__/webhook-registration.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { registerJiraWebhook } from '../webhook-registration'
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('registerJiraWebhook', () => {
+  it('registers with project = KEY and no secret field', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ webhookRegistrationResult: [{ createdWebhookId: 42 }] }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await registerJiraWebhook('tok', 'cloud-1', 'https://app.example.com/hook', 'PROJ')
+
+    expect(result).toEqual({ webhookId: '42' })
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(body.webhooks[0].jqlFilter).toBe('project = PROJ')
+    expect(body).not.toHaveProperty('secret')
+    expect(JSON.stringify(body)).not.toContain('EMPTY')
+  })
+
+  it('surfaces Jira registration errors from a 200 body', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          webhookRegistrationResult: [{ errors: ['Operator is not is unsupported'] }],
+        }),
+      })
+    )
+
+    await expect(
+      registerJiraWebhook('tok', 'cloud-1', 'https://app.example.com/hook', 'PROJ')
+    ).rejects.toThrow('Operator is not is unsupported')
+  })
+
+  it('rejects a project ref that is not a safe JQL token', async () => {
+    await expect(
+      registerJiraWebhook('tok', 'cloud-1', 'https://app.example.com/hook', 'PROJ OR 1=1')
+    ).rejects.toThrow('Invalid Jira project reference')
+  })
+})

--- a/apps/web/src/lib/server/integrations/jira/__tests__/webhook-registration.test.ts
+++ b/apps/web/src/lib/server/integrations/jira/__tests__/webhook-registration.test.ts
@@ -38,6 +38,19 @@ describe('registerJiraWebhook', () => {
     ).rejects.toThrow('Operator is not is unsupported')
   })
 
+  it('accepts a numeric project id from the settings composite', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ webhookRegistrationResult: [{ createdWebhookId: 7 }] }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await registerJiraWebhook('tok', 'cloud-1', 'https://app.example.com/hook', '10000')
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body).webhooks[0].jqlFilter).toBe(
+      'project = 10000'
+    )
+  })
+
   it('rejects a project ref that is not a safe JQL token', async () => {
     await expect(
       registerJiraWebhook('tok', 'cloud-1', 'https://app.example.com/hook', 'PROJ OR 1=1')

--- a/apps/web/src/lib/server/integrations/jira/inbound.ts
+++ b/apps/web/src/lib/server/integrations/jira/inbound.ts
@@ -15,7 +15,14 @@ function verifyHs256Jwt(token: string, secret: string): boolean {
   const [header, payload, signature] = parts
   const expected = createHmac('sha256', secret).update(`${header}.${payload}`).digest()
   const actual = Buffer.from(signature, 'base64url')
-  return actual.length === expected.length && timingSafeEqual(actual, expected)
+  if (actual.length !== expected.length || !timingSafeEqual(actual, expected)) return false
+
+  try {
+    const claims = JSON.parse(Buffer.from(payload, 'base64url').toString()) as { exp?: unknown }
+    return typeof claims.exp === 'number' && claims.exp * 1000 > Date.now()
+  } catch {
+    return false
+  }
 }
 
 export const jiraInboundHandler: InboundWebhookHandler = {

--- a/apps/web/src/lib/server/integrations/jira/inbound.ts
+++ b/apps/web/src/lib/server/integrations/jira/inbound.ts
@@ -1,33 +1,40 @@
 /**
  * Jira inbound webhook handler.
  *
- * Receives webhook events from Jira and extracts status changes.
- * Signature: HMAC-SHA256 in `X-Hub-Signature` header (optional, Jira Cloud).
- * Status field: `changelog.items[]` where `field === 'status'` → `toString`.
+ * OAuth 2.0 dynamic webhooks authenticate with a bearer JWT signed by the
+ * app client secret — not HMAC X-Hub-Signature (that is the admin-webhook API).
+ * Status field: changelog.items[] where field === 'status' → toString.
  */
 
-import { timingSafeEqual, createHmac } from 'crypto'
+import { createHmac, timingSafeEqual } from 'crypto'
 import type { InboundWebhookHandler, InboundWebhookResult } from '../inbound-types'
 
+function verifyHs256Jwt(token: string, secret: string): boolean {
+  const parts = token.split('.')
+  if (parts.length !== 3) return false
+  const [header, payload, signature] = parts
+  const expected = createHmac('sha256', secret).update(`${header}.${payload}`).digest()
+  const actual = Buffer.from(signature, 'base64url')
+  return actual.length === expected.length && timingSafeEqual(actual, expected)
+}
+
 export const jiraInboundHandler: InboundWebhookHandler = {
-  async verifySignature(request: Request, body: string, secret: string): Promise<true | Response> {
-    const rawSignature = request.headers.get('X-Hub-Signature')
-    if (!rawSignature) {
-      // Jira Cloud webhooks may not always have HMAC — but if we configured a secret, require it
-      return new Response('Missing signature', { status: 401 })
+  async verifySignature(request: Request): Promise<true | Response> {
+    const raw = request.headers.get('Authorization')
+    const token = raw?.startsWith('Bearer ') ? raw.slice('Bearer '.length).trim() : ''
+    if (!token) {
+      return new Response('Missing bearer token', { status: 401 })
     }
 
-    // Jira sends the signature as "sha256=<hex>" — strip the prefix for comparison
-    const signature = rawSignature.startsWith('sha256=')
-      ? rawSignature.slice('sha256='.length)
-      : rawSignature
+    const { getPlatformCredentials } =
+      await import('@/lib/server/domains/platform-credentials/platform-credential.service')
+    const credentials = await getPlatformCredentials('jira')
+    const clientSecret = credentials?.clientSecret
+    if (!clientSecret) {
+      return new Response('Jira credentials not configured', { status: 401 })
+    }
 
-    const expected = createHmac('sha256', secret).update(body).digest('hex')
-    const valid =
-      signature.length === expected.length &&
-      timingSafeEqual(Buffer.from(signature), Buffer.from(expected))
-
-    if (!valid) {
+    if (!verifyHs256Jwt(token, clientSecret)) {
       return new Response('Invalid signature', { status: 401 })
     }
 
@@ -37,7 +44,6 @@ export const jiraInboundHandler: InboundWebhookHandler = {
   async parseStatusChange(body: string): Promise<InboundWebhookResult | null> {
     const payload = JSON.parse(body)
 
-    // Jira sends `jira:issue_updated` for issue changes
     if (
       !payload.webhookEvent?.includes('issue_updated') &&
       payload.webhookEvent !== 'jira:issue_updated'
@@ -45,7 +51,6 @@ export const jiraInboundHandler: InboundWebhookHandler = {
       return null
     }
 
-    // Look for a status change in the changelog
     const statusChange = payload.changelog?.items?.find(
       (item: { field: string }) => item.field === 'status'
     )

--- a/apps/web/src/lib/server/integrations/jira/inbound.ts
+++ b/apps/web/src/lib/server/integrations/jira/inbound.ts
@@ -6,20 +6,16 @@
  * Status field: changelog.items[] where field === 'status' → toString.
  */
 
-import { createHmac, timingSafeEqual } from 'crypto'
+import { jwtVerify } from 'jose'
 import type { InboundWebhookHandler, InboundWebhookResult } from '../inbound-types'
 
-function verifyHs256Jwt(token: string, secret: string): boolean {
-  const parts = token.split('.')
-  if (parts.length !== 3) return false
-  const [header, payload, signature] = parts
-  const expected = createHmac('sha256', secret).update(`${header}.${payload}`).digest()
-  const actual = Buffer.from(signature, 'base64url')
-  if (actual.length !== expected.length || !timingSafeEqual(actual, expected)) return false
-
+async function verifyHs256Jwt(token: string, secret: string): Promise<boolean> {
   try {
-    const claims = JSON.parse(Buffer.from(payload, 'base64url').toString()) as { exp?: unknown }
-    return typeof claims.exp === 'number' && claims.exp * 1000 > Date.now()
+    await jwtVerify(token, new TextEncoder().encode(secret), {
+      algorithms: ['HS256'],
+      clockTolerance: '60s',
+    })
+    return true
   } catch {
     return false
   }
@@ -41,7 +37,7 @@ export const jiraInboundHandler: InboundWebhookHandler = {
       return new Response('Jira credentials not configured', { status: 401 })
     }
 
-    if (!verifyHs256Jwt(token, clientSecret)) {
+    if (!(await verifyHs256Jwt(token, clientSecret))) {
       return new Response('Invalid signature', { status: 401 })
     }
 

--- a/apps/web/src/lib/server/integrations/jira/webhook-registration.ts
+++ b/apps/web/src/lib/server/integrations/jira/webhook-registration.ts
@@ -1,23 +1,27 @@
 /**
- * Jira webhook registration.
+ * Jira dynamic webhook registration for inbound status sync.
  *
- * Uses Jira REST API to create/delete webhooks for issue status sync.
- * Note: Jira Cloud webhooks expire after 30 days by default.
+ * Uses POST /rest/api/3/webhook (Connect / OAuth 2.0). That API accepts only
+ * `=`, `!=`, `IN`, `NOT IN` in jqlFilter — not `IS` / `IS NOT`.
+ * Dynamic webhooks have no HMAC secret field.
  */
 
 interface JiraWebhookResult {
   webhookId: string
 }
 
-/**
- * Register a webhook with Jira to receive issue update events.
- */
+const PROJECT_REF = /^[A-Za-z0-9_]+$/
+
 export async function registerJiraWebhook(
   accessToken: string,
   cloudId: string,
   callbackUrl: string,
-  _secret: string
+  projectRef: string
 ): Promise<JiraWebhookResult> {
+  if (!PROJECT_REF.test(projectRef)) {
+    throw new Error('Invalid Jira project reference')
+  }
+
   const response = await fetch(`https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/webhook`, {
     method: 'POST',
     headers: {
@@ -29,7 +33,7 @@ export async function registerJiraWebhook(
       url: callbackUrl,
       webhooks: [
         {
-          jqlFilter: 'project is not EMPTY',
+          jqlFilter: `project = ${projectRef}`,
           events: ['jira:issue_updated'],
         },
       ],
@@ -42,19 +46,17 @@ export async function registerJiraWebhook(
   }
 
   const result = (await response.json()) as {
-    webhookRegistrationResult?: Array<{ createdWebhookId?: number }>
+    webhookRegistrationResult?: Array<{ createdWebhookId?: number; errors?: string[] }>
   }
-  const webhookId = result.webhookRegistrationResult?.[0]?.createdWebhookId
-  if (!webhookId) {
-    throw new Error('No webhook ID returned from Jira')
+  const first = result.webhookRegistrationResult?.[0]
+  if (!first?.createdWebhookId) {
+    const detail = first?.errors?.join('; ')
+    throw new Error(detail || 'No webhook ID returned from Jira')
   }
 
-  return { webhookId: String(webhookId) }
+  return { webhookId: String(first.createdWebhookId) }
 }
 
-/**
- * Delete a webhook from Jira.
- */
 export async function deleteJiraWebhook(
   accessToken: string,
   cloudId: string,


### PR DESCRIPTION
## Summary
Jira status-sync registration posted `project is not EMPTY`. Dynamic-webhook JQL only allows `=`, `!=`, `IN`, `NOT IN`, and Jira replies HTTP 200 with errors in the body — we only read `createdWebhookId` and showed “No webhook ID”.

OAuth 2.0 dynamic webhooks also do not HMAC-sign. After registration succeeded, every delivery hit 401 Missing signature.

- Register `project = <selected project>`
- Surface `webhookRegistrationResult[].errors`
- Verify the `Authorization` bearer JWT with the Jira platform client secret
- Status-sync UI is unchanged (Jira is auto-register, so the HMAC secret is not shown)

Closes #352

Follow-up (not in this PR): dynamic webhooks expire after 30 days unless refreshed.

## Test plan
- [x] Unit: registration JQL and error surfacing
- [x] Unit: inbound accepts a valid HS256 JWT, rejects missing/wrong signature, does not require X-Hub-Signature
- [ ] Enable Status sync on a connected Jira integration → webhook id stored, toggle stays on
- [ ] Change a linked issue’s status in Jira → post status updates
- [x] Linear/GitHub status-sync still HMAC-verifies (untouched)

Verified locally: Jira registration JQL + JWT inbound (13), Linear HMAC inbound (8). GitHub still verifies X-Hub-Signature-256; linear/github dirs unchanged vs main. Live Jira toggle/status-sync not run.