### PR TITLE
docs(readme): point Get Started at the 14-day Cloud trial

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@
 
 ## Get Started
 
-**Cloud** — start free at [app.quackback.io](https://app.quackback.io/signup). We host, scale, and maintain it for you. No setup required.
+**Quackback Cloud** — 14-day free trial, every feature, no credit card. We host it.
 
-**Self-hosted** anywhere with [Docker](#docker) or [one click on Railway](#one-click-deploy).
+→ [Start the trial](https://app.quackback.io/signup)
+
+**Self-host** if you want the same product on your own Postgres — [Docker](#docker) or [Railway](#one-click-deploy). Open source (AGPL-3.0).
 
 ## Why Quackback?
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Retarget the README Get Started Cloud CTA so GitHub traffic starts a Cloud trial instead of a vague “start free” line. Draft only — do not merge.

## What changed

`README.md` Get Started block only:

- Cloud line is now the 14-day trial copy, linking to https://app.quackback.io/signup
- Self-host remains secondary (Docker / Railway), AGPL-3.0
- No other README copy, star badges, or unrelated files

## Requested files not in this repo

These live on the separate `quackback.io` marketing site, not `QuackbackIO/quackback`. Skipped as instructed:

- Compare Switch CTAs (`/compare/quackback-vs-canny`, `/compare/quackback-vs-featurebase`, and sibling compare pages using the shared `compare-cta` component)
- `blog/canny-vs-featurebase` (Fibi $0.29 → $0.49)
- `blog/welcome` (free Cloud plan → 14-day trial)
- Compare tables still showing Canny Core $19

No surrounding marketing copy was invented or rewritten.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b57923aa-89b2-4a75-90cf-245c6d62873e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b57923aa-89b2-4a75-90cf-245c6d62873e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

