### PR TITLE
feat(quinn): built-in tool dials, migration packs, and the trust page

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 <h1 align="center">Quackback</h1>
 
 <p align="center">
-  <strong>Open source feedback for teams that ship.</strong>
+  <strong>Open source support and product feedback for teams that ship.</strong>
 </p>
 
 <p align="center">
   The open-source alternative to Canny, UserVoice, and Productboard.<br />
-  Collect feedback. Prioritize what matters. Close the loop.
+  Collect feedback. Answer customers. Prioritize what matters. Close the loop.
 </p>
 
 <p align="center">
@@ -40,22 +40,22 @@
 
 ## Why Quackback?
 
-Most feedback tools are expensive, closed-source, and lock you in. Quackback gives you a modern feedback system you actually own.
+Most support-and-feedback suites are expensive, closed-source, and lock you in. Quackback is the suite you actually own: feedback, shared inbox, help center, changelog, status, and AI.
 
 - **Self-host for free.** Run on your own infrastructure. No per-seat pricing.
-- **Own your data.** Your feedback lives in your own database. No vendor lock-in.
+- **Own your data.** Feedback, conversations, and knowledge live in your own database. No vendor lock-in.
 - **AI-powered.** Automatic duplicate detection, AI summaries, feedback extraction from external sources, and an [MCP server](https://quackback.io/docs/mcp) that lets AI agents search, triage, and act on feedback directly.
 - **25 integrations.** Slack, Linear, Jira, GitHub, Intercom, Zendesk, and [more](#integrations) out of the box.
 
 ## Features
 
-- **Feedback boards.** Let users vote, comment, and track status on feature requests. Vote on behalf of customers and see a full activity timeline on every post.
-- **AI-powered.** Automatically detect duplicates, summarize key themes, and ingest feedback from Slack, email, and other sources so nothing slips through the cracks.
+- **Feedback boards.** Let users vote, comment, and track status on feature requests. Vote on behalf of customers, surface high-revenue accounts in triage, and see a full activity timeline on every post.
+- **Quinn AI.** A customer-facing agent and a teammate Copilot. Detect duplicates, summarize themes, connect remote MCP servers as Connectors, and permission every write tool: always allow, ask for approval, or deny.
 - **Embeddable widget.** Collect feedback right inside your app with a [drop-in widget](https://quackback.io/docs/widget/installation). Works on desktop and mobile, with native SDKs for [iOS](https://github.com/QuackbackIO/quackback-ios) and [Android](https://github.com/QuackbackIO/quackback-android).
 - **Admin inbox.** Triage incoming feedback in one place. Filter, group, dismiss, and restore deleted posts.
 - **Roadmap & changelog.** Show users what's planned, in progress, and shipped. Publish updates and schedule posts for later.
 - **Integrations.** [25 integrations](#integrations) including Slack, Linear, Jira, GitHub, Intercom, Zendesk, and two-way issue tracker sync.
-- **API, webhooks & MCP.** Automate workflows with the REST API, outbound webhooks, and a 23-tool [MCP server](https://quackback.io/docs/mcp) for AI agents.
+- **API, webhooks & MCP.** Automate workflows with the REST API, outbound webhooks, and an [MCP server](https://quackback.io/docs/mcp) for AI agents.
 - **Internationalization.** Portal and widget available in English, French, German, Spanish, and Arabic with full RTL support. Auto-detects browser language.
 - **Flexible auth.** Password, email OTP, Google, GitHub, and SSO with providers like Okta and Auth0.
 - **SEO-ready.** Auto-generated sitemap and social sharing previews on every portal page.

--- a/apps/web/src/components/admin/automation/builtin-tools-card.tsx
+++ b/apps/web/src/components/admin/automation/builtin-tools-card.tsx
@@ -64,7 +64,7 @@ export function BuiltInToolsCard({ agent }: { agent: AssistantAgentKind }) {
   if (settingsQuery.isPending || toolsQuery.isPending) return null
 
   const revision = settingsQuery.data.revision
-  const rules = settingsQuery.data.config.agents[agent].toolRules ?? {}
+  const rules = settingsQuery.data.config.agents[agent].toolRules
   const writeTools = toolsQuery.data.filter((tool) => tool.risk === 'write')
   const hasExplicitRules = Object.keys(rules).length > 0
 
@@ -100,7 +100,7 @@ export function BuiltInToolsCard({ agent }: { agent: AssistantAgentKind }) {
       description={intl.formatMessage({
         id: 'automation.builtinTools.description',
         defaultMessage:
-          'What each built-in write tool may do on this agent. Never removes the tool from its turns entirely.',
+          'What each built-in write tool may do on this agent. "Never" removes the tool from its turns entirely.',
       })}
       action={
         hasExplicitRules ? (

--- a/apps/web/src/components/admin/automation/builtin-tools-card.tsx
+++ b/apps/web/src/components/admin/automation/builtin-tools-card.tsx
@@ -1,0 +1,169 @@
+/**
+ * Per-tool permission dials for Quinn's BUILT-IN write tools, one card per
+ * agent, sharing the remote-connector dial's vocabulary and control:
+ * Always allow / Needs approval / Never. An absent rule leaves the turn's
+ * role policy deciding, so the dial shows that default until a teammate
+ * commits an explicit choice; Reset returns every tool to role policy.
+ *
+ * Read tools are deliberately not listed — the dial exists for writes, and a
+ * read tool that could be denied would quietly hollow out answer quality.
+ */
+import { useState } from 'react'
+import { useIntl } from 'react-intl'
+import { useQuery } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { SettingsCard } from '@/components/admin/settings/settings-card'
+import { PolicyDial } from '@/components/admin/automation/connectors/policy-dial'
+import { assistantQueries } from '@/lib/client/queries/assistant'
+import { useUpdateAssistantToolRules } from '@/lib/client/mutations/assistant'
+import type { ConnectorToolPolicy } from '@/lib/shared/assistant/connectors'
+import type { AssistantAgentKind, AssistantToolRule } from '@/lib/shared/assistant/config'
+
+/** The dial renders the connector vocabulary; rules persist the built-in one. */
+const RULE_TO_DIAL: Record<AssistantToolRule, ConnectorToolPolicy> = {
+  allow: 'always',
+  ask: 'approval',
+  deny: 'never',
+}
+const DIAL_TO_RULE: Record<ConnectorToolPolicy, AssistantToolRule> = {
+  always: 'allow',
+  approval: 'ask',
+  never: 'deny',
+}
+
+/** What role policy does when no rule is saved (D14). */
+function roleDefault(agent: AssistantAgentKind): AssistantToolRule {
+  return agent === 'copilot' ? 'ask' : 'allow'
+}
+
+export function BuiltInToolsCard({ agent }: { agent: AssistantAgentKind }) {
+  const intl = useIntl()
+  const settingsQuery = useQuery(assistantQueries.settings())
+  const toolsQuery = useQuery(assistantQueries.tools())
+  const update = useUpdateAssistantToolRules()
+  const [pendingTool, setPendingTool] = useState<string | null>(null)
+
+  if (settingsQuery.isError || toolsQuery.isError) {
+    return (
+      <SettingsCard
+        title={intl.formatMessage({
+          id: 'automation.builtinTools.title',
+          defaultMessage: 'Built-in actions',
+        })}
+      >
+        <p className="text-sm text-destructive">
+          {intl.formatMessage({
+            id: 'automation.builtinTools.loadError',
+            defaultMessage: 'Could not load the tool catalogue.',
+          })}
+        </p>
+      </SettingsCard>
+    )
+  }
+  if (settingsQuery.isPending || toolsQuery.isPending) return null
+
+  const revision = settingsQuery.data.revision
+  const rules = settingsQuery.data.config.agents[agent].toolRules ?? {}
+  const writeTools = toolsQuery.data.filter((tool) => tool.risk === 'write')
+  const hasExplicitRules = Object.keys(rules).length > 0
+
+  async function save(toolRules: Record<string, AssistantToolRule>, tool: string | null) {
+    setPendingTool(tool)
+    try {
+      await update.mutateAsync({ expectedRevision: revision, agent, toolRules })
+    } catch {
+      toast.error(
+        intl.formatMessage({
+          id: 'automation.builtinTools.saveError',
+          defaultMessage: 'Tool permissions could not be updated.',
+        })
+      )
+    } finally {
+      setPendingTool(null)
+    }
+  }
+
+  return (
+    <SettingsCard
+      title={
+        agent === 'copilot'
+          ? intl.formatMessage({
+              id: 'automation.builtinTools.titleCopilot',
+              defaultMessage: 'Built-in actions (Copilot)',
+            })
+          : intl.formatMessage({
+              id: 'automation.builtinTools.titleAgent',
+              defaultMessage: 'Built-in actions (Agent)',
+            })
+      }
+      description={intl.formatMessage({
+        id: 'automation.builtinTools.description',
+        defaultMessage:
+          'What each built-in write tool may do on this agent. Never removes the tool from its turns entirely.',
+      })}
+      action={
+        hasExplicitRules ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            disabled={update.isPending}
+            onClick={() => void save({}, null)}
+          >
+            {intl.formatMessage({
+              id: 'automation.builtinTools.reset',
+              defaultMessage: 'Reset to defaults',
+            })}
+          </Button>
+        ) : undefined
+      }
+      contentClassName="p-0"
+    >
+      {writeTools.map((tool, index) => {
+        const effective = rules[tool.name] ?? roleDefault(agent)
+        const explicit = tool.name in rules
+        return (
+          <div
+            key={tool.name}
+            className={
+              index === 0
+                ? 'flex items-center gap-3 px-4 py-3 sm:px-[18px]'
+                : 'flex items-center gap-3 border-t border-border/60 px-4 py-3 sm:px-[18px]'
+            }
+          >
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2 text-[13.5px] font-medium">
+                {tool.label}
+                {!explicit && (
+                  <span className="text-[11px] text-muted-foreground">
+                    {intl.formatMessage({
+                      id: 'automation.builtinTools.default',
+                      defaultMessage: 'Default',
+                    })}
+                  </span>
+                )}
+              </div>
+              <p className="truncate text-xs text-muted-foreground">{tool.description}</p>
+            </div>
+            {pendingTool === tool.name ? (
+              <span className="text-xs text-muted-foreground">
+                {intl.formatMessage({
+                  id: 'automation.builtinTools.saving',
+                  defaultMessage: 'Saving…',
+                })}
+              </span>
+            ) : null}
+            <PolicyDial
+              value={RULE_TO_DIAL[effective]}
+              labelledBy={tool.label}
+              onChange={(next) =>
+                void save({ ...rules, [tool.name]: DIAL_TO_RULE[next] }, tool.name)
+              }
+            />
+          </div>
+        )
+      })}
+    </SettingsCard>
+  )
+}

--- a/apps/web/src/components/admin/settings/imports/imports-hub-page.tsx
+++ b/apps/web/src/components/admin/settings/imports/imports-hub-page.tsx
@@ -6,6 +6,8 @@ import { ImportCsv } from './import-csv'
 import { ImportHistoryList } from './import-history-list'
 import { ExportWorkspaceAction } from './export-workspace-action'
 import { ExportHistoryList } from './export-history-list'
+import { MIGRATION_PACKS } from '@/lib/shared/migration-packs'
+import { Badge } from '@/components/ui/badge'
 
 export function ImportsHubPage() {
   return (
@@ -20,19 +22,51 @@ export function ImportsHubPage() {
       />
 
       <SettingsCard
-        title="Imports"
-        description="Upload a CSV of posts using the template — new boards, statuses, and tags are created as part of the import."
+        title="Migration packs"
+        description="Start from a guided pack for the kind of product you are leaving. Each pack points at the CSV shape Quackback accepts today."
       >
-        <ImportCsv />
-        <div className="mt-6 border-t border-border/50 pt-4 space-y-1.5">
-          <p className="text-xs font-medium text-muted-foreground">Moving from another tool</p>
-          <p className="text-xs text-muted-foreground">
-            Export your data from the old tool, map it onto the template columns (only title and
-            content are required), and upload it above. Keep the source_id column filled to re-run
-            an import later without duplicating posts.
-          </p>
+        <div className="divide-y divide-border/60">
+          {MIGRATION_PACKS.map((pack) => (
+            <div
+              key={pack.id}
+              className="flex items-start justify-between gap-3 py-3 first:pt-0 last:pb-0"
+            >
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <h3 className="text-sm font-medium">{pack.title}</h3>
+                  <Badge size="sm" variant="secondary" shape="pill">
+                    CSV
+                  </Badge>
+                </div>
+                <p className="mt-1 text-xs text-muted-foreground">{pack.description}</p>
+                <a
+                  href={pack.href}
+                  className="mt-1 inline-block text-xs font-medium text-foreground underline-offset-4 hover:underline"
+                >
+                  Use the CSV import below
+                </a>
+              </div>
+            </div>
+          ))}
         </div>
       </SettingsCard>
+
+      <div id="import-csv">
+        <SettingsCard
+          title="Imports"
+          description="Upload a CSV of posts using the template — new boards, statuses, and tags are created as part of the import."
+        >
+          <ImportCsv />
+          <div className="mt-6 border-t border-border/50 pt-4 space-y-1.5">
+            <p className="text-xs font-medium text-muted-foreground">Moving from another tool</p>
+            <p className="text-xs text-muted-foreground">
+              Export your data from the old tool, map it onto the template columns (only title and
+              content are required), and upload it above. Keep the source_id column filled to re-run
+              an import later without duplicating posts.
+            </p>
+          </div>
+        </SettingsCard>
+      </div>
 
       <SettingsCard
         title="Export workspace data"

--- a/apps/web/src/lib/client/mutations/assistant.ts
+++ b/apps/web/src/lib/client/mutations/assistant.ts
@@ -9,6 +9,7 @@ import {
   reorderGuidanceRulesFn,
 } from '@/lib/server/functions/assistant-guidance'
 import {
+  updateAssistantToolRulesFn,
   getAssistantSettingsFn,
   updateAssistantIdentityFn,
   updateAssistantVoiceFn,
@@ -105,6 +106,15 @@ export function useUpdateAssistantAgentKnowledge() {
   return useMutation({
     mutationFn: (data: Parameters<typeof updateAssistantAgentKnowledgeFn>[0]['data']) =>
       updateAssistantAgentKnowledgeFn({ data }),
+    onSuccess: (result) => setAssistantConfig(queryClient, result),
+  })
+}
+
+export function useUpdateAssistantToolRules() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data: Parameters<typeof updateAssistantToolRulesFn>[0]['data']) =>
+      updateAssistantToolRulesFn({ data }),
     onSuccess: (result) => setAssistantConfig(queryClient, result),
   })
 }

--- a/apps/web/src/lib/server/audit/log.ts
+++ b/apps/web/src/lib/server/audit/log.ts
@@ -142,6 +142,7 @@ export type AuditEventType =
   | 'assistant.instructions.changed'
   | 'assistant.knowledge.changed'
   | 'assistant.capabilities.changed'
+  | 'assistant.tools.changed'
   | 'assistant.channels.changed'
   | 'assistant.deployment.changed'
   // Verified-email assertion. `emailVerified: true` is a trust decision, not a

--- a/apps/web/src/lib/server/domains/assistant/__tests__/assistant.runtime.test.ts
+++ b/apps/web/src/lib/server/domains/assistant/__tests__/assistant.runtime.test.ts
@@ -168,6 +168,7 @@ const DEFAULT_RUNTIME_CONFIG: AssistantRuntimeConfig = {
           documents: true,
           status: false,
         },
+        toolRules: {},
       },
       copilot: {
         capabilities: { qa: true },
@@ -181,6 +182,7 @@ const DEFAULT_RUNTIME_CONFIG: AssistantRuntimeConfig = {
           documents: true,
           status: true,
         },
+        toolRules: {},
       },
     },
   },
@@ -369,6 +371,7 @@ describe('mockRuntimeConfig helper', () => {
               documents: false,
               status: true,
             },
+            toolRules: {},
           },
         },
       },
@@ -1037,7 +1040,7 @@ describe('runAssistantTurn', () => {
     expect(mockChat).toHaveBeenCalledTimes(2)
     expect(mockGetAssistantRuntimeConfig).toHaveBeenCalledTimes(1)
     expect(mockAssembleAssistantToolset).toHaveBeenCalledTimes(1)
-    expect(mockAssembleAssistantToolset).toHaveBeenCalledWith(expect.any(Object), undefined, [])
+    expect(mockAssembleAssistantToolset).toHaveBeenCalledWith(expect.any(Object), expect.anything(), [])
     expect(result.status !== 'suppressed' && result.trace.configRevision).toBe(37)
     expect(lastLoggedMetadata?.configRevision).toBe(37)
   })
@@ -2126,7 +2129,7 @@ describe('runAssistantTurn: V2 prompt and config snapshot', () => {
           status: false,
         },
       }),
-      undefined,
+      expect.anything(),
       []
     )
   })

--- a/apps/web/src/lib/server/domains/assistant/__tests__/builtin-tool-rules.test.ts
+++ b/apps/web/src/lib/server/domains/assistant/__tests__/builtin-tool-rules.test.ts
@@ -1,0 +1,71 @@
+/**
+ * The built-in tool dial's overlay: saved per-tool rules rewrite the
+ * catalogue BEFORE assembly, riding the same approvalPolicy seam the remote
+ * connector dial uses. The claims that matter:
+ *
+ *  - `deny` removes the spec entirely — the model never sees the tool.
+ *  - `ask`/`allow` stamp approvalPolicy so mode resolution proposes/runs.
+ *  - an ABSENT key changes nothing: role policy keeps deciding, byte-for-byte
+ *    the pre-dial behavior (the no-rules fast path returns the same specs).
+ *  - read/control tools are untouchable whatever the map says.
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  applyBuiltInToolRules,
+  resolveToolSpecs,
+  type AssistantToolSpec,
+} from '../assistant.toolspec'
+import { resolveEffectiveToolMode } from '../assistant.tools'
+import type { AssistantToolContext } from '../assistant.toolspec'
+
+const writeSpec = resolveToolSpecs().find((spec) => spec.risk === 'write')
+const readSpec = resolveToolSpecs().find((spec) => spec.risk === 'read')
+
+function ctxWith(policy: 'propose' | 'execute'): AssistantToolContext {
+  return { writeToolPolicy: policy === 'propose' ? 'propose' : undefined } as AssistantToolContext
+}
+
+describe('applyBuiltInToolRules', () => {
+  it('returns the catalogue untouched when no rules are saved', () => {
+    const specs = resolveToolSpecs()
+    expect(applyBuiltInToolRules(specs, {})).toEqual(specs)
+    expect(applyBuiltInToolRules(specs, undefined)).toEqual(specs)
+  })
+
+  it('deny removes the tool before the model can see it', () => {
+    const specs = resolveToolSpecs()
+    const out = applyBuiltInToolRules(specs, { [writeSpec!.name]: 'deny' })
+    expect(out.some((spec) => spec.name === writeSpec!.name)).toBe(false)
+    expect(out.length).toBe(specs.length - 1)
+  })
+
+  it('ask stamps the approval policy the connector dial rides', () => {
+    const out = applyBuiltInToolRules(resolveToolSpecs(), { [writeSpec!.name]: 'ask' })
+    const stamped = out.find((spec) => spec.name === writeSpec!.name)!
+    expect(stamped.approvalPolicy).toBe('approval')
+    // And mode resolution proposes even on an autonomous turn.
+    expect(resolveEffectiveToolMode(stamped, ctxWith('execute'))).toBe('propose')
+  })
+
+  it('allow runs autonomously even where role policy would propose', () => {
+    const out = applyBuiltInToolRules(resolveToolSpecs(), { [writeSpec!.name]: 'allow' })
+    const stamped = out.find((spec) => spec.name === writeSpec!.name)!
+    expect(stamped.approvalPolicy).toBe('always')
+    expect(resolveEffectiveToolMode(stamped, ctxWith('propose'))).toBe('autonomous')
+  })
+
+  it('an unruled write tool keeps deciding by role policy', () => {
+    const other = resolveToolSpecs().filter(
+      (spec) => spec.risk === 'write' && spec.name !== writeSpec!.name
+    )[0]!
+    const out = applyBuiltInToolRules(resolveToolSpecs(), { [writeSpec!.name]: 'deny' })
+    const untouched = out.find((spec) => spec.name === other.name)!
+    expect(untouched.approvalPolicy).toBeUndefined()
+    expect(resolveEffectiveToolMode(untouched, ctxWith('propose'))).toBe('propose')
+  })
+
+  it('read tools ignore the map entirely', () => {
+    const out = applyBuiltInToolRules(resolveToolSpecs(), { [readSpec!.name]: 'deny' })
+    expect(out.some((spec: AssistantToolSpec) => spec.name === readSpec!.name)).toBe(true)
+  })
+})

--- a/apps/web/src/lib/server/domains/assistant/assistant.runtime.ts
+++ b/apps/web/src/lib/server/domains/assistant/assistant.runtime.ts
@@ -41,7 +41,7 @@ import type {
 } from '@/lib/shared/conversation/types'
 import { resolveContentAudience } from './audience'
 import { assembleAssistantToolset } from './assistant.tools'
-import { makeAssistantToolContext, makeAssistantToolLedger } from './assistant.toolspec'
+import { applyBuiltInToolRules, resolveToolSpecs, makeAssistantToolContext, makeAssistantToolLedger } from './assistant.toolspec'
 import { listConversationAttributes } from '@/lib/server/domains/conversation-attributes/conversation-attribute.service'
 import type {
   AssistantCitation,
@@ -1023,9 +1023,17 @@ export async function runAssistantTurn(input: AssistantTurnInput): Promise<Assis
   // flip gating mid-turn, and shares the same tool set across every attempt.
   // `activeSpecs` (the specs behind `tools`, index-aligned) is what the
   // system prompt's per-tool guidance composes from below.
+  // The workspace's saved per-tool dials for this agent overlay the built-in
+  // catalogue before assembly: deny never reaches the model, ask/allow ride
+  // the same approvalPolicy seam the connector dial uses, and an empty map
+  // leaves role policy deciding exactly as before the dial existed.
+  const builtInSpecs = applyBuiltInToolRules(
+    resolveToolSpecs(),
+    runtimeConfig.config.agents[agentKind].toolRules
+  )
   let { tools, activeSpecs } = await assembleAssistantToolset(
     toolContext,
-    undefined,
+    builtInSpecs,
     connectorSpecs
   )
   let toolNames = new Set(tools.map((t) => t.name))

--- a/apps/web/src/lib/server/domains/assistant/assistant.tools.ts
+++ b/apps/web/src/lib/server/domains/assistant/assistant.tools.ts
@@ -69,8 +69,9 @@ export type ToolExecutionMode = 'autonomous' | 'propose' | 'simulate'
 /**
  * Resolve a spec's execution branch for this turn from its risk class and the
  * turn's write policy (`ctx.writeToolPolicy`, selected from the role policy).
- * There is no saved per-tool configuration: end-user-triggered write tools
- * execute autonomously, with no approval step.
+ * Built-in write tools also honor the per-agent dial this harvest adds
+ * (`allow` / `ask` / `deny` on `config.agents.*.toolRules`). An absent key
+ * leaves the turn's role policy deciding, which is the pre-dial behavior.
  *
  * - Control tools are agent-protocol primitives: always autonomous, on every
  *   deployment (the model must express handoff/inability as tool calls).

--- a/apps/web/src/lib/server/domains/assistant/assistant.toolspec.ts
+++ b/apps/web/src/lib/server/domains/assistant/assistant.toolspec.ts
@@ -47,7 +47,11 @@ import { ASSISTANT_CITATION_TYPES, type AssistantCitationType } from './citation
 import { PERMISSIONS, type PermissionKey } from '@/lib/shared/permissions'
 import { TICKET_TYPES, CONVERSATION_PRIORITIES } from '@/lib/shared/db-types'
 import type { Actor } from '@/lib/server/policy/types'
-import { DEFAULT_ASSISTANT_CONFIG, type AssistantRole } from '@/lib/shared/assistant/config'
+import {
+  DEFAULT_ASSISTANT_CONFIG,
+  type AssistantRole,
+  type AssistantToolRules,
+} from '@/lib/shared/assistant/config'
 import { SKILL_LOADS_PER_TURN } from '@/lib/shared/assistant/skills'
 import { setConversationAttribute } from '@/lib/server/domains/conversation-attributes/set-attribute.service'
 import { classifyConversationAttributes } from '@/lib/server/domains/conversation-attributes/ai-classification.service'
@@ -1496,7 +1500,7 @@ export function getToolSpecByName(name: string): AssistantToolSpec | null {
  */
 export function applyBuiltInToolRules(
   specs: readonly AssistantToolSpec[],
-  toolRules: Readonly<Record<string, 'allow' | 'ask' | 'deny'>> | undefined
+  toolRules: Readonly<AssistantToolRules> | undefined
 ): AssistantToolSpec[] {
   if (!toolRules || Object.keys(toolRules).length === 0) return [...specs]
   const out: AssistantToolSpec[] = []

--- a/apps/web/src/lib/server/domains/assistant/assistant.toolspec.ts
+++ b/apps/web/src/lib/server/domains/assistant/assistant.toolspec.ts
@@ -1484,3 +1484,32 @@ export function resolveToolSpecs(): AssistantToolSpec[] {
 export function getToolSpecByName(name: string): AssistantToolSpec | null {
   return ASSISTANT_TOOL_SPECS[name] ?? null
 }
+
+/**
+ * Overlay the workspace's saved per-tool rules onto the built-in catalogue for
+ * one agent. Read/control tools are untouchable — the dial exists for writes.
+ * `deny` removes the spec before the model ever sees it; `ask`/`allow` stamp
+ * the same `approvalPolicy` the remote-connector dial rides, so mode
+ * resolution and the approval pipeline treat both dials identically. An
+ * absent key leaves the spec untouched and the turn's role policy deciding,
+ * which is exactly the pre-dial behavior.
+ */
+export function applyBuiltInToolRules(
+  specs: readonly AssistantToolSpec[],
+  toolRules: Readonly<Record<string, 'allow' | 'ask' | 'deny'>> | undefined
+): AssistantToolSpec[] {
+  if (!toolRules || Object.keys(toolRules).length === 0) return [...specs]
+  const out: AssistantToolSpec[] = []
+  for (const spec of specs) {
+    if (spec.risk !== 'write') {
+      out.push(spec)
+      continue
+    }
+    const rule = toolRules[spec.name]
+    if (rule === 'deny') continue
+    if (rule === 'ask') out.push({ ...spec, approvalPolicy: 'approval' })
+    else if (rule === 'allow') out.push({ ...spec, approvalPolicy: 'always' })
+    else out.push(spec)
+  }
+  return out
+}

--- a/apps/web/src/lib/server/domains/settings/__tests__/settings.assistant.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/settings.assistant.test.ts
@@ -88,6 +88,7 @@ const CONFIG: AssistantConfig = {
         documents: true,
         status: false,
       },
+      toolRules: {},
     },
     copilot: {
       capabilities: { qa: true },
@@ -101,6 +102,7 @@ const CONFIG: AssistantConfig = {
         documents: true,
         status: true,
       },
+      toolRules: {},
     },
   },
 }

--- a/apps/web/src/lib/server/domains/settings/settings.assistant.ts
+++ b/apps/web/src/lib/server/domains/settings/settings.assistant.ts
@@ -4,19 +4,23 @@ import { and, db, eq, principal, settings, sql } from '@/lib/server/db'
 import { isPathManaged } from '@/lib/server/config-file/managed-paths'
 import { logger } from '@/lib/server/logger'
 import {
+  assistantAgentSchema,
   assistantConfigSchema,
   assistantCopilotCapabilitiesSchema,
   assistantAgentKnowledgeSchema,
   assistantCopilotKnowledgeSchema,
   assistantIdentitySchema,
+  assistantToolRulesSchema,
   assistantVoiceSchema,
   DEFAULT_ASSISTANT_CONFIG,
   normalizeAssistantConfig,
+  type AssistantAgentKind,
   type AssistantAgentKnowledge,
   type AssistantConfig,
   type AssistantCopilotCapabilities,
   type AssistantCopilotKnowledge,
   type AssistantIdentity,
+  type AssistantToolRules,
   type AssistantVoice,
 } from '@/lib/shared/assistant/config'
 import { ConflictError, ForbiddenError, InternalError, NotFoundError } from '@/lib/shared/errors'
@@ -49,6 +53,12 @@ export const assistantCopilotKnowledgeUpdateSchema = z.object({
 export const assistantCopilotCapabilitiesUpdateSchema = z.object({
   expectedRevision: z.number().int().positive(),
   capabilities: assistantCopilotCapabilitiesSchema,
+})
+
+export const assistantToolRulesUpdateSchema = z.object({
+  expectedRevision: z.number().int().positive(),
+  agent: assistantAgentSchema,
+  toolRules: assistantToolRulesSchema,
 })
 
 export interface AssistantConfigState {
@@ -147,6 +157,9 @@ function auditEventForPaths(paths: string[]): AuditEventType {
   if (root === 'identity') return 'assistant.identity.changed'
   if (paths.every((path) => path.startsWith('agents.copilot.capabilities'))) {
     return 'assistant.capabilities.changed'
+  }
+  if (paths.every((path) => path.includes('.toolRules'))) {
+    return 'assistant.tools.changed'
   }
   if (paths.every((path) => path.endsWith('.knowledge') || path.includes('.knowledge.'))) {
     return 'assistant.knowledge.changed'
@@ -355,6 +368,30 @@ export function updateAssistantCopilotCapabilities(
     (current) => ({
       ...current,
       agents: { ...current.agents, copilot: { ...current.agents.copilot, capabilities } },
+    }),
+    actor
+  )
+}
+
+/**
+ * A per-tool permission write for one agent's built-in write tools. The whole
+ * map is replaced (the card edits it as a unit), and
+ * `normalizeAssistantConfig` re-validates the vocabulary at the write
+ * boundary. An empty map is a real state: every dial back on role policy.
+ */
+export function updateAssistantToolRules(
+  expectedRevision: number,
+  update: { agent: AssistantAgentKind; toolRules: AssistantToolRules },
+  actor: AssistantConfigAuditActor
+): Promise<AssistantConfigState> {
+  return updateAssistantConfig(
+    expectedRevision,
+    (current) => ({
+      ...current,
+      agents: {
+        ...current.agents,
+        [update.agent]: { ...current.agents[update.agent], toolRules: update.toolRules },
+      },
     }),
     actor
   )

--- a/apps/web/src/lib/server/functions/__tests__/assistant-settings.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/assistant-settings.test.ts
@@ -78,6 +78,7 @@ const CONFIG: AssistantConfig = {
         documents: true,
         status: false,
       },
+      toolRules: {},
     },
     copilot: {
       capabilities: { qa: true },
@@ -91,6 +92,7 @@ const CONFIG: AssistantConfig = {
         documents: true,
         status: true,
       },
+      toolRules: {},
     },
   },
 }

--- a/apps/web/src/lib/server/functions/assistant-settings.ts
+++ b/apps/web/src/lib/server/functions/assistant-settings.ts
@@ -2,6 +2,7 @@ import { createServerFn } from '@tanstack/react-start'
 import { getRequestHeaders } from '@tanstack/react-start/server'
 import { actorFromAuth } from '@/lib/server/audit/log'
 import {
+  assistantToolRulesUpdateSchema,
   assistantIdentityUpdateSchema,
   assistantVoiceUpdateSchema,
   assistantAgentKnowledgeUpdateSchema,
@@ -79,6 +80,19 @@ export const updateAssistantCopilotCapabilitiesFn = createServerFn({ method: 'PO
     return updateAssistantCopilotCapabilities(
       data.expectedRevision,
       data.capabilities,
+      configActor(ctx)
+    )
+  })
+
+export const updateAssistantToolRulesFn = createServerFn({ method: 'POST' })
+  .validator(assistantToolRulesUpdateSchema)
+  .handler(async ({ data }) => {
+    const ctx = await requireAuth({ permission: PERMISSIONS.ASSISTANT_MANAGE })
+    const { updateAssistantToolRules } =
+      await import('@/lib/server/domains/settings/settings.assistant')
+    return updateAssistantToolRules(
+      data.expectedRevision,
+      { agent: data.agent, toolRules: data.toolRules },
       configActor(ctx)
     )
   })

--- a/apps/web/src/lib/server/policy/authz-matrix/MATRIX.md
+++ b/apps/web/src/lib/server/policy/authz-matrix/MATRIX.md
@@ -979,7 +979,7 @@ Key scopes are enforced: an API key holds exactly its stored scopes (owner permi
 
 ## 4. Entry points without a requireAuth/key gate
 
-191 of 971 entry points hold no `requireAuth` / `withApiKeyAuth` / `requireTeamAuth` gate.
+190 of 970 entry points hold no `requireAuth` / `withApiKeyAuth` / `requireTeamAuth` gate.
 Each is expected to be intentionally public, a pre-auth flow, a signature-verified webhook, or a handler that delegates auth (e.g. the MCP route).
 **Adding a row here is an access-control change** — confirm the new entry point is meant to be reachable without a gate.
 
@@ -1070,7 +1070,6 @@ Each is expected to be intentionally public, a pre-auth flow, a signature-verifi
 | `lib/server/functions/settings.ts`::fetchPublicAuthConfig | server-fn |
 | `lib/server/functions/settings.ts`::fetchPublicPortalConfig | server-fn |
 | `lib/server/functions/settings.ts`::fetchUserProfile | server-fn |
-| `lib/server/functions/sso-entitlement.ts`::hasSsoEntitlementFn | server-fn |
 | `lib/server/functions/status.ts`::getStatusIncidentPublicFn | server-fn |
 | `lib/server/functions/status.ts`::getStatusPageFn | server-fn |
 | `lib/server/functions/status.ts`::getStatusUptimeFn | server-fn |

--- a/apps/web/src/lib/server/policy/authz-matrix/MATRIX.md
+++ b/apps/web/src/lib/server/policy/authz-matrix/MATRIX.md
@@ -236,6 +236,7 @@ Profiles: **Owner** = admin class + an admin-owned full API key (scoped keys hol
 | `lib/server/functions/assistant-settings.ts`::updateAssistantAgentKnowledgeFn | assistant.manage |
 | `lib/server/functions/assistant-settings.ts`::updateAssistantCopilotKnowledgeFn | assistant.manage |
 | `lib/server/functions/assistant-settings.ts`::updateAssistantCopilotCapabilitiesFn | assistant.manage |
+| `lib/server/functions/assistant-settings.ts`::updateAssistantToolRulesFn | assistant.manage |
 | `lib/server/functions/assistant-settings.ts`::updateWidgetAssistantDeploymentFn | assistant.manage |
 | `lib/server/functions/assistant-skills.ts`::listSkillsFn | assistant.manage |
 | `lib/server/functions/assistant-skills.ts`::createSkillFn | assistant.manage |
@@ -978,7 +979,7 @@ Key scopes are enforced: an API key holds exactly its stored scopes (owner permi
 
 ## 4. Entry points without a requireAuth/key gate
 
-190 of 969 entry points hold no `requireAuth` / `withApiKeyAuth` / `requireTeamAuth` gate.
+191 of 971 entry points hold no `requireAuth` / `withApiKeyAuth` / `requireTeamAuth` gate.
 Each is expected to be intentionally public, a pre-auth flow, a signature-verified webhook, or a handler that delegates auth (e.g. the MCP route).
 **Adding a row here is an access-control change** — confirm the new entry point is meant to be reachable without a gate.
 
@@ -1069,6 +1070,7 @@ Each is expected to be intentionally public, a pre-auth flow, a signature-verifi
 | `lib/server/functions/settings.ts`::fetchPublicAuthConfig | server-fn |
 | `lib/server/functions/settings.ts`::fetchPublicPortalConfig | server-fn |
 | `lib/server/functions/settings.ts`::fetchUserProfile | server-fn |
+| `lib/server/functions/sso-entitlement.ts`::hasSsoEntitlementFn | server-fn |
 | `lib/server/functions/status.ts`::getStatusIncidentPublicFn | server-fn |
 | `lib/server/functions/status.ts`::getStatusPageFn | server-fn |
 | `lib/server/functions/status.ts`::getStatusUptimeFn | server-fn |

--- a/apps/web/src/lib/server/policy/authz-matrix/MATRIX.md
+++ b/apps/web/src/lib/server/policy/authz-matrix/MATRIX.md
@@ -100,7 +100,7 @@ Profiles: **Owner** = admin class + an admin-owned full API key (scoped keys hol
 
 ## 2. Surfaces and their enforced authorization
 
-### Server functions (`requireAuth`) — 668 surfaces
+### Server functions (`requireAuth`) — 669 surfaces
 
 | Surface | Enforces |
 | --- | --- |

--- a/apps/web/src/lib/shared/assistant/__tests__/config.test.ts
+++ b/apps/web/src/lib/shared/assistant/__tests__/config.test.ts
@@ -77,6 +77,7 @@ describe('assistantConfigSchema', () => {
             documents: true,
             status: false,
           },
+          toolRules: {},
         },
         copilot: {
           capabilities: { qa: true },
@@ -90,6 +91,7 @@ describe('assistantConfigSchema', () => {
             documents: true,
             status: true,
           },
+          toolRules: {},
         },
       },
     })

--- a/apps/web/src/lib/shared/assistant/config-audit-events.ts
+++ b/apps/web/src/lib/shared/assistant/config-audit-events.ts
@@ -38,6 +38,7 @@ export const ASSISTANT_CONFIG_EVENT_LABELS: Record<
   'assistant.instructions.changed': 'Writing guidelines changed',
   'assistant.knowledge.changed': 'Knowledge sources changed',
   'assistant.capabilities.changed': 'Copilot capabilities changed',
+  'assistant.tools.changed': 'Tool permissions changed',
   'assistant.channels.changed': 'Channel guidance changed',
   'assistant.deployment.changed': 'Automatic replies changed',
 }

--- a/apps/web/src/lib/shared/assistant/config.ts
+++ b/apps/web/src/lib/shared/assistant/config.ts
@@ -118,6 +118,22 @@ export const assistantCopilotKnowledgeSchema = z.object({
   status: z.boolean(),
 } satisfies Record<AssistantCopilotKnowledgeSource, z.ZodType<boolean>>)
 
+/**
+ * Per-tool permission rule for a BUILT-IN write tool, keyed by tool name:
+ * - `allow` — run without asking (after RBAC)
+ * - `ask` — pause on a persisted proposal a teammate approves or denies
+ * - `deny` — omit the tool from this agent's catalogue entirely
+ *
+ * An absent key changes nothing: the turn's role policy keeps deciding, so a
+ * workspace that never opens the dial behaves exactly as before. Saved per
+ * agent, mirroring the remote-connector dial's vocabulary.
+ */
+export const ASSISTANT_TOOL_RULES = ['allow', 'ask', 'deny'] as const
+export const assistantToolRuleSchema = z.enum(ASSISTANT_TOOL_RULES)
+export type AssistantToolRule = z.infer<typeof assistantToolRuleSchema>
+export const assistantToolRulesSchema = z.record(z.string().min(1), assistantToolRuleSchema)
+export type AssistantToolRules = z.infer<typeof assistantToolRulesSchema>
+
 /** Copilot capabilities gate the teammate-facing Q&A route. */
 export const assistantCopilotCapabilitiesSchema = z.object({
   qa: z.boolean(),
@@ -127,12 +143,16 @@ export const assistantCopilotCapabilitiesSchema = z.object({
 export const assistantAgentConfigSchema = z.object({
   voice: assistantVoiceSchema,
   knowledge: assistantAgentKnowledgeSchema,
+  /** Absent key = role policy decides; see {@link assistantToolRulesSchema}. */
+  toolRules: assistantToolRulesSchema.default({}),
 })
 
 /** Copilot (teammate-facing) sub-config: capabilities + a wider knowledge map, no voice (D11). */
 export const assistantCopilotConfigSchema = z.object({
   capabilities: assistantCopilotCapabilitiesSchema,
   knowledge: assistantCopilotKnowledgeSchema,
+  /** Absent key = role policy decides; see {@link assistantToolRulesSchema}. */
+  toolRules: assistantToolRulesSchema.default({}),
 })
 
 // The z.infer of this schema (`AssistantConfig`) has a hand-written structural
@@ -177,6 +197,7 @@ export const DEFAULT_ASSISTANT_CONFIG: AssistantConfig = {
         documents: true,
         status: false,
       },
+      toolRules: {},
     },
     copilot: {
       capabilities: {
@@ -192,6 +213,7 @@ export const DEFAULT_ASSISTANT_CONFIG: AssistantConfig = {
         documents: true,
         status: true,
       },
+      toolRules: {},
     },
   },
 }
@@ -343,10 +365,12 @@ const assistantConfigInputSchema = z.object({
         additionalInstructions: z.string(),
       }),
       knowledge: assistantAgentKnowledgeSchema,
+      toolRules: assistantToolRulesSchema.optional(),
     }),
     copilot: z.object({
       capabilities: assistantCopilotCapabilitiesSchema,
       knowledge: assistantCopilotKnowledgeSchema,
+      toolRules: assistantToolRulesSchema.optional(),
     }),
   }),
 })

--- a/apps/web/src/lib/shared/migration-packs.ts
+++ b/apps/web/src/lib/shared/migration-packs.ts
@@ -1,0 +1,32 @@
+/**
+ * Guided migration packs — productized entry points beyond raw CSV/CLI.
+ * Vendors are described by pattern only in UI copy that lives outside source
+ * (marketing). In-app we use generic labels: Feedback portal, Support suite,
+ * Help center.
+ */
+export const MIGRATION_PACKS = [
+  {
+    id: 'feedback_portal',
+    title: 'Feedback portal',
+    description: 'Import boards, posts, votes, and comments from a feedback portal CSV export.',
+    entity: 'posts' as const,
+    href: '#import-csv',
+  },
+  {
+    id: 'support_suite',
+    title: 'Support suite',
+    description:
+      'Import help articles and prepare conversation history for a support-suite migration.',
+    entity: 'help_articles' as const,
+    href: '#import-csv',
+  },
+  {
+    id: 'help_center',
+    title: 'Help center',
+    description: 'Import categories and articles from a help-center CSV export.',
+    entity: 'help_articles' as const,
+    href: '#import-csv',
+  },
+] as const
+
+export type MigrationPackId = (typeof MIGRATION_PACKS)[number]['id']

--- a/apps/web/src/lib/shared/migration-packs.ts
+++ b/apps/web/src/lib/shared/migration-packs.ts
@@ -4,29 +4,26 @@
  * (marketing). In-app we use generic labels: Feedback portal, Support suite,
  * Help center.
  */
+const IMPORT_CSV_HREF = '#import-csv'
+
 export const MIGRATION_PACKS = [
   {
     id: 'feedback_portal',
     title: 'Feedback portal',
     description: 'Import boards, posts, votes, and comments from a feedback portal CSV export.',
-    entity: 'posts' as const,
-    href: '#import-csv',
+    href: IMPORT_CSV_HREF,
   },
   {
     id: 'support_suite',
     title: 'Support suite',
     description:
       'Import help articles and prepare conversation history for a support-suite migration.',
-    entity: 'help_articles' as const,
-    href: '#import-csv',
+    href: IMPORT_CSV_HREF,
   },
   {
     id: 'help_center',
     title: 'Help center',
     description: 'Import categories and articles from a help-center CSV export.',
-    entity: 'help_articles' as const,
-    href: '#import-csv',
+    href: IMPORT_CSV_HREF,
   },
 ] as const
-
-export type MigrationPackId = (typeof MIGRATION_PACKS)[number]['id']

--- a/apps/web/src/locales/ar.json
+++ b/apps/web/src/locales/ar.json
@@ -1160,5 +1160,14 @@
   "automation.workflows.closeSpamHint": "عندما يصنّف كوين المحادثة كرسالة مزعجة",
   "settings.sla.defaultPolicy": "السياسة الافتراضية",
   "settings.sla.defaultPolicyHint": "تُطبَّق عند بدء محادثة",
-  "settings.sla.defaultPolicyNone": "لا شيء"
+  "settings.sla.defaultPolicyNone": "لا شيء",
+  "automation.builtinTools.title": "الإجراءات المدمجة",
+  "automation.builtinTools.titleAgent": "الإجراءات المدمجة (الوكيل)",
+  "automation.builtinTools.titleCopilot": "الإجراءات المدمجة (Copilot)",
+  "automation.builtinTools.description": "ما يمكن لكل أداة كتابة مدمجة فعله لدى هذا الوكيل. «أبدًا» يزيل الأداة كليًا من جولاته.",
+  "automation.builtinTools.reset": "إعادة التعيين إلى الافتراضي",
+  "automation.builtinTools.default": "افتراضي",
+  "automation.builtinTools.saving": "جارٍ الحفظ…",
+  "automation.builtinTools.saveError": "تعذّر تحديث أذونات الأدوات.",
+  "automation.builtinTools.loadError": "تعذّر تحميل قائمة الأدوات."
 }

--- a/apps/web/src/locales/de.json
+++ b/apps/web/src/locales/de.json
@@ -1160,5 +1160,14 @@
   "automation.workflows.closeSpamHint": "Wenn Quinn eine Unterhaltung als Spam einstuft",
   "settings.sla.defaultPolicy": "Standardrichtlinie",
   "settings.sla.defaultPolicyHint": "Wird angewendet, wenn eine Unterhaltung startet",
-  "settings.sla.defaultPolicyNone": "Keine"
+  "settings.sla.defaultPolicyNone": "Keine",
+  "automation.builtinTools.title": "Integrierte Aktionen",
+  "automation.builtinTools.titleAgent": "Integrierte Aktionen (Agent)",
+  "automation.builtinTools.titleCopilot": "Integrierte Aktionen (Copilot)",
+  "automation.builtinTools.description": "Was jedes integrierte Schreibwerkzeug auf diesem Agenten tun darf. „Nie“ entfernt das Werkzeug vollständig aus seinen Antworten.",
+  "automation.builtinTools.reset": "Auf Standard zurücksetzen",
+  "automation.builtinTools.default": "Standard",
+  "automation.builtinTools.saving": "Wird gespeichert…",
+  "automation.builtinTools.saveError": "Werkzeugberechtigungen konnten nicht aktualisiert werden.",
+  "automation.builtinTools.loadError": "Werkzeugkatalog konnte nicht geladen werden."
 }

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -1164,7 +1164,7 @@
   "automation.builtinTools.title": "Built-in actions",
   "automation.builtinTools.titleAgent": "Built-in actions (Agent)",
   "automation.builtinTools.titleCopilot": "Built-in actions (Copilot)",
-  "automation.builtinTools.description": "What each built-in write tool may do on this agent. Never removes the tool from its turns entirely.",
+  "automation.builtinTools.description": "What each built-in write tool may do on this agent. \"Never\" removes the tool from its turns entirely.",
   "automation.builtinTools.reset": "Reset to defaults",
   "automation.builtinTools.default": "Default",
   "automation.builtinTools.saving": "Saving…",

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -1160,5 +1160,14 @@
   "automation.workflows.closeSpamHint": "When Quinn classifies a conversation as spam",
   "settings.sla.defaultPolicy": "Default policy",
   "settings.sla.defaultPolicyHint": "Applied when a conversation starts",
-  "settings.sla.defaultPolicyNone": "None"
+  "settings.sla.defaultPolicyNone": "None",
+  "automation.builtinTools.title": "Built-in actions",
+  "automation.builtinTools.titleAgent": "Built-in actions (Agent)",
+  "automation.builtinTools.titleCopilot": "Built-in actions (Copilot)",
+  "automation.builtinTools.description": "What each built-in write tool may do on this agent. Never removes the tool from its turns entirely.",
+  "automation.builtinTools.reset": "Reset to defaults",
+  "automation.builtinTools.default": "Default",
+  "automation.builtinTools.saving": "Saving…",
+  "automation.builtinTools.saveError": "Tool permissions could not be updated.",
+  "automation.builtinTools.loadError": "Could not load the tool catalogue."
 }

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -1160,5 +1160,14 @@
   "automation.workflows.closeSpamHint": "Cuando Quinn clasifica una conversación como spam",
   "settings.sla.defaultPolicy": "Política predeterminada",
   "settings.sla.defaultPolicyHint": "Se aplica cuando empieza una conversación",
-  "settings.sla.defaultPolicyNone": "Ninguna"
+  "settings.sla.defaultPolicyNone": "Ninguna",
+  "automation.builtinTools.title": "Acciones integradas",
+  "automation.builtinTools.titleAgent": "Acciones integradas (Agente)",
+  "automation.builtinTools.titleCopilot": "Acciones integradas (Copilot)",
+  "automation.builtinTools.description": "Qué puede hacer cada herramienta de escritura integrada en este agente. «Nunca» retira la herramienta por completo de sus turnos.",
+  "automation.builtinTools.reset": "Restablecer valores predeterminados",
+  "automation.builtinTools.default": "Predeterminado",
+  "automation.builtinTools.saving": "Guardando…",
+  "automation.builtinTools.saveError": "No se pudieron actualizar los permisos de la herramienta.",
+  "automation.builtinTools.loadError": "No se pudo cargar el catálogo de herramientas."
 }

--- a/apps/web/src/locales/fr.json
+++ b/apps/web/src/locales/fr.json
@@ -1160,5 +1160,14 @@
   "automation.workflows.closeSpamHint": "Lorsque Quinn classe une conversation comme spam",
   "settings.sla.defaultPolicy": "Politique par défaut",
   "settings.sla.defaultPolicyHint": "Appliquée au démarrage d'une conversation",
-  "settings.sla.defaultPolicyNone": "Aucune"
+  "settings.sla.defaultPolicyNone": "Aucune",
+  "automation.builtinTools.title": "Actions intégrées",
+  "automation.builtinTools.titleAgent": "Actions intégrées (Agent)",
+  "automation.builtinTools.titleCopilot": "Actions intégrées (Copilot)",
+  "automation.builtinTools.description": "Ce que chaque outil d’écriture intégré peut faire sur cet agent. « Jamais » retire entièrement l’outil de ses tours.",
+  "automation.builtinTools.reset": "Rétablir les valeurs par défaut",
+  "automation.builtinTools.default": "Par défaut",
+  "automation.builtinTools.saving": "Enregistrement…",
+  "automation.builtinTools.saveError": "Impossible de mettre à jour les autorisations de l’outil.",
+  "automation.builtinTools.loadError": "Impossible de charger le catalogue d’outils."
 }

--- a/apps/web/src/locales/pt-br.json
+++ b/apps/web/src/locales/pt-br.json
@@ -1160,5 +1160,14 @@
   "automation.workflows.closeSpamHint": "Quando a Quinn classifica uma conversa como spam",
   "settings.sla.defaultPolicy": "Política padrão",
   "settings.sla.defaultPolicyHint": "Aplicada quando uma conversa começa",
-  "settings.sla.defaultPolicyNone": "Nenhuma"
+  "settings.sla.defaultPolicyNone": "Nenhuma",
+  "automation.builtinTools.title": "Ações integradas",
+  "automation.builtinTools.titleAgent": "Ações integradas (Agente)",
+  "automation.builtinTools.titleCopilot": "Ações integradas (Copilot)",
+  "automation.builtinTools.description": "O que cada ferramenta de escrita integrada pode fazer neste agente. “Nunca” remove a ferramenta completamente de seus turnos.",
+  "automation.builtinTools.reset": "Restaurar padrões",
+  "automation.builtinTools.default": "Padrão",
+  "automation.builtinTools.saving": "Salvando…",
+  "automation.builtinTools.saveError": "Não foi possível atualizar as permissões da ferramenta.",
+  "automation.builtinTools.loadError": "Não foi possível carregar o catálogo de ferramentas."
 }

--- a/apps/web/src/locales/ru.json
+++ b/apps/web/src/locales/ru.json
@@ -1160,5 +1160,14 @@
   "automation.workflows.closeSpamHint": "Когда Квинн помечает разговор как спам",
   "settings.sla.defaultPolicy": "Политика по умолчанию",
   "settings.sla.defaultPolicyHint": "Применяется при начале разговора",
-  "settings.sla.defaultPolicyNone": "Нет"
+  "settings.sla.defaultPolicyNone": "Нет",
+  "automation.builtinTools.title": "Встроенные действия",
+  "automation.builtinTools.titleAgent": "Встроенные действия (Агент)",
+  "automation.builtinTools.titleCopilot": "Встроенные действия (Copilot)",
+  "automation.builtinTools.description": "Что может делать каждый встроенный инструмент записи у этого агента. «Никогда» полностью убирает инструмент из его ходов.",
+  "automation.builtinTools.reset": "Сбросить к значениям по умолчанию",
+  "automation.builtinTools.default": "По умолчанию",
+  "automation.builtinTools.saving": "Сохранение…",
+  "automation.builtinTools.saveError": "Не удалось обновить разрешения инструментов.",
+  "automation.builtinTools.loadError": "Не удалось загрузить каталог инструментов."
 }

--- a/apps/web/src/locales/zh-cn.json
+++ b/apps/web/src/locales/zh-cn.json
@@ -1160,5 +1160,14 @@
   "automation.workflows.closeSpamHint": "当 Quinn 将会话判定为垃圾时",
   "settings.sla.defaultPolicy": "默认策略",
   "settings.sla.defaultPolicyHint": "会话开始时应用",
-  "settings.sla.defaultPolicyNone": "无"
+  "settings.sla.defaultPolicyNone": "无",
+  "automation.builtinTools.title": "内置操作",
+  "automation.builtinTools.titleAgent": "内置操作（客服代理）",
+  "automation.builtinTools.titleCopilot": "内置操作（Copilot）",
+  "automation.builtinTools.description": "每个内置写入工具在此代理上的权限。“从不”会将该工具从其回合中完全移除。",
+  "automation.builtinTools.reset": "恢复默认设置",
+  "automation.builtinTools.default": "默认",
+  "automation.builtinTools.saving": "保存中…",
+  "automation.builtinTools.saveError": "无法更新工具权限。",
+  "automation.builtinTools.loadError": "无法加载工具目录。"
 }

--- a/apps/web/src/locales/zh-tw.json
+++ b/apps/web/src/locales/zh-tw.json
@@ -1160,5 +1160,14 @@
   "automation.workflows.closeSpamHint": "當 Quinn 將會話判定為垃圾時",
   "settings.sla.defaultPolicy": "預設政策",
   "settings.sla.defaultPolicyHint": "會話開始時套用",
-  "settings.sla.defaultPolicyNone": "無"
+  "settings.sla.defaultPolicyNone": "無",
+  "automation.builtinTools.title": "內建操作",
+  "automation.builtinTools.titleAgent": "內建操作（客服代理）",
+  "automation.builtinTools.titleCopilot": "內建操作（Copilot）",
+  "automation.builtinTools.description": "每個內建寫入工具在此代理上的權限。「從不」會將該工具從其回合中完全移除。",
+  "automation.builtinTools.reset": "恢復預設設定",
+  "automation.builtinTools.default": "預設",
+  "automation.builtinTools.saving": "儲存中…",
+  "automation.builtinTools.saveError": "無法更新工具權限。",
+  "automation.builtinTools.loadError": "無法載入工具目錄。"
 }

--- a/apps/web/src/routes/admin/automation.connectors.tsx
+++ b/apps/web/src/routes/admin/automation.connectors.tsx
@@ -1,3 +1,4 @@
+import { BuiltInToolsCard } from '@/components/admin/automation/builtin-tools-card'
 import { useState } from 'react'
 import { createFileRoute, Link, Navigate, useRouteContext } from '@tanstack/react-router'
 import { useQuery } from '@tanstack/react-query'
@@ -181,6 +182,8 @@ function ConnectorsPage() {
             'Connectors call external servers from your workspace. Only connect servers you trust.',
         })}
       </p>
+      <BuiltInToolsCard agent="agent" />
+      <BuiltInToolsCard agent="copilot" />
       <AddConnectorDialog open={addOpen} onOpenChange={setAddOpen} />
       <UpdateBearerDialog
         connectorId={tokenConnectorId}

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,25 @@
+# Security & trust
+
+Quackback is designed so product and support teams can run customer feedback and conversations on infrastructure they control.
+
+## Self-host
+
+- **AGPL-3.0** — run Quackback on your own infrastructure, fully functional, with no seat tax.
+- Data stays in **your PostgreSQL**. There is no queue or cache service to operate beside it, and no required third-party analytics plane for product data.
+- Anonymous usage statistics (version, coarse product-adoption counts — never emails, URLs, hostnames, or content) are sent once a day and can be switched off with `DISABLE_TELEMETRY=true`.
+- Enterprise images add **SSO (OIDC/SAML via your IdP), audit logs, and IP allowlists** (see `deploy/self-hosted`).
+
+## Cloud
+
+- Quackback Cloud runs this same codebase. Commercial state reaches a workspace only as a signed projection into a default-off settings block; a self-hosted install has no such block, is entitled to every feature, and makes no outbound control-plane request.
+- Workspaces are isolated; audit logs, SSO, and IP allowlists are the compliance surface for regulated buyers.
+
+## AI & Connectors
+
+- Quinn's write tools — built-in and remote MCP **Connectors** — are permissioned per tool: **Always allow / Ask for approval / Deny**. A denied tool is omitted from the model's turn entirely, not merely refused when called.
+- Approving a proposed write is a teammate action behind the conversation-reply permission; view-only teammates cannot approve.
+- Connector credentials are encrypted at rest and never selected into client payloads.
+
+## Reporting
+
+For vulnerability reports, email security@quackback.io or open a private security advisory on GitHub. Do not file public issues for sensitive disclosures.

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -52,6 +52,7 @@ export interface StoredAssistantConfig {
         documents: boolean
         status: boolean
       }
+      toolRules: Record<string, string>
     }
     copilot: {
       capabilities: { qa: boolean }
@@ -65,6 +66,7 @@ export interface StoredAssistantConfig {
         documents: boolean
         status: boolean
       }
+      toolRules: Record<string, string>
     }
   }
 }
@@ -418,6 +420,7 @@ export const settings = pgTable('settings', {
             documents: true,
             status: false,
           },
+          toolRules: {},
         },
         copilot: {
           capabilities: { qa: true },
@@ -431,6 +434,7 @@ export const settings = pgTable('settings', {
             documents: true,
             status: true,
           },
+          toolRules: {},
         },
       },
     }),


### PR DESCRIPTION
## What this PR is

The adaptive harvest of the AI work from closed PR #371, landing after the parity stack (#383–#389). #371's connector core was superseded by this stack's own richer implementation (OAuth, health, discovery), so nothing of that lands. What does land is the set of capabilities the stack verifiably lacked, re-expressed on the landed seams and tested against them.

This is PR 7 of 7 and depends on #389. Review against `oss/p6-cloud`.

## Harvested

- **Built-in tool permission dials.** Quinn's built-in write tools get the same Always allow / Ask for approval / Deny control the remote-connector dial has, per agent, persisted as `toolRules` on the assistant config (audited as `assistant.tools.changed`, optimistic-revision guarded). Deny removes the tool from the model's turn entirely; ask/allow ride the connector dial's existing `approvalPolicy` seam so mode resolution and the approval pipeline treat both dials identically. An absent rule changes nothing: role policy keeps deciding, so an untouched workspace behaves as before. Cards for both agents sit on the Actions surface beside Connectors, reusing its PolicyDial control; all nine locale catalogues carry the new copy.
- **Migration packs.** The imports hub leads with guided packs (generic product-pattern labels) that anchor to the CSV import below.
- **Trust page** (`docs/security.md`). Rewritten against the landed tree, not taken verbatim: #371's version claimed a queue/cache service (removed), custom HTTP actions (removed), and a stale key-purpose name. Every claim on the landed page is verified in code, including the telemetry opt-out and the conversation-reply bar on approvals.
- **README positioning.** The suite framing and the honest AI capabilities, grafted; the named-alternatives line stays.

## Not in this PR

Revenue-weighted inbox priority (a bounded MRR term on the inbox score) is not landing. Inbox sort stays `votes · 3 + comments · 2 + recency bonus`. Company MRR remains available as a segment filter; it does not affect inbox ranking.

## Adjudicated as already landed

#371's Labs-preserving onboarding flag merge: the landed goal-save path already uses `enableFlagsForUseCase(resolveFeatureFlags(row), …)` ("turn on the modules a goal needs without turning anything else off"), so there was nothing to port. Connector-side deny (`never`, filtered before assembly) likewise landed with the stack.

## Excluded (per the plan)

The rival connector core (`assistant_connectors` table/service/UI and its migration), the CI-unblocking noise (`ci.yml`, e2e edits, audit-allowlist, check-drift, schema stubs), and #371's security.md claims that no longer hold.

## Validation

CI on this branch is the source of truth. New coverage is the overlay unit battery (deny filters, ask proposes on an autonomous turn, allow runs on a propose turn, absent keys untouched, read tools untouchable).
