### PR TITLE
feat(comments): images, content holds, and in-place moderation

### DIFF
--- a/apps/web/e2e/tests/public/comments.spec.ts
+++ b/apps/web/e2e/tests/public/comments.spec.ts
@@ -125,6 +125,12 @@ test.describe('Unauthenticated user — comments section', () => {
   })
 
   // -------------------------------------------------------------------------
+  test('unauthenticated visitors do not see an image insert control', async ({ page }) => {
+    await expect(page.getByText(/sign in to comment/i)).toBeVisible({ timeout: 10000 })
+    await expect(page.getByRole('option', { name: /^image$/i })).toHaveCount(0)
+    await expect(page.getByText('Upload an image', { exact: false })).toHaveCount(0)
+  })
+
   test('comment composer is NOT visible to unauthenticated users', async ({ page }) => {
     // CommentThread renders the "Sign in" prompt instead of a comment form for
     // unauthenticated users. Hidden reply-form textareas inside comments may report
@@ -920,6 +926,51 @@ test.describe('Markdown comment rendering', () => {
 
       // Bold marker rendered as <strong>
       await expect(newComment.locator('strong', { hasText: `bold ${marker}` })).toBeVisible()
+    } finally {
+      await page.close()
+    }
+  })
+
+  test('uploading an image into a comment renders it in the thread', async () => {
+    const page = await sharedContext.newPage()
+    try {
+      await goToFirstPost(page)
+      await page.route('**/api/portal/upload', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            publicUrl: 'https://cdn.example.com/portal-images/e2e-comment.png',
+          }),
+        })
+      })
+
+      const editor = commentEditor(page)
+      await editor.click()
+      await clearEditor(editor)
+      await editor.pressSequentially('/image')
+      const imageItem = page
+        .getByRole('option', { name: /^image$/i })
+        .or(page.getByText('Upload an image', { exact: false }))
+      await expect(imageItem.first()).toBeVisible({ timeout: 5000 })
+      const [fileChooser] = await Promise.all([
+        page.waitForEvent('filechooser'),
+        imageItem.first().click(),
+      ])
+      await fileChooser.setFiles({
+        name: 'shot.png',
+        mimeType: 'image/png',
+        buffer: Buffer.from(
+          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+          'base64'
+        ),
+      })
+
+      const submitBtn = page.getByRole('button', { name: /^comment$/i }).first()
+      await submitBtn.click()
+      await expect(page.locator('img[src*="e2e-comment.png"]').first()).toBeVisible({
+        timeout: 15000,
+      })
     } finally {
       await page.close()
     }

--- a/apps/web/src/components/admin/feedback/detail/post-utils.ts
+++ b/apps/web/src/components/admin/feedback/detail/post-utils.ts
@@ -27,6 +27,7 @@ export function toPortalComments(post: PostDetails): PublicCommentView[] {
     isEdited: !!c.updatedAt,
     avatarUrl: (c.principalId && post.avatarUrls?.[c.principalId]) || null,
     statusChange: c.statusChange ?? null,
+    moderationState: c.moderationState ?? 'published',
     reactions: c.reactions,
     replies: c.replies.map(mapComment),
   })

--- a/apps/web/src/components/admin/feedback/post-modal.tsx
+++ b/apps/web/src/components/admin/feedback/post-modal.tsx
@@ -14,7 +14,7 @@ import { ModalHeader } from '@/components/shared/modal-header'
 import { UrlModalShell } from '@/components/shared/url-modal-shell'
 import { Button } from '@/components/ui/button'
 import { RichTextEditor } from '@/components/ui/rich-text-editor'
-import { usePostImageUpload } from '@/lib/client/hooks/use-image-upload'
+import { usePostImageUpload, usePortalImageUpload } from '@/lib/client/hooks/use-image-upload'
 import { adminQueries } from '@/lib/client/queries/admin'
 import { postOwnerQueries } from '@/lib/client/queries/post-owner'
 import { mergeSuggestionQueries } from '@/lib/client/queries/signals'
@@ -69,6 +69,8 @@ import {
 } from '@quackback/ids'
 import { useDeleteComment, useRestoreComment } from '@/lib/client/mutations/portal-comments'
 import { useLoadMoreAdminComments } from '@/lib/client/mutations/load-more-comments'
+import { InlineModerationActions } from '@/components/shared/inline-moderation-actions'
+import { useApprovePost, useRejectPost } from '@/lib/client/mutations/moderation'
 import type { PostDetails, CurrentUser } from '@/lib/shared/types'
 import {
   toPortalComments,
@@ -105,6 +107,9 @@ function PostModalContent({
   // via the same post.set_owner-gated fn the portal uses; the current owner is
   // resolved from it against the post's ownerPrincipalId (already in payload).
   const canSetOwner = usePermission(PERMISSIONS.POST_SET_OWNER)
+  const canModerate = usePermission(PERMISSIONS.POST_APPROVE)
+  const approvePost = useApprovePost(postId)
+  const rejectPost = useRejectPost(postId)
   const { data: ownerCandidates } = useQuery({
     ...postOwnerQueries.candidates(),
     enabled: canSetOwner,
@@ -122,6 +127,7 @@ function PostModalContent({
 
   // Image upload
   const { upload: uploadImage } = usePostImageUpload()
+  const { upload: uploadCommentImage } = usePortalImageUpload()
 
   // Form state - always in edit mode
   const [title, setTitle] = useState(post.title)
@@ -373,6 +379,16 @@ function PostModalContent({
           <div className="flex-1 min-w-0">
             {/* Editor area */}
             <div className="p-6" onKeyDown={handleKeyDown}>
+              {post.moderationState === 'pending' && (
+                <InlineModerationActions
+                  pending
+                  noun="post"
+                  className="mb-4"
+                  busy={approvePost.isPending || rejectPost.isPending}
+                  onApprove={canModerate ? () => approvePost.mutate(postId) : undefined}
+                  onReject={canModerate ? () => rejectPost.mutate({ postId }) : undefined}
+                />
+              )}
               {/* Title input */}
               <input
                 type="text"
@@ -484,6 +500,8 @@ function PostModalContent({
                     onRestoreComment={(commentId: PostCommentId) =>
                       restoreCommentMutation.mutate(commentId)
                     }
+                    onImageUpload={uploadCommentImage}
+                    canModerate={canModerate}
                     restoringCommentId={
                       restoreCommentMutation.isPending
                         ? (restoreCommentMutation.variables as PostCommentId)

--- a/apps/web/src/components/admin/feedback/table/feedback-row.tsx
+++ b/apps/web/src/components/admin/feedback/table/feedback-row.tsx
@@ -3,6 +3,9 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Square2StackIcon } from '@heroicons/react/24/outline'
 import { cn } from '@/lib/shared/utils'
 import type { PostListItem, PostStatusEntity } from '@/lib/shared/db-types'
+import { useApprovePost, useRejectPost } from '@/lib/client/mutations/moderation'
+import { usePermission } from '@/lib/client/hooks/use-permission'
+import { PERMISSIONS } from '@/lib/shared/permissions'
 
 interface FeedbackRowProps {
   post: PostListItem
@@ -25,6 +28,10 @@ export function FeedbackRow({
   selectionActive = false,
   onSelectChange,
 }: FeedbackRowProps) {
+  const canModerate = usePermission(PERMISSIONS.POST_APPROVE)
+  const approve = useApprovePost(post.id)
+  const reject = useRejectPost(post.id)
+  const pending = post.moderationState === 'pending'
   return (
     <div className="group relative flex items-center">
       {/* Selection gutter: reserves its width for every row so the cards stay
@@ -57,6 +64,11 @@ export function FeedbackRow({
           createdAt={post.createdAt}
           boardSlug={post.board.slug}
           tags={post.tags}
+          moderationState={post.moderationState}
+          canModerate={canModerate && pending}
+          moderationBusy={approve.isPending || reject.isPending}
+          onApprove={() => approve.mutate(post.id)}
+          onReject={() => reject.mutate({ postId: post.id })}
           // Admin mode - click to open modal
           onClick={onClick}
           // Admin doesn't need avatars in list view

--- a/apps/web/src/components/public/__tests__/comment-content.test.tsx
+++ b/apps/web/src/components/public/__tests__/comment-content.test.tsx
@@ -93,14 +93,18 @@ describe('<CommentContent>', () => {
     expect(container.querySelector('em')).not.toBeNull()
   })
 
-  it('does not render an <img> for image markdown', () => {
+  it('renders an <img> for image markdown', async () => {
     const { container } = render(<CommentContent content="![alt](https://x.com/y.png)" />)
-    expect(container.querySelector('img')).toBeNull()
+    await waitFor(() => {
+      expect(container.querySelector('img')).not.toBeNull()
+    })
   })
 
-  it('does not render a <table> for table markdown', () => {
+  it('renders a <table> for table markdown', async () => {
     const { container } = render(<CommentContent content={'| a | b |\n|---|---|\n| 1 | 2 |'} />)
-    expect(container.querySelector('table')).toBeNull()
+    await waitFor(() => {
+      expect(container.querySelector('table')).not.toBeNull()
+    })
   })
 
   it('does not render a <script> for embedded HTML', () => {

--- a/apps/web/src/components/public/auth-comments-section.tsx
+++ b/apps/web/src/components/public/auth-comments-section.tsx
@@ -48,6 +48,8 @@ interface AuthCommentsSectionProps {
   onRestoreComment?: (commentId: PostCommentId) => void
   /** ID of the comment currently being restored */
   restoringCommentId?: PostCommentId | null
+  onImageUpload?: (file: File) => Promise<string>
+  canModerate?: boolean
 }
 
 /**
@@ -77,6 +79,8 @@ export function AuthCommentsSection({
   deletingCommentId,
   onRestoreComment,
   restoringCommentId,
+  onImageUpload,
+  canModerate = false,
 }: AuthCommentsSectionProps) {
   const router = useRouter()
   const queryClient = useQueryClient()
@@ -169,6 +173,8 @@ export function AuthCommentsSection({
       deletingCommentId={deletingCommentId}
       onRestoreComment={onRestoreComment}
       restoringCommentId={restoringCommentId}
+      onImageUpload={onImageUpload}
+      canModerate={canModerate}
     />
   )
 }

--- a/apps/web/src/components/public/comment-content.tsx
+++ b/apps/web/src/components/public/comment-content.tsx
@@ -24,6 +24,8 @@ const INLINE_CODE_RX = /`[^`\n]/
 const ITALIC_STAR_RX = /(?<![\w*])\*[^*\s][^*\n]*\*(?!\w)/
 const ITALIC_UNDERSCORE_RX = /(?<![\w_])_[^_\s][^_\n]*_(?!\w)/
 const LINK_RX = /\[[^\]\n]+\]\([^)\n]+\)/
+const IMAGE_RX = /!\[[^\]]*\]\([^)\n]+\)/
+const TABLE_RX = /(^|\n)\s*\|.+\|/
 
 export function hasMarkdownTokens(text: string): boolean {
   if (!text) return false
@@ -34,7 +36,9 @@ export function hasMarkdownTokens(text: string): boolean {
     INLINE_CODE_RX.test(text) ||
     ITALIC_STAR_RX.test(text) ||
     ITALIC_UNDERSCORE_RX.test(text) ||
-    LINK_RX.test(text)
+    LINK_RX.test(text) ||
+    IMAGE_RX.test(text) ||
+    TABLE_RX.test(text)
   )
 }
 

--- a/apps/web/src/components/public/comment-editor-features.ts
+++ b/apps/web/src/components/public/comment-editor-features.ts
@@ -1,28 +1,20 @@
 import type { EditorFeatures } from '@/components/ui/rich-text-editor'
 
 /**
- * EditorFeatures preset for comment composers (portal + widget + admin
- * inline replies). Matches the slim COMMENT_EXTENSIONS set on the server
- * side — headings, blockquotes, task lists, bold/italic/strike/inline-code,
- * underline, links, lists — and intentionally excludes images, tables,
- * code blocks, embeds, and dividers. Bubble + slash menus stay on so power
- * users still get fast formatting affordances.
+ * Same TipTap feature set as the post composer (admin / widget). Image insert
+ * affordances still stay hidden until the composer also passes `onImageUpload`.
  */
 export const COMMENT_EDITOR_FEATURES: EditorFeatures = {
   headings: true,
+  codeBlocks: true,
   taskLists: true,
   blockquotes: true,
+  dividers: true,
+  images: true,
+  tables: true,
+  embeds: true,
+  quackbackEmbeds: true,
   bubbleMenu: true,
   slashMenu: true,
   emojiPicker: true,
-  // Chat-style behaviour: Enter is a single line break; Shift+Enter
-  // splits the paragraph for the rare case it's wanted.
-  enterAsHardBreak: true,
-  images: false,
-  tables: false,
-  codeBlocks: false,
-  dividers: false,
-  embeds: false,
-  // Pasting a Quackback post/changelog link becomes a live embed card.
-  quackbackEmbeds: true,
 }

--- a/apps/web/src/components/public/comment-form.tsx
+++ b/apps/web/src/components/public/comment-form.tsx
@@ -58,6 +58,8 @@ interface CommentFormProps {
   isTeamMember?: boolean
   /** Default the private toggle to on (e.g. replying to a private comment) */
   defaultPrivate?: boolean
+  /** When set, the comment editor exposes image insert (toolbar, slash, paste, drop). */
+  onImageUpload?: (file: File) => Promise<string>
 }
 
 export function CommentForm({
@@ -71,6 +73,7 @@ export function CommentForm({
   currentStatusId,
   isTeamMember,
   defaultPrivate,
+  onImageUpload,
 }: CommentFormProps) {
   const intl = useIntl()
   const router = useRouter()
@@ -222,6 +225,7 @@ export function CommentForm({
                         minHeight="72px"
                         disabled={isSubmitting}
                         features={COMMENT_EDITOR_FEATURES}
+                        onImageUpload={onImageUpload}
                         placeholder={intl.formatMessage({
                           id: 'portal.commentForm.placeholder',
                           defaultMessage: 'Write a comment...',
@@ -455,6 +459,7 @@ export function CommentForm({
                     minHeight="80px"
                     disabled={isSubmitting}
                     features={COMMENT_EDITOR_FEATURES}
+                    onImageUpload={onImageUpload}
                     placeholder={intl.formatMessage({
                       id: 'portal.commentForm.placeholder',
                       defaultMessage: 'Write a comment...',

--- a/apps/web/src/components/public/comment-thread.tsx
+++ b/apps/web/src/components/public/comment-thread.tsx
@@ -34,6 +34,8 @@ import { COMMENT_EDITOR_FEATURES } from './comment-editor-features'
 import { commentMarkdownToTiptapJson } from '@/lib/server/markdown-tiptap'
 import type { TiptapContent } from '@/lib/shared/db-types'
 import type { PostCommentId, PostId, PrincipalId } from '@quackback/ids'
+import { InlineModerationActions } from '@/components/shared/inline-moderation-actions'
+import { useApproveComment, useRejectComment } from '@/lib/client/mutations/moderation'
 
 /**
  * Groups root-level comments so consecutive private comments are wrapped
@@ -151,6 +153,9 @@ interface CommentThreadProps {
   onRestoreComment?: (commentId: PostCommentId) => void
   /** ID of the comment currently being restored */
   restoringCommentId?: PostCommentId | null
+  /** When set, comment composers expose image insert. */
+  onImageUpload?: (file: File) => Promise<string>
+  canModerate?: boolean
 }
 
 export function CommentThread({
@@ -178,6 +183,8 @@ export function CommentThread({
   deletingCommentId,
   onRestoreComment,
   restoringCommentId,
+  onImageUpload,
+  canModerate = false,
 }: CommentThreadProps) {
   const intl = useIntl()
   const sortedComments = [...comments].sort((a, b) => {
@@ -201,6 +208,7 @@ export function CommentThread({
           statuses={statuses}
           currentStatusId={currentStatusId}
           isTeamMember={isTeamMember}
+          onImageUpload={onImageUpload}
         />
       )
     }
@@ -275,6 +283,8 @@ export function CommentThread({
             deletingCommentId,
             onRestoreComment,
             restoringCommentId,
+            onImageUpload,
+            canModerate,
           })}
         </div>
       )}
@@ -311,6 +321,8 @@ interface CommentItemProps {
   restoringCommentId?: PostCommentId | null
   /** Whether this comment is rendered inside a PrivateNoteCard (suppresses per-comment private styling) */
   insidePrivateCard?: boolean
+  onImageUpload?: (file: File) => Promise<string>
+  canModerate?: boolean
 }
 
 const MAX_NESTING_DEPTH = 5
@@ -336,8 +348,12 @@ function CommentItem({
   onRestoreComment,
   restoringCommentId,
   insidePrivateCard = false,
+  onImageUpload,
+  canModerate = false,
 }: CommentItemProps) {
   const intl = useIntl()
+  const approveComment = useApproveComment(postId)
+  const rejectComment = useRejectComment(postId)
   const [showReplyForm, setShowReplyForm] = useState(false)
   const [isCollapsed, setIsCollapsed] = useState(false)
   const [reactions, setReactions] = useState<CommentReactionCount[]>(comment.reactions)
@@ -533,6 +549,8 @@ function CommentItem({
           className={cn(
             'py-2',
             isPinned && 'bg-primary/[0.04] border border-primary/15 rounded-lg px-3 -mx-3',
+            comment.moderationState === 'pending' &&
+              'rounded-lg border border-amber-500/25 bg-amber-500/[0.04] px-3 -mx-3',
             isDeleted && isTeamMember && 'opacity-50'
           )}
         >
@@ -676,6 +694,7 @@ function CommentItem({
                   minHeight="64px"
                   autofocus="end"
                   features={COMMENT_EDITOR_FEATURES}
+                  onImageUpload={onImageUpload}
                   disabled={editMutation.isPending}
                   onChange={(json, _html, markdown) => {
                     editJsonRef.current = json as TiptapContent
@@ -727,6 +746,18 @@ function CommentItem({
               content={comment.content}
               contentJson={comment.contentJson ?? null}
               className="text-sm mt-1.5 ms-10 text-foreground/90 leading-relaxed"
+            />
+          )}
+          {comment.moderationState === 'pending' && (
+            <InlineModerationActions
+              pending
+              noun="comment"
+              className="mt-2 ms-10"
+              busy={approveComment.isPending || rejectComment.isPending}
+              onApprove={canModerate ? () => approveComment.mutate(comment.id) : undefined}
+              onReject={
+                canModerate ? () => rejectComment.mutate({ commentId: comment.id }) : undefined
+              }
             />
           )}
 
@@ -953,6 +984,7 @@ function CommentItem({
                   createComment={createComment}
                   isTeamMember={isTeamMember}
                   defaultPrivate={comment.isPrivate}
+                  onImageUpload={onImageUpload}
                 />
               </div>
             </div>
@@ -991,6 +1023,8 @@ function CommentItem({
                   onRestoreComment={onRestoreComment}
                   restoringCommentId={restoringCommentId}
                   insidePrivateCard={insidePrivateCard}
+                  onImageUpload={onImageUpload}
+                  canModerate={canModerate}
                 />
               ))}
             </div>

--- a/apps/web/src/components/public/feedback/__tests__/portal-moderation-section.test.tsx
+++ b/apps/web/src/components/public/feedback/__tests__/portal-moderation-section.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
 import { IntlProvider } from 'react-intl'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
@@ -8,16 +8,14 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 // gate itself is enforced server-side (covered by moderation.test.ts); these
 // tests assert the portal render contract: zero footprint when the viewer
 // lacks post.approve, and correct wiring when they hold it.
-const { mockList, mockApprove, mockReject } = vi.hoisted(() => ({
+const { mockList, mockListComments } = vi.hoisted(() => ({
   mockList: vi.fn(),
-  mockApprove: vi.fn(),
-  mockReject: vi.fn(),
+  mockListComments: vi.fn(),
 }))
 
 vi.mock('@/lib/server/functions/moderation', () => ({
   listPendingPostsFn: (...args: unknown[]) => mockList(...args),
-  approvePostFn: (...args: unknown[]) => mockApprove(...args),
-  rejectPostFn: (...args: unknown[]) => mockReject(...args),
+  listPendingCommentsFn: (...args: unknown[]) => mockListComments(...args),
 }))
 
 vi.mock('@tanstack/react-router', () => ({
@@ -60,8 +58,7 @@ const PENDING = {
 
 beforeEach(() => {
   mockList.mockReset()
-  mockApprove.mockReset().mockResolvedValue({ ok: true })
-  mockReject.mockReset().mockResolvedValue({ ok: true })
+  mockListComments.mockReset().mockResolvedValue({ comments: [] })
 })
 
 afterEach(() => cleanup())
@@ -78,15 +75,12 @@ describe('PortalModerationSection — render gate', () => {
     expect(container).toBeEmptyDOMElement()
   })
 
-  it('renders the banner and a pending card for a post.approve holder', async () => {
+  it('renders the banner for a post.approve holder without duplicating the post as a card', async () => {
     mockList.mockResolvedValue(PENDING)
     renderSection(true)
-    // Banner count + card content driven by the reused list fn.
-    expect(await screen.findByText(/waiting for approval/i)).toBeInTheDocument()
-    expect(screen.getByText('Dark mode please')).toBeInTheDocument()
-    // Pending state is text, not colour alone.
-    expect(screen.getByText(/pending approval/i)).toBeInTheDocument()
-    expect(screen.getByText(/cannot see this post yet/i)).toBeInTheDocument()
+    expect(await screen.findByText(/waiting for review/i)).toBeInTheDocument()
+    expect(screen.queryByText('Dark mode please')).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /open queue/i })).toBeInTheDocument()
   })
 
   it('renders nothing when the holder has an empty queue', async () => {
@@ -94,34 +88,5 @@ describe('PortalModerationSection — render gate', () => {
     const { container } = renderSection(true)
     await waitFor(() => expect(mockList).toHaveBeenCalled())
     expect(container).toBeEmptyDOMElement()
-  })
-})
-
-describe('PortalModerationSection — actions', () => {
-  it('Approve calls approvePostFn with the post id', async () => {
-    mockList.mockResolvedValue(PENDING)
-    renderSection(true)
-    const approveBtn = await screen.findByRole('button', { name: /approve/i })
-    fireEvent.click(approveBtn)
-    await waitFor(() => {
-      expect(mockApprove).toHaveBeenCalledWith({ data: { postId: 'post_1' } })
-    })
-  })
-
-  it('Reject opens the reason dialog and confirms with the typed reason', async () => {
-    mockList.mockResolvedValue(PENDING)
-    renderSection(true)
-    const rejectBtn = await screen.findByRole('button', { name: /^reject$/i })
-    fireEvent.click(rejectBtn)
-    // Dialog appears with the optional reason field.
-    const textarea = await screen.findByLabelText(/reason/i)
-    fireEvent.change(textarea, { target: { value: 'off topic' } })
-    const confirmBtn = screen.getByRole('button', { name: /reject post/i })
-    fireEvent.click(confirmBtn)
-    await waitFor(() => {
-      expect(mockReject).toHaveBeenCalledWith({
-        data: { postId: 'post_1', reason: 'off topic' },
-      })
-    })
   })
 })

--- a/apps/web/src/components/public/feedback/feedback-container.tsx
+++ b/apps/web/src/components/public/feedback/feedback-container.tsx
@@ -27,6 +27,7 @@ import {
 import { useChangePostStatusId } from '@/lib/client/mutations/posts'
 import { usePortalPermissions } from '@/lib/client/hooks/use-portal-permissions'
 import { PERMISSIONS } from '@/lib/shared/permissions'
+import { useApprovePost, useRejectPost } from '@/lib/client/mutations/moderation'
 import type { PublicPostListItem } from '@/lib/shared/types'
 import { cn } from '@/lib/shared/utils'
 import type { PostId, PostStatusId } from '@quackback/ids'
@@ -83,6 +84,8 @@ export function FeedbackContainer({
   // Holders of post.approve get the inline moderation section (banner + pending
   // cards).
   const canApprove = can(PERMISSIONS.POST_APPROVE)
+  const approvePost = useApprovePost()
+  const rejectPost = useRejectPost()
 
   // List key for animations - only updates when data finishes loading
   // This prevents double animations when filters change (stale data → new data)
@@ -420,6 +423,11 @@ export function FeedbackContainer({
                         onStatusChange={(statusId) => handleStatusChange(post, statusId)}
                         isUpdatingStatus={changeStatus.isPending}
                         showAvatar={false}
+                        moderationState={post.moderationState}
+                        canModerate={canApprove}
+                        moderationBusy={approvePost.isPending || rejectPost.isPending}
+                        onApprove={() => approvePost.mutate(post.id)}
+                        onReject={() => rejectPost.mutate({ postId: post.id })}
                       />
                     </div>
                   ))}

--- a/apps/web/src/components/public/feedback/portal-moderation-section.tsx
+++ b/apps/web/src/components/public/feedback/portal-moderation-section.tsx
@@ -1,55 +1,16 @@
 /**
- * Portal moderation section — the team-only affordance that surfaces posts
- * held for approval directly on the public feed, so a `post.approve` holder
- * can clear the queue without leaving the portal.
- *
- * Renders nothing for customers and non-holders: the pending-posts query is
- * gated behind `enabled` (wired to `can(PERMISSIONS.POST_APPROVE)`), so a
- * disabled viewer issues zero extra requests and sees zero extra markup.
- *
- * Reuses the existing moderation server fns verbatim — listPendingPostsFn,
- * approvePostFn, rejectPostFn — every one already gated on POST_APPROVE, so the
- * portal render gate lines up 1:1 with the server authorization.
+ * Portal moderation banner — team-only. Pending posts now render in the
+ * normal feed (for post.approve holders) with inline Approve/Reject, so
+ * this section is just an attention cue plus a link to the admin queue.
  */
-import { useRef, useState } from 'react'
 import { useIntl, FormattedMessage } from 'react-intl'
 import { Link } from '@tanstack/react-router'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { toast } from 'sonner'
-import {
-  ExclamationTriangleIcon,
-  ArrowTopRightOnSquareIcon,
-  EyeSlashIcon,
-} from '@heroicons/react/24/outline'
-import { listPendingPostsFn, approvePostFn, rejectPostFn } from '@/lib/server/functions/moderation'
-import { publicPostsKeys } from '@/lib/client/hooks/use-portal-posts-query'
-import { Button } from '@/components/ui/button'
-import { Textarea } from '@/components/ui/textarea'
-import { Label } from '@/components/ui/label'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
-import { TimeAgo } from '@/components/ui/time-ago'
-import { contentPreview } from '@/lib/shared/utils/string'
-import { cn } from '@/lib/shared/utils'
+import { useQuery } from '@tanstack/react-query'
+import { ExclamationTriangleIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline'
+import { listPendingPostsFn, listPendingCommentsFn } from '@/lib/server/functions/moderation'
 
-/**
- * A pending post as returned by listPendingPostsFn. Derived from the server
- * fn's own return type so the shape can never drift; `createdAt` is typed as a
- * Date by the fn even though it serialises to a string over the wire, so the
- * card normalises it with `new Date(...)` (a no-op on a real Date).
- */
-type PendingPost = Awaited<ReturnType<typeof listPendingPostsFn>>['posts'][number]
-
-// Local, portal-scoped query key. Distinct from the admin moderation queue key
-// so the two surfaces cache independently (the admin queue also fetches pending
-// comments, which the portal feed does not surface).
 const pendingPostsKey = ['portal', 'moderation', 'pending', 'posts'] as const
+const pendingCommentsKey = ['portal', 'moderation', 'pending', 'comments'] as const
 
 interface PortalModerationSectionProps {
   /** True only for viewers holding post.approve. Gates the query and all markup. */
@@ -60,114 +21,33 @@ export function PortalModerationSection({
   enabled,
 }: PortalModerationSectionProps): React.ReactElement | null {
   const intl = useIntl()
-  const queryClient = useQueryClient()
-  const cardsRef = useRef<HTMLDivElement>(null)
-  const [rejectTarget, setRejectTarget] = useState<PendingPost | null>(null)
-  const [reason, setReason] = useState('')
-
-  const { data } = useQuery({
+  const postsQuery = useQuery({
     queryKey: pendingPostsKey,
     queryFn: () => listPendingPostsFn(),
     enabled,
     staleTime: 30 * 1000,
   })
-
-  const pending = data?.posts ?? []
-
-  // Optimistically drop a decided post from the pending cache; return the prior
-  // snapshot so onError can roll back if the guarded server write is rejected.
-  function removeFromCache(postId: string): { posts: PendingPost[] } | undefined {
-    const prev = queryClient.getQueryData<{ posts: PendingPost[] }>(pendingPostsKey)
-    queryClient.setQueryData<{ posts: PendingPost[] }>(pendingPostsKey, (old) =>
-      old ? { posts: old.posts.filter((p) => p.id !== postId) } : old
-    )
-    return prev
-  }
-
-  const approve = useMutation({
-    mutationFn: (postId: string) => approvePostFn({ data: { postId } }),
-    onMutate: (postId: string) => ({ prev: removeFromCache(postId) }),
-    onError: (_err, _postId, ctx) => {
-      if (ctx?.prev) queryClient.setQueryData(pendingPostsKey, ctx.prev)
-      toast.error(
-        intl.formatMessage({
-          id: 'portal.moderation.approve.error',
-          defaultMessage: 'Failed to approve post',
-        })
-      )
-    },
-    onSuccess: () => {
-      toast.success(
-        intl.formatMessage({
-          id: 'portal.moderation.approve.success',
-          defaultMessage: 'Post approved',
-        })
-      )
-      // The approved post is now published — pull it into the live feed.
-      queryClient.invalidateQueries({ queryKey: publicPostsKeys.lists() })
-    },
-    onSettled: () => queryClient.invalidateQueries({ queryKey: pendingPostsKey }),
+  const commentsQuery = useQuery({
+    queryKey: pendingCommentsKey,
+    queryFn: () => listPendingCommentsFn(),
+    enabled,
+    staleTime: 30 * 1000,
   })
 
-  const reject = useMutation({
-    mutationFn: (vars: { postId: string; reason?: string }) =>
-      rejectPostFn({ data: { postId: vars.postId, reason: vars.reason } }),
-    onMutate: (vars: { postId: string; reason?: string }) => ({
-      prev: removeFromCache(vars.postId),
-    }),
-    onError: (_err, _vars, ctx) => {
-      if (ctx?.prev) queryClient.setQueryData(pendingPostsKey, ctx.prev)
-      toast.error(
-        intl.formatMessage({
-          id: 'portal.moderation.reject.error',
-          defaultMessage: 'Failed to reject post',
-        })
-      )
-    },
-    onSuccess: () => {
-      toast.success(
-        intl.formatMessage({
-          id: 'portal.moderation.reject.success',
-          defaultMessage: 'Post rejected',
-        })
-      )
-    },
-    onSettled: () => queryClient.invalidateQueries({ queryKey: pendingPostsKey }),
-  })
+  const postCount = postsQuery.data?.posts.length ?? 0
+  const commentCount = commentsQuery.data?.comments.length ?? 0
+  const total = postCount + commentCount
 
-  // Zero-footprint for customers, non-holders, and the empty queue: no banner,
-  // no cards, nothing in the accessibility tree.
-  if (!enabled || pending.length === 0) return null
-
-  function scrollToCards(): void {
-    const reduce =
-      typeof window !== 'undefined' &&
-      window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
-    cardsRef.current?.scrollIntoView({
-      behavior: reduce ? 'auto' : 'smooth',
-      block: 'start',
-    })
-  }
-
-  function confirmReject(): void {
-    if (!rejectTarget) return
-    reject.mutate({ postId: rejectTarget.id, reason: reason.trim() || undefined })
-    setRejectTarget(null)
-    setReason('')
-  }
-
-  const count = pending.length
+  if (!enabled || total === 0) return null
 
   return (
     <section
       className="mt-5"
       aria-label={intl.formatMessage({
         id: 'portal.moderation.banner.regionLabel',
-        defaultMessage: 'Posts pending approval',
+        defaultMessage: 'Items pending approval',
       })}
     >
-      {/* Banner. The count is announced politely so a screen-reader user hears
-          the backlog change as posts are approved/rejected. */}
       <div
         className="flex flex-wrap items-center gap-x-3 gap-y-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-2.5 text-sm"
         aria-live="polite"
@@ -176,188 +56,21 @@ export function PortalModerationSection({
         <span className="font-medium text-amber-800 dark:text-amber-200">
           <FormattedMessage
             id="portal.moderation.banner.count"
-            defaultMessage="{count, plural, one {# post is} other {# posts are}} waiting for approval"
-            values={{ count }}
+            defaultMessage="{count, plural, one {# item is} other {# items are}} waiting for review — they appear in the feed and comment threads"
+            values={{ count: total }}
           />
         </span>
-        <div className="ms-auto flex items-center gap-3">
-          <button
-            type="button"
-            onClick={scrollToCards}
-            className="font-medium text-amber-700 underline-offset-2 hover:underline dark:text-amber-300"
-          >
-            <FormattedMessage id="portal.moderation.banner.review" defaultMessage="Review here" />
-          </button>
-          <Link
-            to="/admin/moderation"
-            className="inline-flex items-center gap-1 font-medium text-amber-700 underline-offset-2 hover:underline dark:text-amber-300"
-          >
-            <FormattedMessage
-              id="portal.moderation.banner.openQueue"
-              defaultMessage="Open queue in admin"
-            />
-            <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5" />
-          </Link>
-        </div>
-      </div>
-
-      {/* Quarantined pending cards. */}
-      <div ref={cardsRef} className="mt-3 space-y-3">
-        {pending.map((post) => (
-          <PendingPostCard
-            key={post.id}
-            post={post}
-            busy={approve.isPending || reject.isPending}
-            onApprove={() => approve.mutate(post.id)}
-            onReject={() => {
-              setReason('')
-              setRejectTarget(post)
-            }}
+        <Link
+          to="/admin/moderation"
+          className="ms-auto inline-flex items-center gap-1 font-medium text-amber-700 underline-offset-2 hover:underline dark:text-amber-300"
+        >
+          <FormattedMessage
+            id="portal.moderation.banner.openQueue"
+            defaultMessage="Open queue in admin"
           />
-        ))}
+          <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5" />
+        </Link>
       </div>
-
-      <Dialog
-        open={rejectTarget !== null}
-        onOpenChange={(open) => {
-          if (!open) {
-            setRejectTarget(null)
-            setReason('')
-          }
-        }}
-      >
-        <DialogContent className="max-w-md">
-          <DialogHeader>
-            <DialogTitle>
-              <FormattedMessage
-                id="portal.moderation.reject.dialogTitle"
-                defaultMessage="Reject this post?"
-              />
-            </DialogTitle>
-            <DialogDescription>
-              <FormattedMessage
-                id="portal.moderation.reject.dialogDescription"
-                defaultMessage="Optionally record why. The reason is kept in the audit log and is not shown to the author."
-              />
-            </DialogDescription>
-          </DialogHeader>
-          <div className="space-y-2">
-            <Label htmlFor="portal-moderation-reject-reason">
-              <FormattedMessage
-                id="portal.moderation.reject.reasonLabel"
-                defaultMessage="Reason (optional)"
-              />
-            </Label>
-            <Textarea
-              id="portal-moderation-reject-reason"
-              value={reason}
-              maxLength={500}
-              onChange={(e) => setReason(e.target.value)}
-              placeholder={intl.formatMessage({
-                id: 'portal.moderation.reject.reasonPlaceholder',
-                defaultMessage: 'Why is this being rejected?',
-              })}
-            />
-          </div>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => {
-                setRejectTarget(null)
-                setReason('')
-              }}
-            >
-              <FormattedMessage id="portal.moderation.reject.cancel" defaultMessage="Cancel" />
-            </Button>
-            <Button variant="destructive" onClick={confirmReject}>
-              <FormattedMessage
-                id="portal.moderation.reject.confirm"
-                defaultMessage="Reject post"
-              />
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </section>
-  )
-}
-
-interface PendingPostCardProps {
-  post: PendingPost
-  busy: boolean
-  onApprove: () => void
-  onReject: () => void
-}
-
-/**
- * Lightweight quarantined card. Mirrors PostCard's anatomy (title, excerpt,
- * author, time) but drops votes/status (a pending post has neither yet) and
- * wears an amber tint. The pending state is carried in TEXT ("Pending
- * approval" + the hidden-from-customers note), never by colour alone.
- */
-function PendingPostCard({
-  post,
-  busy,
-  onApprove,
-  onReject,
-}: PendingPostCardProps): React.ReactElement {
-  const intl = useIntl()
-  const authorFallback = intl.formatMessage({
-    id: 'portal.moderation.card.authorFallback',
-    defaultMessage: 'Anonymous',
-  })
-
-  return (
-    <div
-      className={cn(
-        'rounded-lg border border-amber-500/30 bg-amber-500/[0.04] p-4 dark:bg-amber-950/20',
-        'animate-in fade-in duration-200 fill-mode-backwards'
-      )}
-    >
-      <div className="flex items-start justify-between gap-4">
-        <div className="min-w-0 flex-1">
-          <span className="inline-flex items-center gap-1 text-[11px] font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-400">
-            <EyeSlashIcon className="h-3.5 w-3.5" />
-            <FormattedMessage
-              id="portal.moderation.card.pendingLabel"
-              defaultMessage="Pending approval"
-            />
-          </span>
-          <h3 className="mt-1 line-clamp-1 text-base font-semibold text-foreground">
-            {post.title}
-          </h3>
-          {post.content && (
-            <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
-              {contentPreview(post.content)}
-            </p>
-          )}
-          <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-            <span className="text-foreground/80">{post.authorName || authorFallback}</span>
-            {post.boardName && (
-              <>
-                <span className="text-muted-foreground/40">·</span>
-                <span>{post.boardName}</span>
-              </>
-            )}
-            <span className="text-muted-foreground/40">·</span>
-            <TimeAgo date={new Date(post.createdAt)} className="text-muted-foreground/70" />
-          </div>
-        </div>
-        <div className="flex shrink-0 gap-2">
-          <Button size="sm" onClick={onApprove} disabled={busy}>
-            <FormattedMessage id="portal.moderation.card.approve" defaultMessage="Approve" />
-          </Button>
-          <Button size="sm" variant="outline" onClick={onReject} disabled={busy}>
-            <FormattedMessage id="portal.moderation.card.reject" defaultMessage="Reject" />
-          </Button>
-        </div>
-      </div>
-      <p className="mt-2.5 text-xs text-amber-700/80 dark:text-amber-500/70">
-        <FormattedMessage
-          id="portal.moderation.card.hiddenNote"
-          defaultMessage="Customers cannot see this post yet."
-        />
-      </p>
-    </div>
   )
 }

--- a/apps/web/src/components/public/post-card.tsx
+++ b/apps/web/src/components/public/post-card.tsx
@@ -31,6 +31,7 @@ import { cn, getInitials } from '@/lib/shared/utils'
 import { useEnsureAnonSession } from '@/lib/client/hooks/use-ensure-anon-session'
 import { AuthorHoverCard } from '@/components/public/author-hover-card'
 import type { PostId, PostStatusId, PrincipalId } from '@quackback/ids'
+import { InlineModerationActions } from '@/components/shared/inline-moderation-actions'
 
 interface PostCardProps {
   id: PostId
@@ -98,6 +99,11 @@ interface PostCardProps {
   showQuickActions?: boolean
   /** Whether to show avatar in meta row */
   showAvatar?: boolean
+  moderationState?: 'published' | 'pending' | string | null
+  canModerate?: boolean
+  moderationBusy?: boolean
+  onApprove?: () => void
+  onReject?: () => void
 }
 
 export function PostCard({
@@ -131,6 +137,11 @@ export function PostCard({
   onMouseLeave,
   showQuickActions = false,
   showAvatar = true,
+  moderationState,
+  canModerate = false,
+  moderationBusy = false,
+  onApprove,
+  onReject,
 }: PostCardProps): React.ReactElement {
   // Safe hook - returns null in admin context where AuthPopoverProvider isn't available
   const intl = useIntl()
@@ -524,6 +535,17 @@ export function PostCard({
             </span>
           )}
         </div>
+        {moderationState === 'pending' && (
+          <div className="mt-2.5" onClick={(e) => e.stopPropagation()}>
+            <InlineModerationActions
+              pending
+              noun="post"
+              busy={moderationBusy}
+              onApprove={canModerate ? onApprove : undefined}
+              onReject={canModerate ? onReject : undefined}
+            />
+          </div>
+        )}
       </div>
 
       {/* Quick actions */}

--- a/apps/web/src/components/public/post-detail/comments-section.tsx
+++ b/apps/web/src/components/public/post-detail/comments-section.tsx
@@ -95,6 +95,10 @@ interface CommentsSectionProps {
   isLoadingMoreComments?: boolean
   /** Remaining root comments not yet loaded (for the button label). */
   remainingCommentCount?: number
+  /** When set, comment composers expose image insert. */
+  onImageUpload?: (file: File) => Promise<string>
+  /** Team members with post.approve can approve/reject pending comments inline. */
+  canModerate?: boolean
 }
 
 export function CommentsSection({
@@ -119,6 +123,8 @@ export function CommentsSection({
   onLoadMoreComments,
   isLoadingMoreComments = false,
   remainingCommentCount,
+  onImageUpload,
+  canModerate = false,
 }: CommentsSectionProps) {
   const intl = useIntl()
   const commentCount = useMemo(() => countAllComments(comments), [comments])
@@ -180,6 +186,8 @@ export function CommentsSection({
         onRestoreComment={onRestoreComment}
         restoringCommentId={restoringCommentId}
         hideCommentForm={disableCommenting && !!adminUser}
+        onImageUpload={onImageUpload}
+        canModerate={canModerate}
       />
 
       {hasMoreComments && onLoadMoreComments && (

--- a/apps/web/src/components/public/post-detail/post-content-section.tsx
+++ b/apps/web/src/components/public/post-detail/post-content-section.tsx
@@ -28,6 +28,7 @@ import type { PublicPostDetailView } from '@/lib/client/queries/portal-detail'
 import { SimilarPostsSection } from './similar-posts-section'
 import { PostActionsMenu } from './post-actions-menu'
 import type { PostId } from '@quackback/ids'
+import { InlineModerationActions } from '@/components/shared/inline-moderation-actions'
 
 export function PostContentSectionSkeleton(): React.ReactElement {
   return (
@@ -86,6 +87,10 @@ interface PostContentSectionProps {
   isSaving?: boolean
   /** Editor features for inline editing (defaults to simple user-friendly options) */
   editorFeatures?: EditorFeatures
+  canModerate?: boolean
+  moderationBusy?: boolean
+  onApprove?: () => void
+  onReject?: () => void
 }
 
 /** Default editor features for end users */
@@ -119,6 +124,10 @@ export function PostContentSection({
   onImageUpload,
   isSaving = false,
   editorFeatures = DEFAULT_USER_EDITOR_FEATURES,
+  canModerate = false,
+  moderationBusy = false,
+  onApprove,
+  onReject,
 }: PostContentSectionProps): React.ReactElement {
   const intl = useIntl()
   const [editTitle, setEditTitle] = useState(post.title)
@@ -256,6 +265,17 @@ export function PostContentSection({
       </div>
 
       <h1 className="text-xl sm:text-2xl font-semibold text-foreground mb-4">{post.title}</h1>
+
+      {post.moderationState === 'pending' && (
+        <InlineModerationActions
+          pending
+          noun="post"
+          className="mb-4"
+          busy={moderationBusy}
+          onApprove={canModerate ? onApprove : undefined}
+          onReject={canModerate ? onReject : undefined}
+        />
+      )}
 
       <PostContent
         content={post.content}

--- a/apps/web/src/components/shared/inline-moderation-actions.tsx
+++ b/apps/web/src/components/shared/inline-moderation-actions.tsx
@@ -1,0 +1,60 @@
+import { EyeSlashIcon } from '@heroicons/react/24/outline'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/shared/utils'
+
+interface InlineModerationActionsProps {
+  /** When false, nothing renders. */
+  pending: boolean
+  busy?: boolean
+  onApprove?: () => void
+  onReject?: () => void
+  /** Shown in the badge, e.g. "post" or "comment". */
+  noun: string
+  className?: string
+}
+
+/**
+ * Pending-review chrome + Approve/Reject, used wherever a held post or
+ * comment already renders for someone who can moderate it.
+ */
+export function InlineModerationActions({
+  pending,
+  busy = false,
+  onApprove,
+  onReject,
+  noun,
+  className,
+}: InlineModerationActionsProps) {
+  if (!pending) return null
+  const canAct = Boolean(onApprove || onReject)
+  return (
+    <div
+      className={cn(
+        'flex flex-wrap items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-2.5 py-1.5',
+        className
+      )}
+    >
+      <span className="inline-flex items-center gap-1 text-[11px] font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-400">
+        <EyeSlashIcon className="h-3.5 w-3.5" />
+        Pending review
+      </span>
+      <span className="text-xs text-amber-700/80 dark:text-amber-500/70">
+        Customers cannot see this {noun} yet.
+      </span>
+      {canAct && (
+        <span className="ms-auto flex shrink-0 gap-1.5">
+          {onApprove && (
+            <Button size="sm" onClick={onApprove} disabled={busy}>
+              Approve
+            </Button>
+          )}
+          {onReject && (
+            <Button size="sm" variant="outline" onClick={onReject} disabled={busy}>
+              Reject
+            </Button>
+          )}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/widget/widget-comment-form.tsx
+++ b/apps/web/src/components/widget/widget-comment-form.tsx
@@ -16,6 +16,7 @@ interface WidgetCommentFormProps {
   isIdentified: boolean
   user: WidgetUser | null
   onSubmit: (content: string, contentJson: TiptapContent | null) => Promise<void>
+  onImageUpload?: (file: File) => Promise<string>
 }
 
 /**
@@ -23,7 +24,12 @@ interface WidgetCommentFormProps {
  * session — there is no inline email capture; verified identity comes only
  * from host-app SSO identify (see GH issue #300).
  */
-export function WidgetCommentForm({ isIdentified, user, onSubmit }: WidgetCommentFormProps) {
+export function WidgetCommentForm({
+  isIdentified,
+  user,
+  onSubmit,
+  onImageUpload,
+}: WidgetCommentFormProps) {
   const intl = useIntl()
   const { ensureSessionThen } = useWidgetAuth()
   const [commentText, setCommentText] = useState('')
@@ -80,6 +86,7 @@ export function WidgetCommentForm({ isIdentified, user, onSubmit }: WidgetCommen
           borderless
           minHeight="52px"
           features={COMMENT_EDITOR_FEATURES}
+          onImageUpload={onImageUpload}
           disabled={isSubmitting}
           placeholder={intl.formatMessage({
             id: 'widget.commentForm.placeholder',

--- a/apps/web/src/components/widget/widget-comment-list.tsx
+++ b/apps/web/src/components/widget/widget-comment-list.tsx
@@ -33,6 +33,7 @@ interface WidgetCommentListProps {
     contentJson: TiptapContent | null,
     parentId: string
   ) => Promise<void>
+  onImageUpload?: (file: File) => Promise<string>
 }
 
 export function WidgetCommentList({
@@ -40,6 +41,7 @@ export function WidgetCommentList({
   pinnedCommentId,
   canComment = false,
   onSubmitComment,
+  onImageUpload,
 }: WidgetCommentListProps) {
   const sortedComments = [...comments].sort((a, b) => {
     if (pinnedCommentId) {
@@ -70,6 +72,7 @@ export function WidgetCommentList({
           depth={0}
           canComment={canComment}
           onSubmitComment={onSubmitComment}
+          onImageUpload={onImageUpload}
         />
       ))}
     </div>
@@ -86,6 +89,7 @@ interface WidgetCommentItemProps {
     contentJson: TiptapContent | null,
     parentId: string
   ) => Promise<void>
+  onImageUpload?: (file: File) => Promise<string>
 }
 
 function WidgetCommentItem({
@@ -94,6 +98,7 @@ function WidgetCommentItem({
   depth,
   canComment,
   onSubmitComment,
+  onImageUpload,
 }: WidgetCommentItemProps) {
   const intl = useIntl()
   const [isCollapsed, setIsCollapsed] = useState(false)
@@ -221,6 +226,7 @@ function WidgetCommentItem({
                   depth={depth + 1}
                   canComment={canComment}
                   onSubmitComment={onSubmitComment}
+                  onImageUpload={onImageUpload}
                 />
               ))}
             </div>
@@ -370,6 +376,7 @@ function WidgetCommentItem({
                   borderless
                   minHeight="44px"
                   features={COMMENT_EDITOR_FEATURES}
+                  onImageUpload={onImageUpload}
                   disabled={isSubmitting}
                   placeholder={intl.formatMessage(
                     {

--- a/apps/web/src/components/widget/widget-post-detail.tsx
+++ b/apps/web/src/components/widget/widget-post-detail.tsx
@@ -23,6 +23,7 @@ import { WidgetCommentForm } from './widget-comment-form'
 import { WidgetPortalTitle } from './widget-portal-title'
 import type { TiptapContent } from '@/lib/shared/db-types'
 import type { PostId } from '@quackback/ids'
+import { useWidgetImageUpload } from '@/lib/client/hooks/use-image-upload'
 
 interface StatusInfo {
   id: string
@@ -37,6 +38,7 @@ interface WidgetPostDetailProps {
 
 export function WidgetPostDetail({ postId, statuses }: WidgetPostDetailProps) {
   const intl = useIntl()
+  const { upload: uploadImage } = useWidgetImageUpload()
   const { isIdentified, hmacRequired, user, ensureSessionThen, emitEvent, sessionVersion } =
     useWidgetAuth()
   const queryClient = useQueryClient()
@@ -293,7 +295,12 @@ export function WidgetPostDetail({ postId, statuses }: WidgetPostDetailProps) {
           {/* Root comment form — unified: textarea + email (when anonymous) + single Post.
               For an anonymous viewer the email field escalates them to a real user. */}
           {!post.isCommentsLocked && !commentNoAccess && !hmacRequired && (
-            <WidgetCommentForm isIdentified={isIdentified} user={user} onSubmit={submitComment} />
+            <WidgetCommentForm
+              isIdentified={isIdentified}
+              user={user}
+              onSubmit={submitComment}
+              onImageUpload={uploadImage}
+            />
           )}
 
           {!post.isCommentsLocked && !commentNoAccess && hmacRequired && !canComment && (
@@ -323,6 +330,7 @@ export function WidgetPostDetail({ postId, statuses }: WidgetPostDetailProps) {
             pinnedCommentId={post.pinnedCommentId}
             canComment={canComment && !post.isCommentsLocked}
             onSubmitComment={handleSubmitReply}
+            onImageUpload={uploadImage}
           />
 
           {hasMoreComments && (

--- a/apps/web/src/integrations/discord/server/message.ts
+++ b/apps/web/src/integrations/discord/server/message.ts
@@ -5,6 +5,7 @@
 
 import type { EventData } from '@/lib/server/events/types'
 import { stripHtml, truncate, formatStatus, getStatusEmoji } from '@/lib/server/events/hook-utils'
+import { commentPlainText } from '@/lib/server/markdown-tiptap'
 import { getAuthorName, buildPostUrl } from '@/lib/server/integrations/message-utils'
 
 interface DiscordEmbed {
@@ -148,7 +149,7 @@ export function buildDiscordMessage(event: EventData, rootUrl: string): DiscordM
     case 'comment.created': {
       const { comment, post } = event.data
       const postUrl = buildPostUrl(rootUrl, post.boardSlug, post.id)
-      const content = truncate(stripHtml(comment.content), 300)
+      const content = truncate(commentPlainText(comment), 300)
       const author = getAuthorName(comment)
 
       return {

--- a/apps/web/src/integrations/ntfy/server/message.ts
+++ b/apps/web/src/integrations/ntfy/server/message.ts
@@ -3,6 +3,7 @@
  */
 import type { EventData } from '@/lib/server/events/types'
 import { stripHtml, truncate, formatStatus } from '@/lib/server/events/hook-utils'
+import { commentPlainText } from '@/lib/server/markdown-tiptap'
 import { buildPostUrl } from '@/lib/server/integrations/message-utils'
 
 export interface NtfyPayload {
@@ -44,7 +45,7 @@ export function buildNtfyPayload(
 
     case 'comment.created': {
       const { comment, post } = event.data
-      const body = truncate(stripHtml(comment.content ?? ''), 500)
+      const body = truncate(commentPlainText(comment), 500)
       return {
         topic,
         title: `New comment: ${post.title}`,

--- a/apps/web/src/integrations/slack/server/message.ts
+++ b/apps/web/src/integrations/slack/server/message.ts
@@ -5,6 +5,7 @@
 
 import type { EventData } from '@/lib/server/events/types'
 import { stripHtml, truncate, formatStatus, getStatusEmoji } from '@/lib/server/events/hook-utils'
+import { commentPlainText } from '@/lib/server/markdown-tiptap'
 import { getAuthorName, buildPostUrl } from '@/lib/server/integrations/message-utils'
 
 interface SlackMessage {
@@ -181,7 +182,7 @@ export function buildSlackMessage(event: EventData, rootUrl: string): SlackMessa
     case 'comment.created': {
       const { comment, post } = event.data
       const postUrl = buildPostUrl(rootUrl, post.boardSlug, post.id)
-      const content = truncate(stripHtml(comment.content), 300)
+      const content = truncate(commentPlainText(comment), 300)
       const author = getAuthorName(comment)
 
       return {

--- a/apps/web/src/integrations/teams/server/message.ts
+++ b/apps/web/src/integrations/teams/server/message.ts
@@ -12,6 +12,7 @@
 
 import type { EventData } from '@/lib/server/events/types'
 import { stripHtml, truncate, formatStatus, getStatusEmoji } from '@/lib/server/events/hook-utils'
+import { commentPlainText } from '@/lib/server/markdown-tiptap'
 import { getAuthorName, buildPostUrl } from '@/lib/server/integrations/message-utils'
 
 interface TeamsMessage {
@@ -138,7 +139,7 @@ export function buildTeamsMessage(event: EventData, rootUrl: string): TeamsMessa
     case 'comment.created': {
       const { comment, post } = event.data
       const postUrl = buildPostUrl(rootUrl, post.boardSlug, post.id)
-      const content = truncate(stripHtml(comment.content), 300)
+      const content = truncate(commentPlainText(comment), 300)
       const author = getAuthorName(comment)
 
       return buildCard(

--- a/apps/web/src/lib/client/mutations/moderation.ts
+++ b/apps/web/src/lib/client/mutations/moderation.ts
@@ -1,0 +1,64 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  approvePostFn,
+  rejectPostFn,
+  approveCommentFn,
+  rejectCommentFn,
+} from '@/lib/server/functions/moderation'
+import { inboxKeys } from '@/lib/client/hooks/use-inbox-query'
+import { publicPostsKeys } from '@/lib/client/hooks/use-portal-posts-query'
+import { adminQueries } from '@/lib/client/queries/admin'
+import { portalDetailQueries } from '@/lib/client/queries/portal-detail'
+import type { PostId } from '@quackback/ids'
+
+const pendingPostsKey = ['portal', 'moderation', 'pending', 'posts'] as const
+
+function invalidateModerationSurfaces(
+  queryClient: ReturnType<typeof useQueryClient>,
+  postId?: PostId
+) {
+  queryClient.invalidateQueries({ queryKey: inboxKeys.lists() })
+  queryClient.invalidateQueries({ queryKey: publicPostsKeys.lists() })
+  queryClient.invalidateQueries({ queryKey: adminQueries.moderationStatus().queryKey })
+  queryClient.invalidateQueries({ queryKey: ['admin', 'moderation'] })
+  queryClient.invalidateQueries({ queryKey: pendingPostsKey })
+  if (postId) {
+    queryClient.invalidateQueries({ queryKey: inboxKeys.detail(postId) })
+    queryClient.invalidateQueries({ queryKey: portalDetailQueries.postDetail(postId).queryKey })
+  }
+}
+
+export function useApprovePost(postId?: PostId) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) => approvePostFn({ data: { postId: id } }),
+    onSuccess: (_data, id) => invalidateModerationSurfaces(queryClient, (postId ?? id) as PostId),
+  })
+}
+
+export function useRejectPost(postId?: PostId) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (vars: { postId: string; reason?: string }) =>
+      rejectPostFn({ data: { postId: vars.postId, reason: vars.reason } }),
+    onSuccess: (_data, vars) =>
+      invalidateModerationSurfaces(queryClient, (postId ?? vars.postId) as PostId),
+  })
+}
+
+export function useApproveComment(postId?: PostId) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (commentId: string) => approveCommentFn({ data: { commentId } }),
+    onSuccess: () => invalidateModerationSurfaces(queryClient, postId),
+  })
+}
+
+export function useRejectComment(postId?: PostId) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (vars: { commentId: string; reason?: string }) =>
+      rejectCommentFn({ data: { commentId: vars.commentId, reason: vars.reason } }),
+    onSuccess: () => invalidateModerationSurfaces(queryClient, postId),
+  })
+}

--- a/apps/web/src/lib/client/queries/portal-detail.ts
+++ b/apps/web/src/lib/client/queries/portal-detail.ts
@@ -27,6 +27,7 @@ export interface PublicCommentView {
   isEdited: boolean
   avatarUrl: string | null
   statusChange?: CommentStatusChange | null
+  moderationState?: 'published' | 'pending' | string | null
   replies: PublicCommentView[]
   reactions: CommentReactionCount[]
 }
@@ -80,6 +81,7 @@ export interface PublicPostDetailView {
   pinnedCommentId: PostCommentId | null
   /** Whether comments are locked (portal users can't comment) */
   isCommentsLocked?: boolean
+  moderationState?: 'published' | 'pending' | string
   /**
    * Server-computed per-board capability for the requesting viewer (composes
    * the board's vote/comment tier with the workspace anonymous switch). The

--- a/apps/web/src/lib/server/__tests__/markdown-tiptap.test.ts
+++ b/apps/web/src/lib/server/__tests__/markdown-tiptap.test.ts
@@ -7,6 +7,9 @@ import {
   commentMarkdownToTiptapJson,
   tiptapJsonToText,
   hasTextLeaf,
+  hasImageNode,
+  hasExternalLink,
+  commentPlainText,
 } from '../markdown-tiptap'
 
 describe('markdownToTiptapJson', () => {
@@ -342,17 +345,17 @@ describe('commentMarkdownToTiptapJson', () => {
     expect(types.has('paragraph')).toBe(true)
   })
 
-  test('image markdown does not produce an image node', () => {
+  test('image markdown produces an image node', () => {
     const result = commentMarkdownToTiptapJson('![alt](https://example.com/x.png)')
     const hasImage = JSON.stringify(result).includes('"type":"image"')
-    expect(hasImage).toBe(false)
+    expect(hasImage).toBe(true)
   })
 
-  test('table markdown does not produce a table node', () => {
+  test('table markdown produces a table node', () => {
     const md = '| a | b |\n|---|---|\n| 1 | 2 |'
     const result = commentMarkdownToTiptapJson(md)
     const hasTable = JSON.stringify(result).includes('"type":"table"')
-    expect(hasTable).toBe(false)
+    expect(hasTable).toBe(true)
   })
 
   test('javascript: links are stripped or escaped', () => {
@@ -373,10 +376,11 @@ describe('commentMarkdownToTiptapJson', () => {
     expect(json).not.toContain('"type":"script"')
   })
 
-  test('single newline becomes a hard break (GFM)', () => {
+  test('single newline stays in one paragraph (same as posts)', () => {
     const result = commentMarkdownToTiptapJson('line one\nline two')
     const json = JSON.stringify(result)
-    expect(json).toContain('"type":"hardBreak"')
+    expect(json).toContain('line one')
+    expect(json).toContain('line two')
   })
 
   test('Unicode emoji characters in markdown survive as plain text', () => {
@@ -510,5 +514,66 @@ describe('hasTextLeaf', () => {
   test('false for null/undefined', () => {
     expect(hasTextLeaf(null)).toBe(false)
     expect(hasTextLeaf(undefined)).toBe(false)
+  })
+})
+
+describe('hasImageNode / hasExternalLink / commentPlainText', () => {
+  const imageDoc = {
+    type: 'doc',
+    content: [{ type: 'image', attrs: { src: 'https://cdn.example.com/x.png' } }],
+  }
+  const linkDoc = {
+    type: 'doc',
+    content: [
+      {
+        type: 'paragraph',
+        content: [
+          {
+            type: 'text',
+            text: 'click',
+            marks: [{ type: 'link', attrs: { href: 'https://evil.example' } }],
+          },
+        ],
+      },
+    ],
+  }
+  const mentionDoc = {
+    type: 'doc',
+    content: [
+      {
+        type: 'paragraph',
+        content: [{ type: 'mention', attrs: { id: 'principal_x', label: 'Ada' } }],
+      },
+    ],
+  }
+
+  test('hasImageNode finds image and resizableImage', () => {
+    expect(hasImageNode(imageDoc)).toBe(true)
+    expect(
+      hasImageNode({ type: 'doc', content: [{ type: 'resizableImage', attrs: { src: 'x' } }] })
+    ).toBe(true)
+    expect(hasImageNode(linkDoc)).toBe(false)
+    expect(hasImageNode(null)).toBe(false)
+  })
+
+  test('hasExternalLink finds http(s) link marks and not mentions', () => {
+    expect(hasExternalLink(linkDoc)).toBe(true)
+    expect(hasExternalLink(mentionDoc)).toBe(false)
+    expect(hasExternalLink(null, 'see https://evil.example/path')).toBe(true)
+    expect(hasExternalLink(null, 'no urls here')).toBe(false)
+  })
+
+  test('hasExternalLink ignores same-origin and internal product URLs', () => {
+    const origin = 'https://acme.example'
+    expect(hasExternalLink(null, `${origin}/b/ideas/posts/post_01abc`, origin)).toBe(false)
+    expect(hasExternalLink(null, 'https://other.example/page', origin)).toBe(true)
+  })
+
+  test('commentPlainText yields [image] for image-only comments', () => {
+    expect(commentPlainText({ content: '', contentJson: imageDoc })).toBe('[image]')
+  })
+
+  test('commentPlainText parses image markdown when JSON is absent', () => {
+    expect(commentPlainText({ content: '![alt](https://example.com/x.png)' })).toBe('[image]')
   })
 })

--- a/apps/web/src/lib/server/content/__tests__/content-holds.test.ts
+++ b/apps/web/src/lib/server/content/__tests__/content-holds.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@/lib/server/config', () => ({
+  getBaseUrl: () => 'https://acme.example',
+}))
+
+import { contentHoldReason } from '../content-holds'
+import type { TiptapContent } from '@/lib/shared/db-types'
+
+const imageDoc = {
+  type: 'doc',
+  content: [{ type: 'image', attrs: { src: 'https://cdn.example.com/x.png' } }],
+} as TiptapContent
+
+const linkDoc = {
+  type: 'doc',
+  content: [
+    {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'text',
+          text: 'click',
+          marks: [{ type: 'link', attrs: { href: 'https://evil.example' } }],
+        },
+      ],
+    },
+  ],
+} as TiptapContent
+
+const textDoc = {
+  type: 'doc',
+  content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hello' }] }],
+} as TiptapContent
+
+describe('contentHoldReason', () => {
+  it('returns null when flags are off', () => {
+    expect(contentHoldReason({ holdImages: false, holdLinks: false }, imageDoc)).toBeNull()
+  })
+
+  it('holds images when holdImages is on', () => {
+    expect(contentHoldReason({ holdImages: true }, imageDoc)).toBe('images')
+    expect(contentHoldReason({ holdImages: true }, textDoc)).toBeNull()
+  })
+
+  it('holds links when holdLinks is on', () => {
+    expect(contentHoldReason({ holdLinks: true }, linkDoc)).toBe('links')
+    expect(contentHoldReason({ holdLinks: true }, textDoc)).toBeNull()
+  })
+
+  it('returns images+links when both match', () => {
+    const both = {
+      type: 'doc',
+      content: [
+        { type: 'image', attrs: { src: 'https://cdn.example.com/x.png' } },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'x',
+              marks: [{ type: 'link', attrs: { href: 'https://evil.example' } }],
+            },
+          ],
+        },
+      ],
+    } as TiptapContent
+    expect(contentHoldReason({ holdImages: true, holdLinks: true }, both)).toBe('images+links')
+  })
+})

--- a/apps/web/src/lib/server/content/__tests__/rehost-images.test.ts
+++ b/apps/web/src/lib/server/content/__tests__/rehost-images.test.ts
@@ -135,6 +135,17 @@ describe('rehostExternalImages — happy paths', () => {
     expect(uploadImageBufferMock.mock.calls[0][2]).toBe('post-images')
   })
 
+  it('rehosts comment images under the comment-images prefix', async () => {
+    safeFetchMock.mockResolvedValueOnce(okImageResponse('image/png', PNG_HEADER))
+    uploadImageBufferMock.mockResolvedValueOnce({
+      url: 'https://cdn.example.com/comment-images/new.png',
+    })
+
+    const input = docWithImages('https://external.example.com/img.png')
+    await rehostExternalImages(input, { contentType: 'comment' })
+    expect(uploadImageBufferMock.mock.calls[0][2]).toBe('comment-images')
+  })
+
   it('rehosts multiple distinct external images', async () => {
     safeFetchMock
       .mockResolvedValueOnce(okImageResponse('image/png', PNG_HEADER))

--- a/apps/web/src/lib/server/content/content-holds.ts
+++ b/apps/web/src/lib/server/content/content-holds.ts
@@ -1,0 +1,35 @@
+/**
+ * Workspace content-hold signals: hold submissions that contain images or
+ * external links. Orthogonal to the author-type requireApproval policy.
+ */
+import type { TiptapContent } from '@/lib/shared/db-types'
+import { hasExternalLink, hasImageNode } from '@/lib/server/markdown-tiptap'
+import { getBaseUrl } from '@/lib/server/config'
+
+export type ContentHoldReason = 'images' | 'links' | 'images+links'
+
+export interface ContentHoldFlags {
+  holdImages?: boolean
+  holdLinks?: boolean
+}
+
+export function contentHoldReason(
+  flags: ContentHoldFlags | undefined,
+  contentJson: TiptapContent | null | undefined,
+  fallbackText?: string
+): ContentHoldReason | null {
+  if (!flags) return null
+  const origin = (() => {
+    try {
+      return getBaseUrl()
+    } catch {
+      return undefined
+    }
+  })()
+  const images = flags.holdImages === true && hasImageNode(contentJson)
+  const links = flags.holdLinks === true && hasExternalLink(contentJson, fallbackText, origin)
+  if (images && links) return 'images+links'
+  if (images) return 'images'
+  if (links) return 'links'
+  return null
+}

--- a/apps/web/src/lib/server/content/rehost-images.ts
+++ b/apps/web/src/lib/server/content/rehost-images.ts
@@ -29,12 +29,13 @@ const FETCH_TIMEOUT_MS = Number(process.env.REHOST_FETCH_TIMEOUT_MS) || 10_000
 
 const IMAGE_NODE_TYPES = new Set(['image', 'resizableImage'])
 
-export type RehostContentType = 'post' | 'changelog' | 'help-center'
+export type RehostContentType = 'post' | 'changelog' | 'help-center' | 'comment'
 
 const PREFIX_BY_CONTENT_TYPE: Record<RehostContentType, string> = {
   post: 'post-images',
   changelog: 'changelog-images',
   'help-center': 'help-center',
+  comment: 'comment-images',
 }
 
 export interface RehostOptions {

--- a/apps/web/src/lib/server/domains/api/schemas/comments.ts
+++ b/apps/web/src/lib/server/domains/api/schemas/comments.ts
@@ -34,6 +34,11 @@ const CommentListItemSchema: z.ZodType = z.lazy(() =>
     postId: TypeIdSchema,
     parentId: TypeIdSchema.nullable().meta({ description: 'Parent comment ID for replies' }),
     content: z.string().meta({ example: 'Great idea! This would be very useful.' }),
+    contentJson: z
+      .record(z.string(), z.unknown())
+      .nullable()
+      .optional()
+      .meta({ description: 'Rich text content as TipTap JSON' }),
     authorName: z.string().nullable().meta({ example: 'Jane Doe' }),
     principalId: TypeIdSchema.nullable().meta({
       description: 'Principal ID of the comment author',
@@ -56,6 +61,11 @@ const CommentDetailSchema = z.object({
   postId: TypeIdSchema,
   parentId: TypeIdSchema.nullable().meta({ description: 'Parent comment ID for replies' }),
   content: z.string().meta({ example: 'Great idea! This would be very useful.' }),
+  contentJson: z
+    .record(z.string(), z.unknown())
+    .nullable()
+    .optional()
+    .meta({ description: 'Rich text content as TipTap JSON' }),
   authorName: z.string().nullable().meta({ example: 'Jane Doe' }),
   authorEmail: z.string().nullable().meta({ example: 'user@example.com' }),
   principalId: TypeIdSchema.nullable().meta({ description: 'Principal ID of the comment author' }),
@@ -77,6 +87,11 @@ const CommentResponseSchema = z.object({
   postId: TypeIdSchema,
   parentId: TypeIdSchema.nullable(),
   content: z.string(),
+  contentJson: z
+    .record(z.string(), z.unknown())
+    .nullable()
+    .optional()
+    .meta({ description: 'Rich text content as TipTap JSON' }),
   authorName: z.string().nullable(),
   principalId: TypeIdSchema.nullable(),
   isTeamMember: z.boolean(),

--- a/apps/web/src/lib/server/domains/api/schemas/posts.ts
+++ b/apps/web/src/lib/server/domains/api/schemas/posts.ts
@@ -31,6 +31,11 @@ const PinnedCommentSchema = z
   .object({
     id: TypeIdSchema,
     content: z.string(),
+    contentJson: z
+      .record(z.string(), z.unknown())
+      .nullable()
+      .optional()
+      .meta({ description: 'Rich text content as TipTap JSON' }),
     authorName: z.string().nullable(),
     createdAt: TimestampSchema,
   })

--- a/apps/web/src/lib/server/domains/comments/__tests__/comment-content-json.test.ts
+++ b/apps/web/src/lib/server/domains/comments/__tests__/comment-content-json.test.ts
@@ -137,6 +137,14 @@ vi.mock('@/lib/server/domains/settings/settings.service', () => ({
   }),
 }))
 
+vi.mock('@/lib/server/content/rehost-images', () => ({
+  rehostExternalImages: vi.fn(async (json: unknown) => json),
+}))
+
+vi.mock('@/lib/server/audit/log', () => ({
+  recordAuditEvent: vi.fn(),
+}))
+
 const portalActor: Actor = {
   principalId: 'principal_a' as unknown as PrincipalId,
   role: 'user',
@@ -187,6 +195,37 @@ describe('createComment contentJson dual-write', () => {
     )
     expect(insertedComments[0].contentJson).toEqual(providedJson)
   })
+
+  it('stores client markdown verbatim when the comment has no images', async () => {
+    const { createComment } = await import('../comment.service')
+    const markdown = '**bold** body with a [link](https://example.com)'
+    await createComment(
+      { postId: 'post_p' as unknown as PostId, content: markdown },
+      { principalId: 'principal_a' as unknown as PrincipalId, role: 'user' },
+      portalActor,
+      { skipDispatch: true }
+    )
+    expect(insertedComments[0].content).toBe(markdown)
+  })
+
+  it('projects image markdown into content when the doc has an image', async () => {
+    const { createComment } = await import('../comment.service')
+    const providedJson = {
+      type: 'doc',
+      content: [{ type: 'image', attrs: { src: 'https://cdn.example.com/x.png', alt: 'shot' } }],
+    }
+    await createComment(
+      {
+        postId: 'post_p' as unknown as PostId,
+        content: 'see screenshot',
+        contentJson: providedJson,
+      },
+      { principalId: 'principal_a' as unknown as PrincipalId, role: 'user' },
+      portalActor,
+      { skipDispatch: true }
+    )
+    expect(String(insertedComments[0].content)).toMatch(/!\[/)
+  })
 })
 
 describe('userEditComment contentJson dual-write', () => {
@@ -207,5 +246,30 @@ describe('userEditComment contentJson dual-write', () => {
     expect(updatedComments[0].contentJson).not.toBeNull()
     expect(insertedEditHistory[0]).toMatchObject({ previousContent: 'Old content' })
     expect(insertedEditHistory[0]).toHaveProperty('previousContentJson')
+  })
+})
+
+describe('updateComment contentJson-only sanitizes', () => {
+  beforeEach(() => {
+    insertedComments.length = 0
+    updatedComments.length = 0
+  })
+
+  it('strips a hostile image src on a contentJson-only update', async () => {
+    const { updateComment } = await import('../comment.service')
+    await updateComment(
+      'comment_existing' as unknown as PostCommentId,
+      {
+        contentJson: {
+          type: 'doc',
+          content: [
+            { type: 'image', attrs: { src: 'https://evil.example.com/track.gif', alt: 'x' } },
+          ],
+        },
+      },
+      { principalId: 'principal_author' as unknown as PrincipalId, role: 'user' }
+    )
+    const json = JSON.stringify(updatedComments[0].contentJson)
+    expect(json).not.toContain('evil.example.com')
   })
 })

--- a/apps/web/src/lib/server/domains/comments/__tests__/comment-count.test.ts
+++ b/apps/web/src/lib/server/domains/comments/__tests__/comment-count.test.ts
@@ -214,6 +214,10 @@ vi.mock('@/lib/server/domains/settings/settings.service', () => ({
   }),
 }))
 
+vi.mock('@/lib/server/content/rehost-images', () => ({
+  rehostExternalImages: vi.fn(async (json: unknown) => json),
+}))
+
 const portalActor: Actor = {
   principalId: 'principal_mock' as unknown as PrincipalId,
   role: 'user',

--- a/apps/web/src/lib/server/domains/comments/__tests__/comment-create-service.test.ts
+++ b/apps/web/src/lib/server/domains/comments/__tests__/comment-create-service.test.ts
@@ -122,6 +122,10 @@ vi.mock('@/lib/server/domains/settings/settings.service', () => ({
   }),
 }))
 
+vi.mock('@/lib/server/content/rehost-images', () => ({
+  rehostExternalImages: vi.fn(async (json: unknown) => json),
+}))
+
 // A minimal team actor sufficient for all three tests (public board, published post)
 const teamActor: Actor = {
   principalId: 'principal_admin' as unknown as PrincipalId,
@@ -434,5 +438,57 @@ describe('createComment — soft-deleted board is rejected as POST_NOT_FOUND', (
 
     // And no comment is inserted.
     expect(insertedComments).toHaveLength(0)
+  })
+})
+
+describe('createComment content holds', () => {
+  beforeEach(() => {
+    insertedComments.length = 0
+  })
+
+  it('holds a comment with an image when holdImages is on', async () => {
+    const { getPortalConfig } = await import('@/lib/server/domains/settings/settings.service')
+    vi.mocked(getPortalConfig).mockResolvedValueOnce({
+      moderationDefault: { requireApproval: 'none', holdImages: true },
+    } as Awaited<ReturnType<typeof getPortalConfig>>)
+    await mockPostWithApproval(false)
+    const { createComment } = await import('../comment.service')
+    await createComment(
+      {
+        postId: 'post_p' as unknown as PostId,
+        content: 'screenshot',
+        contentJson: {
+          type: 'doc',
+          content: [{ type: 'image', attrs: { src: 'https://cdn.example.com/x.png' } }],
+        },
+      },
+      { principalId: 'principal_uv' as unknown as PrincipalId, role: 'user' },
+      portalActor,
+      { skipDispatch: true }
+    )
+    expect(insertedComments[0]).toMatchObject({ moderationState: 'pending' })
+  })
+
+  it('does not hold a team comment with an image when holdImages is on', async () => {
+    const { getPortalConfig } = await import('@/lib/server/domains/settings/settings.service')
+    vi.mocked(getPortalConfig).mockResolvedValueOnce({
+      moderationDefault: { requireApproval: 'none', holdImages: true },
+    } as Awaited<ReturnType<typeof getPortalConfig>>)
+    await mockPostWithApproval(false)
+    const { createComment } = await import('../comment.service')
+    await createComment(
+      {
+        postId: 'post_p' as unknown as PostId,
+        content: 'screenshot',
+        contentJson: {
+          type: 'doc',
+          content: [{ type: 'image', attrs: { src: 'https://cdn.example.com/x.png' } }],
+        },
+      },
+      { principalId: 'principal_admin' as unknown as PrincipalId, role: 'admin' },
+      teamActor,
+      { skipDispatch: true }
+    )
+    expect(insertedComments[0]).toMatchObject({ moderationState: 'published' })
   })
 })

--- a/apps/web/src/lib/server/domains/comments/__tests__/comment-edit.test.ts
+++ b/apps/web/src/lib/server/domains/comments/__tests__/comment-edit.test.ts
@@ -38,6 +38,20 @@ vi.mock('@/lib/server/domains/activity/activity.service', () => ({
   createActivity: vi.fn(),
 }))
 
+vi.mock('@/lib/server/domains/settings/settings.service', () => ({
+  getPortalConfig: vi.fn().mockResolvedValue({
+    moderationDefault: { requireApproval: 'none' },
+  }),
+}))
+
+vi.mock('@/lib/server/audit/log', () => ({
+  recordAuditEvent: vi.fn(),
+}))
+
+vi.mock('@/lib/server/content/rehost-images', () => ({
+  rehostExternalImages: vi.fn(async (json: unknown) => json),
+}))
+
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
 const COMMENT_ID = 'comment_test123' as unknown as PostCommentId

--- a/apps/web/src/lib/server/domains/comments/comment-content.ts
+++ b/apps/web/src/lib/server/domains/comments/comment-content.ts
@@ -1,0 +1,33 @@
+/**
+ * Canonical write pipeline for comment bodies: sanitize, rehost, project.
+ */
+import { sanitizeTiptapContent } from '@/lib/server/sanitize-tiptap'
+import {
+  commentMarkdownToTiptapJson,
+  hasImageNode,
+  projectContentJsonToMarkdown,
+} from '@/lib/server/markdown-tiptap'
+import { rehostExternalImages } from '@/lib/server/content/rehost-images'
+import type { TiptapContent } from '@/lib/shared/db-types'
+
+export async function prepareCommentContent(opts: {
+  content: string
+  contentJson?: TiptapContent | null
+  authorIsTeamMember: boolean
+  principalId?: string
+}): Promise<{ content: string; contentJson: TiptapContent }> {
+  const restrictImagesToTrustedOrigins = !opts.authorIsTeamMember
+  const sanitized = opts.contentJson
+    ? sanitizeTiptapContent(opts.contentJson, { restrictImagesToTrustedOrigins })
+    : sanitizeTiptapContent(commentMarkdownToTiptapJson(opts.content), {
+        restrictImagesToTrustedOrigins,
+      })
+  const contentJson = await rehostExternalImages(sanitized, {
+    contentType: 'comment',
+    principalId: opts.principalId,
+  })
+  const content = hasImageNode(contentJson)
+    ? projectContentJsonToMarkdown(contentJson, opts.content)
+    : opts.content
+  return { content, contentJson }
+}

--- a/apps/web/src/lib/server/domains/comments/comment.permissions.ts
+++ b/apps/web/src/lib/server/domains/comments/comment.permissions.ts
@@ -40,8 +40,11 @@ function actorHolds(actor: CommentActor, permission: PermissionKey): boolean {
 }
 import { createActivity } from '@/lib/server/domains/activity/activity.service'
 import { dispatchCommentUpdated, buildEventActor } from '@/lib/server/events/dispatch'
-import { commentMarkdownToTiptapJson } from '@/lib/server/markdown-tiptap'
-import { sanitizeTiptapContent } from '@/lib/server/sanitize-tiptap'
+import { getPortalConfig } from '@/lib/server/domains/settings/settings.service'
+import { recordAuditEvent } from '@/lib/server/audit/log'
+import { isTeamMember as roleIsTeamMember } from '@/lib/shared/roles'
+import { prepareCommentContent } from './comment-content'
+import { contentHoldReason } from '@/lib/server/content/content-holds'
 import type { TiptapContent } from '@/lib/shared/db-types'
 import type { CommentPermissionCheckResult } from './comment.types'
 import { logger } from '@/lib/server/logger'
@@ -221,12 +224,21 @@ export async function userEditComment(
   }
 
   const trimmed = content.trim()
-  // Sanitize caller-supplied JSON before storage so the render fast-path
-  // can trust it. See resolveContentJson in comment.service.ts for the
-  // same policy on creates.
-  const nextContentJson = options?.contentJson
-    ? sanitizeTiptapContent(options.contentJson)
-    : commentMarkdownToTiptapJson(trimmed)
+  const authorIsTeamMember = roleIsTeamMember(actor.role)
+  const prepared = await prepareCommentContent({
+    content: trimmed,
+    contentJson: options?.contentJson,
+    authorIsTeamMember,
+    principalId: actor.principalId,
+  })
+
+  const portalConfig = await getPortalConfig()
+  const holdReason = authorIsTeamMember
+    ? null
+    : contentHoldReason(portalConfig.moderationDefault, prepared.contentJson, prepared.content)
+  const wasPublished = existingComment.moderationState === 'published'
+  const nextModerationState =
+    holdReason && wasPublished ? ('pending' as const) : existingComment.moderationState
 
   const updatedComment = await db.transaction(async (tx) => {
     if (actor.principalId) {
@@ -240,7 +252,14 @@ export async function userEditComment(
 
     const [result] = await tx
       .update(postComments)
-      .set({ content: trimmed, contentJson: nextContentJson, updatedAt: new Date() })
+      .set({
+        content: prepared.content,
+        contentJson: prepared.contentJson,
+        updatedAt: new Date(),
+        ...(nextModerationState !== existingComment.moderationState
+          ? { moderationState: nextModerationState }
+          : {}),
+      })
       .where(eq(postComments.id, commentId))
       .returning()
 
@@ -248,8 +267,30 @@ export async function userEditComment(
       throw new NotFoundError('COMMENT_NOT_FOUND', `Comment with ID ${commentId} not found`)
     }
 
+    if (wasPublished && nextModerationState === 'pending' && !result.isPrivate) {
+      await tx
+        .update(posts)
+        .set({ commentCount: sql`GREATEST(${posts.commentCount} - 1, 0)` })
+        .where(eq(posts.id, existingComment.postId))
+      await adjustCanonicalCommentCount(existingComment.postId, -1, tx)
+    }
+
     return result
   })
+
+  if (wasPublished && nextModerationState === 'pending') {
+    await recordAuditEvent({
+      event: 'comment.moderation.held',
+      actor: { role: actor.role, type: 'user' },
+      target: { type: 'comment', id: commentId },
+      after: { moderationState: 'pending' },
+      metadata: {
+        postId: existingComment.postId,
+        reason: holdReason,
+        previouslyPublished: true,
+      },
+    })
+  }
 
   dispatchCommentUpdated(
     buildEventActor({ principalId: actor.principalId }),

--- a/apps/web/src/lib/server/domains/comments/comment.service.ts
+++ b/apps/web/src/lib/server/domains/comments/comment.service.ts
@@ -26,9 +26,8 @@ import {
   buildEventActor,
 } from '@/lib/server/events/dispatch'
 import { dispatchCommentCreatedEvent } from './comment.announce'
-import { commentMarkdownToTiptapJson } from '@/lib/server/markdown-tiptap'
-import { sanitizeTiptapContent } from '@/lib/server/sanitize-tiptap'
-import type { TiptapContent } from '@/lib/shared/db-types'
+import { prepareCommentContent } from './comment-content'
+import { contentHoldReason } from '@/lib/server/content/content-holds'
 import type { CreateCommentInput, CreateCommentResult, UpdateCommentInput } from './comment.types'
 import { canCreateComment } from '@/lib/server/policy/posts'
 import type { Actor } from '@/lib/server/policy/types'
@@ -39,25 +38,6 @@ import { logger } from '@/lib/server/logger'
 import { adjustCanonicalCommentCount } from '@/lib/server/domains/posts/post.merge-ids'
 
 const log = logger.child({ component: 'comments' })
-
-/**
- * Resolve the TipTap doc to store. UI clients send `contentJson` directly
- * (the editor produces it natively); REST/API callers post only markdown,
- * so we parse + sanitise on their behalf. Markdown stays the API source of
- * truth; the JSON column is a render-time cache.
- *
- * Provided JSON is sanitised before storage: the read path prefers
- * contentJson, so a caller who supplied innocuous `content` and a wholly
- * different JSON shape would otherwise be able to render arbitrary nodes
- * regardless of the 5,000-char content cap.
- */
-function resolveContentJson(
-  content: string,
-  provided: TiptapContent | null | undefined
-): TiptapContent {
-  if (provided) return sanitizeTiptapContent(provided)
-  return commentMarkdownToTiptapJson(content)
-}
 
 export async function createComment(
   input: CreateCommentInput,
@@ -102,13 +82,8 @@ export async function createComment(
   if (!decision.allowed) {
     throw new ForbiddenError('FORBIDDEN', decision.reason)
   }
-  // canCreateComment.requiresApproval is true when the actor is non-team and
-  // the resolved `moderation.comments` rule is `'on'`. Held comments land
-  // with moderationState='pending' so they don't appear publicly until a
-  // moderator approves them via approveCommentFn.
-  const initialModerationState: ModerationState = decision.requiresApproval
-    ? 'pending'
-    : 'published'
+  // Author-type hold is decided here; content holds (images/links) are OR'd
+  // on after we have canonical contentJson below.
 
   // Validate parent comment exists if specified
   let parentIsPrivate = false
@@ -159,7 +134,17 @@ export async function createComment(
   const shouldChangeStatus = !!(input.statusId && authorIsTeamMember && !input.parentId)
 
   const trimmedContent = input.content.trim()
-  const contentJson = resolveContentJson(trimmedContent, input.contentJson)
+  const { content: storedContent, contentJson } = await prepareCommentContent({
+    content: trimmedContent,
+    contentJson: input.contentJson,
+    authorIsTeamMember,
+    principalId: author.principalId,
+  })
+  const holdReason = authorIsTeamMember
+    ? null
+    : contentHoldReason(portalConfig.moderationDefault, contentJson, storedContent)
+  const initialModerationState: ModerationState =
+    decision.requiresApproval || holdReason ? 'pending' : 'published'
 
   let comment: PostComment
   let previousStatusName: string | null = null
@@ -189,7 +174,7 @@ export async function createComment(
         .insert(postComments)
         .values({
           postId: input.postId,
-          content: trimmedContent,
+          content: storedContent,
           contentJson,
           parentId: input.parentId || null,
           principalId: author.principalId,
@@ -253,7 +238,7 @@ export async function createComment(
         .insert(postComments)
         .values({
           postId: input.postId,
-          content: trimmedContent,
+          content: storedContent,
           contentJson,
           parentId: input.parentId || null,
           principalId: author.principalId,
@@ -296,7 +281,13 @@ export async function createComment(
       headers: options?.headers,
       target: { type: 'comment', id: comment.id },
       after: { moderationState: 'pending' },
-      metadata: { postId: post.id, boardId: board.id, principalType: actor.principalType },
+      metadata: {
+        postId: post.id,
+        boardId: board.id,
+        principalType: actor.principalType,
+        ...(holdReason ? { reason: holdReason } : {}),
+        previouslyPublished: false,
+      },
     })
   }
 
@@ -378,14 +369,20 @@ export async function updateComment(
     }
   }
 
-  // Build update data
+  // Build update data. contentJson-only updates still go through sanitize +
+  // rehost so a caller cannot persist hostile image srcs (the sanitizer is
+  // the only gate; the zod schema is z.unknown()).
   const updateData: Partial<PostComment> = {}
-  if (input.content !== undefined) {
-    const trimmed = input.content.trim()
-    updateData.content = trimmed
-    updateData.contentJson = resolveContentJson(trimmed, input.contentJson)
-  } else if (input.contentJson !== undefined) {
-    updateData.contentJson = input.contentJson
+  if (input.content !== undefined || input.contentJson !== undefined) {
+    const trimmed = (input.content ?? existingComment.content).trim()
+    const prepared = await prepareCommentContent({
+      content: trimmed,
+      contentJson: input.contentJson ?? undefined,
+      authorIsTeamMember: isTeamMember(actor.role),
+      principalId: actor.principalId,
+    })
+    updateData.content = prepared.content
+    updateData.contentJson = prepared.contentJson
   }
 
   // Update the comment

--- a/apps/web/src/lib/server/domains/moderation/moderation.service.ts
+++ b/apps/web/src/lib/server/domains/moderation/moderation.service.ts
@@ -20,6 +20,7 @@ import {
   postComments,
   boards,
   principal,
+  auditLog,
   eq,
   and,
   isNull,
@@ -36,6 +37,25 @@ import { logger } from '@/lib/server/logger'
 import { adjustCanonicalCommentCount } from '@/lib/server/domains/posts/post.merge-ids'
 
 const log = logger.child({ component: 'moderation' })
+
+async function latestHoldWasPreviouslyPublished(
+  eventType: 'post.moderation.held' | 'comment.moderation.held',
+  targetId: string
+): Promise<boolean> {
+  try {
+    const [row] = await db
+      .select({ metadata: auditLog.metadata })
+      .from(auditLog)
+      .where(and(eq(auditLog.eventType, eventType), eq(auditLog.targetId, targetId)))
+      .orderBy(desc(auditLog.occurredAt))
+      .limit(1)
+    const metadata = row?.metadata as { previouslyPublished?: boolean } | null
+    return metadata?.previouslyPublished === true
+  } catch (err) {
+    log.error({ err, eventType, targetId }, 'lookup hold audit failed')
+    return false
+  }
+}
 
 /** Audit context a caller threads through so both the session and the API-key
  *  path record a correctly-attributed row. `metadata` is merged into the audit
@@ -60,6 +80,7 @@ export interface PendingPostRow {
 export interface PendingCommentRow {
   id: string
   content: string
+  contentJson: import('@/lib/shared/db-types').TiptapContent | null
   createdAt: Date
   postId: string
   postTitle: string
@@ -127,6 +148,7 @@ export async function listPendingComments(): Promise<PendingCommentRow[]> {
     .select({
       id: postComments.id,
       content: postComments.content,
+      contentJson: postComments.contentJson,
       createdAt: postComments.createdAt,
       postId: postComments.postId,
       postTitle: posts.title,
@@ -197,7 +219,15 @@ export async function approvePost(postId: PostId, audit: ModerationAudit): Promi
   // here would surface a 500 to the moderator and the retry path is blocked
   // by the POST_NOT_PENDING guard above, permanently losing webhooks/mentions.
   try {
-    await announcePublishedPost(postId)
+    const skipCreatedWebhook = await latestHoldWasPreviouslyPublished(
+      'post.moderation.held',
+      postId
+    )
+    if (skipCreatedWebhook) {
+      await announcePublishedPost(postId, undefined, { skipCreatedWebhook: true })
+    } else {
+      await announcePublishedPost(postId)
+    }
   } catch (err) {
     log.error({ err }, 'announce published post failed')
   }
@@ -297,7 +327,11 @@ export async function approveComment(
   // comment is already published and audited, so swallow failures rather
   // than surface a 500 to the moderator with no retry path.
   try {
-    await announcePublishedComment(commentId)
+    const skipCreatedWebhook = await latestHoldWasPreviouslyPublished(
+      'comment.moderation.held',
+      commentId
+    )
+    if (!skipCreatedWebhook) await announcePublishedComment(commentId)
   } catch (err) {
     log.error({ err }, 'announce published comment failed')
   }

--- a/apps/web/src/lib/server/domains/posts/__tests__/post.inbox-moderation.test.ts
+++ b/apps/web/src/lib/server/domains/posts/__tests__/post.inbox-moderation.test.ts
@@ -84,16 +84,15 @@ describe('listInboxPosts — pending moderation exclusion', () => {
     mockPostsFindFirst.mockResolvedValue(null)
   })
 
-  it('excludes pending posts (adds ne(moderationState, "pending")) in normal view', async () => {
+  it('includes pending posts in the normal view so moderators can review them in place', async () => {
     const { listInboxPosts } = await import('../post.inbox')
 
     await listInboxPosts({})
 
-    // ne(posts.moderationState, 'pending') must appear in the normal (non-deleted) view
     const neCall = mockNe.mock.calls.find(
       ([col, val]) => col === mockPostsModerationState && val === 'pending'
     )
-    expect(neCall).toBeDefined()
+    expect(neCall).toBeUndefined()
   })
 
   it('does NOT exclude pending posts (no ne(moderationState)) in the deleted view', async () => {
@@ -107,7 +106,7 @@ describe('listInboxPosts — pending moderation exclusion', () => {
     expect(neCall).toBeUndefined()
   })
 
-  it('isNull(deletedAt) is present in normal view alongside the pending exclusion', async () => {
+  it('isNull(deletedAt) is present in normal view', async () => {
     const { listInboxPosts } = await import('../post.inbox')
 
     await listInboxPosts({})
@@ -118,7 +117,7 @@ describe('listInboxPosts — pending moderation exclusion', () => {
     const neCall = mockNe.mock.calls.find(
       ([col, val]) => col === mockPostsModerationState && val === 'pending'
     )
-    expect(neCall).toBeDefined()
+    expect(neCall).toBeUndefined()
   })
 
   it('isNotNull(deletedAt) is present in the deleted view with no pending exclusion', async () => {

--- a/apps/web/src/lib/server/domains/posts/post.announce.ts
+++ b/apps/web/src/lib/server/domains/posts/post.announce.ts
@@ -42,7 +42,8 @@ export async function announcePublishedPost(
     post: PostSnapshot
     board: { slug: string; name: string }
     author: AuthorSnapshot
-  }
+  },
+  opts?: { skipCreatedWebhook?: boolean }
 ): Promise<void> {
   let post: PostSnapshot
   let board: { slug: string; name: string }
@@ -80,16 +81,18 @@ export async function announcePublishedPost(
   }
 
   const actorName = author.displayName ?? author.name
-  await dispatchPostCreated(buildEventActor(author), {
-    id: post.id,
-    title: post.title,
-    content: post.content,
-    boardId: post.boardId,
-    boardSlug: board.slug,
-    authorEmail: realEmail(author.email) ?? undefined,
-    authorName: actorName,
-    voteCount: post.voteCount,
-  })
+  if (!opts?.skipCreatedWebhook) {
+    await dispatchPostCreated(buildEventActor(author), {
+      id: post.id,
+      title: post.title,
+      content: post.content,
+      boardId: post.boardId,
+      boardSlug: board.slug,
+      authorEmail: realEmail(author.email) ?? undefined,
+      authorName: actorName,
+      voteCount: post.voteCount,
+    })
+  }
 
   if (post.contentJson) {
     const mentionedIds = extractMentions(post.contentJson)

--- a/apps/web/src/lib/server/domains/posts/post.inbox.ts
+++ b/apps/web/src/lib/server/domains/posts/post.inbox.ts
@@ -12,7 +12,6 @@ import {
   userSegments,
   eq,
   and,
-  ne,
   inArray,
   desc,
   asc,
@@ -75,10 +74,9 @@ export async function listInboxPosts(params: InboxPostListParams): Promise<Inbox
     conditions.push(sql`${posts.deletedAt} >= ${thirtyDaysAgo}`)
   } else {
     conditions.push(isNull(posts.deletedAt))
-    // Pending posts live in the moderation queue, not the inbox. The
-    // deleted view is exempt — a rejected post is a soft-deleted post
-    // and must stay restorable there.
-    conditions.push(ne(posts.moderationState, 'pending'))
+    // Pending posts render in the inbox for team members (who hold
+    // post.approve / post.view_private) so they can review them in place.
+    // The moderation queue still lists the same items for attention.
   }
 
   // Exclude merged/duplicate posts from inbox listing

--- a/apps/web/src/lib/server/domains/posts/post.public.detail.ts
+++ b/apps/web/src/lib/server/domains/posts/post.public.detail.ts
@@ -226,6 +226,7 @@ export async function getPublicPostDetail(
     sc_from_color: string | null
     sc_to_name: string | null
     sc_to_color: string | null
+    moderation_state: string
   }
 
   // The comment set is the UNION of this post + every merged source the actor
@@ -245,6 +246,7 @@ export async function getPublicPostDetail(
         c.id, c.post_id, c.parent_id, c.principal_id,
         m.display_name as author_name,
         c.content, c.content_json, c.is_team_member, c.is_private,
+        c.moderation_state,
         c.created_at, c.updated_at, c.deleted_at, c.deleted_by_principal_id,
         m.avatar_key, m.avatar_url,
         COALESCE(
@@ -363,6 +365,7 @@ export async function getPublicPostDetail(
       null,
     isTeamMember: comment.is_team_member,
     isPrivate: comment.is_private,
+    moderationState: comment.moderation_state,
     createdAt: ensureDate(comment.created_at),
     updatedAt: comment.updated_at ? ensureDate(comment.updated_at) : null,
     deletedAt: comment.deleted_at ? ensureDate(comment.deleted_at) : null,
@@ -406,6 +409,7 @@ export async function getPublicPostDetail(
       isEdited: !deleted && !!node.updatedAt,
       avatarUrl: deleted ? null : (node.avatarUrl ?? null),
       statusChange: deleted ? null : (node.statusChange ?? null),
+      moderationState: deleted ? 'published' : (node.moderationState ?? 'published'),
       replies: node.replies.map(mapToPublicComment),
       reactions: deleted ? [] : node.reactions,
     }
@@ -488,5 +492,6 @@ export async function getPublicPostDetail(
     pinnedComment,
     pinnedCommentId: pinnedComment ? (postResult.pinnedCommentId as PostCommentId) : null,
     isCommentsLocked: postResult.isCommentsLocked,
+    moderationState: postResult.postModerationState,
   }
 }

--- a/apps/web/src/lib/server/domains/posts/post.public.ts
+++ b/apps/web/src/lib/server/domains/posts/post.public.ts
@@ -95,6 +95,7 @@ export interface PostWithVotesAndAvatars {
   board: { id: string; name: string; slug: string }
   hasVoted: boolean
   avatarUrl: string | null
+  moderationState?: 'published' | 'pending' | string
 }
 
 interface PostListParams {
@@ -248,6 +249,7 @@ export async function listPublicPostsWithVotesAndAvatars(
       principalId: posts.principalId,
       createdAt: posts.createdAt,
       pinnedAt: posts.pinnedAt,
+      moderationState: posts.moderationState,
       boardId: boards.id,
       boardName: boards.name,
       boardSlug: boards.slug,
@@ -323,6 +325,7 @@ export async function listPublicPostsWithVotesAndAvatars(
       principalId: post.principalId,
       createdAt: post.createdAt,
       pinnedAt: post.pinnedAt,
+      moderationState: post.moderationState,
       tags: tagsByPost.get(post.id) ?? [],
       board: { id: post.boardId, name: post.boardName, slug: post.boardSlug },
       hasVoted: post.hasVoted ?? false,
@@ -351,6 +354,7 @@ export async function listPublicPosts(
       commentCount: posts.commentCount,
       principalId: posts.principalId,
       createdAt: posts.createdAt,
+      moderationState: posts.moderationState,
       boardId: boards.id,
       boardName: boards.name,
       boardSlug: boards.slug,
@@ -386,6 +390,7 @@ export async function listPublicPosts(
     principalId: post.principalId,
     createdAt: post.createdAt,
     commentCount: post.commentCount,
+    moderationState: post.moderationState,
     tags: parseJson<Array<{ id: PostTagId; name: string; color: string }>>(post.tagsJson),
     board: { id: post.boardId, name: post.boardName, slug: post.boardSlug },
   }))

--- a/apps/web/src/lib/server/domains/posts/post.service.ts
+++ b/apps/web/src/lib/server/domains/posts/post.service.ts
@@ -49,7 +49,8 @@ import { rehostExternalImages } from '@/lib/server/content/rehost-images'
 import { subscribeToPost } from '@/lib/server/domains/subscriptions/subscription.service'
 import type { CreatePostInput, UpdatePostInput, CreatePostResult } from './post.types'
 import { createActivity } from '@/lib/server/domains/activity/activity.service'
-import { canCreatePost, ANONYMOUS_ACTOR, type Actor } from '@/lib/server/policy'
+import { canCreatePost, ANONYMOUS_ACTOR, isTeamActor, type Actor } from '@/lib/server/policy'
+import { contentHoldReason } from '@/lib/server/content/content-holds'
 import { getPortalConfig } from '@/lib/server/domains/settings/settings.service'
 import { startOfUtcMonth } from '@/lib/shared/utils/date'
 import { extractMentions, extractMentionExcerpts } from './extract-mentions'
@@ -175,6 +176,7 @@ export async function createPost(
   let moderationState: 'published' | 'pending' = createDecision.requiresApproval
     ? 'pending'
     : 'published'
+  let holdReason: ReturnType<typeof contentHoldReason> = null
 
   // Determine statusId - either from input or use default "open" status
   let statusId = input.statusId
@@ -227,6 +229,11 @@ export async function createPost(
       throw new ValidationError('POST_CREATE_DENIED', lockedDecision.reason)
     }
     moderationState = lockedDecision.requiresApproval ? 'pending' : 'published'
+    const actor = author.actor ?? ANONYMOUS_ACTOR
+    holdReason = isTeamActor(actor)
+      ? null
+      : contentHoldReason(portalConfig.moderationDefault, contentJson, `${title}\n${content}`)
+    if (holdReason) moderationState = 'pending'
 
     const [newPost] = await tx
       .insert(posts)
@@ -277,7 +284,11 @@ export async function createPost(
       headers: options?.headers,
       target: { type: 'post', id: post.id },
       after: { moderationState: 'pending' },
-      metadata: { principalType: author.actor?.principalType ?? 'anonymous' },
+      metadata: {
+        principalType: author.actor?.principalType ?? 'anonymous',
+        ...(holdReason ? { reason: holdReason } : {}),
+        previouslyPublished: false,
+      },
     })
   }
 

--- a/apps/web/src/lib/server/domains/posts/post.types.ts
+++ b/apps/web/src/lib/server/domains/posts/post.types.ts
@@ -106,6 +106,7 @@ export interface PublicPostListItem {
   commentCount: number
   tags: Array<{ id: PostTagId; name: string; color: string }>
   board?: { id: BoardId; name: string; slug: string }
+  moderationState?: 'published' | 'pending' | string
 }
 
 /**
@@ -238,6 +239,7 @@ export interface PublicComment {
   isEdited: boolean
   avatarUrl: string | null
   statusChange?: CommentStatusChange | null
+  moderationState?: 'published' | 'pending' | string | null
   replies: PublicComment[]
   reactions: CommentReactionCount[]
 }
@@ -286,6 +288,7 @@ export interface PublicPostDetail {
   pinnedCommentId: PostCommentId | null
   /** Whether comments are locked (portal users can't comment) */
   isCommentsLocked: boolean
+  moderationState?: 'published' | 'pending' | string
 }
 
 /**

--- a/apps/web/src/lib/server/domains/posts/post.user-actions.ts
+++ b/apps/web/src/lib/server/domains/posts/post.user-actions.ts
@@ -28,6 +28,9 @@ import {
 } from '@/lib/server/events/dispatch'
 import { DEFAULT_PORTAL_CONFIG, type PortalConfig } from '@/lib/server/domains/settings'
 import type { UserEditPostInput } from './post.types'
+import { markdownToTiptapJson } from '@/lib/server/markdown-tiptap'
+import { contentHoldReason } from '@/lib/server/content/content-holds'
+import { recordAuditEvent } from '@/lib/server/audit/log'
 import { logger } from '@/lib/server/logger'
 import { recalculateCanonicalVoteCount } from './post.merge-ids'
 
@@ -57,6 +60,10 @@ async function getPortalConfig(): Promise<PortalConfig> {
     features: {
       ...DEFAULT_PORTAL_CONFIG.features,
       ...(config?.features ?? {}),
+    },
+    moderationDefault: {
+      ...DEFAULT_PORTAL_CONFIG.moderationDefault,
+      ...(config?.moderationDefault ?? {}),
     },
   }
 }
@@ -177,6 +184,18 @@ export async function userEditPost(
     })
   }
 
+  const authorIsTeam = isTeamMember(actor.role)
+  const nextJson = input.contentJson ?? markdownToTiptapJson(input.content.trim())
+  const holdReason = authorIsTeam
+    ? null
+    : contentHoldReason(
+        config.moderationDefault,
+        nextJson,
+        `${input.title.trim()}\n${input.content.trim()}`
+      )
+  const wasPublished = existingPost.moderationState === 'published'
+  const rehold = Boolean(holdReason && wasPublished)
+
   // Update the post
   const [updatedPost] = await db
     .update(posts)
@@ -185,12 +204,23 @@ export async function userEditPost(
       content: input.content.trim(),
       contentJson: input.contentJson,
       updatedAt: new Date(),
+      ...(rehold ? { moderationState: 'pending' as const } : {}),
     })
     .where(eq(posts.id, postId))
     .returning()
 
   if (!updatedPost) {
     throw new NotFoundError('POST_NOT_FOUND', `Post with ID ${postId} not found`)
+  }
+
+  if (rehold) {
+    await recordAuditEvent({
+      event: 'post.moderation.held',
+      actor: { role: actor.role, type: 'user' },
+      target: { type: 'post', id: postId },
+      after: { moderationState: 'pending' },
+      metadata: { reason: holdReason, previouslyPublished: true },
+    })
   }
 
   // Regenerate embedding (and cascade to merge check) after user edit

--- a/apps/web/src/lib/server/domains/settings/__tests__/parse-json-config.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/parse-json-config.test.ts
@@ -9,8 +9,12 @@ import {
 } from '../settings.types'
 
 describe('DEFAULT_PORTAL_CONFIG', () => {
-  it('DEFAULT_PORTAL_CONFIG carries a moderationDefault of none', () => {
-    expect(DEFAULT_PORTAL_CONFIG.moderationDefault).toEqual({ requireApproval: 'none' })
+  it('DEFAULT_PORTAL_CONFIG carries a moderationDefault of none with holds off', () => {
+    expect(DEFAULT_PORTAL_CONFIG.moderationDefault).toEqual({
+      requireApproval: 'none',
+      holdImages: false,
+      holdLinks: false,
+    })
   })
 
   it('DEFAULT_PORTAL_CONFIG has widgetSignIn defaulting to false', () => {

--- a/apps/web/src/lib/server/domains/settings/settings.types.ts
+++ b/apps/web/src/lib/server/domains/settings/settings.types.ts
@@ -201,11 +201,16 @@ export interface PortalFeatures {
 }
 
 /**
- * Workspace-wide post-approval policy. Applies to every board — there is
- * no per-board override.
+ * Workspace-wide post-approval policy. Author-type hold (`requireApproval`)
+ * can be overridden per board; content holds (`holdImages` / `holdLinks`)
+ * are workspace-wide only.
  */
 export interface ModerationDefault {
   requireApproval: 'none' | 'anonymous' | 'authenticated' | 'all'
+  /** Hold posts and comments that contain an image. Default false. */
+  holdImages?: boolean
+  /** Hold posts and comments that contain an external link. Default false. */
+  holdLinks?: boolean
 }
 
 /**
@@ -330,7 +335,7 @@ export const DEFAULT_PORTAL_CONFIG: PortalConfig = {
     title: '',
     body: { type: 'doc', content: [{ type: 'paragraph' }] },
   },
-  moderationDefault: { requireApproval: 'none' },
+  moderationDefault: { requireApproval: 'none', holdImages: false, holdLinks: false },
   access: { visibility: 'public', allowedDomains: [], widgetSignIn: false, allowedSegmentIds: [] },
   support: { enabled: false },
 }

--- a/apps/web/src/lib/server/domains/summary/summary.service.ts
+++ b/apps/web/src/lib/server/domains/summary/summary.service.ts
@@ -28,6 +28,7 @@ import {
 } from '@/lib/server/domains/ai/config'
 import { getChatModel } from '@/lib/server/domains/ai/models'
 import { enforceAiTokenBudget } from '@/lib/server/domains/settings/tier-enforce'
+import { commentPlainText } from '@/lib/server/markdown-tiptap'
 import type { PostId } from '@quackback/ids'
 import { logger } from '@/lib/server/logger'
 
@@ -133,6 +134,7 @@ export async function generateAndSavePostSummary(postId: PostId): Promise<void> 
   const commentRows = await db
     .select({
       content: postComments.content,
+      contentJson: postComments.contentJson,
       isTeamMember: postComments.isTeamMember,
     })
     .from(postComments)
@@ -146,7 +148,7 @@ export async function generateAndSavePostSummary(postId: PostId): Promise<void> 
     input += '\n\n## Comments\n'
     for (const c of commentRows) {
       const prefix = c.isTeamMember ? '[Team]' : '[User]'
-      input += `\n${prefix}: ${c.content}`
+      input += `\n${prefix}: ${commentPlainText(c)}`
     }
   }
 

--- a/apps/web/src/lib/server/events/targets.ts
+++ b/apps/web/src/lib/server/events/targets.ts
@@ -44,7 +44,8 @@ import {
 } from '@/lib/server/domains/subscriptions/subscription.service'
 import { shouldNotify } from '@/lib/server/domains/subscriptions/notification-matrix'
 import type { HookTarget, EmailTarget, NoteMentionEmailConfig } from './hook-types'
-import { stripHtml, truncate } from './hook-utils'
+import { truncate } from './hook-utils'
+import { commentPlainText } from '@/lib/server/markdown-tiptap'
 import { type HookContext } from './hook-context'
 import type { EventData, EventActor, PostMergedPayload, PostUnmergedPayload } from './types'
 import { logger } from '@/lib/server/logger'
@@ -451,7 +452,7 @@ async function buildEmailEventConfig(
       postTitle: post.title,
       postUrl: `${buildPostUrl(rootUrl, post)}#comment-${comment.id}`,
       commenterName: resolveCommenterName(comment),
-      commentPreview: truncate(stripHtml(comment.content), 200),
+      commentPreview: truncate(commentPlainText(comment), 200),
       isTeamMember: await isActorTeamMember(event.actor),
     }
   }
@@ -507,7 +508,7 @@ async function buildNotificationConfig(
       postUrl: `${buildPostUrl(rootUrl, post)}#comment-${comment.id}`,
       commentId: comment.id,
       commenterName: resolveCommenterName(comment),
-      commentPreview: truncate(stripHtml(comment.content), 200),
+      commentPreview: truncate(commentPlainText(comment), 200),
       isTeamMember: await isActorTeamMember(event.actor),
     }
   }

--- a/apps/web/src/lib/server/functions/__tests__/moderation-default.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/moderation-default.test.ts
@@ -211,6 +211,18 @@ describe('updateModerationDefaultFn — happy path (admin)', () => {
     expect(result).toEqual({ moderationDefault: { requireApproval: 'authenticated' } })
   })
 
+  it('accepts holdImages and holdLinks flags', async () => {
+    mockUpdatePortalConfig.mockResolvedValue({
+      moderationDefault: { requireApproval: 'none', holdImages: true, holdLinks: true },
+    })
+    await getUpdateModerationDefaultFn()({
+      data: { requireApproval: 'none', holdImages: true, holdLinks: true },
+    })
+    expect(mockUpdatePortalConfig).toHaveBeenCalledWith({
+      moderationDefault: { requireApproval: 'none', holdImages: true, holdLinks: true },
+    })
+  })
+
   it.each(['none', 'anonymous', 'authenticated', 'all'] as const)(
     'accepts requireApproval=%s',
     async (ra) => {

--- a/apps/web/src/lib/server/functions/__tests__/moderation.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/moderation.test.ts
@@ -1096,6 +1096,30 @@ describe('getModerationStatus', () => {
     expect(result.enabled).toBe(false)
   })
 
+  it('enabled=true when holdImages is on even if requireApproval is none', async () => {
+    stubSelectCalls(0)
+    mockGetPortalConfig.mockResolvedValue({
+      moderationDefault: { requireApproval: 'none', holdImages: true },
+    })
+    const result = (await getModerationStatusHandler()({ data: {} })) as {
+      enabled: boolean
+      pendingCount: number
+    }
+    expect(result.enabled).toBe(true)
+  })
+
+  it('enabled=true when holdLinks is on even if requireApproval is none', async () => {
+    stubSelectCalls(0)
+    mockGetPortalConfig.mockResolvedValue({
+      moderationDefault: { requireApproval: 'none', holdLinks: true },
+    })
+    const result = (await getModerationStatusHandler()({ data: {} })) as {
+      enabled: boolean
+      pendingCount: number
+    }
+    expect(result.enabled).toBe(true)
+  })
+
   it('enabled=true when policy is none but a per-board backlog exists', async () => {
     // Per-board approval can route items to pending while the workspace
     // default is 'none'. The sidebar status must surface that backlog so

--- a/apps/web/src/lib/server/functions/moderation.ts
+++ b/apps/web/src/lib/server/functions/moderation.ts
@@ -178,6 +178,8 @@ export const getModerationStatus = createServerFn({ method: 'GET' }).handler(asy
   // items to pending while the workspace default is 'none'), surface it.
   const enabled =
     portalConfig.moderationDefault.requireApproval !== 'none' ||
+    portalConfig.moderationDefault.holdImages === true ||
+    portalConfig.moderationDefault.holdLinks === true ||
     pendingCount > 0 ||
     approvalCount > 0
 

--- a/apps/web/src/lib/server/functions/settings.ts
+++ b/apps/web/src/lib/server/functions/settings.ts
@@ -995,6 +995,8 @@ export const updateSpamFilterConfigFn = createServerFn({ method: 'POST' })
 
 const moderationDefaultSchema = z.object({
   requireApproval: z.enum(['none', 'anonymous', 'authenticated', 'all']),
+  holdImages: z.boolean().optional(),
+  holdLinks: z.boolean().optional(),
 })
 
 /**

--- a/apps/web/src/lib/server/integrations/webhook-payload.ts
+++ b/apps/web/src/lib/server/integrations/webhook-payload.ts
@@ -5,6 +5,7 @@
 
 import type { EventData } from '@/lib/server/events/types'
 import { stripHtml, truncate, formatStatus } from '@/lib/server/events/hook-utils'
+import { commentPlainText } from '@/lib/server/markdown-tiptap'
 
 interface WebhookPayload {
   event: string
@@ -104,7 +105,7 @@ export function buildWebhookPayload(event: EventData, rootUrl: string): WebhookP
         },
         comment: {
           id: comment.id,
-          content: truncate(stripHtml(comment.content), 1000),
+          content: truncate(commentPlainText(comment), 1000),
           author_name: comment.authorName,
           author_email: comment.authorEmail,
         },

--- a/apps/web/src/lib/server/markdown-tiptap.ts
+++ b/apps/web/src/lib/server/markdown-tiptap.ts
@@ -22,6 +22,7 @@ import type { TiptapContent } from '@/lib/server/db'
 import type { JSONContent } from '@tiptap/core'
 import { sanitizeTiptapContent } from '@/lib/server/sanitize-tiptap'
 import { lookupEmoji } from '@/lib/shared/content-emoji'
+import { parseEmbedUrl } from '@/lib/shared/embeds/parse-embed-url'
 
 /**
  * Server-safe extensions for markdown conversion.
@@ -171,7 +172,8 @@ export function projectContentJsonToMarkdown(
  * tree. Runs before the serialize try/catch, so it must stay total: a malformed
  * row whose `content` is present but not an array must not throw.
  */
-function hasImageNode(node: JSONContent): boolean {
+export function hasImageNode(node: JSONContent | null | undefined): boolean {
+  if (!node || typeof node !== 'object') return false
   if (typeof node.type === 'string' && IMAGE_NODE_TYPES.has(node.type)) return true
   return Array.isArray(node.content) ? node.content.some(hasImageNode) : false
 }
@@ -228,31 +230,11 @@ function normalizeForMarkdown(node: JSONContent): JSONContent {
 }
 
 /**
- * Slim extension set for comments — no images, no tables, no YouTube.
- * Comments are short, dense, and inline; we want the safe subset only.
- */
-const COMMENT_EXTENSIONS = [
-  StarterKit.configure({
-    heading: { levels: [1, 2, 3] },
-    hardBreak: { keepMarks: true },
-  }),
-  Link.configure({ openOnClick: false, autolink: true }),
-  Underline,
-  TaskList,
-  TaskItem.configure({ nested: true }),
-]
-
-const commentManager = new MarkdownManager({
-  extensions: COMMENT_EXTENSIONS,
-  markedOptions: { gfm: true, breaks: true },
-})
-
-/**
- * Parse a comment-style markdown string into TipTap JSON.
+ * Parse comment markdown with the same extension set as posts, then sanitize.
+ * API/MCP callers post markdown; UI clients send contentJson directly.
  */
 export function commentMarkdownToTiptapJson(markdown: string): TiptapContent {
-  const json = commentManager.parse(markdown) as TiptapContent
-  return sanitizeTiptapContent(json) as TiptapContent
+  return sanitizeTiptapContent(markdownToTiptapJson(markdown)) as TiptapContent
 }
 
 /**
@@ -325,4 +307,87 @@ export function hasTextLeaf(json: TiptapContent | null | undefined): boolean {
     return (node.content ?? []).some(visit)
   }
   return visit(json)
+}
+
+const HTTP_URL_RE = /https?:\/\/[^\s<>"']+/gi
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+function isSameOriginUrl(href: string, origin?: string): boolean {
+  if (!origin) return false
+  try {
+    return new URL(href).origin === new URL(origin).origin
+  } catch {
+    return false
+  }
+}
+
+function hrefIsExternalLink(href: string, origin?: string): boolean {
+  if (!isHttpUrl(href)) return false
+  if (isSameOriginUrl(href, origin)) return false
+  // Internal product URLs (post / changelog / article / ticket) are first-class
+  // embeds, not the external-link spam vector.
+  return parseEmbedUrl(href) === null
+}
+
+function nodeHasExternalLink(node: JSONContent, origin?: string): boolean {
+  if (node.type === 'youtube' && typeof node.attrs?.src === 'string') {
+    return hrefIsExternalLink(String(node.attrs.src), origin)
+  }
+  if (Array.isArray(node.marks)) {
+    for (const mark of node.marks) {
+      if (mark && typeof mark === 'object' && mark.type === 'link') {
+        const href = (mark as { attrs?: { href?: unknown } }).attrs?.href
+        if (typeof href === 'string' && hrefIsExternalLink(href, origin)) return true
+      }
+    }
+  }
+  return Array.isArray(node.content)
+    ? node.content.some((child) => nodeHasExternalLink(child, origin))
+    : false
+}
+
+/**
+ * True when the doc (or fallback markdown/title) contains an external http(s)
+ * link. Mentions, same-origin URLs, and internal product URLs are not links.
+ */
+export function hasExternalLink(
+  node: JSONContent | null | undefined,
+  fallbackText?: string,
+  origin?: string
+): boolean {
+  if (node && typeof node === 'object' && nodeHasExternalLink(node, origin)) return true
+  if (typeof fallbackText !== 'string' || fallbackText.length === 0) return false
+  const matches = fallbackText.match(HTTP_URL_RE) ?? []
+  return matches.some((href) => hrefIsExternalLink(href.replace(/[),.;]+$/, ''), origin))
+}
+
+/**
+ * Plain-text preview of a comment. Prefers the TipTap tree (so image-only
+ * comments become `[image]`); falls back to parsing stored markdown.
+ */
+export function commentPlainText(comment: {
+  content: string
+  contentJson?: TiptapContent | JSONContent | null
+}): string {
+  if (comment.contentJson) {
+    const fromJson = tiptapJsonToText(comment.contentJson as TiptapContent)
+    if (fromJson) return fromJson
+  }
+  const markdown = comment.content?.trim()
+  if (!markdown) return ''
+  try {
+    const fromMd = tiptapJsonToText(commentMarkdownToTiptapJson(markdown))
+    if (fromMd) return fromMd
+  } catch {
+    // fall through
+  }
+  return markdown
 }

--- a/apps/web/src/lib/server/mcp/__tests__/content-format-metadata.test.ts
+++ b/apps/web/src/lib/server/mcp/__tests__/content-format-metadata.test.ts
@@ -72,13 +72,16 @@ describe('MCP content format metadata', () => {
     expect(tool.description).toContain('PNG, JPEG, WebP, GIF, AVIF')
   })
 
-  it.each(COMMENT_TOOLS)(
-    '%s: content field declares plain text and no markdown support',
-    (toolName) => {
-      const tool = tools.find((t) => t.name === toolName)!
-      const description = tool.schema.content?.description ?? ''
-      expect(description.toLowerCase()).toContain('plain text')
-      expect(description.toLowerCase()).toContain('not supported')
-    }
-  )
+  it.each(COMMENT_TOOLS)('%s: content field mentions markdown and auto-rehost', (toolName) => {
+    const tool = tools.find((t) => t.name === toolName)!
+    const description = tool.schema.content?.description ?? ''
+    expect(description.toLowerCase()).toContain('markdown')
+    expect(description.toLowerCase()).toContain('auto-rehost')
+  })
+
+  it.each(COMMENT_TOOLS)('%s: tool description contains the content format block', (toolName) => {
+    const tool = tools.find((t) => t.name === toolName)!
+    expect(tool.description).toContain('Content format:')
+    expect(tool.description).toContain('PNG, JPEG, WebP, GIF, AVIF')
+  })
 })

--- a/apps/web/src/lib/server/mcp/tools/comments.ts
+++ b/apps/web/src/lib/server/mcp/tools/comments.ts
@@ -13,19 +13,26 @@ import { userEditComment } from '@/lib/server/domains/comments/comment.permissio
 import { addReaction, removeReaction } from '@/lib/server/domains/comments/comment.reactions'
 import type { PostId, PostCommentId } from '@quackback/ids'
 import type { McpAuthContext } from '../types'
-import { registerTool, mcpMemberActor, jsonResult, WRITE, DESTRUCTIVE } from './helpers'
+import {
+  registerTool,
+  mcpMemberActor,
+  jsonResult,
+  WRITE,
+  DESTRUCTIVE,
+  CONTENT_FORMAT_BLOCK,
+  CONTENT_FIELD_DESCRIBE,
+} from './helpers'
 
 // ============================================================================
 // Schemas
 // ============================================================================
 
-/** Shared tail for the comment content `.describe()` blurbs. */
-const COMMENT_PLAIN_TEXT_DESCRIBE =
-  'Plain text only (max 5,000 characters). Rich content, markdown, and image embedding are not supported for comments today.'
-
 const addCommentSchema = {
   postId: z.string().describe('Post TypeID to comment on'),
-  content: z.string().max(5000).describe(`Comment text. ${COMMENT_PLAIN_TEXT_DESCRIBE}`),
+  content: z
+    .string()
+    .max(5000)
+    .describe(`Comment content (max 5,000 characters). ${CONTENT_FIELD_DESCRIBE}`),
   parentId: z.string().optional().describe('Parent comment TypeID for threaded reply'),
   isPrivate: z
     .boolean()
@@ -35,7 +42,10 @@ const addCommentSchema = {
 
 const updateCommentSchema = {
   commentId: z.string().describe('Comment TypeID to edit'),
-  content: z.string().max(5000).describe(`New comment text. ${COMMENT_PLAIN_TEXT_DESCRIBE}`),
+  content: z
+    .string()
+    .max(5000)
+    .describe(`New comment content (max 5,000 characters). ${CONTENT_FIELD_DESCRIBE}`),
 }
 
 const deleteCommentSchema = {
@@ -82,6 +92,7 @@ export function registerCommentTools(server: McpServer, auth: McpAuthContext) {
   registerTool<AddCommentArgs>(server, auth, {
     name: 'add_comment',
     description: `Post a comment on a feedback post. Supports threaded replies via parentId. Set isPrivate to create an internal note visible only to team members.
+${CONTENT_FORMAT_BLOCK}
 
 Examples:
 - Top-level comment: add_comment({ postId: "post_01abc...", content: "Thanks for the feedback!" })
@@ -126,6 +137,7 @@ Examples:
   registerTool<UpdateCommentArgs>(server, auth, {
     name: 'update_comment',
     description: `Edit a comment's content. Team members can edit any comment; authors can edit their own.
+${CONTENT_FORMAT_BLOCK}
 
 Examples:
 - Edit: update_comment({ commentId: "post_comment_01abc...", content: "Updated feedback response." })`,

--- a/apps/web/src/lib/server/mcp/tools/search.ts
+++ b/apps/web/src/lib/server/mcp/tools/search.ts
@@ -22,6 +22,7 @@ import {
 import { getTypeIdPrefix } from '@quackback/ids'
 import { truncate } from '@/lib/shared/utils/string'
 import { contentJsonToMarkdown } from '@/lib/server/markdown-tiptap'
+import type { CommentTreeNode } from '@/lib/shared/comment-tree'
 import type {
   PostId,
   BoardId,
@@ -417,6 +418,22 @@ async function searchArticles(args: SearchArgs): Promise<CallToolResult> {
 // Get details dispatchers
 // ============================================================================
 
+function serializeMcpComment(c: CommentTreeNode): Record<string, unknown> {
+  return {
+    id: c.id,
+    postId: c.postId,
+    parentId: c.parentId,
+    content: contentJsonToMarkdown(c.contentJson, c.content),
+    authorName: c.authorName,
+    principalId: c.principalId,
+    isTeamMember: c.isTeamMember,
+    isPrivate: c.isPrivate,
+    createdAt: c.createdAt,
+    deletedAt: c.deletedAt,
+    replies: c.replies.map(serializeMcpComment),
+  }
+}
+
 async function getPostDetails(postId: PostId): Promise<CallToolResult> {
   const [post, comments, mergedPosts] = await Promise.all([
     getPostWithDetails(postId),
@@ -440,7 +457,10 @@ async function getPostDetails(postId: PostId): Promise<CallToolResult> {
     pinnedComment: post.pinnedComment
       ? {
           id: post.pinnedComment.id,
-          content: post.pinnedComment.content,
+          content: contentJsonToMarkdown(
+            post.pinnedComment.contentJson,
+            post.pinnedComment.content
+          ),
           authorName: post.pinnedComment.authorName,
           createdAt: post.pinnedComment.createdAt,
         }
@@ -460,7 +480,7 @@ async function getPostDetails(postId: PostId): Promise<CallToolResult> {
     createdAt: post.createdAt,
     updatedAt: post.updatedAt,
     deletedAt: post.deletedAt ?? null,
-    comments,
+    comments: comments.map(serializeMcpComment),
   })
 }
 

--- a/apps/web/src/lib/shared/comment-tree.ts
+++ b/apps/web/src/lib/shared/comment-tree.ts
@@ -65,6 +65,7 @@ export interface CommentWithReactions {
   deletedByPrincipalId?: string | null
   avatarUrl?: string | null
   statusChange?: CommentStatusChange | null
+  moderationState?: 'published' | 'pending' | string | null
   reactions: Array<{
     emoji: string
     principalId: string
@@ -90,6 +91,7 @@ export interface CommentTreeNode {
   deletedByPrincipalId: string | null
   avatarUrl?: string | null
   statusChange?: CommentStatusChange | null
+  moderationState?: 'published' | 'pending' | string | null
   replies: CommentTreeNode[]
   reactions: CommentReactionCount[]
 }
@@ -184,6 +186,7 @@ export function buildCommentTree<T extends CommentWithReactions>(
       deletedByPrincipalId: comment.deletedByPrincipalId ?? null,
       avatarUrl: comment.avatarUrl,
       statusChange: comment.statusChange,
+      moderationState: comment.moderationState ?? 'published',
       replies: [],
       reactions: aggregateReactions(comment.reactions, principalId),
     }

--- a/apps/web/src/lib/shared/types/inbox.ts
+++ b/apps/web/src/lib/shared/types/inbox.ts
@@ -64,6 +64,7 @@ export interface PostDetails {
   pinnedCommentId: PostCommentId | null
   /** Whether comments are locked (portal users can't comment) */
   isCommentsLocked?: boolean
+  moderationState?: 'published' | 'pending' | string
   /** Map of principalId to avatar URL (base64 or external URL) */
   avatarUrls?: Record<string, string | null>
   /** AI-generated post summary */

--- a/apps/web/src/routes/_portal.b.$slug.posts.$postId.tsx
+++ b/apps/web/src/routes/_portal.b.$slug.posts.$postId.tsx
@@ -37,6 +37,9 @@ import { isValidTypeId, type PostCommentId, type PostId } from '@quackback/ids'
 import type { TiptapContent } from '@/lib/shared/schemas/posts'
 import type { PostStatusEntity } from '@/lib/shared/db-types'
 import { isProductEnabled } from '@/lib/shared/types/settings'
+import { usePortalPermissions } from '@/lib/client/hooks/use-portal-permissions'
+import { PERMISSIONS } from '@/lib/shared/permissions'
+import { useApprovePost, useRejectPost } from '@/lib/client/mutations/moderation'
 
 export const Route = createFileRoute('/_portal/b/$slug/posts/$postId')({
   loader: async ({ params, context }) => {
@@ -155,9 +158,14 @@ function PostDetailPage() {
   // author rights go through the permission-enforced admin path.
   const effectiveCanEdit = canEdit || team.canTeamEdit
   const effectiveCanDelete = canDelete || team.canTeamDelete
+  const { can } = usePortalPermissions()
+  const canModerate = can(PERMISSIONS.POST_APPROVE)
+  const approvePost = useApprovePost(postId)
+  const rejectPost = useRejectPost(postId)
 
   const isAnonymousSession = session?.user?.principalType === 'anonymous'
   const canUploadImages = effectiveCanEdit && !isAnonymousSession && !!session?.user
+  const canUploadCommentImages = !isAnonymousSession && !!session?.user
   const { upload: uploadImage } = usePortalImageUpload()
 
   const {
@@ -311,6 +319,10 @@ function PostDetailPage() {
             onEditCancel={() => setIsEditingPost(false)}
             onImageUpload={canUploadImages ? uploadImage : undefined}
             isSaving={isSavingEdit || team.isTeamSavingEdit}
+            canModerate={canModerate}
+            moderationBusy={approvePost.isPending || rejectPost.isPending}
+            onApprove={() => approvePost.mutate(postId)}
+            onReject={() => rejectPost.mutate({ postId })}
           />
 
           <Suspense fallback={<MetadataSidebarSkeleton />}>
@@ -385,6 +397,8 @@ function PostDetailPage() {
                 ? Math.max(0, post.commentsTotalRootCount - post.comments.length)
                 : undefined
             }
+            onImageUpload={canUploadCommentImages ? uploadImage : undefined}
+            canModerate={canModerate}
           />
         </Suspense>
       </div>

--- a/apps/web/src/routes/admin/moderation.tsx
+++ b/apps/web/src/routes/admin/moderation.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, Link } from '@tanstack/react-router'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'react'
 import { ShieldCheckIcon } from '@heroicons/react/24/outline'
@@ -16,6 +16,8 @@ import { Button } from '@/components/ui/button'
 import { Spinner } from '@/components/shared/spinner'
 import { EmptyState } from '@/components/shared/empty-state'
 import { PageHeader } from '@/components/shared/page-header'
+import { CommentContent } from '@/components/public/comment-content'
+import type { TiptapContent } from '@/lib/shared/db-types'
 
 export const Route = createFileRoute('/admin/moderation')({
   // Auth is enforced by the parent `/admin` guard (admin/member wall) plus each
@@ -117,7 +119,15 @@ function ModerationPage() {
                       className="flex items-start justify-between gap-4 rounded-lg border bg-card p-4"
                     >
                       <div className="min-w-0 flex-1">
-                        <p className="font-medium truncate">{post.title}</p>
+                        <p className="font-medium truncate">
+                          <Link
+                            to="/admin/feedback"
+                            search={{ post: post.id as string }}
+                            className="hover:underline"
+                          >
+                            {post.title}
+                          </Link>
+                        </p>
                         <p className="mt-0.5 text-xs text-muted-foreground">
                           by {post.authorName ?? 'Anonymous'} in {post.boardName}
                         </p>
@@ -168,15 +178,25 @@ function ModerationPage() {
                       <div className="min-w-0 flex-1">
                         <p className="text-sm text-muted-foreground">
                           on{' '}
-                          <span className="font-medium text-foreground">{comment.postTitle}</span>{' '}
+                          <Link
+                            to="/admin/feedback"
+                            search={{ post: comment.postId as string }}
+                            hash={`comment-${comment.id}`}
+                            className="font-medium text-foreground hover:underline"
+                          >
+                            {comment.postTitle}
+                          </Link>{' '}
                           in {comment.boardName}
                         </p>
                         <p className="mt-0.5 text-xs text-muted-foreground">
                           by {comment.authorName ?? 'Anonymous'}
                         </p>
-                        <p className="mt-1 text-sm text-foreground line-clamp-3">
-                          {comment.content}
-                        </p>
+                        <div className="mt-1 text-sm text-foreground line-clamp-3">
+                          <CommentContent
+                            content={comment.content}
+                            contentJson={comment.contentJson as TiptapContent | null}
+                          />
+                        </div>
                       </div>
                       <div className="flex shrink-0 gap-2">
                         <Button

--- a/apps/web/src/routes/admin/settings.moderation.tsx
+++ b/apps/web/src/routes/admin/settings.moderation.tsx
@@ -87,6 +87,12 @@ function ModerationPage() {
   const [moderationToggles, setModerationToggles] = useState<ApprovalToggles>(() =>
     requireApprovalToToggles(portalConfigQuery.data.moderationDefault?.requireApproval ?? 'none')
   )
+  const [holdImages, setHoldImages] = useState(
+    portalConfigQuery.data.moderationDefault?.holdImages === true
+  )
+  const [holdLinks, setHoldLinks] = useState(
+    portalConfigQuery.data.moderationDefault?.holdLinks === true
+  )
 
   const [savingField, setSavingField] = useState<string | null>(null)
 
@@ -116,6 +122,23 @@ function ModerationPage() {
       startTransition(() => router.invalidate())
     } catch {
       setModerationToggles(prev)
+    } finally {
+      setSavingField(null)
+    }
+  }
+
+  async function updateContentHold(key: 'holdImages' | 'holdLinks', checked: boolean) {
+    const setFlag = key === 'holdImages' ? setHoldImages : setHoldLinks
+    setFlag(checked)
+    setSavingField(`moderation-${key}`)
+    try {
+      await updateModerationDefault.mutateAsync({
+        requireApproval: togglesToRequireApproval(moderationToggles),
+        [key]: checked,
+      })
+      startTransition(() => router.invalidate())
+    } catch {
+      setFlag(!checked)
     } finally {
       setSavingField(null)
     }
@@ -175,6 +198,32 @@ function ModerationPage() {
             checked={moderationToggles.authenticated}
             saving={savingField === 'moderation-authenticated'}
             onCheckedChange={(checked) => updateModeration('authenticated', checked)}
+            disabled={isBusy}
+          />
+        </div>
+      </SettingsCard>
+
+      <SettingsCard
+        title="Content review"
+        description="Hold submissions that include media or outbound links, regardless of who authored them."
+      >
+        <div className="divide-y divide-border/50">
+          <PermissionToggle
+            id="moderate-images"
+            label="Hold posts and comments that contain images"
+            description="Submissions with an attached or embedded image wait for review before they appear."
+            checked={holdImages}
+            saving={savingField === 'moderation-holdImages'}
+            onCheckedChange={(checked) => updateContentHold('holdImages', checked)}
+            disabled={isBusy}
+          />
+          <PermissionToggle
+            id="moderate-links"
+            label="Hold posts and comments that contain links"
+            description="Submissions with an external link wait for review before they appear."
+            checked={holdLinks}
+            saving={savingField === 'moderation-holdLinks'}
+            onCheckedChange={(checked) => updateContentHold('holdLinks', checked)}
             disabled={isBusy}
           />
         </div>

--- a/apps/web/src/routes/api/portal/__tests__/upload.test.ts
+++ b/apps/web/src/routes/api/portal/__tests__/upload.test.ts
@@ -25,6 +25,14 @@ vi.mock('@/lib/server/storage/s3', async () => {
   return createS3MockFactory()
 })
 
+const { incrementBucket } = vi.hoisted(() => ({
+  incrementBucket: vi.fn().mockResolvedValue({ count: 1 }),
+}))
+vi.mock('@/lib/server/utils/redis-rate-bucket', () => ({
+  incrementBucket: (...args: unknown[]) => incrementBucket(...args),
+  bucketRetryAfter: vi.fn().mockResolvedValue(60),
+}))
+
 import { auth } from '@/lib/server/auth'
 import { db } from '@/lib/server/db'
 import { isS3Configured, uploadObject } from '@/lib/server/storage/s3'
@@ -118,6 +126,16 @@ describe('POST /api/portal/upload', () => {
       expect.any(Buffer),
       'image/jpeg'
     )
+  })
+
+  it('returns 429 when the per-principal upload quota is exceeded', async () => {
+    incrementBucket.mockResolvedValueOnce({ count: 21 })
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce(identifiedSession)
+    vi.mocked(db.query.principal.findFirst).mockResolvedValueOnce(identifiedPrincipal)
+    const file = mockImageFile('photo.jpg', 'image/jpeg')
+    const res = await handlePortalUpload({ request: makeRequest(file) })
+    expect(res.status).toBe(429)
+    expect(await res.json()).toMatchObject({ error: expect.stringContaining('Too many uploads') })
   })
 
   it('uses portal-images prefix for storage key', async () => {

--- a/apps/web/src/routes/api/portal/upload.ts
+++ b/apps/web/src/routes/api/portal/upload.ts
@@ -3,6 +3,7 @@ import type { UserId } from '@quackback/ids'
 import { auth } from '@/lib/server/auth'
 import { db, eq, principal } from '@/lib/server/db'
 import { isS3Configured, uploadImageFromFormData } from '@/lib/server/storage/s3'
+import { incrementBucket, bucketRetryAfter } from '@/lib/server/utils/redis-rate-bucket'
 
 export async function handlePortalUpload({ request }: { request: Request }): Promise<Response> {
   const session = await auth.api.getSession({ headers: request.headers })
@@ -15,6 +16,15 @@ export async function handlePortalUpload({ request }: { request: Request }): Pro
   })
   if (!principalRecord || principalRecord.type === 'anonymous') {
     return Response.json({ error: 'Authentication required to upload images' }, { status: 403 })
+  }
+  const bucket = { key: `portal-upload:user:${session.user.id}`, windowSeconds: 60 }
+  const { count } = await incrementBucket(bucket)
+  if (count !== null && count > 20) {
+    const retryAfter = await bucketRetryAfter(bucket)
+    return Response.json(
+      { error: 'Too many uploads, slow down' },
+      { status: 429, headers: { 'Retry-After': String(retryAfter) } }
+    )
   }
   if (!isS3Configured()) {
     return Response.json({ error: 'Storage not configured' }, { status: 503 })

--- a/apps/web/src/routes/api/v1/comments/$commentId.ts
+++ b/apps/web/src/routes/api/v1/comments/$commentId.ts
@@ -11,6 +11,7 @@ import {
 import { parseTypeId } from '@/lib/server/domains/api/validation'
 import { PERMISSIONS } from '@/lib/shared/permissions'
 import type { PostCommentId } from '@quackback/ids'
+import { contentJsonToMarkdown } from '@/lib/server/markdown-tiptap'
 
 // Input validation schema
 const updateCommentSchema = z.object({
@@ -43,7 +44,8 @@ export const Route = createFileRoute('/api/v1/comments/$commentId')({
             id: comment.id,
             postId: comment.postId,
             parentId: comment.parentId,
-            content: comment.content,
+            content: contentJsonToMarkdown(comment.contentJson, comment.content),
+            contentJson: comment.contentJson ?? null,
             authorName: comment.authorName,
             authorEmail: comment.authorEmail,
             principalId: comment.principalId,
@@ -114,7 +116,8 @@ export const Route = createFileRoute('/api/v1/comments/$commentId')({
             id: result.id,
             postId: result.postId,
             parentId: result.parentId,
-            content: result.content,
+            content: contentJsonToMarkdown(result.contentJson, result.content),
+            contentJson: result.contentJson ?? null,
             authorName: commentMember?.user?.name ?? null,
             principalId: result.principalId,
             isTeamMember: result.isTeamMember,

--- a/apps/web/src/routes/api/v1/posts/$postId.comments.ts
+++ b/apps/web/src/routes/api/v1/posts/$postId.comments.ts
@@ -12,6 +12,7 @@ import {
 import { parseTypeId, parseOptionalTypeId } from '@/lib/server/domains/api/validation'
 import type { Role } from '@/lib/shared/roles'
 import type { PostId, PostCommentId, PrincipalId } from '@quackback/ids'
+import { contentJsonToMarkdown } from '@/lib/server/markdown-tiptap'
 
 // Input validation schema
 const createCommentSchema = z.object({
@@ -44,7 +45,8 @@ export const Route = createFileRoute('/api/v1/posts/$postId/comments')({
             id: c.id,
             postId: c.postId,
             parentId: c.parentId,
-            content: c.content,
+            content: contentJsonToMarkdown(c.contentJson, c.content),
+            contentJson: c.contentJson ?? null,
             authorName: c.authorName,
             principalId: c.principalId,
             isTeamMember: c.isTeamMember,

--- a/apps/web/src/routes/api/v1/posts/$postId.ts
+++ b/apps/web/src/routes/api/v1/posts/$postId.ts
@@ -76,7 +76,11 @@ export const Route = createFileRoute('/api/v1/posts/$postId')({
             pinnedComment: post.pinnedComment
               ? {
                   id: post.pinnedComment.id,
-                  content: post.pinnedComment.content,
+                  content: contentJsonToMarkdown(
+                    post.pinnedComment.contentJson,
+                    post.pinnedComment.content
+                  ),
+                  contentJson: post.pinnedComment.contentJson ?? null,
                   authorName: post.pinnedComment.authorName,
                   createdAt: post.pinnedComment.createdAt.toISOString(),
                 }


### PR DESCRIPTION
## Summary

- Comments use the same rich editor as posts (images, links, tables, embeds, code blocks). Portal, widget, and admin composers can insert images; anonymous portal sessions still cannot. Comment images rehost to a private `comment-images` prefix and project into markdown only when the doc actually contains an image, so text-only comments still round-trip.
- Workspace moderation gains two content holds: submissions with images, and submissions with external links. Both apply to posts and comments on create and non-team edit. Team members still bypass. Settings → Moderation has the new toggles.
- Held posts and comments now render in place for people who can approve them (inbox, portal feed, post detail, comment threads) with inline Approve/Reject. Customers still only see published items; authors still see their own pending items. The moderation queue stays the attention list and links into those surfaces instead of quarantining a second copy of pending posts on the portal.

## Test plan

- [ ] Signed-in portal user: insert an image into a comment (toolbar / slash / paste); it renders in the thread. Sign out / anonymous: no image insert control.
- [ ] Settings → Moderation: enable “hold images” and “hold links”. Create a post and a comment with each; both land pending. Text-only submissions still publish when author-type rules allow it.
- [ ] As a moderator: pending posts appear in the inbox and portal feed with Approve/Reject. Pending comments show the same bar in the thread. After approve they become public; reject still soft-deletes.
- [ ] As a customer: pending posts/comments stay hidden. As the author: own pending items remain visible without approve/reject.
- [ ] `/admin/moderation` still lists pending posts and comments, with links into the inbox post. Enabling content holds with `requireApproval: none` still shows the queue nav.
- [ ] REST/MCP comment create with `![alt](url)` keeps the image; text-only comments return the original content string.