### PR TITLE
ci(test): shard the unit suite for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,16 @@ jobs:
       - run: bun run --cwd packages/db typecheck
       - run: bunx tsc --noEmit -p packages/email/tsconfig.json
 
-  test:
+  # Four shards on four-core runners. The ~1,300-file suite was ~8–9 min of
+  # wall clock on one job; splitting files plus isolate:false in vitest.config
+  # is what makes the unit gate finish in a couple of minutes.
+  unit:
+    name: test (${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     services:
       postgres:
         image: pgvector/pgvector:pg17
@@ -66,13 +74,28 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.4.0
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
       - run: bun install --frozen-lockfile
       - run: bun run db:migrate
-      # Applies every migration to a scratch DB on the postgres service and
-      # diffs the result against the Drizzle TS schema (packages/db/README.md).
+      # Drift only needs to run once; shard 1 owns it so the other three start
+      # the suite immediately after migrate.
       - name: Check migration/schema drift
+        if: matrix.shard == 1
         run: bun run db:check-drift
-      - run: bun run test --run
+      - run: bun run test --run --shard=${{ matrix.shard }}/4 --reporter=dot --reporter=github-actions
+
+  # Single check name so existing "test" required-status wiring still matches.
+  test:
+    needs: unit
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: All unit shards passed
+        run: test "${{ needs.unit.result }}" = "success"
 
   e2e-smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,8 @@ jobs:
       - run: bunx tsc --noEmit -p packages/email/tsconfig.json
 
   # Four shards on four-core runners. The ~1,300-file suite was ~8–9 min of
-  # wall clock on one job; splitting files plus isolate:false in vitest.config
-  # is what makes the unit gate finish in a couple of minutes.
+  # wall clock on one job; splitting files is what makes the unit gate finish
+  # in a couple of minutes.
   unit:
     name: test (${{ matrix.shard }}/4)
     runs-on: ubuntu-latest

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
     maxWorkers: process.env.CI ? 4 : undefined,
     fileParallelism: true,
     pool: 'forks',
-    isolate: false,
-    clearMocks: true,
-    mockReset: true,
-    restoreMocks: true,
     // The default 5s is too tight for a ~590-file suite run fully in parallel:
     // a test's first `await import()` of a heavy module graph pays that graph's
     // esbuild transform inside the timed body, and under CPU saturation that

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -7,6 +7,13 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'happy-dom',
+    maxWorkers: process.env.CI ? 4 : undefined,
+    fileParallelism: true,
+    pool: 'forks',
+    isolate: false,
+    clearMocks: true,
+    mockReset: true,
+    restoreMocks: true,
     // The default 5s is too tight for a ~590-file suite run fully in parallel:
     // a test's first `await import()` of a heavy module graph pays that graph's
     // esbuild transform inside the timed body, and under CPU saturation that

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,19 +7,11 @@ export default defineConfig({
     environment: 'node',
     // GitHub-hosted ubuntu-latest is 4 vCPU. Default maxWorkers is ~50% of
     // cores, which leaves half the runner idle. Pin to 4 in CI; locally leave
-    // headroom for the rest of the machine.
+    // headroom for the rest of the machine. Isolation stays on: turning it
+    // off leaked vi.mock state across files (~200 failures on a shard).
     maxWorkers: process.env.CI ? 4 : undefined,
     fileParallelism: true,
     pool: 'forks',
-    // Default isolate reloads the whole module graph for every file (~1,300
-    // files). CI spent ~8 min of wall clock on import+setup, not assertions.
-    // vi.mock is still per-file; shared module cache is the win.
-    isolate: false,
-    clearMocks: true,
-    mockReset: true,
-    restoreMocks: true,
-    unstubEnvs: true,
-    unstubGlobals: true,
     // Many server tests do a first-time dynamic import() inside the test body
     // (the vi.mock factory pattern). Under parallel CPU contention that load
     // can exceed the 5s default — and a timeout firing mid-import() corrupts

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,21 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    // GitHub-hosted ubuntu-latest is 4 vCPU. Default maxWorkers is ~50% of
+    // cores, which leaves half the runner idle. Pin to 4 in CI; locally leave
+    // headroom for the rest of the machine.
+    maxWorkers: process.env.CI ? 4 : undefined,
+    fileParallelism: true,
+    pool: 'forks',
+    // Default isolate reloads the whole module graph for every file (~1,300
+    // files). CI spent ~8 min of wall clock on import+setup, not assertions.
+    // vi.mock is still per-file; shared module cache is the win.
+    isolate: false,
+    clearMocks: true,
+    mockReset: true,
+    restoreMocks: true,
+    unstubEnvs: true,
+    unstubGlobals: true,
     // Many server tests do a first-time dynamic import() inside the test body
     // (the vi.mock factory pattern). Under parallel CPU contention that load
     // can exceed the 5s default — and a timeout firing mid-import() corrupts
@@ -32,6 +47,11 @@ export default defineConfig({
     },
     env: {
       DATABASE_URL: 'postgresql://postgres:password@localhost:5432/quackback_test',
+    },
+    deps: {
+      optimizer: {
+        ssr: { enabled: true },
+      },
     },
   },
   esbuild: {


### PR DESCRIPTION
## Why

The `test` job on `ubuntu-latest` (4 vCPU) was ~8–9 minutes of wall clock for ~1,300 files. Default Vitest uses about half the cores, and a single job ran the whole suite.

## What changed

- **Four shards** (`--shard=N/4`) as parallel `test (N/4)` jobs. Drift check stays on shard 1 only.
- **`maxWorkers: 4` in CI** so each runner uses all four cores.
- A final **`test` job** still reports a single check name, so required-status wiring does not change.
- Bun install cache (`~/.bun/install/cache`) on the unit shards.

Per-file isolation stays on. Sharing the module cache leaked `vi.mock` state across files (~200 failures on a shard).

## Expected CI effect

One ~9 minute unit job becomes four parallel jobs, each running a quarter of the files. Wall clock should drop toward install + migrate + ~2–3 minutes of tests.