### PR TITLE
Restore merged-feedback list and roll votes/comments onto the canonical

### DIFF
--- a/apps/web/src/components/admin/feedback/merge-section.tsx
+++ b/apps/web/src/components/admin/feedback/merge-section.tsx
@@ -26,11 +26,114 @@ import {
 } from '@/components/ui/dialog'
 import { Checkbox } from '@/components/ui/checkbox'
 import { StatusBadge } from '@/components/ui/status-badge'
-import { useMergePost } from '@/lib/client/mutations/post-merge'
+import { useMergePost, useUnmergePost } from '@/lib/client/mutations/post-merge'
 import { findSimilarPostsFn, type SimilarPost } from '@/lib/server/functions/public-posts'
+import { getMergedPostsFn } from '@/lib/server/functions/post-merge'
 import { mergeSuggestionQueries } from '@/lib/client/queries/signals'
 import { inboxKeys } from '@/lib/client/hooks/use-inbox-query'
 import type { PostId } from '@quackback/ids'
+import type { MergedPostItem } from '@/lib/shared/types/inbox'
+
+// ============================================================================
+// Merged Posts List (shown on canonical posts)
+// ============================================================================
+
+interface MergedPostsListProps {
+  postId: PostId
+  mergedPosts?: MergedPostItem[]
+}
+
+export function MergedPostsList({ postId, mergedPosts: initialMergedPosts }: MergedPostsListProps) {
+  const queryClient = useQueryClient()
+  const unmerge = useUnmergePost()
+  const [confirmUnmergeId, setConfirmUnmergeId] = useState<PostId | null>(null)
+  const confirmTarget = initialMergedPosts?.find((p) => p.id === confirmUnmergeId)
+
+  const { data: mergedPosts } = useQuery({
+    queryKey: ['merged-posts', postId],
+    queryFn: async () => {
+      const result = await getMergedPostsFn({ data: { canonicalPostId: postId } })
+      return result as MergedPostItem[]
+    },
+    initialData: initialMergedPosts,
+    staleTime: 30_000,
+  })
+
+  if (!mergedPosts || mergedPosts.length === 0) return null
+
+  const handleUnmerge = async () => {
+    if (!confirmUnmergeId) return
+    try {
+      await unmerge.mutateAsync(confirmUnmergeId)
+      queryClient.invalidateQueries({ queryKey: ['merged-posts', postId] })
+      toast.success('Post unmerged successfully')
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to unmerge post')
+    } finally {
+      setConfirmUnmergeId(null)
+    }
+  }
+
+  return (
+    <div className="border-t border-border/40 px-6 py-4">
+      <h3 className="text-sm font-medium text-foreground mb-3">
+        Merged Feedback ({mergedPosts.length})
+      </h3>
+      <div className="space-y-2">
+        {mergedPosts.map((merged) => (
+          <div
+            key={merged.id}
+            className="flex items-center justify-between gap-3 p-3 rounded-lg bg-muted/30 border border-border/30"
+          >
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-foreground truncate">{merged.title}</p>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                {merged.voteCount} vote{merged.voteCount !== 1 ? 's' : ''}
+                {merged.authorName ? ` · by ${merged.authorName}` : ''}
+              </p>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setConfirmUnmergeId(merged.id)}
+              disabled={unmerge.isPending}
+              className="text-xs shrink-0"
+            >
+              Unmerge
+            </Button>
+          </div>
+        ))}
+      </div>
+
+      <AlertDialog
+        open={!!confirmUnmergeId}
+        onOpenChange={(open) => !open && setConfirmUnmergeId(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Unmerge this post?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {confirmTarget ? (
+                <>
+                  <span className="font-medium text-foreground">{confirmTarget.title}</span> will be
+                  restored as independent feedback. Its votes will no longer count toward this post.
+                </>
+              ) : (
+                'This post will be restored as independent feedback.'
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={unmerge.isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleUnmerge} disabled={unmerge.isPending}>
+              {unmerge.isPending ? 'Unmerging...' : 'Unmerge'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}
 
 // ============================================================================
 // Merge Into Dialog (shown when admin wants to merge current post into another)
@@ -512,6 +615,7 @@ interface MergeActionsProps {
   postId: PostId
   postTitle: string
   canonicalPostId?: PostId | null
+  mergedPosts?: MergedPostItem[]
   /** Controlled dialog state (optional — falls back to internal state) */
   showDialog?: boolean
   onShowDialogChange?: (show: boolean) => void
@@ -521,6 +625,7 @@ export function MergeActions({
   postId,
   postTitle,
   canonicalPostId,
+  mergedPosts,
   showDialog,
   onShowDialogChange,
 }: MergeActionsProps) {
@@ -528,8 +633,12 @@ export function MergeActions({
   const isDialogOpen = showDialog ?? internalShowDialog
   const setDialogOpen = onShowDialogChange ?? setInternalShowDialog
 
+  const hasMergedPosts = mergedPosts && mergedPosts.length > 0
+
   return (
     <>
+      {hasMergedPosts && <MergedPostsList postId={postId} mergedPosts={mergedPosts} />}
+
       {!canonicalPostId && (
         <MergeIntoDialog
           postId={postId}

--- a/apps/web/src/components/admin/feedback/post-modal.tsx
+++ b/apps/web/src/components/admin/feedback/post-modal.tsx
@@ -427,6 +427,7 @@ function PostModalContent({
               postId={postId}
               postTitle={post.title}
               canonicalPostId={post.canonicalPostId as PostId | undefined}
+              mergedPosts={post.mergedPosts}
               showDialog={showMergeDialog}
               onShowDialogChange={setShowMergeDialog}
             />
@@ -533,6 +534,7 @@ function PostModalContent({
               hideSubscribe
               variant="card"
               manageActions={manageActions}
+              votersAdditionalPostIds={post.mergedPosts?.map((p) => p.id)}
             />
           </Suspense>
 

--- a/apps/web/src/lib/server/domains/posts/__tests__/post-merge.db.test.ts
+++ b/apps/web/src/lib/server/domains/posts/__tests__/post-merge.db.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Real-DB coverage for post merge aggregation.
+ *
+ * Merge only links the source (`canonical_post_id`); votes and comments stay
+ * on their original rows. The survivor must still show the combined unique
+ * vote count, the combined public comment count, the source comments in the
+ * thread, and the source in getMergedPosts (the admin Unmerge list).
+ */
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createId, type BoardId, type PostId, type PrincipalId, type UserId } from '@quackback/ids'
+import { createDbTestFixture, testDb } from '@/lib/server/__tests__/db-test-fixture'
+import { boards, eq, postComments, postVotes, posts, principal, user } from '@/lib/server/db'
+
+vi.mock('@/lib/server/db', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/server/db')>()),
+  db: (await import('@/lib/server/__tests__/db-test-fixture')).testDb,
+}))
+
+vi.mock('@/lib/server/events/scheduler', () => ({
+  scheduleDispatch: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/lib/server/events/dispatch', () => ({
+  dispatchPostMerged: vi.fn(),
+  dispatchPostUnmerged: vi.fn(),
+  buildEventActor: vi.fn((actor) => actor),
+}))
+
+vi.mock('@/lib/server/domains/activity/activity.service', () => ({
+  createActivity: vi.fn(),
+}))
+
+import { mergePost, getMergedPosts } from '../post.merge'
+import { getCommentsWithReplies } from '../post.query'
+import { hasUserVoted } from '../post.public.utils'
+import { DEFAULT_BOARD_ACCESS } from '@/lib/shared/db-types'
+
+const fixture = await createDbTestFixture({
+  probe: async (db) => {
+    await db.select({ id: posts.id, canonicalPostId: posts.canonicalPostId }).from(posts).limit(0)
+  },
+})
+
+const suffix = () => `${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`
+
+async function seedPrincipal(name: string): Promise<PrincipalId> {
+  const userId = createId('user') as UserId
+  const principalId = createId('principal') as PrincipalId
+  await testDb.insert(user).values({ id: userId, name })
+  await testDb.insert(principal).values({
+    id: principalId,
+    userId,
+    role: 'admin',
+    type: 'user',
+    displayName: name,
+    createdAt: new Date(),
+  })
+  return principalId
+}
+
+async function seedBoard(): Promise<BoardId> {
+  const [board] = await testDb
+    .insert(boards)
+    .values({
+      slug: `merge-${suffix()}`,
+      name: 'Merge board',
+      access: DEFAULT_BOARD_ACCESS,
+    })
+    .returning()
+  return board.id
+}
+
+async function seedPost(opts: {
+  boardId: BoardId
+  principalId: PrincipalId
+  title: string
+  voteCount?: number
+  commentCount?: number
+}): Promise<PostId> {
+  const [post] = await testDb
+    .insert(posts)
+    .values({
+      boardId: opts.boardId,
+      title: opts.title,
+      content: '',
+      principalId: opts.principalId,
+      voteCount: opts.voteCount ?? 0,
+      commentCount: opts.commentCount ?? 0,
+    })
+    .returning()
+  return post.id
+}
+
+async function seedVote(postId: PostId, principalId: PrincipalId): Promise<void> {
+  await testDb.insert(postVotes).values({ postId, principalId })
+}
+
+async function seedComment(
+  postId: PostId,
+  principalId: PrincipalId,
+  content: string
+): Promise<void> {
+  await testDb.insert(postComments).values({
+    postId,
+    principalId,
+    content,
+    isTeamMember: false,
+    isPrivate: false,
+    moderationState: 'published',
+  })
+}
+
+describe.skipIf(!fixture.available)('post merge aggregation (real DB)', () => {
+  beforeEach(fixture.begin)
+  afterEach(fixture.rollback)
+  afterAll(fixture.close)
+
+  it('rolls unique votes and public comments onto the canonical and keeps the source listed', async () => {
+    const actor = await seedPrincipal('Admin')
+    const voterA = await seedPrincipal('Voter A')
+    const voterB = await seedPrincipal('Voter B')
+    const boardId = await seedBoard()
+    const canonical = await seedPost({
+      boardId,
+      principalId: actor,
+      title: 'Canonical',
+      voteCount: 1,
+      commentCount: 1,
+    })
+    const source = await seedPost({
+      boardId,
+      principalId: actor,
+      title: 'Source',
+      voteCount: 1,
+      commentCount: 1,
+    })
+
+    await seedVote(canonical, voterA)
+    await seedVote(source, voterB)
+    await seedComment(canonical, voterA, 'comment on canonical')
+    await seedComment(source, voterB, 'comment on source')
+
+    const result = await mergePost(source, canonical, actor)
+
+    expect(result.canonicalPost.voteCount).toBe(2)
+
+    const [canonicalRow] = await testDb.select().from(posts).where(eq(posts.id, canonical))
+    expect(canonicalRow.voteCount).toBe(2)
+    expect(canonicalRow.commentCount).toBe(2)
+
+    const [sourceRow] = await testDb.select().from(posts).where(eq(posts.id, source))
+    expect(sourceRow.canonicalPostId).toBe(canonical)
+
+    const merged = await getMergedPosts(canonical)
+    expect(merged.map((p) => p.id)).toEqual([source])
+
+    const comments = await getCommentsWithReplies(canonical)
+    expect(comments.map((c) => c.content).sort()).toEqual([
+      'comment on canonical',
+      'comment on source',
+    ])
+
+    expect(await hasUserVoted(canonical, voterB)).toBe(true)
+    expect(await hasUserVoted(canonical, voterA)).toBe(true)
+  })
+})

--- a/apps/web/src/lib/server/domains/posts/__tests__/post-merge.test.ts
+++ b/apps/web/src/lib/server/domains/posts/__tests__/post-merge.test.ts
@@ -146,7 +146,7 @@ describe('mergePost', () => {
     mockPrincipalFindFirst.mockResolvedValue({ displayName: 'Author' })
     mockBoardsFindFirst.mockResolvedValue({ id: 'board_mock', slug: 'feedback' })
     // Default: vote count recalculation returns 5
-    mockDbExecute.mockResolvedValue([{ unique_voters: 5 }])
+    mockDbExecute.mockResolvedValue([{ unique_voters: 5, visible_comments: 2 }])
     // Default in-transaction re-check sequence: no existing child on the
     // duplicate, canonical not merged elsewhere — i.e. the happy path.
     // `clearAllMocks` clears call history but not a queued `Once` chain
@@ -241,7 +241,7 @@ describe('mergePost', () => {
     mockPostsFindFirst
       .mockResolvedValueOnce(mockPost({ id: POST_A }))
       .mockResolvedValueOnce(mockPost({ id: POST_B }))
-    mockDbExecute.mockResolvedValue([{ unique_voters: 8 }])
+    mockDbExecute.mockResolvedValue([{ unique_voters: 8, visible_comments: 3 }])
 
     const result = await mergePost(POST_A, POST_B, ACTOR)
 
@@ -341,7 +341,7 @@ describe('unmergePost', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockBoardsFindFirst.mockResolvedValue({ id: 'board_mock', slug: 'feedback' })
-    mockDbExecute.mockResolvedValue([{ unique_voters: 3 }])
+    mockDbExecute.mockResolvedValue([{ unique_voters: 3, visible_comments: 1 }])
   })
 
   it('throws NotFoundError when post not found', async () => {

--- a/apps/web/src/lib/server/domains/posts/post.merge-ids.ts
+++ b/apps/web/src/lib/server/domains/posts/post.merge-ids.ts
@@ -1,0 +1,91 @@
+/**
+ * Shared "this post + posts merged into it" id set.
+ *
+ * Merge links the source (`canonical_post_id`) rather than moving votes or
+ * comments. Every read/write that should treat a canonical and its sources as
+ * one thread (vote identity, voter list, comment/vote recounts) uses this set.
+ */
+import { db, posts, postVotes, postComments, and, or, eq, isNull, sql } from '@/lib/server/db'
+import { toUuid, type PostId } from '@quackback/ids'
+import { getExecuteRows } from '@/lib/server/utils'
+
+type TransactionalDb = Pick<typeof db, 'execute' | 'update'>
+
+/**
+ * Drizzle subquery of post ids in a merge thread: the given post plus every
+ * non-deleted source merged into it. Safe to pass to `inArray`.
+ */
+export function relatedPostIdsSubquery(postId: PostId) {
+  return db
+    .select({ id: posts.id })
+    .from(posts)
+    .where(
+      and(isNull(posts.deletedAt), or(eq(posts.id, postId), eq(posts.canonicalPostId, postId)))
+    )
+}
+
+/**
+ * Raw-SQL id list for `IN (...)` clauses that already speak UUIDs (the
+ * vote/comment recount CTEs, hasVoted EXISTS, etc.).
+ */
+export function relatedPostIdsSql(postUuid: string) {
+  return sql`(
+    SELECT ${postUuid}::uuid
+    UNION ALL
+    SELECT id FROM ${posts}
+    WHERE canonical_post_id = ${postUuid}::uuid
+      AND deleted_at IS NULL
+  )`
+}
+
+/**
+ * Recount unique voters and public comments across a canonical + its sources.
+ * Runs via the transaction handle when called from merge/unmerge so the
+ * recount commits atomically with the link change.
+ */
+export async function recalculateCanonicalVoteCount(
+  canonicalPostId: PostId,
+  options?: { resetMergeCheck?: boolean },
+  tx?: TransactionalDb
+): Promise<number> {
+  const conn = tx ?? db
+  const canonicalUuid = toUuid(canonicalPostId)
+  const result = await conn.execute<{ unique_voters: number; visible_comments: number }>(sql`
+    WITH related_post_ids AS (
+      SELECT ${canonicalUuid}::uuid AS post_id
+      UNION ALL
+      SELECT id FROM ${posts}
+      WHERE canonical_post_id = ${canonicalUuid}::uuid
+        AND deleted_at IS NULL
+    )
+    SELECT
+      (
+        SELECT COUNT(DISTINCT v.principal_id)::int
+        FROM ${postVotes} v
+        WHERE v.post_id IN (SELECT post_id FROM related_post_ids)
+      ) AS unique_voters,
+      (
+        SELECT COUNT(*)::int
+        FROM ${postComments} c
+        WHERE c.post_id IN (SELECT post_id FROM related_post_ids)
+          AND c.deleted_at IS NULL
+          AND c.is_private = false
+          AND c.moderation_state = 'published'
+      ) AS visible_comments
+  `)
+
+  const rows = getExecuteRows<{ unique_voters: number; visible_comments: number }>(result)
+  const newCount = rows[0]?.unique_voters ?? 0
+  const newCommentCount = rows[0]?.visible_comments ?? 0
+
+  await conn
+    .update(posts)
+    .set({
+      voteCount: newCount,
+      commentCount: newCommentCount,
+      ...(options?.resetMergeCheck && { mergeCheckedAt: null }),
+    })
+    .where(eq(posts.id, canonicalPostId))
+
+  return newCount
+}

--- a/apps/web/src/lib/server/domains/posts/post.merge.ts
+++ b/apps/web/src/lib/server/domains/posts/post.merge.ts
@@ -28,11 +28,7 @@ import { getExecuteRows } from '@/lib/server/utils'
 import { NotFoundError, ValidationError, ConflictError } from '@/lib/shared/errors'
 import { createActivity } from '@/lib/server/domains/activity/activity.service'
 import { ANONYMOUS_ACTOR, canViewPost, type Actor } from '@/lib/server/policy'
-
-// Drizzle's PgTransaction is structurally compatible with `db` for the
-// subset of operations recalculateCanonicalVoteCount uses (execute +
-// update). Type as a permissive shape so callers can pass either.
-type TransactionalDb = Pick<typeof db, 'execute' | 'update'>
+import { recalculateCanonicalVoteCount } from './post.merge-ids'
 import {
   dispatchPostMerged,
   dispatchPostUnmerged,
@@ -520,52 +516,4 @@ export async function previewMergedPost(
     duplicateComments,
     duplicatePostTitle: duplicateDetails.title,
   }
-}
-
-/**
- * Recalculate the vote count for a canonical post.
- * Counts unique voters across the canonical post and all its merged duplicates.
- *
- * @param canonicalPostId - The canonical post to recalculate
- * @returns The new vote count
- */
-async function recalculateCanonicalVoteCount(
-  canonicalPostId: PostId,
-  options?: { resetMergeCheck?: boolean },
-  tx?: TransactionalDb
-): Promise<number> {
-  // Run via the transaction handle when called from inside mergePost /
-  // unmergePost so the recalc commits atomically with the merge link.
-  // Outside-of-tx callers (the BullMQ merge-recheck handler) fall back
-  // to the global db connection.
-  const conn = tx ?? db
-  // Count unique member votes across canonical + all merged duplicates
-  // Note: must convert TypeID to raw UUID for use in raw SQL
-  const canonicalUuid = toUuid(canonicalPostId)
-  const result = await conn.execute<{ unique_voters: number }>(sql`
-    WITH related_post_ids AS (
-      SELECT ${canonicalUuid}::uuid AS post_id
-      UNION ALL
-      SELECT id FROM ${posts}
-      WHERE canonical_post_id = ${canonicalUuid}::uuid
-        AND deleted_at IS NULL
-    )
-    SELECT COUNT(DISTINCT v.principal_id)::int AS unique_voters
-    FROM ${postVotes} v
-    WHERE v.post_id IN (SELECT post_id FROM related_post_ids)
-  `)
-
-  const rows = getExecuteRows<{ unique_voters: number }>(result)
-  const newCount = rows[0]?.unique_voters ?? 0
-
-  // Update the canonical post's vote count (and optionally reset mergeCheckedAt)
-  await conn
-    .update(posts)
-    .set({
-      voteCount: newCount,
-      ...(options?.resetMergeCheck && { mergeCheckedAt: null }),
-    })
-    .where(eq(posts.id, canonicalPostId))
-
-  return newCount
 }

--- a/apps/web/src/lib/server/domains/posts/post.public.ts
+++ b/apps/web/src/lib/server/domains/posts/post.public.ts
@@ -394,11 +394,22 @@ export async function listPublicPosts(
 }
 
 export async function getAllUserVotedPostIds(principalId: PrincipalId): Promise<Set<PostId>> {
+  // Include both the post the vote was cast on and, when that post has been
+  // merged away, the canonical — so the survivor highlights as voted.
   const result = await db
-    .select({ postId: postVotes.postId })
+    .select({
+      postId: postVotes.postId,
+      canonicalPostId: posts.canonicalPostId,
+    })
     .from(postVotes)
-    .where(eq(postVotes.principalId, principalId))
-  return new Set(result.map((r) => r.postId))
+    .innerJoin(posts, eq(posts.id, postVotes.postId))
+    .where(and(eq(postVotes.principalId, principalId), isNull(posts.deletedAt)))
+  const ids = new Set<PostId>()
+  for (const row of result) {
+    ids.add(row.postId)
+    if (row.canonicalPostId) ids.add(row.canonicalPostId)
+  }
+  return ids
 }
 
 export async function getVotedPostIdsByUserId(

--- a/apps/web/src/lib/server/domains/posts/post.public.utils.ts
+++ b/apps/web/src/lib/server/domains/posts/post.public.utils.ts
@@ -12,6 +12,7 @@ import {
   postSubscriptions,
 } from '@/lib/server/db'
 import { toUuid, type PostId, type PostStatusId, type PrincipalId } from '@quackback/ids'
+import { relatedPostIdsSql } from './post.merge-ids'
 import type { RoadmapPostListResult } from './post.types'
 import { getExecuteRows } from '@/lib/server/utils'
 import { postViewFilter, ANONYMOUS_ACTOR, type Actor } from '@/lib/server/policy'
@@ -81,10 +82,16 @@ export async function getPublicRoadmapPostsPaginated(params: {
 }
 
 export async function hasUserVoted(postId: PostId, principalId: PrincipalId): Promise<boolean> {
-  const vote = await db.query.postVotes.findFirst({
-    where: and(eq(postVotes.postId, postId), eq(postVotes.principalId, principalId)),
-  })
-  return !!vote
+  const postUuid = toUuid(postId)
+  const principalUuid = toUuid(principalId)
+  const result = await db.execute<{ has_voted: boolean }>(sql`
+    SELECT EXISTS(
+      SELECT 1 FROM ${postVotes}
+      WHERE principal_id = ${principalUuid}::uuid
+        AND post_id IN ${relatedPostIdsSql(postUuid)}
+    ) as has_voted
+  `)
+  return getExecuteRows<{ has_voted: boolean }>(result)[0]?.has_voted ?? false
 }
 
 /**
@@ -115,8 +122,8 @@ export async function getVoteAndSubscriptionStatus(
     SELECT
       EXISTS(
         SELECT 1 FROM ${postVotes}
-        WHERE ${postVotes.postId} = ${postUuid}::uuid
-        AND ${postVotes.principalId} = ${principalUuid}::uuid
+        WHERE ${postVotes.principalId} = ${principalUuid}::uuid
+          AND ${postVotes.postId} IN ${relatedPostIdsSql(postUuid)}
       ) as has_voted,
       ps.post_id IS NOT NULL as subscribed,
       ps.notify_comments,

--- a/apps/web/src/lib/server/domains/posts/post.voters.ts
+++ b/apps/web/src/lib/server/domains/posts/post.voters.ts
@@ -1,0 +1,145 @@
+/**
+ * Voter listing for a post thread (canonical + merged sources).
+ */
+import {
+  db,
+  postVotes,
+  postSubscriptions,
+  principal,
+  user,
+  sql,
+  eq,
+  and,
+  inArray,
+  desc,
+} from '@/lib/server/db'
+import { toUuid, type PostId, type PostVoteId, type PrincipalId } from '@quackback/ids'
+import { relatedPostIdsSubquery } from './post.merge-ids'
+import { realEmail } from '@/lib/shared/anonymous-email'
+import {
+  levelFromFlags,
+  type SubscriptionLevel,
+} from '@/lib/server/domains/subscriptions/subscription.types'
+
+export interface VoterInfo {
+  principalId: string
+  displayName: string | null
+  email: string | null
+  avatarUrl: string | null
+  isAnonymous: boolean
+  sourceType: string | null
+  sourceExternalUrl: string | null
+  addedByName: string | null
+  createdAt: Date | string
+  subscriptionLevel: SubscriptionLevel
+}
+
+export interface ListPostVotersResult {
+  items: VoterInfo[]
+  nextCursor: PostVoteId | null
+  hasMore: boolean
+}
+
+/**
+ * List the voters on a post thread, newest first, with optional keyset
+ * pagination. Includes votes cast on posts later merged into this one.
+ */
+export async function listPostVoters(
+  postId: PostId,
+  options: { limit?: number; cursor?: PostVoteId } = {}
+): Promise<ListPostVotersResult> {
+  const { limit, cursor } = options
+
+  const conditions = [inArray(postVotes.postId, relatedPostIdsSubquery(postId))]
+  if (cursor) {
+    const cursorVote = await db.query.postVotes.findFirst({
+      where: eq(postVotes.id, cursor),
+      columns: { id: true, createdAt: true },
+    })
+    if (cursorVote) {
+      conditions.push(
+        sql`(${postVotes.createdAt}, ${postVotes.id}) < (${cursorVote.createdAt.toISOString()}, ${toUuid(cursorVote.id)}::uuid)`
+      )
+    }
+  }
+
+  const query = db
+    .select({
+      voteId: postVotes.id,
+      principalId: principal.id,
+      displayName: principal.displayName,
+      email: user.email,
+      avatarUrl: principal.avatarUrl,
+      principalType: principal.type,
+      sourceType: postVotes.sourceType,
+      sourceExternalUrl: postVotes.sourceExternalUrl,
+      addedByName: sql<string | null>`(
+        SELECT p2.display_name FROM ${principal} p2
+        WHERE p2.id = ${postVotes.addedByPrincipalId}
+      )`.as('added_by_name'),
+      createdAt: postVotes.createdAt,
+      notifyComments: postSubscriptions.notifyComments,
+      notifyStatusChanges: postSubscriptions.notifyStatusChanges,
+    })
+    .from(postVotes)
+    .innerJoin(principal, eq(principal.id, postVotes.principalId))
+    .leftJoin(user, eq(user.id, principal.userId))
+    .leftJoin(
+      postSubscriptions,
+      and(
+        eq(postSubscriptions.postId, postVotes.postId),
+        eq(postSubscriptions.principalId, postVotes.principalId)
+      )
+    )
+    .where(and(...conditions))
+    .orderBy(desc(postVotes.createdAt), desc(postVotes.id))
+    .$dynamic()
+
+  const rows = limit !== undefined ? await query.limit(limit + 1) : await query
+
+  const hasMore = limit !== undefined && rows.length > limit
+  const pageRows = hasMore ? rows.slice(0, limit) : rows
+
+  return {
+    items: pageRows.map(mapVoterRow),
+    nextCursor: hasMore ? pageRows[pageRows.length - 1].voteId : null,
+    hasMore,
+  }
+}
+
+type VoterRow = {
+  principalId: PrincipalId
+  displayName: string | null
+  email: string | null
+  avatarUrl: string | null
+  principalType: string
+  sourceType: string | null
+  sourceExternalUrl: string | null
+  addedByName: string | null
+  createdAt: Date
+  notifyComments: boolean | null
+  notifyStatusChanges: boolean | null
+}
+
+function mapVoterRow(row: VoterRow): VoterInfo {
+  const isAnonymous = row.principalType === 'anonymous'
+  return {
+    principalId: row.principalId,
+    displayName: isAnonymous ? null : row.displayName,
+    email: realEmail(row.email),
+    avatarUrl: isAnonymous ? null : row.avatarUrl,
+    isAnonymous,
+    sourceType: row.sourceType,
+    sourceExternalUrl: row.sourceExternalUrl,
+    addedByName: row.addedByName,
+    createdAt: row.createdAt,
+    subscriptionLevel: isAnonymous
+      ? ('none' as const)
+      : levelFromFlags(row.notifyComments ?? false, row.notifyStatusChanges ?? false),
+  }
+}
+
+export async function getPostVoters(postId: PostId): Promise<VoterInfo[]> {
+  const { items } = await listPostVoters(postId)
+  return items
+}

--- a/apps/web/src/lib/server/domains/posts/post.voting.ts
+++ b/apps/web/src/lib/server/domains/posts/post.voting.ts
@@ -14,10 +14,9 @@ import {
   user,
   sql,
   eq,
-  and,
-  desc,
 } from '@/lib/server/db'
-import { createId, toUuid, type PostId, type PostVoteId, type PrincipalId } from '@quackback/ids'
+import { createId, toUuid, type PostId, type PrincipalId } from '@quackback/ids'
+import { relatedPostIdsSql } from './post.merge-ids'
 import { getExecuteRows } from '@/lib/server/utils'
 import { NotFoundError } from '@/lib/shared/errors'
 import { realEmail } from '@/lib/shared/anonymous-email'
@@ -26,23 +25,6 @@ import { dispatchPostVoted } from '@/lib/server/events/dispatch'
 import type { VoteResult } from './post.types'
 
 const log = logger.child({ component: 'post-voting' })
-import {
-  levelFromFlags,
-  type SubscriptionLevel,
-} from '@/lib/server/domains/subscriptions/subscription.types'
-
-export interface VoterInfo {
-  principalId: string
-  displayName: string | null
-  email: string | null
-  avatarUrl: string | null
-  isAnonymous: boolean
-  sourceType: string | null
-  sourceExternalUrl: string | null
-  addedByName: string | null
-  createdAt: Date | string
-  subscriptionLevel: SubscriptionLevel
-}
 
 /**
  * Emit the post.voted event for a freshly cast vote: one indexed lookup for
@@ -137,7 +119,8 @@ export async function voteOnPost(postId: PostId, principalId: PrincipalId): Prom
     ),
     existing AS (
       SELECT id FROM ${postVotes}
-      WHERE post_id = ${postUuid}::uuid AND principal_id = ${principalUuid}::uuid
+      WHERE principal_id = ${principalUuid}::uuid
+        AND post_id IN ${relatedPostIdsSql(postUuid)}
     ),
     deleted AS (
       DELETE FROM ${postVotes}
@@ -267,6 +250,11 @@ export async function addVoteOnBehalf(
       SELECT ${voteId}::uuid, ${postUuid}::uuid, ${principalUuid}::uuid, ${sourceType}, ${sourceExternalUrl}, ${addedByUuid}::uuid, ${createdAtSql}, ${createdAtSql}
       WHERE EXISTS (SELECT 1 FROM post_check)
         AND EXISTS (SELECT 1 FROM board_check)
+        AND NOT EXISTS (
+          SELECT 1 FROM ${postVotes}
+          WHERE principal_id = ${principalUuid}::uuid
+            AND post_id IN ${relatedPostIdsSql(postUuid)}
+        )
       ON CONFLICT (post_id, principal_id) DO NOTHING
       RETURNING id
     ),
@@ -345,8 +333,8 @@ export async function removeVote(
     ),
     deleted AS (
       DELETE FROM ${postVotes}
-      WHERE post_id = ${postUuid}::uuid
-        AND principal_id = ${principalUuid}::uuid
+      WHERE principal_id = ${principalUuid}::uuid
+        AND post_id IN ${relatedPostIdsSql(postUuid)}
         AND EXISTS (SELECT 1 FROM post_check)
         AND EXISTS (SELECT 1 FROM board_check)
       RETURNING id
@@ -385,121 +373,9 @@ export async function removeVote(
   return { removed: row.deleted, voteCount: row.vote_count ?? 0 }
 }
 
-export interface ListPostVotersResult {
-  items: VoterInfo[]
-  nextCursor: PostVoteId | null
-  hasMore: boolean
-}
-
-/**
- * List the voters on a post, newest votes first, with optional keyset
- * pagination. The cursor is a vote ID; the page continues strictly after that
- * vote in (createdAt, id) order. A cursor that no longer resolves is ignored
- * rather than erroring, matching the inbox listing. When no limit is given
- * the full list is returned and hasMore is always false.
- */
-export async function listPostVoters(
-  postId: PostId,
-  options: { limit?: number; cursor?: PostVoteId } = {}
-): Promise<ListPostVotersResult> {
-  const { limit, cursor } = options
-
-  const conditions = [eq(postVotes.postId, postId)]
-  if (cursor) {
-    const cursorVote = await db.query.postVotes.findFirst({
-      where: eq(postVotes.id, cursor),
-      columns: { id: true, createdAt: true },
-    })
-    if (cursorVote) {
-      conditions.push(
-        sql`(${postVotes.createdAt}, ${postVotes.id}) < (${cursorVote.createdAt.toISOString()}, ${toUuid(cursorVote.id)}::uuid)`
-      )
-    }
-  }
-
-  const query = db
-    .select({
-      voteId: postVotes.id,
-      principalId: principal.id,
-      displayName: principal.displayName,
-      email: user.email,
-      avatarUrl: principal.avatarUrl,
-      principalType: principal.type,
-      sourceType: postVotes.sourceType,
-      sourceExternalUrl: postVotes.sourceExternalUrl,
-      addedByName: sql<string | null>`(
-        SELECT p2.display_name FROM ${principal} p2
-        WHERE p2.id = ${postVotes.addedByPrincipalId}
-      )`.as('added_by_name'),
-      createdAt: postVotes.createdAt,
-      notifyComments: postSubscriptions.notifyComments,
-      notifyStatusChanges: postSubscriptions.notifyStatusChanges,
-    })
-    .from(postVotes)
-    .innerJoin(principal, eq(principal.id, postVotes.principalId))
-    .leftJoin(user, eq(user.id, principal.userId))
-    .leftJoin(
-      postSubscriptions,
-      and(
-        eq(postSubscriptions.postId, postVotes.postId),
-        eq(postSubscriptions.principalId, postVotes.principalId)
-      )
-    )
-    .where(and(...conditions))
-    // Secondary id key keeps the order total so pages never overlap on ties.
-    .orderBy(desc(postVotes.createdAt), desc(postVotes.id))
-    .$dynamic()
-
-  const rows = limit !== undefined ? await query.limit(limit + 1) : await query
-
-  const hasMore = limit !== undefined && rows.length > limit
-  const pageRows = hasMore ? rows.slice(0, limit) : rows
-
-  return {
-    items: pageRows.map(mapVoterRow),
-    nextCursor: hasMore ? pageRows[pageRows.length - 1].voteId : null,
-    hasMore,
-  }
-}
-
-type VoterRow = {
-  principalId: PrincipalId
-  displayName: string | null
-  email: string | null
-  avatarUrl: string | null
-  principalType: string
-  sourceType: string | null
-  sourceExternalUrl: string | null
-  addedByName: string | null
-  createdAt: Date
-  notifyComments: boolean | null
-  notifyStatusChanges: boolean | null
-}
-
-function mapVoterRow(row: VoterRow): VoterInfo {
-  const isAnonymous = row.principalType === 'anonymous'
-  return {
-    principalId: row.principalId,
-    displayName: isAnonymous ? null : row.displayName,
-    // Anonymous voters carry the synthetic placeholder email — never expose it.
-    email: realEmail(row.email),
-    avatarUrl: isAnonymous ? null : row.avatarUrl,
-    isAnonymous,
-    sourceType: row.sourceType,
-    sourceExternalUrl: row.sourceExternalUrl,
-    addedByName: row.addedByName,
-    createdAt: row.createdAt,
-    subscriptionLevel: isAnonymous
-      ? ('none' as const)
-      : levelFromFlags(row.notifyComments ?? false, row.notifyStatusChanges ?? false),
-  }
-}
-
-/**
- * Get all voters for a post with their identity and source attribution.
- * Returns newest votes first.
- */
-export async function getPostVoters(postId: PostId): Promise<VoterInfo[]> {
-  const { items } = await listPostVoters(postId)
-  return items
-}
+export {
+  getPostVoters,
+  listPostVoters,
+  type VoterInfo,
+  type ListPostVotersResult,
+} from './post.voters'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
After merge, the source post vanished from the inbox (by design) and the **Merged Feedback** list that used to sit on the canonical — with Unmerge — was removed in #88. The survivor also never got the source’s `commentCount`, and `hasVoted` / the voter list still keyed off a single post id.

## Fix
- Restore the always-visible **Merged Feedback** list on the canonical (unmerge lives there again, not only in the Activity tab)
- Recount public comments with unique votes on merge/unmerge
- Treat votes on merged sources as votes on the survivor (`hasVoted`, voter list, vote toggle, voted-post set)

Inbox/portal lists still hide merged sources. You unmerge from the canonical’s Merged Feedback list.

## Test
- Unit: merge mocks include `visible_comments`
- DB: merge two posts with distinct voters/comments and assert combined counts, thread comments, `getMergedPosts`, and `hasUserVoted`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://quackback.slack.com/archives/D0BR4JJF7FS/p1787057559516529?thread_ts=1787057559.516529&cid=D0BR4JJF7FS)

<div><a href="https://cursor.com/agents/bc-c8da95b3-e6d3-5964-b263-919fb7e78b0d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8da95b3-e6d3-5964-b263-919fb7e78b0d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

