### PR TITLE
fix(users): detach portal users instead of deleting against RESTRICT FKs

### DIFF
--- a/apps/web/src/lib/client/mutations/users.ts
+++ b/apps/web/src/lib/client/mutations/users.ts
@@ -14,6 +14,7 @@ import {
   updatePortalUserFn,
 } from '@/lib/server/functions/admin'
 import { usersKeys } from '@/lib/client/hooks/use-users-queries'
+import { toast } from 'sonner'
 
 // ============================================================================
 // Mutation Hooks
@@ -86,7 +87,7 @@ export function useRemovePortalUser() {
 
       return { previousLists }
     },
-    onError: (_err, _principalId, context) => {
+    onError: (err, _principalId, context) => {
       if (context?.previousLists) {
         for (const [queryKey, data] of context.previousLists) {
           if (data) {
@@ -94,6 +95,7 @@ export function useRemovePortalUser() {
           }
         }
       }
+      toast.error(err instanceof Error ? err.message : 'Failed to remove portal user')
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: usersKeys.lists() })

--- a/apps/web/src/lib/server/domains/users/__tests__/remove-portal-user.test.ts
+++ b/apps/web/src/lib/server/domains/users/__tests__/remove-portal-user.test.ts
@@ -6,7 +6,7 @@ const hoisted = vi.hoisted(() => ({
   updateSet: vi.fn(),
   updateWhere: vi.fn(),
   deleteWhere: vi.fn(),
-  eq: vi.fn((col: unknown, val: unknown) => ({ col, val })),
+  eq: vi.fn((...args: unknown[]) => ({ col: args[0], val: args[1] })),
   and: vi.fn((...args: unknown[]) => args),
   cacheDel: vi.fn(),
 }))

--- a/apps/web/src/lib/server/domains/users/__tests__/remove-portal-user.test.ts
+++ b/apps/web/src/lib/server/domains/users/__tests__/remove-portal-user.test.ts
@@ -30,6 +30,10 @@ vi.mock('@/lib/server/db', () => {
     },
     principal: { id: 'principal.id', role: 'principal.role' },
     session: { userId: 'session.userId' },
+    conversations: {
+      visitorEmail: 'conversations.visitorEmail',
+      visitorPrincipalId: 'conversations.visitorPrincipalId',
+    },
     user: {},
     posts: {},
     comments: {},
@@ -54,7 +58,7 @@ vi.mock('@/lib/server/redis', () => ({
 }))
 
 vi.mock('@/lib/server/logger', () => ({
-  logger: { child: () => ({ error: vi.fn(), debug: vi.fn(), info: vi.fn() }) },
+  logger: { child: () => ({ error: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn() }) },
 }))
 
 const { removePortalUser } = await import('../user.service')
@@ -87,7 +91,7 @@ describe('removePortalUser', () => {
 
     await removePortalUser(PRINCIPAL_ID)
 
-    expect(hoisted.updateSet).toHaveBeenCalledWith({
+    expect(hoisted.updateSet).toHaveBeenNthCalledWith(1, {
       userId: null,
       type: 'anonymous',
       displayName: 'Removed user',
@@ -95,9 +99,27 @@ describe('removePortalUser', () => {
       avatarKey: null,
       contactEmail: null,
     })
+    expect(hoisted.updateSet).toHaveBeenNthCalledWith(2, { visitorEmail: null })
     expect(hoisted.updateWhere).toHaveBeenCalledWith({ col: 'principal.id', val: PRINCIPAL_ID })
+    expect(hoisted.updateWhere).toHaveBeenCalledWith({
+      col: 'conversations.visitorPrincipalId',
+      val: PRINCIPAL_ID,
+    })
     expect(hoisted.deleteWhere).toHaveBeenCalledWith({ col: 'session.userId', val: 'user_1' })
     expect(hoisted.cacheDel).toHaveBeenCalledWith('principal:user:user_1')
+  })
+
+  it('does not fail the remove when cache invalidation throws', async () => {
+    hoisted.findFirst.mockResolvedValue({
+      id: PRINCIPAL_ID,
+      userId: 'user_1',
+      role: 'user',
+    })
+    hoisted.cacheDel.mockRejectedValue(new Error('redis down'))
+
+    await expect(removePortalUser(PRINCIPAL_ID)).resolves.toBeUndefined()
+    expect(hoisted.updateSet).toHaveBeenCalled()
+    expect(hoisted.deleteWhere).toHaveBeenCalled()
   })
 
   it('skips session delete when the principal has no userId', async () => {

--- a/apps/web/src/lib/server/domains/users/__tests__/remove-portal-user.test.ts
+++ b/apps/web/src/lib/server/domains/users/__tests__/remove-portal-user.test.ts
@@ -8,6 +8,7 @@ const hoisted = vi.hoisted(() => ({
   deleteWhere: vi.fn(),
   eq: vi.fn((col: unknown, val: unknown) => ({ col, val })),
   and: vi.fn((...args: unknown[]) => args),
+  cacheDel: vi.fn(),
 }))
 
 vi.mock('@/lib/server/db', () => {
@@ -46,6 +47,11 @@ vi.mock('@/lib/server/db', () => {
     sql: vi.fn(),
   }
 })
+
+vi.mock('@/lib/server/redis', () => ({
+  cacheDel: (...args: unknown[]) => hoisted.cacheDel(...args),
+  CACHE_KEYS: { PRINCIPAL_BY_USER: (userId: string) => `principal:user:${userId}` },
+}))
 
 vi.mock('@/lib/server/logger', () => ({
   logger: { child: () => ({ error: vi.fn(), debug: vi.fn(), info: vi.fn() }) },
@@ -91,6 +97,7 @@ describe('removePortalUser', () => {
     })
     expect(hoisted.updateWhere).toHaveBeenCalledWith({ col: 'principal.id', val: PRINCIPAL_ID })
     expect(hoisted.deleteWhere).toHaveBeenCalledWith({ col: 'session.userId', val: 'user_1' })
+    expect(hoisted.cacheDel).toHaveBeenCalledWith('principal:user:user_1')
   })
 
   it('skips session delete when the principal has no userId', async () => {
@@ -104,5 +111,6 @@ describe('removePortalUser', () => {
 
     expect(hoisted.updateSet).toHaveBeenCalled()
     expect(hoisted.deleteWhere).not.toHaveBeenCalled()
+    expect(hoisted.cacheDel).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/lib/server/domains/users/__tests__/remove-portal-user.test.ts
+++ b/apps/web/src/lib/server/domains/users/__tests__/remove-portal-user.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { PrincipalId } from '@quackback/ids'
+
+const hoisted = vi.hoisted(() => ({
+  findFirst: vi.fn(),
+  updateSet: vi.fn(),
+  updateWhere: vi.fn(),
+  deleteWhere: vi.fn(),
+  eq: vi.fn((col: unknown, val: unknown) => ({ col, val })),
+  and: vi.fn((...args: unknown[]) => args),
+}))
+
+vi.mock('@/lib/server/db', () => {
+  const tx = {
+    update: () => ({
+      set: (values: unknown) => {
+        hoisted.updateSet(values)
+        return { where: (...args: unknown[]) => hoisted.updateWhere(...args) }
+      },
+    }),
+    delete: () => ({
+      where: (...args: unknown[]) => hoisted.deleteWhere(...args),
+    }),
+  }
+  return {
+    db: {
+      query: { principal: { findFirst: (...args: unknown[]) => hoisted.findFirst(...args) } },
+      transaction: async (fn: (t: typeof tx) => unknown) => fn(tx),
+    },
+    principal: { id: 'principal.id', role: 'principal.role' },
+    session: { userId: 'session.userId' },
+    user: {},
+    posts: {},
+    comments: {},
+    votes: {},
+    userSegments: {},
+    segments: {},
+    eq: (...args: unknown[]) => hoisted.eq(...args),
+    and: (...args: unknown[]) => hoisted.and(...args),
+    or: vi.fn(),
+    ilike: vi.fn(),
+    inArray: vi.fn(),
+    isNull: vi.fn(),
+    desc: vi.fn(),
+    asc: vi.fn(),
+    sql: vi.fn(),
+  }
+})
+
+vi.mock('@/lib/server/logger', () => ({
+  logger: { child: () => ({ error: vi.fn(), debug: vi.fn(), info: vi.fn() }) },
+}))
+
+const { removePortalUser } = await import('../user.service')
+
+const PRINCIPAL_ID = 'principal_portal1' as PrincipalId
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  hoisted.updateWhere.mockResolvedValue(undefined)
+  hoisted.deleteWhere.mockResolvedValue(undefined)
+})
+
+describe('removePortalUser', () => {
+  it('throws when the principal is missing or not a portal user', async () => {
+    hoisted.findFirst.mockResolvedValue(null)
+
+    await expect(removePortalUser(PRINCIPAL_ID)).rejects.toMatchObject({
+      code: 'MEMBER_NOT_FOUND',
+    })
+    expect(hoisted.updateSet).not.toHaveBeenCalled()
+    expect(hoisted.deleteWhere).not.toHaveBeenCalled()
+  })
+
+  it('anonymizes the principal and revokes sessions for the detached user', async () => {
+    hoisted.findFirst.mockResolvedValue({
+      id: PRINCIPAL_ID,
+      userId: 'user_1',
+      role: 'user',
+    })
+
+    await removePortalUser(PRINCIPAL_ID)
+
+    expect(hoisted.updateSet).toHaveBeenCalledWith({
+      userId: null,
+      type: 'anonymous',
+      displayName: 'Removed user',
+      avatarUrl: null,
+      avatarKey: null,
+      contactEmail: null,
+    })
+    expect(hoisted.updateWhere).toHaveBeenCalledWith({ col: 'principal.id', val: PRINCIPAL_ID })
+    expect(hoisted.deleteWhere).toHaveBeenCalledWith({ col: 'session.userId', val: 'user_1' })
+  })
+
+  it('skips session delete when the principal has no userId', async () => {
+    hoisted.findFirst.mockResolvedValue({
+      id: PRINCIPAL_ID,
+      userId: null,
+      role: 'user',
+    })
+
+    await removePortalUser(PRINCIPAL_ID)
+
+    expect(hoisted.updateSet).toHaveBeenCalled()
+    expect(hoisted.deleteWhere).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/lib/server/domains/users/__tests__/user-service.test.ts
+++ b/apps/web/src/lib/server/domains/users/__tests__/user-service.test.ts
@@ -347,6 +347,33 @@ describe('user.service', () => {
       expect(metadata._externalUserId).toBe('ext-789') // must be preserved
     })
 
+    it('mints a principal when the user exists after a detach', async () => {
+      const existingUser = {
+        id: 'user_existing' as UserId,
+        name: 'Existing User',
+        email: 'existing@example.com',
+        image: null,
+        emailVerified: false,
+        metadata: null,
+        createdAt: new Date('2024-01-01'),
+      }
+
+      mockFindFirst.mockResolvedValueOnce(existingUser).mockResolvedValueOnce(existingUser)
+      const { db } = await import('@/lib/server/db')
+      vi.mocked(db.query.principal.findFirst).mockResolvedValueOnce(undefined)
+
+      const { identifyPortalUser } = await import('../user.identify')
+      const result = await identifyPortalUser({ email: 'existing@example.com' })
+
+      expect(result.created).toBe(true)
+      expect(
+        insertValuesCalls.some((args) => {
+          const row = args[0] as Record<string, unknown>
+          return row.role === 'user' && row.userId === 'user_existing'
+        })
+      ).toBe(true)
+    })
+
     it('should remove _externalUserId when externalId is set to null', async () => {
       const existingUser = {
         id: 'user_existing' as UserId,

--- a/apps/web/src/lib/server/domains/users/user.identify.ts
+++ b/apps/web/src/lib/server/domains/users/user.identify.ts
@@ -149,12 +149,24 @@ export async function identifyPortalUser(
     }
   }
 
-  const principalRecord = await db.query.principal.findFirst({
+  let principalRecord = await db.query.principal.findFirst({
     where: eq(principal.userId, userRecord.id),
     columns: { id: true },
   })
   if (!principalRecord) {
-    throw new NotFoundError('PRINCIPAL_NOT_FOUND', `No principal found for user ${userRecord.id}`)
+    const [inserted] = await db
+      .insert(principal)
+      .values({
+        id: generateId('principal'),
+        userId: userRecord.id,
+        role: 'user',
+        displayName: userRecord.name ?? defaultName,
+        avatarUrl: userRecord.image ?? null,
+        createdAt: new Date(),
+      })
+      .returning({ id: principal.id })
+    principalRecord = inserted
+    created = true
   }
 
   return {

--- a/apps/web/src/lib/server/domains/users/user.service.ts
+++ b/apps/web/src/lib/server/domains/users/user.service.ts
@@ -407,6 +407,11 @@ export async function removePortalUser(principalId: PrincipalId): Promise<void> 
         await tx.delete(session).where(eq(session.userId, userId))
       }
     })
+
+    if (userId) {
+      const { cacheDel, CACHE_KEYS } = await import('@/lib/server/redis')
+      await cacheDel(CACHE_KEYS.PRINCIPAL_BY_USER(userId))
+    }
   } catch (error) {
     if (error instanceof NotFoundError) throw error
     log.error({ err: error }, 'failed to remove portal user')

--- a/apps/web/src/lib/server/domains/users/user.service.ts
+++ b/apps/web/src/lib/server/domains/users/user.service.ts
@@ -368,12 +368,9 @@ export async function listPortalUsers(
 /**
  * Remove a portal user from the portal (soft removal).
  *
- * Deletes the `principal` record (role='user') only — the Better-Auth `user`
- * and `account` rows are intentionally retained so we still recognize the
- * person if they return (and their re-join shows distinct "joined" vs
- * "account created" dates). The FK is `principal.userId -> user` with
- * onDelete cascade, so deleting the principal does NOT remove the user; a
- * returning sign-in re-provisions a principal via the SSO hooks or lazily.
+ * Detaches the `principal` from its Better-Auth `user` instead of deleting
+ * the row: chat/posts/comments RESTRICT principal deletes. The user row is
+ * kept so a later sign-in provisions a fresh principal.
  */
 export async function removePortalUser(principalId: PrincipalId): Promise<void> {
   try {
@@ -389,8 +386,21 @@ export async function removePortalUser(principalId: PrincipalId): Promise<void> 
       )
     }
 
-    // Delete principal record (user record will be deleted via CASCADE since user is org-scoped)
-    await db.delete(principal).where(eq(principal.id, principalId))
+    // Detach rather than DELETE: chat/posts/comments RESTRICT the principal
+    // row. Clearing userId drops them from the portal-user list (inner join
+    // on user) while keeping history. The user row stays so a later sign-in
+    // provisions a fresh principal.
+    await db
+      .update(principal)
+      .set({
+        userId: null,
+        type: 'anonymous',
+        displayName: 'Removed user',
+        avatarUrl: null,
+        avatarKey: null,
+        contactEmail: null,
+      })
+      .where(eq(principal.id, principalId))
   } catch (error) {
     if (error instanceof NotFoundError) throw error
     log.error({ err: error }, 'failed to remove portal user')

--- a/apps/web/src/lib/server/domains/users/user.service.ts
+++ b/apps/web/src/lib/server/domains/users/user.service.ts
@@ -23,6 +23,7 @@ import {
   sql,
   principal,
   user,
+  session,
   posts,
   comments,
   votes,
@@ -369,12 +370,13 @@ export async function listPortalUsers(
  * Remove a portal user from the portal (soft removal).
  *
  * Detaches the `principal` from its Better-Auth `user` instead of deleting
- * the row: chat/posts/comments RESTRICT principal deletes. The user row is
- * kept so a later sign-in provisions a fresh principal.
+ * the row: chat/posts/comments RESTRICT principal deletes. Sessions are
+ * revoked in the same transaction so getOptionalAuth cannot immediately
+ * provision a replacement principal for a still-cookied user. The user
+ * row is kept so a later sign-in provisions a fresh principal.
  */
 export async function removePortalUser(principalId: PrincipalId): Promise<void> {
   try {
-    // Verify principal exists and has role='user'
     const existingPrincipal = await db.query.principal.findFirst({
       where: and(eq(principal.id, principalId), eq(principal.role, 'user')),
     })
@@ -386,21 +388,25 @@ export async function removePortalUser(principalId: PrincipalId): Promise<void> 
       )
     }
 
-    // Detach rather than DELETE: chat/posts/comments RESTRICT the principal
-    // row. Clearing userId drops them from the portal-user list (inner join
-    // on user) while keeping history. The user row stays so a later sign-in
-    // provisions a fresh principal.
-    await db
-      .update(principal)
-      .set({
-        userId: null,
-        type: 'anonymous',
-        displayName: 'Removed user',
-        avatarUrl: null,
-        avatarKey: null,
-        contactEmail: null,
-      })
-      .where(eq(principal.id, principalId))
+    const userId = existingPrincipal.userId
+
+    await db.transaction(async (tx) => {
+      await tx
+        .update(principal)
+        .set({
+          userId: null,
+          type: 'anonymous',
+          displayName: 'Removed user',
+          avatarUrl: null,
+          avatarKey: null,
+          contactEmail: null,
+        })
+        .where(eq(principal.id, principalId))
+
+      if (userId) {
+        await tx.delete(session).where(eq(session.userId, userId))
+      }
+    })
   } catch (error) {
     if (error instanceof NotFoundError) throw error
     log.error({ err: error }, 'failed to remove portal user')

--- a/apps/web/src/lib/server/domains/users/user.service.ts
+++ b/apps/web/src/lib/server/domains/users/user.service.ts
@@ -24,6 +24,7 @@ import {
   principal,
   user,
   session,
+  conversations,
   posts,
   comments,
   votes,
@@ -403,14 +404,26 @@ export async function removePortalUser(principalId: PrincipalId): Promise<void> 
         })
         .where(eq(principal.id, principalId))
 
+      await tx
+        .update(conversations)
+        .set({ visitorEmail: null })
+        .where(eq(conversations.visitorPrincipalId, principalId))
+
       if (userId) {
         await tx.delete(session).where(eq(session.userId, userId))
       }
     })
 
     if (userId) {
-      const { cacheDel, CACHE_KEYS } = await import('@/lib/server/redis')
-      await cacheDel(CACHE_KEYS.PRINCIPAL_BY_USER(userId))
+      try {
+        const { cacheDel, CACHE_KEYS } = await import('@/lib/server/redis')
+        await cacheDel(CACHE_KEYS.PRINCIPAL_BY_USER(userId))
+      } catch (error) {
+        log.warn(
+          { err: error, user_id: userId },
+          'failed to invalidate principal cache after remove'
+        )
+      }
     }
   } catch (error) {
     if (error instanceof NotFoundError) throw error


### PR DESCRIPTION
## Summary
Admin → Users → Remove from portal deleted the principal. Chat conversations/messages (and posts/comments) are `ON DELETE RESTRICT`, so Postgres failed, React Query rolled back, and no toast was shown.

Deleting would also drop history. Instead we detach: clear `userId`, mark the principal anonymous as “Removed user”, keep the Better-Auth user so a later sign-in provisions a fresh principal. The users list inner-joins `user`, so they disappear immediately. Failures now toast.

Closes #363

## Test plan
- [x] Remove a portal user who only opened chat → they leave the list, conversation remains as “Removed user”
- [x] Remove a portal user with posts → posts remain, author shows as Removed user
- [x] Same email can sign in again and get a new principal
- [x] Include Anonymous filter still does not list them (no user row join)

Verified locally against Docker Postgres (transaction rollback): detach clears visitorEmail/sessions, remints a new principal on identify, authored posts stay as Removed user, inner-join list omits the detached row.