### PR TITLE
feat(feedback): show matching counts on inbox filter options

### DIFF
--- a/apps/web/src/components/admin/feedback/__tests__/single-select-filter-list.test.tsx
+++ b/apps/web/src/components/admin/feedback/__tests__/single-select-filter-list.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { FilterList, StatusFilterList } from '../single-select-filter-list'
+
+afterEach(cleanup)
+
+describe('FilterList counts', () => {
+  it('renders a count next to each item when counts are provided', () => {
+    render(
+      <FilterList
+        items={[
+          { id: 'responded', name: 'Responded' },
+          { id: 'unresponded', name: 'Unresponded' },
+        ]}
+        selectedIds={[]}
+        onSelect={() => {}}
+        counts={{ responded: 4, unresponded: 12 }}
+      />
+    )
+
+    expect(screen.getByRole('option', { name: 'Responded, 4' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Unresponded, 12' })).toBeInTheDocument()
+  })
+
+  it('hides counts while they are still loading', () => {
+    render(
+      <FilterList
+        items={[{ id: 'deleted', name: 'Deleted posts' }]}
+        selectedIds={[]}
+        onSelect={() => {}}
+      />
+    )
+
+    expect(screen.getByRole('option', { name: 'Deleted posts' })).toBeInTheDocument()
+    expect(screen.queryByText('0')).not.toBeInTheDocument()
+  })
+
+  it('shows 0 when a loaded counts map has no entry for the item', () => {
+    render(
+      <FilterList
+        items={[{ id: 'deleted', name: 'Deleted posts' }]}
+        selectedIds={[]}
+        onSelect={() => {}}
+        counts={{}}
+      />
+    )
+
+    expect(screen.getByRole('option', { name: 'Deleted posts, 0' })).toBeInTheDocument()
+  })
+
+  it('forwards a click to onSelect', async () => {
+    const onSelect = vi.fn()
+    render(
+      <FilterList
+        items={[{ id: 'responded', name: 'Responded' }]}
+        selectedIds={[]}
+        onSelect={onSelect}
+        counts={{ responded: 1 }}
+      />
+    )
+
+    screen.getByRole('option', { name: 'Responded, 1' }).click()
+    expect(onSelect).toHaveBeenCalledWith('responded', false)
+  })
+})
+
+describe('StatusFilterList counts', () => {
+  it('shows the status name and count', () => {
+    render(
+      <StatusFilterList
+        statuses={[{ id: 's1', slug: 'open', name: 'Open', color: '#3b82f6' }]}
+        selectedSlugs={[]}
+        onSelect={() => {}}
+        counts={{ open: 8 }}
+      />
+    )
+
+    expect(screen.getByRole('option', { name: 'Open, 8' })).toBeInTheDocument()
+    expect(screen.getByText('Open')).toBeInTheDocument()
+    expect(screen.getByText('8')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/admin/feedback/inbox-filters.tsx
+++ b/apps/web/src/components/admin/feedback/inbox-filters.tsx
@@ -1,7 +1,11 @@
 import { FilterList, StatusFilterList, BoardFilterList } from './single-select-filter-list'
 import { toggleItem } from '@/components/shared/filter-utils'
 import { FilterSection } from '@/components/shared/filter-section'
+import { MENU_ROW } from '@/components/ui/menu'
+import { cn } from '@/lib/shared/utils'
+import { useInboxFacetCounts } from '@/lib/client/hooks/use-inbox-query'
 import type { InboxFilters } from '@/components/admin/feedback/use-inbox-filters'
+import type { InboxFilterCounts } from '@/lib/shared/types'
 import type { Board, PostTag, PostStatusEntity } from '@/lib/shared/db-types'
 import type { SegmentListItem } from '@/lib/client/hooks/use-segments-queries'
 
@@ -14,6 +18,11 @@ interface InboxFiltersProps {
   segments?: SegmentListItem[]
 }
 
+function countFor(counts: Record<string, number> | undefined, id: string): number | undefined {
+  if (!counts) return undefined
+  return counts[id] ?? 0
+}
+
 export function InboxFiltersPanel({
   filters,
   onFiltersChange,
@@ -22,6 +31,8 @@ export function InboxFiltersPanel({
   statuses,
   segments,
 }: InboxFiltersProps) {
+  const { data: facetCounts } = useInboxFacetCounts(filters)
+
   // Handle filter selection with multi-select support
   // - Regular click: select only this item (replace), or clear if already the only one selected
   // - Ctrl/Cmd+click: add/remove from selection (toggle)
@@ -54,6 +65,9 @@ export function InboxFiltersPanel({
   const handleSegmentSelect = (id: string, addToSelection: boolean) =>
     handleFilterSelect('segmentIds', filters.segmentIds, id, addToSelection)
 
+  const respondedCounts = respondedCountMap(facetCounts)
+  const deletedCounts = deletedCountMap(facetCounts)
+
   return (
     <div className="space-y-0">
       {/* Status Filter */}
@@ -62,6 +76,7 @@ export function InboxFiltersPanel({
           statuses={statuses}
           selectedSlugs={filters.status || []}
           onSelect={handleStatusSelect}
+          counts={facetCounts?.statuses}
         />
       </FilterSection>
 
@@ -72,6 +87,7 @@ export function InboxFiltersPanel({
             boards={boards}
             selectedIds={filters.board || []}
             onSelect={handleBoardSelect}
+            counts={facetCounts?.boards}
           />
         </FilterSection>
       )}
@@ -82,11 +98,13 @@ export function InboxFiltersPanel({
           <div className="flex flex-wrap gap-1.5">
             {tags.map((tag) => {
               const isSelected = filters.tags?.includes(tag.id)
+              const count = countFor(facetCounts?.tags, tag.id)
               return (
                 <button
                   key={tag.id}
                   type="button"
                   onClick={() => handleTagToggle(tag.id)}
+                  aria-label={count == null ? tag.name : `${tag.name}, ${count}`}
                   className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium transition-colors ${
                     isSelected
                       ? 'bg-foreground text-background'
@@ -94,6 +112,9 @@ export function InboxFiltersPanel({
                   }`}
                 >
                   {tag.name}
+                  {count != null && (
+                    <span className="ml-1 text-[11px] tabular-nums opacity-70">{count}</span>
+                  )}
                 </button>
               )
             })}
@@ -104,28 +125,32 @@ export function InboxFiltersPanel({
       {/* Segments Filter */}
       {segments && segments.length > 0 && (
         <FilterSection title="Segments" defaultOpen={true}>
-          <div className="space-y-0.5">
+          <div className="space-y-1">
             {segments.map((segment) => {
               const isSelected = filters.segmentIds?.includes(segment.id)
+              const count = countFor(facetCounts?.segments, segment.id)
               return (
                 <button
                   key={segment.id}
                   type="button"
                   onClick={(e) => handleSegmentSelect(segment.id, e.ctrlKey || e.metaKey)}
-                  className={`w-full flex items-center gap-2 px-2.5 py-1.5 rounded-md text-[13px] transition-colors ${
+                  aria-label={count == null ? segment.name : `${segment.name}, ${count}`}
+                  className={cn(
+                    MENU_ROW,
+                    'w-full',
                     isSelected
-                      ? 'bg-foreground/10 text-foreground font-medium'
+                      ? 'bg-muted text-foreground font-medium'
                       : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground'
-                  }`}
+                  )}
                 >
                   <span
                     className="h-2.5 w-2.5 rounded-full shrink-0"
                     style={{ backgroundColor: segment.color }}
                   />
-                  <span className="truncate">{segment.name}</span>
-                  {segment.memberCount != null && (
-                    <span className="ml-auto text-[11px] text-muted-foreground">
-                      {segment.memberCount}
+                  <span className="min-w-0 flex-1 truncate text-left">{segment.name}</span>
+                  {count != null && (
+                    <span className="ml-auto shrink-0 text-[11px] tabular-nums text-muted-foreground">
+                      {count}
                     </span>
                   )}
                 </button>
@@ -149,6 +174,7 @@ export function InboxFiltersPanel({
               responded: isAlreadySelected ? undefined : (id as 'responded' | 'unresponded'),
             })
           }}
+          counts={respondedCounts}
         />
       </FilterSection>
 
@@ -160,8 +186,26 @@ export function InboxFiltersPanel({
           onSelect={() => {
             onFiltersChange({ showDeleted: !filters.showDeleted || undefined })
           }}
+          counts={deletedCounts}
         />
       </FilterSection>
     </div>
   )
+}
+
+function respondedCountMap(
+  counts: InboxFilterCounts | undefined
+): Record<string, number> | undefined {
+  if (!counts) return undefined
+  return {
+    responded: counts.responded.responded,
+    unresponded: counts.responded.unresponded,
+  }
+}
+
+function deletedCountMap(
+  counts: InboxFilterCounts | undefined
+): Record<string, number> | undefined {
+  if (!counts) return undefined
+  return { deleted: counts.deleted }
 }

--- a/apps/web/src/components/admin/feedback/single-select-filter-list.tsx
+++ b/apps/web/src/components/admin/feedback/single-select-filter-list.tsx
@@ -1,11 +1,21 @@
 import { cn } from '@/lib/shared/utils'
+import { MENU_ROW } from '@/components/ui/menu'
 
 interface FilterListProps<T extends { id: string; name: string }> {
   items: T[]
   selectedIds: string[]
   onSelect: (id: string, addToSelection: boolean) => void
   renderItem?: (item: T, isSelected: boolean) => React.ReactNode
+  /** Per-item counts keyed by item id. Omitted while counts are loading. */
+  counts?: Record<string, number>
   className?: string
+}
+
+function FilterCount({ count }: { count: number | undefined }) {
+  if (count == null) return null
+  return (
+    <span className="ml-auto shrink-0 text-[11px] tabular-nums text-muted-foreground">{count}</span>
+  )
 }
 
 export function FilterList<T extends { id: string; name: string }>({
@@ -13,6 +23,7 @@ export function FilterList<T extends { id: string; name: string }>({
   selectedIds,
   onSelect,
   renderItem,
+  counts,
   className,
 }: FilterListProps<T>) {
   const handleClick = (id: string, event: React.MouseEvent) => {
@@ -24,15 +35,18 @@ export function FilterList<T extends { id: string; name: string }>({
     <div className={cn('space-y-1', className)} role="listbox" aria-label="Filter selection">
       {items.map((item) => {
         const isSelected = selectedIds.includes(item.id)
+        const count = counts ? (counts[item.id] ?? 0) : undefined
         return (
           <button
             key={item.id}
             type="button"
             role="option"
             aria-selected={isSelected}
+            aria-label={count == null ? item.name : `${item.name}, ${count}`}
             onClick={(e) => handleClick(item.id, e)}
             className={cn(
-              'w-full text-left px-2.5 py-1.5 rounded-md text-[13px] font-normal transition-colors',
+              MENU_ROW,
+              'w-full',
               isSelected
                 ? 'bg-muted text-foreground font-medium'
                 : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
@@ -41,8 +55,9 @@ export function FilterList<T extends { id: string; name: string }>({
             {renderItem ? (
               renderItem(item, isSelected)
             ) : (
-              <span className="truncate">{item.name}</span>
+              <span className="min-w-0 flex-1 truncate text-left">{item.name}</span>
             )}
+            <FilterCount count={count} />
           </button>
         )
       })}
@@ -55,9 +70,15 @@ interface StatusFilterListProps {
   statuses: Array<{ id: string; slug: string; name: string; color: string }>
   selectedSlugs: string[]
   onSelect: (slug: string, addToSelection: boolean) => void
+  counts?: Record<string, number>
 }
 
-export function StatusFilterList({ statuses, selectedSlugs, onSelect }: StatusFilterListProps) {
+export function StatusFilterList({
+  statuses,
+  selectedSlugs,
+  onSelect,
+  counts,
+}: StatusFilterListProps) {
   const items = statuses.map((s) => ({ id: s.slug, name: s.name, color: s.color }))
 
   return (
@@ -65,8 +86,9 @@ export function StatusFilterList({ statuses, selectedSlugs, onSelect }: StatusFi
       items={items}
       selectedIds={selectedSlugs}
       onSelect={onSelect}
+      counts={counts}
       renderItem={(status) => (
-        <span className="flex items-center gap-2">
+        <span className="flex min-w-0 flex-1 items-center gap-2">
           <span
             className="h-2.5 w-2.5 rounded-full shrink-0"
             style={{ backgroundColor: status.color }}
@@ -84,10 +106,12 @@ export function BoardFilterList({
   boards,
   selectedIds,
   onSelect,
+  counts,
 }: {
   boards: Array<{ id: string; name: string }>
   selectedIds: string[]
   onSelect: (id: string, addToSelection: boolean) => void
+  counts?: Record<string, number>
 }) {
-  return <FilterList items={boards} selectedIds={selectedIds} onSelect={onSelect} />
+  return <FilterList items={boards} selectedIds={selectedIds} onSelect={onSelect} counts={counts} />
 }

--- a/apps/web/src/lib/client/hooks/use-inbox-query.ts
+++ b/apps/web/src/lib/client/hooks/use-inbox-query.ts
@@ -9,10 +9,15 @@ import {
   useQuery,
   useInfiniteQuery,
   infiniteQueryOptions,
+  queryOptions,
   keepPreviousData,
   type InfiniteData,
 } from '@tanstack/react-query'
-import { fetchInboxPostsForAdmin, fetchPostWithDetails } from '@/lib/server/functions/posts'
+import {
+  fetchInboxPostsForAdmin,
+  fetchInboxFilterCounts,
+  fetchPostWithDetails,
+} from '@/lib/server/functions/posts'
 import type { InboxFilters, PostDetails } from '@/lib/shared/types'
 import type { PostListItem, InboxPostListResult } from '@/lib/shared/db-types'
 import type { BoardId, PrincipalId, PostId, PostTagId, SegmentId } from '@quackback/ids'
@@ -38,6 +43,8 @@ export const inboxKeys = {
   all: ['inbox'] as const,
   lists: () => [...inboxKeys.all, 'list'] as const,
   list: (filters: InboxFilters) => [...inboxKeys.lists(), filters] as const,
+  /** Nested under lists() so mutations that invalidate the list also refresh counts. */
+  facetCounts: (filters: InboxFilters) => [...inboxKeys.lists(), 'facet-counts', filters] as const,
   details: () => [...inboxKeys.all, 'detail'] as const,
   detail: (postId: PostId) => [...inboxKeys.details(), postId] as const,
 }
@@ -46,26 +53,39 @@ export const inboxKeys = {
 // Fetch Functions
 // ============================================================================
 
+/** Shared list/count payload. Sort, cursor, and limit are list-only. */
+function toInboxListInput(filters: InboxFilters) {
+  return {
+    boardIds: filters.board as BoardId[] | undefined,
+    statusSlugs: filters.status,
+    tagIds: filters.tags as PostTagId[] | undefined,
+    segmentIds: filters.segmentIds as SegmentId[] | undefined,
+    ownerId: (filters.owner || undefined) as PrincipalId | null | undefined,
+    search: filters.search,
+    dateFrom: filters.dateFrom,
+    dateTo: filters.dateTo,
+    minVotes: filters.minVotes,
+    minComments: filters.minComments,
+    responded: filters.responded,
+    updatedBefore: filters.updatedBefore,
+    showDeleted: filters.showDeleted,
+  }
+}
+
+/** Sort does not affect facet counts, so drop it from the counts cache key. */
+function facetCountFilters(filters: InboxFilters): InboxFilters {
+  const { sort: _sort, ...rest } = filters
+  return rest
+}
+
 async function fetchInboxPosts(
   filters: InboxFilters,
   cursor?: string
 ): Promise<InboxPostListResult> {
   return (await fetchInboxPostsForAdmin({
     data: {
-      boardIds: filters.board as BoardId[] | undefined,
-      statusSlugs: filters.status,
-      tagIds: filters.tags as PostTagId[] | undefined,
-      segmentIds: filters.segmentIds as SegmentId[] | undefined,
-      ownerId: (filters.owner || undefined) as PrincipalId | null | undefined,
-      search: filters.search,
-      dateFrom: filters.dateFrom,
-      dateTo: filters.dateTo,
-      minVotes: filters.minVotes,
-      minComments: filters.minComments,
-      responded: filters.responded,
-      updatedBefore: filters.updatedBefore,
+      ...toInboxListInput(filters),
       sort: filters.sort,
-      showDeleted: filters.showDeleted,
       cursor,
       limit: 20,
     },
@@ -124,6 +144,24 @@ export function useInboxPosts({ filters }: UseInboxPostsOptions) {
     ...inboxPostsInfiniteOptions(filters),
     placeholderData: keepPreviousData,
   })
+}
+
+/**
+ * Facet counts for the inbox filter pane. Nested under `inboxKeys.lists()` so
+ * post mutations that invalidate the list also refresh counts.
+ */
+export function inboxFacetCountsOptions(filters: InboxFilters) {
+  const countFilters = facetCountFilters(filters)
+  return queryOptions({
+    queryKey: inboxKeys.facetCounts(countFilters),
+    queryFn: () => fetchInboxFilterCounts({ data: toInboxListInput(countFilters) }),
+    placeholderData: keepPreviousData,
+    staleTime: 15_000,
+  })
+}
+
+export function useInboxFacetCounts(filters: InboxFilters) {
+  return useQuery(inboxFacetCountsOptions(filters))
 }
 
 export function usePostDetail({ postId, enabled = true }: UsePostDetailOptions) {

--- a/apps/web/src/lib/server/domains/posts/__tests__/post.inbox-filter-counts.test.ts
+++ b/apps/web/src/lib/server/domains/posts/__tests__/post.inbox-filter-counts.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Inbox filter facet counts: each dimension omits its own filter so the
+ * number next to an option is "other currently applied filters + posts that
+ * would newly match this option". Pure unit test — mocks drizzle like
+ * post.inbox-moderation.test.ts.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockPosts = {
+  id: Symbol('posts.id'),
+  boardId: Symbol('posts.boardId'),
+  principalId: Symbol('posts.principalId'),
+  ownerPrincipalId: Symbol('posts.ownerPrincipalId'),
+  statusId: Symbol('posts.statusId'),
+  canonicalPostId: Symbol('posts.canonicalPostId'),
+  deletedAt: Symbol('posts.deletedAt'),
+  moderationState: Symbol('posts.moderationState'),
+  voteCount: Symbol('posts.voteCount'),
+  commentCount: Symbol('posts.commentCount'),
+  createdAt: Symbol('posts.createdAt'),
+  updatedAt: Symbol('posts.updatedAt'),
+  searchVector: Symbol('posts.searchVector'),
+}
+
+const mockPostStatuses = { id: Symbol('postStatuses.id'), slug: Symbol('postStatuses.slug') }
+const mockTagAssignments = {
+  postId: Symbol('postTagAssignments.postId'),
+  tagId: Symbol('postTagAssignments.tagId'),
+}
+const mockUserSegments = {
+  principalId: Symbol('userSegments.principalId'),
+  segmentId: Symbol('userSegments.segmentId'),
+}
+
+const mockNe = vi.fn((col, val) => ({ _tag: 'ne', col, val }))
+const mockIsNull = vi.fn((col) => ({ _tag: 'isNull', col }))
+const mockIsNotNull = vi.fn((col) => ({ _tag: 'isNotNull', col }))
+const mockAnd = vi.fn((...args) => ({ _tag: 'and', args }))
+const mockInArray = vi.fn((col, arr) => ({ _tag: 'inArray', col, arr }))
+const mockEq = vi.fn((col, val) => ({ _tag: 'eq', col, val }))
+const mockSql = vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
+  _tag: 'sql',
+  text: strings.join('?'),
+  values,
+}))
+
+function selectBuilder(result: unknown = []) {
+  const builder: Record<string | symbol, unknown> = {}
+  const passthrough = () => builder
+  for (const method of ['from', 'innerJoin', 'leftJoin', 'where', 'groupBy', 'orderBy', 'limit']) {
+    builder[method] = vi.fn(passthrough)
+  }
+  builder.then = (onFulfilled: (v: unknown) => unknown, onRejected?: (e: unknown) => unknown) =>
+    Promise.resolve(result).then(onFulfilled, onRejected)
+  return builder
+}
+
+const mockDbSelect = vi.fn(() => selectBuilder())
+const mockSelectDistinct = vi.fn(() => selectBuilder())
+
+vi.mock('@/lib/server/db', () => ({
+  db: {
+    query: {
+      posts: {
+        findMany: vi.fn().mockResolvedValue([]),
+        findFirst: vi.fn().mockResolvedValue(null),
+      },
+    },
+    select: mockDbSelect,
+    selectDistinct: mockSelectDistinct,
+  },
+  posts: mockPosts,
+  postStatuses: mockPostStatuses,
+  postTagAssignments: mockTagAssignments,
+  userSegments: mockUserSegments,
+  ne: mockNe,
+  eq: mockEq,
+  and: mockAnd,
+  isNull: mockIsNull,
+  isNotNull: mockIsNotNull,
+  inArray: mockInArray,
+  desc: vi.fn((col) => ({ _tag: 'desc', col })),
+  asc: vi.fn((col) => ({ _tag: 'asc', col })),
+  sql: mockSql,
+}))
+
+async function loadInbox() {
+  return import('../post.inbox')
+}
+
+describe('inboxFilterConditions — disjunctive facet omit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('applies board + status together when nothing is omitted', async () => {
+    const { inboxFilterConditions } = await loadInbox()
+    inboxFilterConditions({
+      boardIds: ['board_1'] as never,
+      statusSlugs: ['open'],
+    })
+
+    expect(mockInArray.mock.calls.some(([col]) => col === mockPosts.boardId)).toBe(true)
+    expect(mockInArray.mock.calls.some(([col]) => col === mockPosts.statusId)).toBe(true)
+  })
+
+  it('omitting status keeps other filters (board) and skips the status predicate', async () => {
+    const { inboxFilterConditions } = await loadInbox()
+    inboxFilterConditions(
+      {
+        boardIds: ['board_1'] as never,
+        statusSlugs: ['open'],
+      },
+      'status'
+    )
+
+    expect(mockInArray.mock.calls.some(([col]) => col === mockPosts.boardId)).toBe(true)
+    expect(mockInArray.mock.calls.some(([col]) => col === mockPosts.statusId)).toBe(false)
+  })
+
+  it('omitting board keeps the status predicate and skips the board predicate', async () => {
+    const { inboxFilterConditions } = await loadInbox()
+    inboxFilterConditions(
+      {
+        boardIds: ['board_1'] as never,
+        statusSlugs: ['open'],
+      },
+      'board'
+    )
+
+    expect(mockInArray.mock.calls.some(([col]) => col === mockPosts.boardId)).toBe(false)
+    expect(mockInArray.mock.calls.some(([col]) => col === mockPosts.statusId)).toBe(true)
+  })
+
+  it('omitting tags skips the tag-assignment subquery', async () => {
+    const { inboxFilterConditions } = await loadInbox()
+    inboxFilterConditions({ tagIds: ['tag_1'] as never }, 'tags')
+
+    expect(mockInArray.mock.calls.some(([col]) => col === mockPosts.id)).toBe(false)
+  })
+
+  it('omitting segments skips the segment membership subquery', async () => {
+    const { inboxFilterConditions } = await loadInbox()
+    inboxFilterConditions({ segmentIds: ['seg_1'] as never }, 'segments')
+
+    expect(mockInArray.mock.calls.some(([col]) => col === mockPosts.principalId)).toBe(false)
+  })
+
+  it('omitting deleted skips both the live and restorable-deleted predicates', async () => {
+    const { inboxFilterConditions } = await loadInbox()
+    inboxFilterConditions({}, 'deleted')
+
+    expect(mockIsNull.mock.calls.some(([col]) => col === mockPosts.deletedAt)).toBe(false)
+    expect(mockIsNotNull.mock.calls.some(([col]) => col === mockPosts.deletedAt)).toBe(false)
+    expect(
+      mockNe.mock.calls.some(([col, val]) => col === mockPosts.moderationState && val === 'pending')
+    ).toBe(false)
+  })
+
+  it('still constrains to live (non-deleted) posts when counting a non-deleted facet', async () => {
+    const { inboxFilterConditions } = await loadInbox()
+    inboxFilterConditions({}, 'status')
+
+    expect(mockIsNull.mock.calls.some(([col]) => col === mockPosts.deletedAt)).toBe(true)
+    expect(
+      mockNe.mock.calls.some(([col, val]) => col === mockPosts.moderationState && val === 'pending')
+    ).toBe(false)
+  })
+})
+
+describe('countInboxFilterFacets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('issues one grouped query per facet and maps rows onto the count payload', async () => {
+    const builders: ReturnType<typeof selectBuilder>[] = []
+    mockDbSelect.mockImplementation((cols?: Record<string, unknown>) => {
+      let result: unknown = []
+      if (cols && 'key' in cols && cols.key === mockPostStatuses.slug) {
+        result = [{ key: 'open', count: 4 }]
+      } else if (cols && 'key' in cols && cols.key === mockPosts.boardId) {
+        result = [{ key: 'board_1', count: 7 }]
+      } else if (cols && 'key' in cols && cols.key === mockTagAssignments.tagId) {
+        result = [{ key: 'tag_1', count: 2 }]
+      } else if (cols && 'key' in cols && cols.key === mockUserSegments.segmentId) {
+        result = [{ key: 'seg_1', count: 1 }]
+      } else if (cols && 'responded' in cols) {
+        result = [{ responded: 3, unresponded: 5 }]
+      } else if (cols && 'count' in cols && !('key' in cols)) {
+        result = [{ count: 9 }]
+      }
+      const builder = selectBuilder(result)
+      builders.push(builder)
+      return builder
+    })
+
+    const { countInboxFilterFacets } = await loadInbox()
+    const counts = await countInboxFilterFacets({ statusSlugs: ['open'] })
+
+    expect(counts.statuses).toEqual({ open: 4 })
+    expect(counts.boards).toEqual({ board_1: 7 })
+    expect(counts.tags).toEqual({ tag_1: 2 })
+    expect(counts.segments).toEqual({ seg_1: 1 })
+    expect(counts.responded).toEqual({ responded: 3, unresponded: 5 })
+    expect(counts.deleted).toBe(9)
+
+    expect(
+      builders.some((b) => (b.groupBy as ReturnType<typeof vi.fn>).mock.calls.length > 0)
+    ).toBe(true)
+    expect(
+      builders.some((b) => (b.innerJoin as ReturnType<typeof vi.fn>).mock.calls.length > 0)
+    ).toBe(true)
+  })
+})

--- a/apps/web/src/lib/server/domains/posts/index.ts
+++ b/apps/web/src/lib/server/domains/posts/index.ts
@@ -26,6 +26,7 @@ export type {
   PublicPostListItem,
   InboxPostListParams,
   InboxPostListResult,
+  InboxFilterCounts,
   PostListItem,
   PostForExport,
   CreatePostResult,

--- a/apps/web/src/lib/server/domains/posts/post.inbox.ts
+++ b/apps/web/src/lib/server/domains/posts/post.inbox.ts
@@ -20,7 +20,155 @@ import {
   isNotNull,
 } from '@/lib/server/db'
 import { toUuid, type PostId, type PrincipalId } from '@quackback/ids'
-import type { PostListItem, InboxPostListParams, InboxPostListResult } from './post.types'
+import type {
+  PostListItem,
+  InboxPostListParams,
+  InboxPostListResult,
+  InboxFilterCounts,
+} from './post.types'
+
+/** Facet whose own filter is skipped when counting that facet's options. */
+export type InboxFilterFacet = 'status' | 'board' | 'tags' | 'segments' | 'responded' | 'deleted'
+
+const RESTORABLE_DELETED_MS = 30 * 24 * 60 * 60 * 1000
+
+/**
+ * Team-member comment exists. Raw SQL table/column names — Drizzle's
+ * relational query builder rewrites `${postComments.postId}` onto the outer
+ * posts alias, producing `"posts"."post_id"`.
+ */
+const teamResponseExistsSql = sql`EXISTS (SELECT 1 FROM post_comments WHERE post_comments.post_id = ${posts.id} AND post_comments.is_team_member = true AND post_comments.deleted_at IS NULL)`
+
+function restorableDeletedConditions() {
+  const thirtyDaysAgo = new Date(Date.now() - RESTORABLE_DELETED_MS).toISOString()
+  return [isNotNull(posts.deletedAt), sql`${posts.deletedAt} >= ${thirtyDaysAgo}`]
+}
+
+function toCountMap(rows: Array<{ key: string | null; count: number }>): Record<string, number> {
+  const out: Record<string, number> = {}
+  for (const row of rows) {
+    if (row.key != null) out[row.key] = Number(row.count) || 0
+  }
+  return out
+}
+
+/**
+ * Shared inbox WHERE predicates. `omit` drops one dimension so facet counts
+ * for that dimension stay disjunctive: other applied filters still constrain
+ * the count, and the count for an unselected option is the number of posts
+ * that would newly match if that option were selected (or added).
+ */
+export function inboxFilterConditions(params: InboxPostListParams, omit?: InboxFilterFacet) {
+  const {
+    boardIds,
+    statusIds,
+    statusSlugs,
+    tagIds,
+    segmentIds,
+    ownerId,
+    search,
+    dateFrom,
+    dateTo,
+    minVotes,
+    minComments,
+    responded,
+    updatedBefore,
+    showDeleted,
+  } = params
+
+  const conditions = []
+
+  if (omit !== 'deleted') {
+    if (showDeleted) {
+      conditions.push(...restorableDeletedConditions())
+    } else {
+      conditions.push(isNull(posts.deletedAt))
+      // Pending posts render in the inbox for team members (who hold
+      // post.approve / post.view_private) so they can review them in place.
+      // The moderation queue still lists the same items for attention.
+    }
+  }
+
+  // Exclude merged/duplicate posts from inbox listing
+  conditions.push(isNull(posts.canonicalPostId))
+
+  if (omit !== 'board' && boardIds?.length) {
+    conditions.push(inArray(posts.boardId, boardIds))
+  }
+
+  if (omit !== 'status') {
+    if (statusSlugs && statusSlugs.length > 0) {
+      const statusIdSubquery = db
+        .select({ id: postStatuses.id })
+        .from(postStatuses)
+        .where(inArray(postStatuses.slug, statusSlugs))
+      conditions.push(inArray(posts.statusId, statusIdSubquery))
+    } else if (statusIds && statusIds.length > 0) {
+      conditions.push(inArray(posts.statusId, statusIds))
+    }
+  }
+
+  if (ownerId === null) {
+    conditions.push(sql`${posts.ownerPrincipalId} IS NULL`)
+  } else if (ownerId) {
+    conditions.push(eq(posts.ownerPrincipalId, ownerId as PrincipalId))
+  }
+
+  if (search) {
+    conditions.push(sql`${posts.searchVector} @@ websearch_to_tsquery('english', ${search})`)
+  }
+
+  if (dateFrom) {
+    conditions.push(sql`${posts.createdAt} >= ${dateFrom.toISOString()}`)
+  }
+  if (dateTo) {
+    conditions.push(sql`${posts.createdAt} <= ${dateTo.toISOString()}`)
+  }
+
+  if (minVotes !== undefined && minVotes > 0) {
+    conditions.push(sql`${posts.voteCount} >= ${minVotes}`)
+  }
+
+  if (minComments !== undefined && minComments > 0) {
+    conditions.push(sql`${posts.commentCount} >= ${minComments}`)
+  }
+
+  if (omit !== 'tags' && tagIds && tagIds.length > 0) {
+    const postIdsWithTagsSubquery = db
+      .selectDistinct({ postId: postTagAssignments.postId })
+      .from(postTagAssignments)
+      .where(inArray(postTagAssignments.tagId, tagIds))
+    conditions.push(inArray(posts.id, postIdsWithTagsSubquery))
+  }
+
+  if (omit !== 'segments' && segmentIds && segmentIds.length > 0) {
+    conditions.push(
+      inArray(
+        posts.principalId,
+        db
+          .select({ principalId: userSegments.principalId })
+          .from(userSegments)
+          .where(inArray(userSegments.segmentId, segmentIds))
+      )
+    )
+  }
+
+  if (omit !== 'responded') {
+    if (responded === 'responded') {
+      conditions.push(teamResponseExistsSql)
+    } else if (responded === 'unresponded') {
+      conditions.push(
+        sql`NOT EXISTS (SELECT 1 FROM post_comments WHERE post_comments.post_id = ${posts.id} AND post_comments.is_team_member = true AND post_comments.deleted_at IS NULL)`
+      )
+    }
+  }
+
+  if (updatedBefore) {
+    conditions.push(sql`${posts.updatedAt} < ${updatedBefore.toISOString()}`)
+  }
+
+  return conditions
+}
 
 /**
  * Priority score: `votes · 3 + comments · 2 + recency bonus`, where the
@@ -43,134 +191,9 @@ const priorityScoreSql = sql<number>`
  * @returns Result containing inbox post list or an error
  */
 export async function listInboxPosts(params: InboxPostListParams): Promise<InboxPostListResult> {
-  const {
-    boardIds,
-    statusIds,
-    statusSlugs,
-    tagIds,
-    segmentIds,
-    ownerId,
-    search,
-    dateFrom,
-    dateTo,
-    minVotes,
-    minComments,
-    responded,
-    updatedBefore,
-    showDeleted,
-    sort = 'newest',
-    cursor,
-    limit = 20,
-  } = params
+  const { sort = 'newest', cursor, limit = 20 } = params
 
-  // Build conditions array
-  const conditions = []
-
-  // Deleted posts filter
-  if (showDeleted) {
-    // Only show posts deleted within the last 30 days (restorable window)
-    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString()
-    conditions.push(isNotNull(posts.deletedAt))
-    conditions.push(sql`${posts.deletedAt} >= ${thirtyDaysAgo}`)
-  } else {
-    conditions.push(isNull(posts.deletedAt))
-    // Pending posts render in the inbox for team members (who hold
-    // post.approve / post.view_private) so they can review them in place.
-    // The moderation queue still lists the same items for attention.
-  }
-
-  // Exclude merged/duplicate posts from inbox listing
-  conditions.push(isNull(posts.canonicalPostId))
-
-  // Board filter
-  if (boardIds?.length) {
-    conditions.push(inArray(posts.boardId, boardIds))
-  }
-
-  // Status filter - use subquery to resolve slugs inline if needed
-  if (statusSlugs && statusSlugs.length > 0) {
-    // Use subquery to resolve status slugs to IDs in a single query
-    const statusIdSubquery = db
-      .select({ id: postStatuses.id })
-      .from(postStatuses)
-      .where(inArray(postStatuses.slug, statusSlugs))
-    conditions.push(inArray(posts.statusId, statusIdSubquery))
-  } else if (statusIds && statusIds.length > 0) {
-    conditions.push(inArray(posts.statusId, statusIds))
-  }
-
-  // Owner filter
-  if (ownerId === null) {
-    conditions.push(sql`${posts.ownerPrincipalId} IS NULL`)
-  } else if (ownerId) {
-    conditions.push(eq(posts.ownerPrincipalId, ownerId as PrincipalId))
-  }
-
-  // Search filter
-  // Full-text search using tsvector (much faster than ILIKE)
-  if (search) {
-    conditions.push(sql`${posts.searchVector} @@ websearch_to_tsquery('english', ${search})`)
-  }
-
-  // Date range filters
-  if (dateFrom) {
-    conditions.push(sql`${posts.createdAt} >= ${dateFrom.toISOString()}`)
-  }
-  if (dateTo) {
-    conditions.push(sql`${posts.createdAt} <= ${dateTo.toISOString()}`)
-  }
-
-  // Min votes filter
-  if (minVotes !== undefined && minVotes > 0) {
-    conditions.push(sql`${posts.voteCount} >= ${minVotes}`)
-  }
-
-  // Min comments filter
-  if (minComments !== undefined && minComments > 0) {
-    conditions.push(sql`${posts.commentCount} >= ${minComments}`)
-  }
-
-  // PostTag filter - use subquery to find posts with at least one of the selected tags
-  if (tagIds && tagIds.length > 0) {
-    const postIdsWithTagsSubquery = db
-      .selectDistinct({ postId: postTagAssignments.postId })
-      .from(postTagAssignments)
-      .where(inArray(postTagAssignments.tagId, tagIds))
-    conditions.push(inArray(posts.id, postIdsWithTagsSubquery))
-  }
-
-  // Segment filter - posts authored by users in any of the selected segments
-  if (segmentIds && segmentIds.length > 0) {
-    conditions.push(
-      inArray(
-        posts.principalId,
-        db
-          .select({ principalId: userSegments.principalId })
-          .from(userSegments)
-          .where(inArray(userSegments.segmentId, segmentIds))
-      )
-    )
-  }
-
-  // Responded filter - filter by whether any team member has commented
-  // NOTE: Use raw SQL column names for the comments table inside the subquery.
-  // Drizzle's relational query builder (db.query.posts.findMany) rewrites all
-  // column references to use the outer table's alias, so ${postComments.postId}
-  // becomes "posts"."post_id" instead of "comments"."post_id".
-  if (responded === 'responded') {
-    conditions.push(
-      sql`EXISTS (SELECT 1 FROM post_comments WHERE post_comments.post_id = ${posts.id} AND post_comments.is_team_member = true AND post_comments.deleted_at IS NULL)`
-    )
-  } else if (responded === 'unresponded') {
-    conditions.push(
-      sql`NOT EXISTS (SELECT 1 FROM post_comments WHERE post_comments.post_id = ${posts.id} AND post_comments.is_team_member = true AND post_comments.deleted_at IS NULL)`
-    )
-  }
-
-  // Updated before filter (for "stale" view)
-  if (updatedBefore) {
-    conditions.push(sql`${posts.updatedAt} < ${updatedBefore.toISOString()}`)
-  }
+  const conditions = inboxFilterConditions(params)
 
   // Cursor-based keyset pagination: resolve cursor to sort-field values
   if (cursor) {
@@ -286,5 +309,67 @@ export async function listInboxPosts(params: InboxPostListParams): Promise<Inbox
     items,
     nextCursor,
     hasMore,
+  }
+}
+
+/**
+ * Facet counts for the inbox filter pane. One grouped query per dimension,
+ * each omitting that dimension's own filter so counts stay disjunctive.
+ */
+export async function countInboxFilterFacets(
+  params: InboxPostListParams
+): Promise<InboxFilterCounts> {
+  const countSql = sql<number>`count(*)::int`
+  const teamRespondedFilter = sql<number>`count(*) filter (where exists (select 1 from post_comments where post_comments.post_id = ${posts.id} and post_comments.is_team_member = true and post_comments.deleted_at is null))::int`
+  const teamUnrespondedFilter = sql<number>`count(*) filter (where not exists (select 1 from post_comments where post_comments.post_id = ${posts.id} and post_comments.is_team_member = true and post_comments.deleted_at is null))::int`
+
+  const [statusRows, boardRows, tagRows, segmentRows, respondedRow, deletedRow] = await Promise.all(
+    [
+      db
+        .select({ key: postStatuses.slug, count: countSql })
+        .from(posts)
+        .innerJoin(postStatuses, eq(posts.statusId, postStatuses.id))
+        .where(and(...inboxFilterConditions(params, 'status')))
+        .groupBy(postStatuses.slug),
+      db
+        .select({ key: posts.boardId, count: countSql })
+        .from(posts)
+        .where(and(...inboxFilterConditions(params, 'board')))
+        .groupBy(posts.boardId),
+      db
+        .select({ key: postTagAssignments.tagId, count: countSql })
+        .from(posts)
+        .innerJoin(postTagAssignments, eq(postTagAssignments.postId, posts.id))
+        .where(and(...inboxFilterConditions(params, 'tags')))
+        .groupBy(postTagAssignments.tagId),
+      db
+        .select({ key: userSegments.segmentId, count: countSql })
+        .from(posts)
+        .innerJoin(userSegments, eq(userSegments.principalId, posts.principalId))
+        .where(and(...inboxFilterConditions(params, 'segments')))
+        .groupBy(userSegments.segmentId),
+      db
+        .select({ responded: teamRespondedFilter, unresponded: teamUnrespondedFilter })
+        .from(posts)
+        .where(and(...inboxFilterConditions(params, 'responded')))
+        .then((rows) => rows[0] ?? { responded: 0, unresponded: 0 }),
+      db
+        .select({ count: countSql })
+        .from(posts)
+        .where(and(...inboxFilterConditions(params, 'deleted'), ...restorableDeletedConditions()))
+        .then((rows) => rows[0]?.count ?? 0),
+    ]
+  )
+
+  return {
+    statuses: toCountMap(statusRows),
+    boards: toCountMap(boardRows),
+    tags: toCountMap(tagRows),
+    segments: toCountMap(segmentRows),
+    responded: {
+      responded: Number(respondedRow.responded) || 0,
+      unresponded: Number(respondedRow.unresponded) || 0,
+    },
+    deleted: Number(deletedRow) || 0,
   }
 }

--- a/apps/web/src/lib/server/domains/posts/post.types.ts
+++ b/apps/web/src/lib/server/domains/posts/post.types.ts
@@ -156,6 +156,22 @@ export interface InboxPostListResult {
 }
 
 /**
+ * Per-option counts for the admin inbox filter pane. Each map is keyed by the
+ * same id the filter UI uses (status slug, board/tag/segment id). Counts for
+ * a dimension omit that dimension's own filter so an unselected option shows
+ * how many posts would newly match if it were selected, given every other
+ * currently applied filter.
+ */
+export interface InboxFilterCounts {
+  statuses: Record<string, number>
+  boards: Record<string, number>
+  tags: Record<string, number>
+  segments: Record<string, number>
+  responded: { responded: number; unresponded: number }
+  deleted: number
+}
+
+/**
  * Post list item with board, tags, and comment count
  */
 export interface PostListItem extends Post {

--- a/apps/web/src/lib/server/functions/posts.ts
+++ b/apps/web/src/lib/server/functions/posts.ts
@@ -23,7 +23,7 @@ import { db, eq, posts } from '@/lib/server/db'
 import { createActivity } from '@/lib/server/domains/activity/activity.service'
 import { getMemberById } from '@/lib/server/domains/principals/principal.service'
 import { createPost, updatePost } from '@/lib/server/domains/posts/post.service'
-import { listInboxPosts } from '@/lib/server/domains/posts/post.inbox'
+import { listInboxPosts, countInboxFilterFacets } from '@/lib/server/domains/posts/post.inbox'
 import {
   getPostWithDetails,
   getPaginatedCommentsWithReplies,
@@ -94,6 +94,12 @@ const listInboxPostsSchema = z.object({
   showDeleted: z.boolean().optional(),
   cursor: z.string().optional(),
   limit: z.number().int().min(1).max(100).optional().default(20),
+})
+
+const inboxFilterCountsSchema = listInboxPostsSchema.omit({
+  cursor: true,
+  limit: true,
+  sort: true,
 })
 
 const createPostSchema = z.object({
@@ -221,6 +227,34 @@ export const fetchInboxPostsForAdmin = createServerFn({ method: 'GET' })
         contentJson: (p.contentJson ?? {}) as TiptapContent,
       })),
     }
+  })
+
+/**
+ * Facet counts for the admin inbox filter pane. Same filter shape as the
+ * list, minus pagination/sort. Each dimension omits its own filter so the
+ * count next to an option is "currently applied filters + posts that would
+ * newly match this option".
+ */
+export const fetchInboxFilterCounts = createServerFn({ method: 'GET' })
+  .validator(inboxFilterCountsSchema)
+  .handler(async ({ data }) => {
+    await requireAuth({ permission: PERMISSIONS.POST_VIEW_PRIVATE })
+    return countInboxFilterFacets({
+      boardIds: data.boardIds as BoardId[] | undefined,
+      statusIds: data.statusIds as PostStatusId[] | undefined,
+      statusSlugs: data.statusSlugs,
+      tagIds: data.tagIds as PostTagId[] | undefined,
+      segmentIds: data.segmentIds as SegmentId[] | undefined,
+      ownerId: data.ownerId as PrincipalId | null | undefined,
+      search: data.search,
+      dateFrom: data.dateFrom ? new Date(data.dateFrom) : undefined,
+      dateTo: data.dateTo ? new Date(data.dateTo) : undefined,
+      minVotes: data.minVotes,
+      minComments: data.minComments,
+      responded: data.responded,
+      updatedBefore: data.updatedBefore ? new Date(data.updatedBefore) : undefined,
+      showDeleted: data.showDeleted,
+    })
   })
 
 /**

--- a/apps/web/src/lib/server/policy/authz-matrix/MATRIX.md
+++ b/apps/web/src/lib/server/policy/authz-matrix/MATRIX.md
@@ -100,7 +100,7 @@ Profiles: **Owner** = admin class + an admin-owned full API key (scoped keys hol
 
 ## 2. Surfaces and their enforced authorization
 
-### Server functions (`requireAuth`) — 630 surfaces
+### Server functions (`requireAuth`) — 631 surfaces
 
 | Surface | Enforces |
 | --- | --- |
@@ -484,6 +484,7 @@ Profiles: **Owner** = admin class + an admin-owned full API key (scoped keys hol
 | `lib/server/functions/post-views.ts`::deletePostViewFn | post.edit |
 | `lib/server/functions/post-voters-context.ts`::listPostVotersForVoteManagerFn | post.vote_on_behalf |
 | `lib/server/functions/posts.ts`::fetchInboxPostsForAdmin | post.view_private |
+| `lib/server/functions/posts.ts`::fetchInboxFilterCounts | post.view_private |
 | `lib/server/functions/posts.ts`::fetchPostWithDetails | post.view_private |
 | `lib/server/functions/posts.ts`::fetchPostVotersFn | post.view_private |
 | `lib/server/functions/posts.ts`::createPostFn | post.create |
@@ -934,7 +935,7 @@ Key scopes are enforced: an API key holds exactly its stored scopes (owner permi
 
 ## 4. Entry points without a requireAuth/key gate
 
-182 of 923 entry points hold no `requireAuth` / `withApiKeyAuth` / `requireTeamAuth` gate.
+182 of 924 entry points hold no `requireAuth` / `withApiKeyAuth` / `requireTeamAuth` gate.
 Each is expected to be intentionally public, a pre-auth flow, a signature-verified webhook, or a handler that delegates auth (e.g. the MCP route).
 **Adding a row here is an access-control change** — confirm the new entry point is meant to be reachable without a gate.
 

--- a/apps/web/src/lib/shared/types/index.ts
+++ b/apps/web/src/lib/shared/types/index.ts
@@ -25,7 +25,12 @@ export type {
 } from './inbox'
 
 // Post domain types
-export type { CreatePostInput, AdminEditPostInput, PublicPostListItem } from './posts'
+export type {
+  CreatePostInput,
+  AdminEditPostInput,
+  PublicPostListItem,
+  InboxFilterCounts,
+} from './posts'
 
 // User domain types
 export type {

--- a/apps/web/src/lib/shared/types/posts.ts
+++ b/apps/web/src/lib/shared/types/posts.ts
@@ -9,4 +9,5 @@ export type {
   CreatePostInput,
   AdminEditPostInput,
   PublicPostListItem,
+  InboxFilterCounts,
 } from '@/lib/server/domains/posts'

--- a/apps/web/src/routes/admin/feedback.index.tsx
+++ b/apps/web/src/routes/admin/feedback.index.tsx
@@ -1,7 +1,11 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { useSuspenseQuery, useQuery } from '@tanstack/react-query'
 import { adminQueries } from '@/lib/client/queries/admin'
-import { inboxPostsInfiniteOptions, defaultInboxFilters } from '@/lib/client/hooks/use-inbox-query'
+import {
+  inboxPostsInfiniteOptions,
+  inboxFacetCountsOptions,
+  defaultInboxFilters,
+} from '@/lib/client/hooks/use-inbox-query'
 import { mergeSuggestionQueries } from '@/lib/client/queries/signals'
 import { InboxContainer } from '@/components/admin/feedback/inbox-container'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
@@ -38,6 +42,7 @@ export const Route = createFileRoute('/admin/feedback/')({
       // prefetched; a filtered URL on first load falls through to the client
       // fetch inside InboxContainer.
       queryClient.ensureInfiniteQueryData(inboxPostsInfiniteOptions(defaultInboxFilters)),
+      queryClient.ensureQueryData(inboxFacetCountsOptions(defaultInboxFilters)),
       queryClient.ensureQueryData(adminQueries.boards()),
       queryClient.ensureQueryData(adminQueries.tags()),
       queryClient.ensureQueryData(adminQueries.statuses()),


### PR DESCRIPTION
## Summary

- Admin inbox filters now show a count next to every status, board, tag, segment, team-response, and deleted-posts option.
- Counts are faceted: they respect every *other* currently applied filter, so an unselected option shows how many posts would newly match if you selected it.
- Nested under the existing inbox list query key so post mutations already invalidate counts.

## Test plan

- [ ] Open `/admin/feedback` and confirm every filter row has a count after first load
- [ ] Filter by a board and confirm status counts shrink to that board
- [ ] With a status selected, confirm other statuses still show non-zero counts for posts that would newly match
- [ ] Toggle tags / team response / deleted posts and confirm counts update