### PR TITLE
fix(auth): retry Open when a parallel GET consumes the token

### DIFF
--- a/apps/web/src/lib/server/functions/__tests__/open-handoff.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/open-handoff.test.ts
@@ -1,9 +1,40 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { consumeOpenHandoff } from '../origin-transfer'
 
-const hoisted = vi.hoisted(() => ({ handler: vi.fn(), getSession: vi.fn() }))
+const hoisted = vi.hoisted(() => {
+  const snapshotRows: { value: string; expiresAt: Date }[][] = []
+  return {
+    handler: vi.fn(),
+    getSession: vi.fn(),
+    snapshotRows,
+    nextSnapshot: () => snapshotRows.shift() ?? [],
+  }
+})
+
 vi.mock('@/lib/server/auth', () => ({
   auth: { handler: hoisted.handler, api: { getSession: hoisted.getSession } },
+}))
+
+vi.mock('@/lib/server/db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => hoisted.nextSnapshot(),
+        }),
+      }),
+    }),
+    insert: () => ({
+      values: async () => undefined,
+    }),
+  },
+  verification: {
+    id: 'id',
+    identifier: 'identifier',
+    value: 'value',
+    expiresAt: 'expiresAt',
+  },
+  eq: () => true,
 }))
 
 describe('consumeOpenHandoff', () => {
@@ -11,6 +42,7 @@ describe('consumeOpenHandoff', () => {
     hoisted.handler.mockReset()
     hoisted.getSession.mockReset()
     hoisted.getSession.mockResolvedValue(null)
+    hoisted.snapshotRows.length = 0
   })
 
   it('does not require an identity projection', async () => {
@@ -64,5 +96,26 @@ describe('consumeOpenHandoff', () => {
     await expect(
       consumeOpenHandoff({ ott: 'token-1', returnTo: '/onboarding/workspace' })
     ).resolves.toMatchObject({ kind: 'redirect', to: '/' })
+  })
+
+  it('retries when a parallel GET consumed the token before snapshot', async () => {
+    const live = { value: 'sess', expiresAt: new Date(Date.now() + 60_000) }
+    hoisted.snapshotRows.push([], [live])
+    hoisted.handler
+      .mockResolvedValueOnce(new Response('no', { status: 400 }))
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: {
+          getSetCookie: () => ['session=abc; Path=/; HttpOnly'],
+          get: () => null,
+        },
+      })
+
+    await expect(consumeOpenHandoff({ ott: 'token-1' })).resolves.toEqual({
+      kind: 'redirect',
+      to: '/',
+      cookies: ['session=abc; Path=/; HttpOnly'],
+    })
+    expect(hoisted.handler).toHaveBeenCalledTimes(2)
   })
 })

--- a/apps/web/src/lib/server/functions/__tests__/origin-transfer.db.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/origin-transfer.db.test.ts
@@ -52,7 +52,7 @@ const hoisted = vi.hoisted(() => {
 
 vi.mock('@/lib/server/auth', () => ({ auth: hoisted.auth }))
 
-import { consumeOriginTransfer } from '../origin-transfer'
+import { consumeOpenHandoff, consumeOriginTransfer } from '../origin-transfer'
 
 const fixture = await createDbTestFixture({
   probe: async (db) => {
@@ -242,5 +242,50 @@ describe.skipIf(!fixture.available)('rename-transfer OTT consume', () => {
     expect(result).toEqual({ kind: 'error', status: 'invalid' })
     expect(await ottRowCount(token)).toBe(1)
     expect(hoisted.handler).not.toHaveBeenCalled()
+  })
+
+  it('lets Visit replay the Open token until it expires', async () => {
+    const { sessionToken } = await seedSessionUser()
+    const token = await seedOtt({ sessionToken, expiresAt: future() })
+
+    const first = await consumeOpenHandoff({ ott: token })
+    expect(first).toMatchObject({ kind: 'redirect', to: '/' })
+    if (first.kind !== 'redirect') return
+    expect(first.cookies.some((cookie) => cookie.toLowerCase().includes('session'))).toBe(true)
+    expect(await ottRowCount(token)).toBe(1)
+
+    const replay = await consumeOpenHandoff({ ott: token })
+    expect(replay).toMatchObject({ kind: 'redirect', to: '/' })
+    if (replay.kind !== 'redirect') return
+    expect(replay.cookies.some((cookie) => cookie.toLowerCase().includes('session'))).toBe(true)
+    expect(await ottRowCount(token)).toBe(1)
+  })
+
+  it('still refuses an expired Open token', async () => {
+    const { sessionToken } = await seedSessionUser()
+    const token = await seedOtt({ sessionToken, expiresAt: past() })
+
+    const result = await consumeOpenHandoff({ ott: token })
+    expect(result).toEqual({ kind: 'error', status: 'invalid' })
+  })
+
+  it('retries Open when a parallel GET snapshots after the sibling consume', async () => {
+    const { sessionToken } = await seedSessionUser()
+    const token = await seedOtt({ sessionToken, expiresAt: future() })
+    const [row] = await testDb
+      .select()
+      .from(verification)
+      .where(eq(verification.identifier, `one-time-token:${token}`))
+      .limit(1)
+    expect(row).toBeTruthy()
+    await testDb.delete(verification).where(eq(verification.identifier, `one-time-token:${token}`))
+
+    const pending = consumeOpenHandoff({ ott: token })
+    await new Promise((resolve) => setTimeout(resolve, 40))
+    await testDb.insert(verification).values(row!)
+
+    const result = await pending
+    expect(result).toMatchObject({ kind: 'redirect', to: '/' })
+    expect(await ottRowCount(token)).toBe(1)
   })
 })

--- a/apps/web/src/lib/server/functions/origin-transfer.ts
+++ b/apps/web/src/lib/server/functions/origin-transfer.ts
@@ -113,11 +113,45 @@ async function restoreOpenHandoffOtt(snapshot: OpenHandoffOttSnapshot): Promise<
   }
 }
 
+/** Backoff while a parallel Open GET restores the OTT row it just consumed. */
+const OPEN_HANDOFF_SNAPSHOT_RETRY_MS = [25, 50, 100] as const
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+type OpenHandoffAttempt =
+  | Extract<OriginTransferResult, { kind: 'redirect' }>
+  | (Extract<OriginTransferResult, { kind: 'error' }> & { missedSnapshot: boolean })
+
+async function consumeOpenHandoffOnce(ott: string, headers?: Headers): Promise<OpenHandoffAttempt> {
+  const snapshot = await snapshotOpenHandoffOtt(ott)
+  const first = await consumeOrContinueExistingSession(ott, '/', headers)
+  if (first.kind === 'redirect') {
+    if (snapshot) await restoreOpenHandoffOtt(snapshot)
+    return first
+  }
+  if (snapshot) {
+    await restoreOpenHandoffOtt(snapshot)
+    const retry = await verifyOttCookies(ott, '/', headers)
+    if (retry.kind === 'redirect') {
+      await restoreOpenHandoffOtt(snapshot)
+      return retry
+    }
+    return { ...first, missedSnapshot: false }
+  }
+  return { ...first, missedSnapshot: true }
+}
+
 /**
  * Consume the control-plane Open handoff. First arrival uses the immutable
  * system host and may happen before the identity projection lands, so this
  * path must not require a verified projection. The token stays redeemable
  * until it expires: Visit is a GET, and a second load must still sign in.
+ *
+ * Two GETs can overlap: the second snapshot can run after the first verify
+ * deleted the row and before the first restore put it back. When the snapshot
+ * misses, wait briefly and try again so the sibling restore can land.
  */
 export async function consumeOpenHandoff(input: {
   ott?: string
@@ -129,21 +163,17 @@ export async function consumeOpenHandoff(input: {
   // caller returnTo — Open must not drop a finished workspace into the
   // wizard or /admin.
   if (!input.ott) return { kind: 'error', status: 'invalid' }
-  const snapshot = await snapshotOpenHandoffOtt(input.ott)
-  const first = await consumeOrContinueExistingSession(input.ott, '/', input.headers)
-  if (first.kind === 'redirect') {
-    if (snapshot) await restoreOpenHandoffOtt(snapshot)
-    return first
+  const first = await consumeOpenHandoffOnce(input.ott, input.headers)
+  if (first.kind === 'redirect') return first
+  if (!first.missedSnapshot) return { kind: 'error', status: first.status }
+
+  for (const delayMs of OPEN_HANDOFF_SNAPSHOT_RETRY_MS) {
+    await wait(delayMs)
+    const retry = await consumeOpenHandoffOnce(input.ott, input.headers)
+    if (retry.kind === 'redirect') return retry
+    if (!retry.missedSnapshot) return { kind: 'error', status: retry.status }
   }
-  if (snapshot) {
-    await restoreOpenHandoffOtt(snapshot)
-    const retry = await verifyOttCookies(input.ott, '/', input.headers)
-    if (retry.kind === 'redirect') {
-      await restoreOpenHandoffOtt(snapshot)
-      return retry
-    }
-  }
-  return first
+  return { kind: 'error', status: first.status }
 }
 
 /**


### PR DESCRIPTION
Better Auth deletes the OTT row on verify. Two overlapping Open GETs can snapshot after that delete and before the sibling restore, which is the first-visit error page.

Wait and retry when the snapshot misses so the sibling restore can land. Sequential replay until expiry is unchanged.