### PR TITLE
fix(auth): require Accept on portal invite magic-link callbacks

### DIFF
--- a/apps/web/src/lib/server/functions/invitations.ts
+++ b/apps/web/src/lib/server/functions/invitations.ts
@@ -3,7 +3,7 @@ import { getRequestHeaders } from '@tanstack/react-start/server'
 import { z } from 'zod'
 import type { InviteId, PrincipalId, UserId } from '@quackback/ids'
 import { generateId } from '@quackback/ids'
-import { db, invitation, principal, user, and, eq } from '@/lib/server/db'
+import { db, invitation, principal, user, and, eq, or } from '@/lib/server/db'
 import { getPublicUrlOrNull } from '@/lib/server/storage/s3'
 import { getSession } from '@/lib/server/auth/session'
 import { logger } from '@/lib/server/logger'
@@ -304,7 +304,10 @@ export const getInviteBrandingFn = createServerFn({ method: 'GET' })
       db.query.settings.findFirst(),
       db.query.invitation
         .findFirst({
-          where: and(eq(invitation.id, invitationId as InviteId), eq(invitation.kind, 'team')),
+          where: and(
+            eq(invitation.id, invitationId as InviteId),
+            or(eq(invitation.kind, 'team'), eq(invitation.kind, 'portal'))
+          ),
           with: { inviter: true },
         })
         .catch(() => null),

--- a/apps/web/src/lib/server/functions/invitations.ts
+++ b/apps/web/src/lib/server/functions/invitations.ts
@@ -3,7 +3,7 @@ import { getRequestHeaders } from '@tanstack/react-start/server'
 import { z } from 'zod'
 import type { InviteId, PrincipalId, UserId } from '@quackback/ids'
 import { generateId } from '@quackback/ids'
-import { db, invitation, principal, user, and, eq } from '@/lib/server/db'
+import { db, invitation, principal, user, and, eq, or } from '@/lib/server/db'
 import { getPublicUrlOrNull } from '@/lib/server/storage/s3'
 import { getSession } from '@/lib/server/auth/session'
 import { logger } from '@/lib/server/logger'
@@ -300,7 +300,6 @@ export const setPasswordFn = createServerFn({ method: 'POST' })
 export const getInviteBrandingFn = createServerFn({ method: 'GET' })
   .validator((invitationId: string) => invitationId)
   .handler(async ({ data: invitationId }) => {
-    const { or } = await import('@/lib/server/db')
     const [settings, inv] = await Promise.all([
       db.query.settings.findFirst(),
       db.query.invitation

--- a/apps/web/src/lib/server/functions/invitations.ts
+++ b/apps/web/src/lib/server/functions/invitations.ts
@@ -3,7 +3,7 @@ import { getRequestHeaders } from '@tanstack/react-start/server'
 import { z } from 'zod'
 import type { InviteId, PrincipalId, UserId } from '@quackback/ids'
 import { generateId } from '@quackback/ids'
-import { db, invitation, principal, user, and, eq, or } from '@/lib/server/db'
+import { db, invitation, principal, user, and, eq } from '@/lib/server/db'
 import { getPublicUrlOrNull } from '@/lib/server/storage/s3'
 import { getSession } from '@/lib/server/auth/session'
 import { logger } from '@/lib/server/logger'
@@ -300,6 +300,7 @@ export const setPasswordFn = createServerFn({ method: 'POST' })
 export const getInviteBrandingFn = createServerFn({ method: 'GET' })
   .validator((invitationId: string) => invitationId)
   .handler(async ({ data: invitationId }) => {
+    const { or } = await import('@/lib/server/db')
     const [settings, inv] = await Promise.all([
       db.query.settings.findFirst(),
       db.query.invitation

--- a/apps/web/src/lib/shared/__tests__/parse-invitation-id.test.ts
+++ b/apps/web/src/lib/shared/__tests__/parse-invitation-id.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { parseInvitationId } from '../parse-invitation-id'
+
+describe('parseInvitationId', () => {
+  it('recognizes team signup callbacks', () => {
+    expect(parseInvitationId('https://acme.test/complete-signup/invite_abc123')).toBe(
+      'invite_abc123'
+    )
+  })
+
+  it('recognizes portal invite callbacks', () => {
+    expect(parseInvitationId('https://acme.test/portal-invite/invite_abc123')).toBe('invite_abc123')
+  })
+
+  it('ignores ordinary magic-link callbacks', () => {
+    expect(parseInvitationId('https://acme.test/auth/login')).toBeNull()
+  })
+
+  it('returns null for missing or unparseable input', () => {
+    expect(parseInvitationId(undefined)).toBeNull()
+    expect(parseInvitationId('not a url')).toBeNull()
+  })
+})

--- a/apps/web/src/lib/shared/__tests__/parse-invitation-id.test.ts
+++ b/apps/web/src/lib/shared/__tests__/parse-invitation-id.test.ts
@@ -20,4 +20,10 @@ describe('parseInvitationId', () => {
     expect(parseInvitationId(undefined)).toBeNull()
     expect(parseInvitationId('not a url')).toBeNull()
   })
+
+  it('reads the id from a full magic-link callbackURL with query string', () => {
+    expect(
+      parseInvitationId('https://acme.test/portal-invite/invite_abc123?error=INVALID_TOKEN')
+    ).toBe('invite_abc123')
+  })
 })

--- a/apps/web/src/lib/shared/parse-invitation-id.ts
+++ b/apps/web/src/lib/shared/parse-invitation-id.ts
@@ -1,0 +1,11 @@
+/** Invitation id from a magic-link callback URL (`/complete-signup/…` or `/portal-invite/…`). */
+export function parseInvitationId(callbackURL: string | undefined): string | null {
+  if (!callbackURL) return null
+  try {
+    const path = new URL(callbackURL).pathname
+    const match = path.match(/\/(?:complete-signup|portal-invite)\/(invite_[a-z0-9]+)/)
+    return match?.[1] ?? null
+  } catch {
+    return null
+  }
+}

--- a/apps/web/src/routes/verify-magic-link.tsx
+++ b/apps/web/src/routes/verify-magic-link.tsx
@@ -9,6 +9,7 @@ import {
 import { ArrowPathIcon } from '@heroicons/react/24/solid'
 import { Button } from '@/components/ui/button'
 import { getInviteBrandingFn } from '@/lib/server/functions/invitations'
+import { parseInvitationId } from '@/lib/shared/parse-invitation-id'
 
 interface InviteBranding {
   workspaceName: string
@@ -22,18 +23,6 @@ const FEATURES = [
   { icon: BoltIcon, label: '24 integrations' },
   { icon: MapIcon, label: 'Roadmap & changelog' },
 ] as const
-
-/** Extract an invitation ID (invite_...) from a callback URL path */
-function parseInvitationId(callbackURL: string | undefined): string | null {
-  if (!callbackURL) return null
-  try {
-    const path = new URL(callbackURL).pathname
-    const match = path.match(/\/complete-signup\/(invite_[a-z0-9]+)/)
-    return match?.[1] ?? null
-  } catch {
-    return null
-  }
-}
 
 export const Route = createFileRoute('/verify-magic-link')({
   validateSearch: (search: Record<string, unknown>) => ({


### PR DESCRIPTION
## Summary
Portal invite emails use `/portal-invite/invite_…` as the magic-link callback. `parseInvitationId` only recognized `/complete-signup/…`, so portal invites rendered the generic auto-verify page and a preloader could consume the single-use token. The recipient then saw “An unexpected error occurred” (`#362`).

- Treat `/portal-invite/` as an invitation callback (explicit Accept)
- Shared branding lookup now includes portal invites so the Accept page can show the inviter
- Ordinary magic-link sign-in is unchanged

Closes #344

`#362` is the same copy as the portal-invite error page; close as duplicate after this lands unless a team-invite repro appears.

## Test plan
- [x] Unit: parseInvitationId for team, portal, and non-invite callbacks
- [ ] Send a portal invite, open the link → Accept button, no auto-redirect
- [ ] Click Accept → account/session created, invite accepted, portal loads
- [x] Team invite `/complete-signup/` still requires Accept
- [x] Password/magic-link sign-in still auto-verifies

Verified locally: parseInvitationId + portal-invite loader/accept (103) and branding against Docker Postgres. `/complete-signup/` and `/portal-invite/` both route to InvitationVerifyPage (Accept, no auto-redirect). Non-invite callbacks still use GenericVerifyPage (auto-verify). Live send/click not run (local DB schema is ahead of this branch).