### PR TITLE
refactor(settings): drop the Enable Help Center master switch

### DIFF
--- a/apps/web/e2e/tests/public/help-center.spec.ts
+++ b/apps/web/e2e/tests/public/help-center.spec.ts
@@ -6,9 +6,9 @@ import { test, expect } from '@playwright/test'
  * These tests cover the public-facing help center at /hc.
  * No authentication is required.
  *
- * The help center requires the `helpCenter` feature flag and `helpCenterConfig.enabled`
- * to be true for the acme workspace. Tests degrade gracefully (early return or
- * conditional assertions) when the flag is off or seed data is absent.
+ * The help center requires the `helpCenter` feature flag to be on for the acme
+ * workspace. Tests degrade gracefully (early return or conditional assertions)
+ * when the flag is off or seed data is absent.
  */
 
 test.describe('Public Help Center', () => {

--- a/apps/web/src/components/public/portal-header.tsx
+++ b/apps/web/src/components/public/portal-header.tsx
@@ -67,8 +67,7 @@ export function PortalHeader({
 
   const flags = settings?.featureFlags
   const feedbackEnabled = isProductEnabled(flags, 'feedback')
-  const helpCenterEnabled =
-    isProductEnabled(flags, 'helpCenter') && !!settings?.helpCenterConfig?.enabled
+  const helpCenterEnabled = isProductEnabled(flags, 'helpCenter')
   const supportEnabled =
     !!flags?.supportTickets || (!!flags?.supportInbox && !!settings?.portalConfig?.support?.enabled)
   // Default true so a workspace that never customized this setting keeps

--- a/apps/web/src/lib/server/domains/settings/__tests__/widget-config.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/widget-config.test.ts
@@ -249,6 +249,26 @@ describe('getPublicWidgetConfig — messenger tab projection', () => {
   })
 })
 
+describe('getPublicWidgetConfig — help tab projection', () => {
+  it('projects tabs.help from the flag + tab, ignoring stored helpCenterConfig.enabled', async () => {
+    settingsRow.current = {
+      ...fixtureRow({ enabled: true, tabs: { help: true, feedback: false } }, { helpCenter: true }),
+      helpCenterConfig: JSON.stringify({ enabled: false }),
+    }
+    const projected = await getPublicWidgetConfig()
+    expect(projected.tabs?.help).toBe(true)
+  })
+
+  it('projects tabs.help false when the flag is off', async () => {
+    settingsRow.current = fixtureRow(
+      { enabled: true, tabs: { help: true, feedback: false } },
+      { helpCenter: false }
+    )
+    const projected = await getPublicWidgetConfig()
+    expect(projected.tabs?.help).toBe(false)
+  })
+})
+
 describe('getPublicWidgetConfig — tickets projection (converged Messages)', () => {
   it('projects tabs.tickets from the supportTickets flag alone — no per-tab toggle', async () => {
     // The flag is set explicitly, and the stored tabs deliberately carry no

--- a/apps/web/src/lib/server/domains/settings/settings.types.ts
+++ b/apps/web/src/lib/server/domains/settings/settings.types.ts
@@ -889,6 +889,10 @@ export interface HelpCenterHeaderLink {
 export const HELP_CENTER_HEADER_LINKS_MAX = 3
 
 export interface HelpCenterConfig {
+  /**
+   * @deprecated Ignored at read time. Help Center is public when the
+   * `helpCenter` product flag is on; widget visibility is `tabs.help`.
+   */
   enabled: boolean
   homepageTitle: string
   homepageDescription: string

--- a/apps/web/src/lib/server/domains/settings/settings.widget.ts
+++ b/apps/web/src/lib/server/domains/settings/settings.widget.ts
@@ -14,7 +14,6 @@ import type {
 import {
   DEFAULT_WIDGET_CONFIG,
   DEFAULT_MESSENGER_CONFIG,
-  DEFAULT_HELP_CENTER_CONFIG,
   resolveFeatureFlags,
 } from './settings.types'
 import type { AssistantConfigAuditActor } from './settings.assistant'
@@ -332,11 +331,10 @@ export async function getPublicWidgetConfig(): Promise<PublicWidgetConfig> {
       ? assistantConfig.data.identity
       : DEFAULT_ASSISTANT_CONFIG.identity
     const flags = resolveFeatureFlags(org.featureFlags)
-    const helpCenter = parseJsonConfig(org.helpCenterConfig, DEFAULT_HELP_CENTER_CONFIG)
     const tabs = {
       feedback: (config.tabs?.feedback ?? true) && flags.feedback,
       changelog: (config.tabs?.changelog ?? false) && flags.changelog,
-      help: (config.tabs?.help ?? false) && flags.helpCenter && helpCenter.enabled,
+      help: (config.tabs?.help ?? false) && flags.helpCenter,
       messenger: (config.tabs?.messenger ?? false) && flags.supportInbox,
       // Converged Messages: ticket pairs surface through the messenger tab,
       // gated by the supportTickets flag alone (there is no Tickets tab).

--- a/apps/web/src/routes/_portal/hc.tsx
+++ b/apps/web/src/routes/_portal/hc.tsx
@@ -39,7 +39,7 @@ export const Route = createFileRoute('/_portal/hc')({
     // redirect needs to live (domains/languages §1).
     const currentHost = currentRequestHost()
     const target = resolveHelpCenterDomainRedirect({
-      domainConfig: helpCenterConfig.domain,
+      domainConfig: helpCenterConfig?.domain,
       currentHost,
       pathname: location.pathname,
       // `searchStr` already includes the leading `?` when non-empty.

--- a/apps/web/src/routes/_portal/hc.tsx
+++ b/apps/web/src/routes/_portal/hc.tsx
@@ -33,7 +33,6 @@ export const Route = createFileRoute('/_portal/hc')({
     if (!flags?.helpCenter) throw notFound()
 
     const helpCenterConfig = settings?.helpCenterConfig as HelpCenterConfig | undefined
-    if (!helpCenterConfig?.enabled) throw notFound()
 
     // Full-coverage 301: every /hc/* route is nested under this layout, so
     // this is the single place the default-host -> verified-custom-domain

--- a/apps/web/src/routes/_portal/index.tsx
+++ b/apps/web/src/routes/_portal/index.tsx
@@ -67,7 +67,7 @@ export const Route = createFileRoute('/_portal/')({
           (org.featureFlags.supportInbox && org.portalConfig.support?.enabled === true)
         if (supportPublished) throw redirect({ to: '/support' })
       }
-      if (isProductEnabled(org.featureFlags, 'helpCenter') && org.helpCenterConfig.enabled) {
+      if (isProductEnabled(org.featureFlags, 'helpCenter')) {
         throw redirect({ to: '/hc' })
       }
       if (isProductEnabled(org.featureFlags, 'changelog')) {

--- a/apps/web/src/routes/admin/settings.branding.tsx
+++ b/apps/web/src/routes/admin/settings.branding.tsx
@@ -275,7 +275,7 @@ function BrandingPage() {
       changelog:
         isProductEnabled(flags, 'changelog') &&
         (settings?.changelogConfig?.portalTabEnabled ?? true),
-      help: isProductEnabled(flags, 'helpCenter') && !!settings?.helpCenterConfig?.enabled,
+      help: isProductEnabled(flags, 'helpCenter'),
       support:
         !!flags?.supportTickets ||
         (!!flags?.supportInbox && !!settings?.portalConfig?.support?.enabled),

--- a/apps/web/src/routes/admin/settings.help-center.tsx
+++ b/apps/web/src/routes/admin/settings.help-center.tsx
@@ -9,7 +9,6 @@ import { InlineSpinner } from '@/components/admin/settings/inline-spinner'
 import { BackLink } from '@/components/ui/back-link'
 import { PageHeader } from '@/components/shared/page-header'
 import { SettingsCard } from '@/components/admin/settings/settings-card'
-import { Switch } from '@/components/ui/switch'
 import { Label } from '@/components/ui/label'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
@@ -27,7 +26,7 @@ import {
 
 /**
  * Split by concern, matching the Access & Security page's `?tab=` pattern:
- *  - `general`            — enable/disable + homepage chrome
+ *  - `general`            — homepage chrome
  *  - `domains-languages`  — custom domain, redirect rules, indexing (IA:
  *                           Products > Help Center > Domains & languages)
  */
@@ -65,7 +64,6 @@ function HelpCenterSettingsPage() {
   const helpCenterConfigQuery = useSuspenseQuery(settingsQueries.helpCenterConfig())
   const config = helpCenterConfigQuery.data as HelpCenterConfig
 
-  const [enabled, setEnabled] = useState(config.enabled)
   const [homepageTitle, setHomepageTitle] = useState(config.homepageTitle)
   const [homepageDescription, setHomepageDescription] = useState(config.homepageDescription)
   const [headerLinks, setHeaderLinks] = useState<HelpCenterHeaderLink[]>(config.headerLinks ?? [])
@@ -98,11 +96,6 @@ function HelpCenterSettingsPage() {
   const { queue: queueDescriptionSave } = useDebouncedSave<string>((value) => {
     saveField({ homepageDescription: value })
   }, 800)
-
-  function handleEnabledToggle(checked: boolean) {
-    setEnabled(checked)
-    saveField({ enabled: checked })
-  }
 
   function handleTitleChange(value: string) {
     setHomepageTitle(value)
@@ -175,34 +168,6 @@ function HelpCenterSettingsPage() {
         </TabsList>
 
         <TabsContent value="general" className="space-y-6">
-          {/* Enable / Disable */}
-          <SettingsCard
-            title="Help Center"
-            description="Enable or disable the help center for your users"
-          >
-            <div className="flex items-center justify-between rounded-lg border border-border/50 p-4">
-              <div>
-                <Label htmlFor="hc-enable" className="text-sm font-medium cursor-pointer">
-                  Enable Help Center
-                </Label>
-                <p className="text-xs text-muted-foreground mt-0.5">
-                  When enabled, your help center will be accessible to users
-                </p>
-              </div>
-              <div className="flex items-center gap-2">
-                <InlineSpinner visible={isBusy} />
-                <Switch
-                  id="hc-enable"
-                  checked={enabled}
-                  onCheckedChange={handleEnabledToggle}
-                  disabled={isBusy}
-                  aria-label="Enable Help Center"
-                />
-              </div>
-            </div>
-          </SettingsCard>
-
-          {/* Homepage */}
           <SettingsCard title="Homepage" description="Customize the help center landing page">
             <div className="space-y-4">
               <div className="space-y-1.5">

--- a/apps/web/src/routes/admin/settings.widget.tsx
+++ b/apps/web/src/routes/admin/settings.widget.tsx
@@ -87,7 +87,6 @@ export const Route = createFileRoute('/admin/settings/widget')({
     const { queryClient } = context
     await Promise.all([
       queryClient.ensureQueryData(settingsQueries.widgetConfig()),
-      queryClient.ensureQueryData(settingsQueries.helpCenterConfig()),
       queryClient.ensureQueryData(adminQueries.boards()),
       queryClient.ensureQueryData(adminQueries.onboardingStatus()),
     ])
@@ -105,17 +104,14 @@ export function WidgetSettingsGate() {
 
 function WidgetSettingsPage() {
   const widgetConfigQuery = useSuspenseQuery(settingsQueries.widgetConfig())
-  const helpCenterConfigQuery = useSuspenseQuery(settingsQueries.helpCenterConfig())
   const boardsQuery = useSuspenseQuery(adminQueries.boards())
   const onboardingQuery = useSuspenseQuery(adminQueries.onboardingStatus())
   const { settings } = useRouteContext({ from: '__root__' })
 
   const flags = settings?.featureFlags as FeatureFlags | undefined
   const config = widgetConfigQuery.data
-  const helpCenterConfig = helpCenterConfigQuery.data
 
   const helpCenterFlagEnabled = flags?.helpCenter ?? false
-  const helpCenterEnabled = helpCenterConfig?.enabled ?? false
   const supportInboxFlagEnabled = flags?.supportInbox ?? false
 
   // Lifted editor state: position drives the preview's launcher chrome.
@@ -171,7 +167,6 @@ function WidgetSettingsPage() {
             launcherLabel={launcherLabel}
             onLabelChange={setLauncherLabel}
             helpCenterFlagEnabled={helpCenterFlagEnabled}
-            helpCenterEnabled={helpCenterEnabled}
             supportInboxFlagEnabled={supportInboxFlagEnabled}
           />
 
@@ -313,7 +308,6 @@ function ModulesCard({
   launcherLabel,
   onLabelChange,
   helpCenterFlagEnabled,
-  helpCenterEnabled,
   supportInboxFlagEnabled,
 }: {
   config: {
@@ -334,7 +328,6 @@ function ModulesCard({
   launcherLabel: string
   onLabelChange: (val: string) => void
   helpCenterFlagEnabled: boolean
-  helpCenterEnabled: boolean
   supportInboxFlagEnabled: boolean
 }) {
   const router = useRouter()
@@ -350,7 +343,7 @@ function ModulesCard({
     help: config.tabs?.help ?? false,
   })
 
-  const showHelpToggle = helpCenterFlagEnabled && helpCenterEnabled
+  const showHelpToggle = helpCenterFlagEnabled
 
   const isBusy = saving || isPending
 

--- a/apps/web/src/routes/hc/sitemap[.]xml.ts
+++ b/apps/web/src/routes/hc/sitemap[.]xml.ts
@@ -24,9 +24,6 @@ export const Route = createFileRoute('/hc/sitemap.xml')({
         }
 
         const helpCenterConfig = await getHelpCenterConfig()
-        if (!helpCenterConfig.enabled) {
-          return new Response('Not Found', { status: 404 })
-        }
 
         // Indexing toggle (domains/languages §1): an operator that turned off
         // "allow search engines to index" doesn't want a sitemap advertised either.

--- a/apps/web/src/routes/robots[.]txt.ts
+++ b/apps/web/src/routes/robots[.]txt.ts
@@ -11,7 +11,7 @@ export const Route = createFileRoute('/robots.txt')({
         const baseUrl = config.baseUrl
 
         const helpCenterConfig = await getHelpCenterConfig()
-        const helpCenterEnabled = (await isFeatureEnabled('helpCenter')) && helpCenterConfig.enabled
+        const helpCenterEnabled = await isFeatureEnabled('helpCenter')
         // Indexing toggle (domains/languages §1): off means neither crawlable
         // nor advertised via a sitemap link.
         const helpCenterIndexable = helpCenterEnabled && helpCenterConfig.seo?.indexable !== false

--- a/apps/web/src/routes/widget/index.tsx
+++ b/apps/web/src/routes/widget/index.tsx
@@ -113,7 +113,6 @@ export const Route = createFileRoute('/widget/')({
 
     const helpTabEnabled =
       ((settings?.featureFlags as { helpCenter?: boolean } | undefined)?.helpCenter ?? false) &&
-      (settings?.helpCenterConfig?.enabled ?? false) &&
       (settings?.publicWidgetConfig?.tabs?.help ?? false)
     const changelogTabEnabled =
       changelogProductEnabled && (settings?.publicWidgetConfig?.tabs?.changelog ?? false)
@@ -241,10 +240,7 @@ export const Route = createFileRoute('/widget/')({
       tabs: {
         feedback: feedbackProductEnabled && (settings?.publicWidgetConfig?.tabs?.feedback ?? true),
         changelog: changelogTabEnabled,
-        help:
-          ((settings?.featureFlags as { helpCenter?: boolean } | undefined)?.helpCenter ?? false) &&
-          (settings?.helpCenterConfig?.enabled ?? false) &&
-          (settings?.publicWidgetConfig?.tabs?.help ?? false),
+        help: helpTabEnabled,
         // Support Inbox flag + Messages tab on (computed above), OR
         // tickets on (the converged surface lists ticket pairs here). The
         // persisted config names the messenger surface `messenger`; the widget


### PR DESCRIPTION
Help Center is public when the product flag is on. The extra enable
toggle hid the widget Help tab and the portal Help nav behind a
second switch. Widget visibility stays on tabs.help; stored
helpCenterConfig.enabled is ignored at read time.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>