### PR TITLE
refactor(settings): drop the Enable Messenger master switch

### DIFF
--- a/apps/web/e2e/scripts/set-support-surfaces.ts
+++ b/apps/web/e2e/scripts/set-support-surfaces.ts
@@ -4,7 +4,6 @@
  * "on" turns on everything the three conversation surfaces need:
  *   - featureFlags.supportInbox        (gates /admin/inbox + all conversation paths)
  *   - widgetConfig.enabled             (widget master switch)
- *   - widgetConfig.messenger.enabled   (widget messenger surface)
  *   - widgetConfig.tabs.messenger      (widget Messages tab)
  *   - portalConfig.support.enabled     (portal /support tab)
  *

--- a/apps/web/src/lib/server/domains/settings/__tests__/widget-config.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/widget-config.test.ts
@@ -205,6 +205,50 @@ describe('getPublicWidgetConfig — launcher projection', () => {
   })
 })
 
+describe('getPublicWidgetConfig — messenger tab projection', () => {
+  it('projects tabs.messenger from the flag + tab, ignoring stored messenger.enabled', async () => {
+    settingsRow.current = fixtureRow(
+      {
+        enabled: true,
+        tabs: { messenger: true, feedback: false },
+        messenger: { enabled: false },
+      },
+      { supportInbox: true }
+    )
+    const projected = await getPublicWidgetConfig()
+    expect(projected.tabs?.messenger).toBe(true)
+    expect(projected.messenger?.enabled).toBe(true)
+  })
+
+  it('keeps the Messages tab off when the tab is off, even if stored messenger.enabled is true', async () => {
+    settingsRow.current = fixtureRow(
+      {
+        enabled: true,
+        tabs: { messenger: false, feedback: false },
+        messenger: { enabled: true },
+      },
+      { supportInbox: true }
+    )
+    const projected = await getPublicWidgetConfig()
+    expect(projected.tabs?.messenger).toBe(false)
+    expect(projected.messenger?.enabled).toBe(true)
+  })
+
+  it('projects messenger.enabled false when supportInbox is off', async () => {
+    settingsRow.current = fixtureRow(
+      {
+        enabled: true,
+        tabs: { messenger: true, feedback: false },
+        messenger: { enabled: true },
+      },
+      { supportInbox: false }
+    )
+    const projected = await getPublicWidgetConfig()
+    expect(projected.tabs?.messenger).toBe(false)
+    expect(projected.messenger?.enabled).toBe(false)
+  })
+})
+
 describe('getPublicWidgetConfig — tickets projection (converged Messages)', () => {
   it('projects tabs.tickets from the supportTickets flag alone — no per-tab toggle', async () => {
     // The flag is set explicitly, and the stored tabs deliberately carry no

--- a/apps/web/src/lib/server/domains/settings/settings.service.ts
+++ b/apps/web/src/lib/server/domains/settings/settings.service.ts
@@ -961,13 +961,15 @@ export async function getWorkspaceSettings(): Promise<WorkspaceSettings | null> 
         // Home customisation is client-safe (greeting, hero style, quick links);
         // the stored hero-image key is resolved to a public URL.
         home: publicHomeConfig(widgetConfig.home),
-        // Client-safe messenger config — the widget gates its messenger tab on
-        // messenger.enabled, so this must be projected here (routing stays
-        // agent-only).
-        messenger: publicMessengerConfig(
-          widgetConfig.messenger ?? DEFAULT_MESSENGER_CONFIG,
-          assistantIdentity
-        ),
+        // Client-safe messenger config (routing stays agent-only). `enabled`
+        // mirrors the module flag — widget visibility is `tabs.messenger`.
+        messenger: {
+          ...publicMessengerConfig(
+            widgetConfig.messenger ?? DEFAULT_MESSENGER_CONFIG,
+            assistantIdentity
+          ),
+          enabled: featureFlags.supportInbox,
+        },
       },
       featureFlags,
       brandingData,

--- a/apps/web/src/lib/server/domains/settings/settings.types.ts
+++ b/apps/web/src/lib/server/domains/settings/settings.types.ts
@@ -356,7 +356,7 @@ export interface PortalConfig {
 
 /**
  * Portal Support tab configuration. Gated (with the `supportInbox` feature
- * flag) by `isPortalSupportEnabled`; independent of the widget messenger toggles.
+ * flag) by `isPortalSupportEnabled`; independent of the widget Messages tab.
  */
 export interface PortalSupportConfig {
   enabled: boolean
@@ -546,7 +546,11 @@ export interface PublicAssistantConfig extends AssistantDeploymentConfig {
 }
 
 export interface MessengerConfig {
-  /** Master toggle for the messenger tab + endpoints. */
+  /**
+   * @deprecated Ignored at read time. Messenger is on when the `supportInbox`
+   * flag is on; widget visibility is `tabs.messenger`. Still written by the
+   * widget-activation path so stored JSON stays consistent with older readers.
+   */
   enabled: boolean
   /** Greeting shown when a visitor opens the messenger with no history. */
   welcomeMessage?: string

--- a/apps/web/src/lib/server/domains/settings/settings.widget.ts
+++ b/apps/web/src/lib/server/domains/settings/settings.widget.ts
@@ -141,6 +141,8 @@ export function publicMessengerConfig(
   identity: AssistantIdentity = DEFAULT_ASSISTANT_CONFIG.identity
 ): PublicMessengerConfig {
   return {
+    // Callers override this with the `supportInbox` flag. Stored
+    // `messenger.enabled` is ignored at the gate.
     enabled: messenger.enabled,
     welcomeMessage: messenger.welcomeMessage,
     offlineMessage: messenger.offlineMessage,
@@ -335,10 +337,7 @@ export async function getPublicWidgetConfig(): Promise<PublicWidgetConfig> {
       feedback: (config.tabs?.feedback ?? true) && flags.feedback,
       changelog: (config.tabs?.changelog ?? false) && flags.changelog,
       help: (config.tabs?.help ?? false) && flags.helpCenter && helpCenter.enabled,
-      messenger:
-        (config.tabs?.messenger ?? false) &&
-        flags.supportInbox &&
-        (config.messenger?.enabled ?? false),
+      messenger: (config.tabs?.messenger ?? false) && flags.supportInbox,
       // Converged Messages: ticket pairs surface through the messenger tab,
       // gated by the supportTickets flag alone (there is no Tickets tab).
       tickets: flags.supportTickets,
@@ -359,7 +358,12 @@ export async function getPublicWidgetConfig(): Promise<PublicWidgetConfig> {
       // the stored hero-image key is resolved to a public URL.
       home: publicHomeConfig(config.home),
       // Project only client-safe messenger fields; routing is agent-only.
-      messenger: publicMessengerConfig(config.messenger ?? DEFAULT_MESSENGER_CONFIG, identity),
+      // `enabled` mirrors the module flag — there is no separate messenger
+      // master switch; widget visibility is `tabs.messenger`.
+      messenger: {
+        ...publicMessengerConfig(config.messenger ?? DEFAULT_MESSENGER_CONFIG, identity),
+        enabled: flags.supportInbox,
+      },
       // Per-locale copy overrides — client-safe (customer-facing strings the
       // widget resolves against its own locale for the Home surface).
       translations: config.translations,
@@ -380,16 +384,18 @@ export async function getMessengerConfig(): Promise<MessengerConfig> {
 }
 
 /**
- * Whether messenger is enabled for this workspace. Gated first by the
+ * Whether the widget messenger surface is live. Gated first by the
  * experimental `supportInbox` feature flag (off by default); below it the
- * per-widget master + messenger toggles still apply. This is the single choke point the
- * widget-facing messenger paths (send, stream, visitor history) already consult, so
- * flipping the flag off fails them all closed.
+ * widget master and the Messages tab still apply. There is no separate
+ * messenger master switch — the module flag is that switch. This is the
+ * single choke point the widget-facing messenger paths (send, stream,
+ * visitor history) already consult, so flipping the flag off fails them all
+ * closed.
  */
 export async function isMessengerEnabled(): Promise<boolean> {
   const { isFeatureEnabled } = await import('./settings.service')
   const [flagOn, widget] = await Promise.all([isFeatureEnabled('supportInbox'), getWidgetConfig()])
-  return Boolean(flagOn && widget.enabled && widget.messenger?.enabled)
+  return Boolean(flagOn && widget.enabled && widget.tabs?.messenger)
 }
 
 /**

--- a/apps/web/src/lib/server/functions/admin.ts
+++ b/apps/web/src/lib/server/functions/admin.ts
@@ -407,11 +407,8 @@ export const fetchOnboardingStatus = createServerFn({ method: 'GET' }).handler(a
   const permissions = permissionsForLegacyRole(auth.principal.role)
   const hasBranding = Boolean(orgSettings?.logoKey)
   const hasWidgetEnabled = widgetConfig.enabled === true
-  // Messenger is "live" when the messenger surface is on and the widget is enabled
-  const hasMessengerEnabled =
-    hasWidgetEnabled &&
-    (widgetConfig.messenger?.enabled ?? false) &&
-    (widgetConfig.tabs?.messenger ?? false)
+  // Messenger is "live" when the widget is on and the Messages tab is shown.
+  const hasMessengerEnabled = hasWidgetEnabled && (widgetConfig.tabs?.messenger ?? false)
   const hasIntegration = Boolean(connectedIntegration)
   const hasInternalBoard = orgBoards.some((board) => board.access.view === 'team')
   const publicBoard = orgBoards.find((board) => board.access.view === 'anonymous')

--- a/apps/web/src/lib/shared/launch-checklist.ts
+++ b/apps/web/src/lib/shared/launch-checklist.ts
@@ -206,7 +206,7 @@ export function buildLaunchTasks(
       ? `Messenger was found on ${status.widgetOriginHost ?? 'your site'}.`
       : status.hasMessengerEnabled
         ? 'Messenger is configured. Add the SDK to your website to connect it.'
-        : 'Enable Messenger and add the SDK to your website.',
+        : 'Turn on the Messages tab and add the SDK to your website.',
     completed: status.hasWidgetInstalled === true,
     canAct: permissions.settingsManage,
     unavailableReason: features.supportInbox

--- a/apps/web/src/routes/admin/settings.channels.tsx
+++ b/apps/web/src/routes/admin/settings.channels.tsx
@@ -23,7 +23,10 @@ import { getChannelDescriptor } from '@/lib/shared/channels'
 export const Route = createFileRoute('/admin/settings/channels')({
   loader: async ({ context }) => {
     assertRoutePermission(context.permissions, PERMISSIONS.SETTINGS_MANAGE)
-    await context.queryClient.ensureQueryData(settingsQueries.widgetConfig())
+    await Promise.all([
+      context.queryClient.ensureQueryData(settingsQueries.widgetConfig()),
+      context.queryClient.ensureQueryData(settingsQueries.portalConfig()),
+    ])
     return {}
   },
   component: ChannelsHubRoute,
@@ -38,6 +41,7 @@ function ChannelsHubRoute() {
 
 function ChannelsHubPage() {
   const widget = useSuspenseQuery(settingsQueries.widgetConfig())
+  const portal = useSuspenseQuery(settingsQueries.portalConfig())
   const emailStatusQuery = useQuery({
     queryKey: ['settings', 'email-channel-status'],
     queryFn: () => getEmailChannelStatusFn(),
@@ -53,7 +57,7 @@ function ChannelsHubPage() {
   const enabled = routingEnabled ?? routingQuery.data?.enabled ?? false
   const messenger = getChannelDescriptor('messenger')
   const email = getChannelDescriptor('email')
-  const messengerOn = widget.data.messenger?.enabled === true
+  const messengerOn = widget.data.tabs?.messenger === true || portal.data?.support?.enabled === true
   const receiving = emailStatusQuery.data?.inboundConfigured === true
   const sendingOnly = !receiving && !!emailStatusQuery.data?.fromAddress
   const emailStatus = receiving ? 'Receiving' : sendingOnly ? 'Sending only' : 'Set up'

--- a/apps/web/src/routes/admin/settings.channels_.messenger.tsx
+++ b/apps/web/src/routes/admin/settings.channels_.messenger.tsx
@@ -3,7 +3,7 @@ import { PERMISSIONS } from '@/lib/shared/permissions'
 import { assertRoutePermission } from '@/lib/shared/route-permission'
 import { createFileRoute, useRouter, Navigate, Link } from '@tanstack/react-router'
 import { useSuspenseQuery } from '@tanstack/react-query'
-import { ChatBubbleLeftRightIcon, ArrowPathIcon } from '@heroicons/react/24/solid'
+import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/solid'
 import type { FeatureFlags } from '@/lib/shared/types/settings'
 import { settingsQueries } from '@/lib/client/queries/settings'
 import { useUpdatePortalConfig, useUpdateWidgetConfig } from '@/lib/client/mutations/settings'
@@ -47,7 +47,6 @@ function MessengerChannelPage() {
   const [portalSupportEnabled, setPortalSupportEnabled] = useState(
     portalConfigQuery.data?.support?.enabled ?? false
   )
-  const [enabled, setEnabled] = useState(messengerConfig?.enabled ?? false)
   const [preventRepliesWhenClosed, setPreventRepliesWhenClosed] = useState(
     messengerConfig?.preventRepliesWhenClosed ?? false
   )
@@ -84,46 +83,12 @@ function MessengerChannelPage() {
         description="Live chat in the widget and on the portal."
       />
 
-      <SettingsCard
-        title="Enable Messenger"
-        description="Accept new conversations and show the Messages tab."
-      >
-        <div className="flex items-center justify-between py-1">
-          <div className="pr-4">
-            <Label htmlFor="messenger-enabled" className="text-sm font-medium cursor-pointer">
-              Enable Messenger
-            </Label>
-            <p className="mt-0.5 text-xs text-muted-foreground">
-              Adds the Messages tab to the widget. Turning it off also hides the tab.
-            </p>
-          </div>
-          <div className="flex items-center gap-2">
-            {savingField === 'enabled' && (
-              <ArrowPathIcon className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
-            )}
-            <Switch
-              id="messenger-enabled"
-              checked={enabled}
-              onCheckedChange={(checked) => {
-                setEnabled(checked)
-                persist(
-                  'enabled',
-                  { messenger: { enabled: checked }, tabs: { messenger: checked } },
-                  () => setEnabled(!checked)
-                )
-              }}
-              disabled={isBusy}
-            />
-          </div>
-        </div>
-      </SettingsCard>
-
       <SettingsCard title="Surfaces" description="Where customers see their conversations.">
         <div className="flex items-center justify-between py-1">
           <div className="pr-4">
             <p className="text-sm font-medium">Widget</p>
             <p className="mt-0.5 text-xs text-muted-foreground">
-              Launcher, tabs, and appearance are in Widget settings.
+              Show the Messages tab from Widget settings.
             </p>
           </div>
           <Link to="/admin/settings/widget" className="text-sm font-medium text-primary">
@@ -170,7 +135,7 @@ function MessengerChannelPage() {
               placeholder="Support"
               onChange={(e) => setTeamName(e.target.value)}
               onBlur={() => persist('teamName', { messenger: { teamName: teamName.trim() } })}
-              disabled={isBusy || !enabled}
+              disabled={isBusy}
             />
             <p className="text-xs text-muted-foreground">
               Shown in the messenger header. Falls back to the workspace name.
@@ -188,7 +153,7 @@ function MessengerChannelPage() {
               onBlur={() =>
                 persist('welcomeMessage', { messenger: { welcomeMessage: welcomeMessage.trim() } })
               }
-              disabled={isBusy || !enabled}
+              disabled={isBusy}
             />
             <p className="text-xs text-muted-foreground">
               Greets a customer opening a new conversation.{' '}
@@ -208,7 +173,7 @@ function MessengerChannelPage() {
               onBlur={() =>
                 persist('offlineMessage', { messenger: { offlineMessage: offlineMessage.trim() } })
               }
-              disabled={isBusy || !enabled}
+              disabled={isBusy}
             />
             <p className="text-xs text-muted-foreground">
               Shown outside{' '}
@@ -243,7 +208,7 @@ function MessengerChannelPage() {
                 setPreventRepliesWhenClosed(!checked)
               )
             }}
-            disabled={isBusy || !enabled}
+            disabled={isBusy}
           />
         </div>
       </SettingsCard>

--- a/apps/web/src/routes/admin/settings.widget.install.tsx
+++ b/apps/web/src/routes/admin/settings.widget.install.tsx
@@ -57,7 +57,7 @@ function WidgetInstallPage() {
   const configured =
     config.enabled &&
     (mode === 'messenger'
-      ? Boolean(config.tabs?.messenger && config.messenger?.enabled)
+      ? Boolean(config.tabs?.messenger)
       : Boolean(config.tabs?.feedback && config.defaultBoard))
   const [copying, setCopying] = useState<'snippet' | 'secret' | null>(null)
   const [identifyUsers, setIdentifyUsers] = useState(true)
@@ -125,7 +125,7 @@ function WidgetInstallPage() {
         title="1. Enable the channel"
         description={
           mode === 'messenger'
-            ? 'Turns on the widget, Messenger, and the Messages tab together.'
+            ? 'Turns on the widget and the Messages tab together.'
             : 'Turns on the widget and Feedback tab with your public board selected.'
         }
       >

--- a/apps/web/src/routes/admin/settings.widget.tsx
+++ b/apps/web/src/routes/admin/settings.widget.tsx
@@ -117,7 +117,6 @@ function WidgetSettingsPage() {
   const helpCenterFlagEnabled = flags?.helpCenter ?? false
   const helpCenterEnabled = helpCenterConfig?.enabled ?? false
   const supportInboxFlagEnabled = flags?.supportInbox ?? false
-  const messengerEnabled = config.messenger?.enabled ?? false
 
   // Lifted editor state: position drives the preview's launcher chrome.
   const [position, setPosition] = useState<'bottom-right' | 'bottom-left'>(
@@ -174,7 +173,6 @@ function WidgetSettingsPage() {
             helpCenterFlagEnabled={helpCenterFlagEnabled}
             helpCenterEnabled={helpCenterEnabled}
             supportInboxFlagEnabled={supportInboxFlagEnabled}
-            messengerEnabled={messengerEnabled}
           />
 
           <HomeCustomizationCard
@@ -317,7 +315,6 @@ function ModulesCard({
   helpCenterFlagEnabled,
   helpCenterEnabled,
   supportInboxFlagEnabled,
-  messengerEnabled,
 }: {
   config: {
     defaultBoard?: string
@@ -339,7 +336,6 @@ function ModulesCard({
   helpCenterFlagEnabled: boolean
   helpCenterEnabled: boolean
   supportInboxFlagEnabled: boolean
-  messengerEnabled: boolean
 }) {
   const router = useRouter()
   const updateWidgetConfig = useUpdateWidgetConfig()
@@ -355,8 +351,6 @@ function ModulesCard({
   })
 
   const showHelpToggle = helpCenterFlagEnabled && helpCenterEnabled
-  const showMessagesToggle = supportInboxFlagEnabled && messengerEnabled
-  const showMessagesHint = supportInboxFlagEnabled && !messengerEnabled
 
   const isBusy = saving || isPending
 
@@ -401,7 +395,7 @@ function ModulesCard({
           onChange={(checked) => void saveTab('home', checked)}
         />
 
-        {showMessagesToggle && (
+        {supportInboxFlagEnabled && (
           <TabRow
             id="tab-messages"
             label="Messages"
@@ -411,17 +405,6 @@ function ModulesCard({
             saving={saving}
             onChange={(checked) => void saveTab('messenger', checked)}
           />
-        )}
-        {showMessagesHint && (
-          <div className="rounded-lg border border-border/50 bg-muted/30 px-3 py-2.5">
-            <p className="text-xs text-muted-foreground">
-              Enable Messenger in{' '}
-              <Link to="/admin/settings/channels/messenger" className="font-medium text-primary">
-                Messenger settings
-              </Link>{' '}
-              to add a Messages tab.
-            </p>
-          </div>
         )}
 
         <TabRow

--- a/apps/web/src/routes/widget/index.tsx
+++ b/apps/web/src/routes/widget/index.tsx
@@ -97,12 +97,11 @@ export const Route = createFileRoute('/widget/')({
     const feedbackProductEnabled = settings?.featureFlags?.feedback ?? true
     const changelogProductEnabled = settings?.featureFlags?.changelog ?? true
 
-    // Same triple-gate as the `messages` tab below: Support Inbox flag +
-    // Messenger enabled + tab on. Hoisted so we only compute presence when
-    // Messenger shows.
+    // Support Inbox flag + Messages tab on. Messenger is on whenever the
+    // module is; the tab is the widget surface. Hoisted so we only compute
+    // presence when Messenger shows.
     const messengerTabEnabled =
       ((settings?.featureFlags as { supportInbox?: boolean } | undefined)?.supportInbox ?? false) &&
-      (settings?.publicWidgetConfig?.messenger?.enabled ?? false) &&
       (settings?.publicWidgetConfig?.tabs?.messenger ?? false)
 
     // Converged Messages surface: a tickets-enabled workspace surfaces its
@@ -246,7 +245,7 @@ export const Route = createFileRoute('/widget/')({
           ((settings?.featureFlags as { helpCenter?: boolean } | undefined)?.helpCenter ?? false) &&
           (settings?.helpCenterConfig?.enabled ?? false) &&
           (settings?.publicWidgetConfig?.tabs?.help ?? false),
-        // Support Inbox flag + Messenger enabled + tab on (computed above), OR
+        // Support Inbox flag + Messages tab on (computed above), OR
         // tickets on (the converged surface lists ticket pairs here). The
         // persisted config names the messenger surface `messenger`; the widget
         // speaks `messages`.


### PR DESCRIPTION
Messenger is on when Support Inbox is on. The Widget Messages tab and Portal Support already control the surfaces, so the extra Enable Messenger toggle was a third on/off that hid the tab behind a settings round-trip.

- Remove the toggle from Messenger channel settings. The page opens on Surfaces.
- Always show the Messages tab in Widget settings when Support Inbox is on.
- Channels hub On/Off follows those surfaces, not stored `messenger.enabled`.
- Stop gating the widget messenger surface on `messenger.enabled`. The field is still written by widget activation so older stored JSON stays consistent.