### PR TITLE
refactor(settings): let Branding own changelog and status portal tabs

### DIFF
--- a/apps/web/src/components/admin/settings/changelog/visibility-card.tsx
+++ b/apps/web/src/components/admin/settings/changelog/visibility-card.tsx
@@ -1,5 +1,4 @@
 import { SettingsCard } from '@/components/admin/settings/settings-card'
-import { Switch } from '@/components/ui/switch'
 import { Label } from '@/components/ui/label'
 import {
   Select,
@@ -20,51 +19,29 @@ export function VisibilityCard({ settings, onChange, disabled }: VisibilityCardP
   return (
     <SettingsCard
       title="Visibility"
-      description="Choose who can see your changelog and whether it appears in the portal nav."
+      description="Choose who can see your changelog. Hide or rename the portal tab in Branding → Navigation."
     >
-      <div className="space-y-5">
-        <div className="flex items-center justify-between gap-4 py-1">
-          <div className="pr-4">
-            <Label className="text-sm font-medium">Audience</Label>
-            <p className="mt-0.5 text-xs text-muted-foreground">
-              Public shows the changelog to everyone. Authenticated limits it to signed-in portal
-              users.
-            </p>
-          </div>
-          <Select
-            value={settings.audience}
-            onValueChange={(value) =>
-              onChange({ audience: value as ChangelogSettings['audience'] })
-            }
-            disabled={disabled}
-          >
-            <SelectTrigger className="w-44">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="public">Public</SelectItem>
-              <SelectItem value="authenticated">Authenticated</SelectItem>
-            </SelectContent>
-          </Select>
+      <div className="flex items-center justify-between gap-4 py-1">
+        <div className="pr-4">
+          <Label className="text-sm font-medium">Audience</Label>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            Public shows the changelog to everyone. Authenticated limits it to signed-in portal
+            users.
+          </p>
         </div>
-
-        <div className="flex items-center justify-between gap-4 py-1">
-          <div className="pr-4">
-            <Label htmlFor="changelog-portal-tab" className="text-sm font-medium cursor-pointer">
-              Show in portal navigation
-            </Label>
-            <p className="mt-0.5 text-xs text-muted-foreground">
-              Adds a "Changelog" tab to the portal top nav. Turning this off does not disable the
-              public changelog page or its RSS feed.
-            </p>
-          </div>
-          <Switch
-            id="changelog-portal-tab"
-            checked={settings.portalTabEnabled}
-            onCheckedChange={(checked) => onChange({ portalTabEnabled: checked })}
-            disabled={disabled}
-          />
-        </div>
+        <Select
+          value={settings.audience}
+          onValueChange={(value) => onChange({ audience: value as ChangelogSettings['audience'] })}
+          disabled={disabled}
+        >
+          <SelectTrigger className="w-44">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="public">Public</SelectItem>
+            <SelectItem value="authenticated">Authenticated</SelectItem>
+          </SelectContent>
+        </Select>
       </div>
     </SettingsCard>
   )

--- a/apps/web/src/components/admin/settings/status/status-general-card.tsx
+++ b/apps/web/src/components/admin/settings/status/status-general-card.tsx
@@ -21,39 +21,22 @@ export function StatusGeneralCard({
   return (
     <SettingsCard
       title="General"
-      description="Turn the status page on and control where it appears."
+      description="Publish the status page. Hide or rename the portal tab in Branding → Navigation."
     >
       <div className="space-y-5">
         <div className="flex items-center justify-between gap-4 py-1">
           <div className="pr-4">
             <Label htmlFor="status-enabled" className="text-sm font-medium cursor-pointer">
-              Enable status page
+              Publish status page
             </Label>
             <p className="mt-0.5 text-xs text-muted-foreground">
-              Publishes your status page and starts recording uptime history.
+              Makes the page public and starts recording uptime history.
             </p>
           </div>
           <Switch
             id="status-enabled"
             checked={settings.enabled}
             onCheckedChange={(checked) => onChange({ enabled: checked })}
-            disabled={disabled}
-          />
-        </div>
-
-        <div className="flex items-center justify-between gap-4 py-1">
-          <div className="pr-4">
-            <Label htmlFor="status-portal-tab" className="text-sm font-medium cursor-pointer">
-              Show tab on portal
-            </Label>
-            <p className="mt-0.5 text-xs text-muted-foreground">
-              Adds a Status tab to the portal navigation for viewers who can see the page.
-            </p>
-          </div>
-          <Switch
-            id="status-portal-tab"
-            checked={settings.portalTabEnabled}
-            onCheckedChange={(checked) => onChange({ portalTabEnabled: checked })}
             disabled={disabled}
           />
         </div>

--- a/apps/web/src/components/public/portal-header.tsx
+++ b/apps/web/src/components/public/portal-header.tsx
@@ -70,20 +70,16 @@ export function PortalHeader({
   const helpCenterEnabled = isProductEnabled(flags, 'helpCenter')
   const supportEnabled =
     !!flags?.supportTickets || (!!flags?.supportInbox && !!settings?.portalConfig?.support?.enabled)
-  // Default true so a workspace that never customized this setting keeps
-  // the changelog tab it had before this toggle existed.
-  const changelogEnabled =
-    isProductEnabled(flags, 'changelog') && (settings?.changelogConfig?.portalTabEnabled ?? true)
-  // Status tab: flag + product enabled + tab toggle. A non-public audience
-  // still needs a signed-in viewer to bother showing the tab; the route
-  // enforces the real per-viewer segment gate (settings here are
-  // workspace-global, not per-viewer).
+  const changelogEnabled = isProductEnabled(flags, 'changelog')
+  // Status tab: product flag + published. A non-public audience still needs
+  // a signed-in viewer to bother showing the tab; the route enforces the
+  // real per-viewer segment gate (settings here are workspace-global, not
+  // per-viewer). Hide or reorder the tab in Branding → Navigation.
   const statusAudience = settings?.statusConfig?.audience ?? 'public'
   const statusLoggedIn = !!session?.user && session.user.principalType !== 'anonymous'
   const statusEnabled =
     isProductEnabled(flags, 'status') &&
     !!settings?.statusConfig?.enabled &&
-    (settings?.statusConfig?.portalTabEnabled ?? true) &&
     (statusAudience === 'public' || statusLoggedIn)
   const onHelpPages = pathname === '/hc' || pathname.startsWith('/hc/')
   // Admin-configured help center links render beside the built-in nav on help

--- a/apps/web/src/lib/server/domains/settings/settings.status.ts
+++ b/apps/web/src/lib/server/domains/settings/settings.status.ts
@@ -1,7 +1,7 @@
 /**
  * Status page settings family (Status Product Spec §3): enablement, the
- * portal nav tab toggle, the page visibility ladder (public / authenticated /
- * segments), and the email switches.
+ * page visibility ladder (public / authenticated / segments), and the
+ * email switches. Portal chrome lives in Branding → Navigation.
  *
  * Storage: like changelog and office-hours settings, these ride in the
  * generic `settings.metadata` JSON bag (no dedicated column, no migration).

--- a/apps/web/src/lib/shared/changelog-settings.ts
+++ b/apps/web/src/lib/shared/changelog-settings.ts
@@ -12,7 +12,9 @@ export type ChangelogAudience = 'public' | 'authenticated'
 export interface ChangelogSettings {
   /** Public visitors vs. signed-in portal users only. */
   audience: ChangelogAudience
-  /** Show the "Changelog" tab in the portal top nav. */
+  /**
+   * @deprecated Ignored at read time. Portal chrome is Branding → Navigation.
+   */
   portalTabEnabled: boolean
   /** Turns off comments + reactions on changelog entries (one toggle, per spec). */
   collaborationDisabled: boolean

--- a/apps/web/src/lib/shared/status-settings.ts
+++ b/apps/web/src/lib/shared/status-settings.ts
@@ -17,7 +17,9 @@ export type StatusAudience = 'public' | 'authenticated' | 'segments'
 export interface StatusSettings {
   /** Master switch: publishes the page and starts recording uptime history. */
   enabled: boolean
-  /** Show the "Status" tab in the portal top nav. */
+  /**
+   * @deprecated Ignored at read time. Portal chrome is Branding → Navigation.
+   */
   portalTabEnabled: boolean
   audience: StatusAudience
   /** Segments allowed to view the page when audience = 'segments'. */

--- a/apps/web/src/routes/admin/settings.branding.tsx
+++ b/apps/web/src/routes/admin/settings.branding.tsx
@@ -272,17 +272,12 @@ function BrandingPage() {
     const gates: Record<PortalBuiltInNavType, boolean> = {
       feedback: isProductEnabled(flags, 'feedback'),
       roadmap: isProductEnabled(flags, 'feedback'),
-      changelog:
-        isProductEnabled(flags, 'changelog') &&
-        (settings?.changelogConfig?.portalTabEnabled ?? true),
+      changelog: isProductEnabled(flags, 'changelog'),
       help: isProductEnabled(flags, 'helpCenter'),
       support:
         !!flags?.supportTickets ||
         (!!flags?.supportInbox && !!settings?.portalConfig?.support?.enabled),
-      status:
-        isProductEnabled(flags, 'status') &&
-        !!settings?.statusConfig?.enabled &&
-        (settings?.statusConfig?.portalTabEnabled ?? true),
+      status: isProductEnabled(flags, 'status') && !!settings?.statusConfig?.enabled,
     }
     return new Set(
       (Object.keys(gates) as PortalBuiltInNavType[]).filter((type) => !gates[type])


### PR DESCRIPTION
The Changelog and Status product pages each had a "show this tab" switch
on top of Branding → Navigation, which already hides, renames, and
reorders those rows. Drop the extra toggles; stored portalTabEnabled is
ignored at read time. Status still has a publish switch because it
starts uptime recording.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>