### PR TITLE
chore(cloud-agent): add Cloud Agent development environment

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,66 @@
+# Base image for the Quackback Cloud Agent environment.
+#
+# Provides the slow, stable system layer: Bun (pinned to the repo's
+# packageManager version), Docker Engine + Compose (used to run the local
+# datastores from docker-compose.yml), and the userspace overlay tooling that
+# lets dockerd run nested inside the Cloud Agent VM. Repo dependencies and
+# per-boot services are handled by install.sh / start.sh, not here.
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Core tooling + Docker's nested-container prerequisites. fuse-overlayfs lets
+# the Docker daemon use a userspace overlay storage driver, which is required
+# because the native overlay driver cannot create whiteout device nodes inside
+# an unprivileged nested container.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+        openssl \
+        sudo \
+        unzip \
+        fuse-overlayfs \
+        uidmap \
+        iptables \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Docker Engine + CLI + Compose plugin from Docker's official apt repo.
+RUN install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc \
+    && chmod a+r /etc/apt/keyrings/docker.asc \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+        > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        docker-ce \
+        docker-ce-cli \
+        containerd.io \
+        docker-buildx-plugin \
+        docker-compose-plugin \
+    && rm -rf /var/lib/apt/lists/*
+
+# Configure the Docker daemon to use the classic image store with the
+# fuse-overlayfs storage driver so image builds and container filesystems work
+# in the nested VM. dockerd itself is started per-boot by start.sh.
+RUN mkdir -p /etc/docker \
+    && printf '%s\n' '{"features":{"containerd-snapshotter":false},"storage-driver":"fuse-overlayfs"}' \
+        > /etc/docker/daemon.json
+
+# The `ubuntu` user (uid 1000) already exists in the base image. Give it
+# passwordless sudo (start.sh needs it to launch dockerd) and Docker access.
+RUN usermod -aG docker ubuntu \
+    && echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/ubuntu \
+    && chmod 0440 /etc/sudoers.d/ubuntu
+
+# Install Bun, pinned to the version in the repo's package.json "packageManager".
+ARG BUN_VERSION=1.3.7
+RUN curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local/bun bash -s "bun-v${BUN_VERSION}" \
+    && ln -s /usr/local/bun/bin/bun /usr/local/bin/bun \
+    && ln -s /usr/local/bun/bin/bunx /usr/local/bin/bunx
+ENV BUN_INSTALL=/usr/local/bun
+ENV PATH=/usr/local/bun/bin:$PATH
+
+USER ubuntu

--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -25,6 +25,8 @@ RUN apt-get update \
         fuse-overlayfs \
         uidmap \
         iptables \
+    && update-alternatives --set iptables /usr/sbin/iptables-legacy \
+    && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Docker Engine + CLI + Compose plugin from Docker's official apt repo.

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,21 @@
+{
+  "name": "Quackback",
+  "user": "ubuntu",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "install": "bash .cursor/install.sh",
+  "start": "bash .cursor/start.sh",
+  "terminals": [
+    {
+      "name": "dev",
+      "command": "bun run dev",
+      "description": "Quackback web app (TanStack Start) — http://localhost:3000"
+    }
+  ],
+  "ports": [
+    { "name": "web", "port": 3000 },
+    { "name": "mailpit", "port": 8025 },
+    { "name": "minio-console", "port": 9001 }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -19,4 +19,27 @@ bun install --frozen-lockfile
 echo "[install] Building @quackback/widget bundle..."
 bun run --filter @quackback/widget build
 
+# Snapshot the datastore images so start.sh is not paying pull/build on every
+# agent VM. dockerd is only up for this step.
+echo "[install] Prefetching datastore images..."
+if ! sudo docker info >/dev/null 2>&1; then
+  sudo bash -c 'nohup dockerd >/var/log/dockerd.log 2>&1 &'
+  for i in $(seq 1 60); do
+    if sudo docker info >/dev/null 2>&1; then break; fi
+    sleep 1
+  done
+fi
+if sudo docker info >/dev/null 2>&1; then
+  sudo chmod 666 /var/run/docker.sock 2>/dev/null || true
+  docker compose pull postgres minio dragonfly mailpit minio-init
+  docker compose build postgres
+  sudo kill "$(pidof dockerd)" 2>/dev/null || true
+  for i in $(seq 1 30); do
+    if ! sudo docker info >/dev/null 2>&1; then break; fi
+    sleep 1
+  done
+else
+  echo "[install] Docker daemon failed to start; images will be pulled on first start" >&2
+fi
+
 echo "[install] Done."

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Repository bootstrap for the Quackback Cloud Agent environment.
+#
+# Runs after the source is checked out. Installs JS dependencies and builds the
+# widget bundle that the web build imports (packages/widget/dist/browser.js).
+# Must be idempotent and must NOT start long-running processes or depend on the
+# datastores (those are handled per-boot by start.sh).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "[install] Installing dependencies with Bun..."
+bun install --frozen-lockfile
+
+# apps/web imports packages/widget/dist/browser.js via Vite `?raw`, so the
+# widget must be built before any web build. This is fast (tsup) and safe to
+# re-run.
+echo "[install] Building @quackback/widget bundle..."
+bun run --filter @quackback/widget build
+
+echo "[install] Done."

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Per-boot startup for the Quackback Cloud Agent environment.
+#
+# Brings up the local datastores the app depends on (PostgreSQL with pg_cron +
+# pgvector, MinIO, Dragonfly, Mailpit) via docker-compose, then applies database
+# migrations. Idempotent: safe to run on every boot, tolerates an already-running
+# daemon/containers, and only creates databases when missing.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+DB_URL_DEV="postgresql://postgres:password@localhost:5432/quackback"
+DB_URL_TEST="postgresql://postgres:password@localhost:5432/quackback_test"
+
+echo "[start] Ensuring Docker daemon is running..."
+if ! sudo docker info >/dev/null 2>&1; then
+  sudo bash -c 'nohup dockerd >/var/log/dockerd.log 2>&1 &'
+  for i in $(seq 1 60); do
+    if sudo docker info >/dev/null 2>&1; then break; fi
+    sleep 1
+  done
+fi
+sudo docker info >/dev/null 2>&1 || { echo "[start] Docker daemon failed to start" >&2; exit 1; }
+# Let the non-root user talk to the daemon without sudo for the rest of the session.
+sudo chmod 666 /var/run/docker.sock 2>/dev/null || true
+echo "[start] Docker is up."
+
+# Create .env from the example if absent, and fill in a SECRET_KEY.
+if [ ! -f .env ]; then
+  cp .env.example .env
+  echo "[start] Created .env from .env.example"
+fi
+if grep -q '^SECRET_KEY=$' .env 2>/dev/null; then
+  SECRET="$(openssl rand -hex 32)"
+  sed -i "s/^SECRET_KEY=$/SECRET_KEY=$SECRET/" .env
+  echo "[start] Generated SECRET_KEY"
+fi
+
+echo "[start] Starting datastores (postgres, minio, dragonfly, mailpit)..."
+docker compose up -d postgres minio minio-init dragonfly mailpit
+
+echo "[start] Waiting for PostgreSQL..."
+until docker compose exec -T postgres pg_isready -U postgres >/dev/null 2>&1; do sleep 1; done
+echo "[start] Waiting for Dragonfly..."
+until docker compose exec -T dragonfly redis-cli ping >/dev/null 2>&1; do sleep 1; done
+echo "[start] Waiting for MinIO..."
+until curl -sf http://localhost:9000/minio/health/live >/dev/null 2>&1; do sleep 1; done
+
+# Create the dev and test databases if they do not exist yet. The test DB is
+# used by the DB-integration parts of `bun run test`.
+for DBNAME in quackback quackback_test; do
+  if ! docker compose exec -T postgres psql -U postgres -tc "SELECT 1 FROM pg_database WHERE datname = '$DBNAME'" | grep -q 1; then
+    docker compose exec -T postgres psql -U postgres -c "CREATE DATABASE $DBNAME;"
+    echo "[start] Created database $DBNAME"
+  fi
+done
+
+echo "[start] Applying migrations (dev + test databases)..."
+DATABASE_URL="$DB_URL_DEV" bun run db:migrate
+DATABASE_URL="$DB_URL_TEST" bun run db:migrate
+
+echo "[start] Ready. Run 'bun run db:seed' for demo data; 'bun run dev' serves http://localhost:3000"

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -38,14 +38,7 @@ if grep -q '^SECRET_KEY=$' .env 2>/dev/null; then
 fi
 
 echo "[start] Starting datastores (postgres, minio, dragonfly, mailpit)..."
-docker compose up -d postgres minio minio-init dragonfly mailpit
-
-echo "[start] Waiting for PostgreSQL..."
-until docker compose exec -T postgres pg_isready -U postgres >/dev/null 2>&1; do sleep 1; done
-echo "[start] Waiting for Dragonfly..."
-until docker compose exec -T dragonfly redis-cli ping >/dev/null 2>&1; do sleep 1; done
-echo "[start] Waiting for MinIO..."
-until curl -sf http://localhost:9000/minio/health/live >/dev/null 2>&1; do sleep 1; done
+docker compose up -d --wait postgres minio minio-init dragonfly mailpit
 
 # Create the dev and test databases if they do not exist yet. The test DB is
 # used by the DB-integration parts of `bun run test`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `.cursor/` configuration so Cursor Cloud Agents can run Quackback end to end. The repo's dev flow relies on Bun 1.3.7 and Docker (custom Postgres with `pg_cron` + `pgvector`, MinIO, Dragonfly, Mailpit), neither of which exists in the default Cloud Agent image, so this wires up the full stack as a repo-managed environment.

## What's included

- **`.cursor/Dockerfile`** — base image (Ubuntu 24.04) with Bun 1.3.7 (matching `package.json` `packageManager`), Docker Engine + Compose, and `fuse-overlayfs`/`uidmap`/`iptables` for nested-container support. Configures `/etc/docker/daemon.json` to use the classic image store with the `fuse-overlayfs` storage driver (the native overlay driver can't create whiteout device nodes in the unprivileged nested VM). Grants the `ubuntu` user passwordless sudo + docker group.
- **`.cursor/install.sh`** — `bun install --frozen-lockfile` then builds the `@quackback/widget` bundle (`apps/web` imports `packages/widget/dist/browser.js` via Vite `?raw`, so it must exist before any web build). Idempotent, no long-running processes.
- **`.cursor/start.sh`** — per-boot: starts `dockerd`, brings up the datastores via `docker compose`, waits for health, ensures `.env` (+ generates `SECRET_KEY`), creates the `quackback` and `quackback_test` databases if missing, and applies migrations to both. Idempotent.
- **`.cursor/environment.json`** — wires `install`/`start` and a `dev` terminal running `bun run dev` on port 3000 (plus Mailpit 8025, MinIO console 9001).

## Validation

Verified on the Cloud Agent VM:

| Check | Result |
| --- | --- |
| `install.sh` (bun install + widget build) | Passed, idempotent |
| `start.sh` (dockerd + datastores + migrate) | Passed, idempotent |
| `bun run lint` | 0 errors (20 pre-existing warnings) |
| `bun run typecheck` | Passed |
| `bun run test --run` | 5217 passed, 2 skipped (after test DB migration) |
| `bun run build` (widget + web) | Passed |
| Dockerfile build + tool versions | Bun 1.3.7, Docker 29.7.2, Compose 5.4.0 |
| End-to-end app flow | Login as `demo@example.com`, admin feedback dashboard, seeded posts, post detail, board filter |

Local re-check (this machine, not a Cloud Agent VM): `install.sh`/`start.sh` parse (`bash -n`), Bun pinned to 1.3.7, `docker compose up -d --wait`, iptables-legacy, install-time image prefetch.

Additionally validated in a **fresh Cloud Agent booted from a draft environment build** (`bld-20260814-944ada44-...`): install ran automatically on the pod, `start.sh` brought up all four datastores + migrated both databases, seed succeeded, and the dev server served the app with a working `demo@example.com` login.

### Demo

[quackback_login_and_feedback_walkthrough.mp4](https://cursor.com/agents/bc-a5386046-a297-435a-86cf-4c98e11bf6a1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fquackback_login_and_feedback_walkthrough.mp4)

[Admin feedback dashboard with seeded posts](https://cursor.com/agents/bc-a5386046-a297-435a-86cf-4c98e11bf6a1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fquackback_admin_feedback.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5386046-a297-435a-86cf-4c98e11bf6a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5386046-a297-435a-86cf-4c98e11bf6a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

