### PR TITLE
fix(invitations): claim team invites in one transaction

### DIFF
--- a/apps/web/src/lib/server/functions/__tests__/accept-invitation.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/accept-invitation.test.ts
@@ -188,6 +188,20 @@ describe('acceptInvitationFn', () => {
     expect(hoisted.sets.some((s) => s.values.status === 'pending')).toBe(false)
   })
 
+  it('reports canceled before expiry when a canceled invite is also past due', async () => {
+    hoisted.invitationReturning.mockResolvedValue([])
+    hoisted.findInvitation.mockResolvedValue({
+      id: INVITE_ID,
+      email: 'alex@example.com',
+      kind: 'team',
+      status: 'canceled',
+      expiresAt: PAST,
+    })
+
+    await expect(accept({ data: { invitationId: INVITE_ID } })).rejects.toThrow('cancelled')
+    expect(hoisted.sets.some((s) => s.values.status === 'pending')).toBe(false)
+  })
+
   it('leaves the row untouched when the invite is expired', async () => {
     hoisted.invitationReturning.mockResolvedValue([])
     hoisted.findInvitation.mockResolvedValue({

--- a/apps/web/src/lib/server/functions/__tests__/accept-invitation.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/accept-invitation.test.ts
@@ -1,0 +1,215 @@
+/**
+ * acceptInvitationFn — claim lives in one transaction with principal writes.
+ * A failed accept must not write `pending` after a claim (the reopen bug).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+type AnyHandler = (args: { data: Record<string, unknown> }) => Promise<unknown>
+
+const handlers: AnyHandler[] = []
+
+vi.mock('@tanstack/react-start', () => ({
+  createServerFn: () => {
+    const chain = {
+      validator() {
+        return chain
+      },
+      handler(fn: AnyHandler) {
+        handlers.push(fn)
+        return chain
+      },
+    }
+    return chain
+  },
+}))
+
+vi.mock('@tanstack/react-start/server', () => ({
+  getRequestHeaders: () => new Headers(),
+}))
+
+const hoisted = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  findInvitation: vi.fn(),
+  findPrincipal: vi.fn(),
+  invitationReturning: vi.fn(),
+  insertValues: vi.fn(),
+  sets: [] as Array<{ table: string; values: Record<string, unknown> }>,
+  revokeMagicLinkTokens: vi.fn(),
+  generateId: vi.fn(() => 'principal_new'),
+}))
+
+vi.mock('@/lib/server/auth/session', () => ({
+  getSession: hoisted.getSession,
+}))
+
+vi.mock('@/lib/server/auth/magic-link-mint', () => ({
+  revokeMagicLinkTokens: hoisted.revokeMagicLinkTokens,
+}))
+
+vi.mock('@quackback/ids', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@quackback/ids')>()
+  return { ...actual, generateId: hoisted.generateId }
+})
+
+vi.mock('@/lib/server/storage/s3', () => ({
+  getPublicUrlOrNull: vi.fn(),
+}))
+
+vi.mock('@/lib/server/logger', () => ({
+  logger: { child: () => ({ debug: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn() }) },
+}))
+
+vi.mock('@/lib/server/db', () => {
+  const invitation = {
+    id: 'invitation.id',
+    status: 'invitation.status',
+    kind: 'invitation.kind',
+    email: 'invitation.email',
+    expiresAt: 'invitation.expiresAt',
+    $inferSelect: {},
+  }
+  const principal = { id: 'principal.id', userId: 'principal.userId' }
+  const user = { id: 'user.id' }
+
+  const tx = {
+    query: {
+      invitation: { findFirst: (...args: unknown[]) => hoisted.findInvitation(...args) },
+      principal: { findFirst: (...args: unknown[]) => hoisted.findPrincipal(...args) },
+    },
+    update: (table: { id?: string }) => ({
+      set: (values: Record<string, unknown>) => {
+        const name =
+          table === invitation ? 'invitation' : table === principal ? 'principal' : 'user'
+        hoisted.sets.push({ table: name, values })
+        return {
+          where: () => ({
+            returning: () =>
+              name === 'invitation' ? hoisted.invitationReturning() : Promise.resolve([]),
+          }),
+        }
+      },
+    }),
+    insert: () => ({
+      values: (values: unknown) => hoisted.insertValues(values),
+    }),
+  }
+
+  return {
+    db: {
+      transaction: async (fn: (t: typeof tx) => unknown) => fn(tx),
+      query: tx.query,
+    },
+    invitation,
+    principal,
+    user,
+    eq: vi.fn((col, val) => ({ col, val })),
+    and: vi.fn((...args: unknown[]) => args),
+    gt: vi.fn((col, val) => ({ col, val })),
+    sql: vi.fn((parts: TemplateStringsArray) => parts.raw[0]),
+  }
+})
+
+const ACCEPT_IDX = 1
+const FUTURE = new Date(Date.now() + 86_400_000)
+const PAST = new Date(Date.now() - 1000)
+const INVITE_ID = 'invite_team1'
+const SESSION = { user: { id: 'user_1', email: 'Alex@Example.com' } }
+
+const CLAIMED = {
+  id: INVITE_ID,
+  email: 'alex@example.com',
+  kind: 'team',
+  status: 'accepted',
+  role: 'member',
+  expiresAt: FUTURE,
+  magicLinkTokens: ['tok_1'],
+}
+
+let accept: AnyHandler
+
+beforeEach(async () => {
+  vi.clearAllMocks()
+  hoisted.sets.length = 0
+  hoisted.generateId.mockReturnValue('principal_new')
+  hoisted.revokeMagicLinkTokens.mockResolvedValue(undefined)
+  hoisted.getSession.mockResolvedValue(SESSION)
+  hoisted.findPrincipal.mockResolvedValue(null)
+  hoisted.insertValues.mockResolvedValue(undefined)
+  hoisted.invitationReturning.mockResolvedValue([CLAIMED])
+
+  if (handlers.length === 0) {
+    await import('../invitations')
+  }
+  accept = handlers[ACCEPT_IDX]
+})
+
+describe('acceptInvitationFn', () => {
+  it('claims a pending team invite and does not write pending afterwards', async () => {
+    const result = await accept({ data: { invitationId: INVITE_ID } })
+
+    expect(result).toEqual({ invitationId: INVITE_ID })
+    expect(hoisted.sets.filter((s) => s.table === 'invitation')).toEqual([
+      { table: 'invitation', values: { status: 'accepted' } },
+    ])
+    expect(hoisted.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user_1', role: 'member' })
+    )
+    expect(hoisted.revokeMagicLinkTokens).toHaveBeenCalledWith(['tok_1'])
+  })
+
+  it('does not reopen an already-accepted invite', async () => {
+    hoisted.invitationReturning.mockResolvedValue([])
+    hoisted.findInvitation.mockResolvedValue({
+      ...CLAIMED,
+      status: 'accepted',
+    })
+
+    await expect(accept({ data: { invitationId: INVITE_ID } })).rejects.toThrow(
+      'already been accepted'
+    )
+    expect(hoisted.sets.some((s) => s.values.status === 'pending')).toBe(false)
+    expect(hoisted.insertValues).not.toHaveBeenCalled()
+    expect(hoisted.revokeMagicLinkTokens).not.toHaveBeenCalled()
+  })
+
+  it('leaves the row untouched on email mismatch', async () => {
+    hoisted.invitationReturning.mockResolvedValue([])
+    hoisted.findInvitation.mockResolvedValue({
+      id: INVITE_ID,
+      email: 'other@example.com',
+      kind: 'team',
+      status: 'pending',
+      expiresAt: FUTURE,
+    })
+
+    await expect(accept({ data: { invitationId: INVITE_ID } })).rejects.toThrow(
+      'different email address'
+    )
+    expect(hoisted.sets.some((s) => s.values.status === 'pending')).toBe(false)
+  })
+
+  it('leaves the row untouched when the invite is expired', async () => {
+    hoisted.invitationReturning.mockResolvedValue([])
+    hoisted.findInvitation.mockResolvedValue({
+      id: INVITE_ID,
+      email: 'alex@example.com',
+      kind: 'team',
+      status: 'pending',
+      expiresAt: PAST,
+    })
+
+    await expect(accept({ data: { invitationId: INVITE_ID } })).rejects.toThrow('expired')
+    expect(hoisted.sets.some((s) => s.values.status === 'pending')).toBe(false)
+  })
+
+  it('does not reopen the invite when a principal write fails after claim', async () => {
+    hoisted.insertValues.mockRejectedValue(new Error('unique violation'))
+
+    await expect(accept({ data: { invitationId: INVITE_ID } })).rejects.toThrow('unique violation')
+    expect(hoisted.sets.filter((s) => s.table === 'invitation')).toEqual([
+      { table: 'invitation', values: { status: 'accepted' } },
+    ])
+    expect(hoisted.sets.some((s) => s.values.status === 'pending')).toBe(false)
+    expect(hoisted.revokeMagicLinkTokens).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/lib/server/functions/invitations.ts
+++ b/apps/web/src/lib/server/functions/invitations.ts
@@ -3,7 +3,7 @@ import { getRequestHeaders } from '@tanstack/react-start/server'
 import { z } from 'zod'
 import type { InviteId, PrincipalId, UserId } from '@quackback/ids'
 import { generateId } from '@quackback/ids'
-import { db, invitation, principal, user, and, eq } from '@/lib/server/db'
+import { db, invitation, principal, user, and, eq, gt, sql } from '@/lib/server/db'
 import { getPublicUrlOrNull } from '@/lib/server/storage/s3'
 import { getSession } from '@/lib/server/auth/session'
 import { logger } from '@/lib/server/logger'
@@ -126,154 +126,124 @@ export const acceptInvitationFn = createServerFn({ method: 'POST' })
   .handler(async ({ data }) => {
     const { invitationId, name } = data
     log.debug({ invitation_id: invitationId }, 'accept invitation: entry')
-    // Track whether we successfully claimed the invitation so the catch
-    // block only rolls back when we actually changed its status.
-    let didClaim = false
+
+    const session = await getSession()
+    if (!session?.user) {
+      log.warn('accept invitation: no session')
+      throw new Error('Your session has expired. Please sign in again using the invitation link.')
+    }
+
+    const userId = session.user.id as UserId
+    const userEmail = session.user.email?.toLowerCase()
+    log.debug({ user_id: userId }, 'accept invitation: session resolved')
+
+    if (!userEmail) {
+      throw new Error(
+        'Your account is missing an email address. Please contact your administrator.'
+      )
+    }
+
+    let claimed: typeof invitation.$inferSelect
     try {
-      // Get current session
-      const session = await getSession()
-      if (!session?.user) {
-        log.warn('accept invitation: no session')
-        throw new Error('Your session has expired. Please sign in again using the invitation link.')
-      }
-
-      const userId = session.user.id as UserId
-      const userEmail = session.user.email?.toLowerCase()
-      log.debug({ user_id: userId }, 'accept invitation: session resolved')
-
-      if (!userEmail) {
-        throw new Error(
-          'Your account is missing an email address. Please contact your administrator.'
-        )
-      }
-
-      // Atomically claim the invitation with a conditional update to prevent
-      // double-accept race conditions (e.g., double-click, network retry).
-      // The `kind='team'` guard ensures portal invites cannot be consumed here.
-      const [claimed] = await db
-        .update(invitation)
-        .set({ status: 'accepted' })
-        .where(
-          and(
-            eq(invitation.id, invitationId as InviteId),
-            eq(invitation.status, 'pending'),
-            eq(invitation.kind, 'team')
-          )
-        )
-        .returning()
-
-      if (!claimed) {
-        // Either doesn't exist, already accepted, cancelled, or expired
-        const inv = await db.query.invitation.findFirst({
-          where: and(eq(invitation.id, invitationId as InviteId), eq(invitation.kind, 'team')),
-        })
-        log.warn(
-          { invitation_id: invitationId, exists: !!inv, status: inv?.status },
-          'accept invitation: claim failed'
-        )
-        if (!inv) throw new Error('This invitation could not be found. It may have been cancelled.')
-        throw new Error(
-          inv.status === 'accepted'
-            ? 'This invitation has already been accepted'
-            : 'This invitation has been cancelled. Please ask your administrator to send a new one.'
-        )
-      }
-
-      didClaim = true
-      log.debug({ invitation_id: invitationId, role: claimed.role }, 'accept invitation: claimed')
-
-      async function rollbackAndThrow(message: string): Promise<never> {
-        await db
+      claimed = await db.transaction(async (tx) => {
+        // Claim only a still-valid pending team invite for this email.
+        // Expiry and email live in the predicate so a failed validation
+        // never writes accepted, and nothing is reopened after side effects.
+        const [row] = await tx
           .update(invitation)
-          .set({ status: 'pending' })
-          .where(eq(invitation.id, invitationId as InviteId))
-        throw new Error(message)
-      }
+          .set({ status: 'accepted' })
+          .where(
+            and(
+              eq(invitation.id, invitationId as InviteId),
+              eq(invitation.status, 'pending'),
+              eq(invitation.kind, 'team'),
+              sql`lower(${invitation.email}) = ${userEmail}`,
+              gt(invitation.expiresAt, new Date())
+            )
+          )
+          .returning()
 
-      if (new Date(claimed.expiresAt) < new Date()) {
-        await rollbackAndThrow(
-          'This invitation has expired. Please ask your administrator to resend it.'
-        )
-      }
-
-      if (claimed.email.toLowerCase() !== userEmail) {
-        await rollbackAndThrow(
-          'This invitation was sent to a different email address. Please sign in with the correct email.'
-        )
-      }
-
-      const role = claimed.role || 'member'
-      const displayName = name?.trim() || undefined
-
-      const existingPrincipal = await db.query.principal.findFirst({
-        where: eq(principal.userId, userId),
-      })
-
-      if (existingPrincipal) {
-        // Update existing principal's role if the invitation grants a higher role
-        const roleHierarchy = ['user', 'member', 'admin']
-        const existingRoleIndex = roleHierarchy.indexOf(existingPrincipal.role)
-        const newRoleIndex = roleHierarchy.indexOf(role)
-
-        const updates: Record<string, unknown> = {}
-        if (newRoleIndex > existingRoleIndex) updates.role = role
-        if (displayName) updates.displayName = displayName
-
-        if (Object.keys(updates).length > 0) {
-          await db
-            .update(principal)
-            .set(updates)
-            .where(eq(principal.id, existingPrincipal.id as PrincipalId))
+        if (!row) {
+          const inv = await tx.query.invitation.findFirst({
+            where: and(eq(invitation.id, invitationId as InviteId), eq(invitation.kind, 'team')),
+          })
+          log.warn(
+            { invitation_id: invitationId, exists: !!inv, status: inv?.status },
+            'accept invitation: claim failed'
+          )
+          if (!inv) {
+            throw new Error('This invitation could not be found. It may have been cancelled.')
+          }
+          if (inv.status === 'accepted') {
+            throw new Error('This invitation has already been accepted')
+          }
+          if (new Date(inv.expiresAt) < new Date()) {
+            throw new Error(
+              'This invitation has expired. Please ask your administrator to resend it.'
+            )
+          }
+          if (inv.email.toLowerCase() !== userEmail) {
+            throw new Error(
+              'This invitation was sent to a different email address. Please sign in with the correct email.'
+            )
+          }
+          throw new Error(
+            'This invitation has been cancelled. Please ask your administrator to send a new one.'
+          )
         }
-      } else {
-        // Create new principal record
-        await db.insert(principal).values({
-          id: generateId('principal'),
-          userId,
-          role,
-          displayName,
-          createdAt: new Date(),
+
+        const role = row.role || 'member'
+        const displayName = name?.trim() || undefined
+
+        const existingPrincipal = await tx.query.principal.findFirst({
+          where: eq(principal.userId, userId),
         })
-      }
 
-      // Update user name if provided
-      if (displayName) {
-        await db.update(user).set({ name: displayName }).where(eq(user.id, userId))
-      }
+        if (existingPrincipal) {
+          const roleHierarchy = ['user', 'member', 'admin']
+          const existingRoleIndex = roleHierarchy.indexOf(existingPrincipal.role)
+          const newRoleIndex = roleHierarchy.indexOf(role)
 
-      // The invite is accepted — revoke every token in its set so no other
-      // emailed/copied link for this invite can still sign anyone in. (The link
-      // just used was already consumed by the magic-link verify; siblings from
-      // resends/copies would otherwise stay live until their 30-day expiry.)
-      // Best-effort: the membership is already committed, so a cleanup failure
-      // here must NOT hit the outer catch and roll the accept back to pending —
-      // log it and move on (the stray tokens still expire with the invite).
-      try {
-        const { revokeMagicLinkTokens } = await import('@/lib/server/auth/magic-link-mint')
-        await revokeMagicLinkTokens(claimed.magicLinkTokens)
-      } catch (revokeError) {
-        log.error({ err: revokeError }, 'token revoke failed')
-      }
+          const updates: Record<string, unknown> = {}
+          if (newRoleIndex > existingRoleIndex) updates.role = role
+          if (displayName) updates.displayName = displayName
 
-      log.info({ invitation_id: invitationId }, 'accept invitation: accepted')
-      return { invitationId: invitationId as InviteId }
+          if (Object.keys(updates).length > 0) {
+            await tx
+              .update(principal)
+              .set(updates)
+              .where(eq(principal.id, existingPrincipal.id as PrincipalId))
+          }
+        } else {
+          await tx.insert(principal).values({
+            id: generateId('principal'),
+            userId,
+            role,
+            displayName,
+            createdAt: new Date(),
+          })
+        }
+
+        if (displayName) {
+          await tx.update(user).set({ name: displayName }).where(eq(user.id, userId))
+        }
+
+        return row
+      })
     } catch (error) {
       log.error({ err: error }, 'accept invitation failed')
-      // Only roll back if we actually claimed the invitation. If the error
-      // came from the !claimed branch (already accepted / invalid), rolling
-      // back would incorrectly reopen it to 'pending'.
-      if (didClaim) {
-        try {
-          await db
-            .update(invitation)
-            .set({ status: 'pending' })
-            .where(eq(invitation.id, invitationId as InviteId))
-        } catch (rollbackError) {
-          log.error({ err: rollbackError }, 'rollback failed')
-        }
-      }
       throw error
     }
+
+    try {
+      const { revokeMagicLinkTokens } = await import('@/lib/server/auth/magic-link-mint')
+      await revokeMagicLinkTokens(claimed.magicLinkTokens)
+    } catch (revokeError) {
+      log.error({ err: revokeError }, 'token revoke failed')
+    }
+
+    log.info({ invitation_id: invitationId }, 'accept invitation: accepted')
+    return { invitationId: invitationId as InviteId }
   })
 
 /**

--- a/apps/web/src/lib/server/functions/invitations.ts
+++ b/apps/web/src/lib/server/functions/invitations.ts
@@ -146,9 +146,7 @@ export const acceptInvitationFn = createServerFn({ method: 'POST' })
     let claimed: typeof invitation.$inferSelect
     try {
       claimed = await db.transaction(async (tx) => {
-        // Claim only a still-valid pending team invite for this email.
-        // Expiry and email live in the predicate so a failed validation
-        // never writes accepted, and nothing is reopened after side effects.
+        // Email and expiry stay in the UPDATE so a rejected accept never writes accepted.
         const [row] = await tx
           .update(invitation)
           .set({ status: 'accepted' })
@@ -177,7 +175,12 @@ export const acceptInvitationFn = createServerFn({ method: 'POST' })
           if (inv.status === 'accepted') {
             throw new Error('This invitation has already been accepted')
           }
-          if (new Date(inv.expiresAt) < new Date()) {
+          if (inv.status === 'canceled') {
+            throw new Error(
+              'This invitation has been cancelled. Please ask your administrator to send a new one.'
+            )
+          }
+          if (inv.status === 'expired' || new Date(inv.expiresAt) < new Date()) {
             throw new Error(
               'This invitation has expired. Please ask your administrator to resend it.'
             )


### PR DESCRIPTION
## Summary
Team invite accept set `status=accepted`, then on expiry/email mismatch/later errors rolled the row back to `pending`. That reopened a claimed invite after principal/user side effects.

Claim now requires pending + team + matching email + not expired in one transaction with the principal/user writes. Failures abort the transaction; nothing is reopened. Token revoke stays best-effort after commit.

Closes #308

## Test plan
- [x] Accept a valid team invite → member created, invite stays accepted
- [x] Wrong-email session cannot accept; invite stays pending
- [x] Expired invite is not claimed
- [x] Double-click / retry cannot accept twice
- [x] complete-signup error copy still matches (“already been accepted”, expired, session)

Verified locally against Docker Postgres (transaction rollback): claim, canceled-before-expiry, wrong email, expired, and second accept. Matching unit copy tests.