### PR TITLE
feat(admin): information-rich user profile with CRM rail and enriched hover cards

### DIFF
--- a/apps/web/src/components/admin/__tests__/admin-author-hover-card.test.tsx
+++ b/apps/web/src/components/admin/__tests__/admin-author-hover-card.test.tsx
@@ -1,0 +1,177 @@
+// @vitest-environment happy-dom
+/**
+ * AdminAuthorHoverCard — the lazy admin author hover card.
+ *
+ * Covers the data contract that matters:
+ *   - Hovering fetches the public profile AND the people.view-gated team
+ *     context on open (not on mount).
+ *   - A null public profile shows no card body.
+ *   - Team rows (company, last seen, segments with a +N cap) render from
+ *     the team payload; clicking the trigger navigates to the admin profile.
+ */
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import type { ReactElement } from 'react'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const navigate = vi.fn()
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => navigate,
+}))
+
+const getPublicUserProfileFn = vi.fn()
+const getProfileTeamContextFn = vi.fn()
+vi.mock('@/lib/server/functions/public-profile', () => ({
+  getPublicUserProfileFn: (...args: unknown[]) => getPublicUserProfileFn(...args),
+  getProfileTeamContextFn: (...args: unknown[]) => getProfileTeamContextFn(...args),
+}))
+
+import { AdminAuthorHoverCard } from '../admin-author-hover-card'
+
+const PROFILE = {
+  principalId: 'principal_abc',
+  displayName: 'Ada Lovelace',
+  avatarUrl: null,
+  isTeamMember: false,
+  joinedAt: '2024-03-01T00:00:00.000Z',
+  postCount: 7,
+  commentCount: 12,
+  voteCount: 42,
+  posts: [],
+  comments: [],
+  upvotes: [],
+}
+
+const TEAM = {
+  email: 'ada@example.com',
+  emailVerified: true,
+  blocked: false,
+  lastSeenAt: '2026-04-01T12:00:00.000Z',
+  company: { id: 'company_1', name: 'Northwind', plan: 'Growth', mrrCents: 49900 },
+  segments: [
+    { id: 'segment_1', name: 'Beta cohort', color: '#a855f7' },
+    { id: 'segment_2', name: 'High MRR', color: '#22c55e' },
+  ],
+}
+
+function renderCard(ui: ReactElement) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>)
+}
+
+beforeEach(() => {
+  navigate.mockReset()
+  getPublicUserProfileFn.mockReset()
+  getProfileTeamContextFn.mockReset()
+})
+afterEach(cleanup)
+
+describe('AdminAuthorHoverCard', () => {
+  it('does not fetch on mount, only on open', () => {
+    renderCard(
+      <AdminAuthorHoverCard principalId="principal_abc" displayName="Ada Lovelace">
+        Ada Lovelace
+      </AdminAuthorHoverCard>
+    )
+    expect(screen.getByText('Ada Lovelace')).toBeInTheDocument()
+    expect(getPublicUserProfileFn).not.toHaveBeenCalled()
+    expect(getProfileTeamContextFn).not.toHaveBeenCalled()
+  })
+
+  it('opens on hover, fetches both payloads, and renders team rows + votes label', async () => {
+    getPublicUserProfileFn.mockResolvedValue(PROFILE)
+    getProfileTeamContextFn.mockResolvedValue(TEAM)
+    renderCard(
+      <AdminAuthorHoverCard principalId="principal_abc" displayName="Ada Lovelace">
+        Ada Lovelace
+      </AdminAuthorHoverCard>
+    )
+
+    fireEvent.mouseEnter(screen.getByText('Ada Lovelace'))
+
+    await waitFor(() => expect(getPublicUserProfileFn).toHaveBeenCalledTimes(1))
+    expect(getProfileTeamContextFn).toHaveBeenCalledWith({
+      data: { principalId: 'principal_abc' },
+    })
+
+    const body = await screen.findByTestId('admin-author-hover-card-body')
+    expect(body).toHaveTextContent('ada@example.com')
+    expect(body).toHaveTextContent('Northwind')
+    expect(body).toHaveTextContent('Growth')
+    expect(body).toHaveTextContent('Beta cohort')
+    expect(body).toHaveTextContent('High MRR')
+    expect(body).toHaveTextContent('Votes')
+    expect(body).toHaveTextContent('Open full profile')
+    expect(body.querySelector('svg')) // verified icon
+  })
+
+  it('caps overflowing segments to one named chip plus a +N counter', async () => {
+    getPublicUserProfileFn.mockResolvedValue(PROFILE)
+    getProfileTeamContextFn.mockResolvedValue({
+      ...TEAM,
+      segments: [
+        { id: 's1', name: 'Alpha', color: '#000' },
+        { id: 's2', name: 'Beta', color: '#111' },
+        { id: 's3', name: 'Gamma', color: '#222' },
+        { id: 's4', name: 'Delta', color: '#333' },
+      ],
+    })
+    renderCard(
+      <AdminAuthorHoverCard principalId="principal_abc" displayName="Ada Lovelace">
+        Ada Lovelace
+      </AdminAuthorHoverCard>
+    )
+    fireEvent.mouseEnter(screen.getByText('Ada Lovelace'))
+    const body = await screen.findByTestId('admin-author-hover-card-body')
+    expect(body).toHaveTextContent('Alpha')
+    expect(body).toHaveTextContent('+3')
+    expect(body).not.toHaveTextContent('Beta')
+  })
+
+  it('shows a Blocked badge when the team payload says so', async () => {
+    getPublicUserProfileFn.mockResolvedValue(PROFILE)
+    getProfileTeamContextFn.mockResolvedValue({ ...TEAM, blocked: true })
+    renderCard(
+      <AdminAuthorHoverCard principalId="principal_abc" displayName="Ada Lovelace">
+        Ada Lovelace
+      </AdminAuthorHoverCard>
+    )
+    fireEvent.mouseEnter(screen.getByText('Ada Lovelace'))
+    const body = await screen.findByTestId('admin-author-hover-card-body')
+    expect(body).toHaveTextContent('Blocked')
+  })
+
+  it('shows no card body when the public profile resolves null', async () => {
+    getPublicUserProfileFn.mockResolvedValue(null)
+    getProfileTeamContextFn.mockResolvedValue(null)
+    renderCard(
+      <AdminAuthorHoverCard principalId="principal_ghost" displayName="Ghost">
+        Ghost
+      </AdminAuthorHoverCard>
+    )
+
+    fireEvent.mouseEnter(screen.getByText('Ghost'))
+    await waitFor(() => expect(getPublicUserProfileFn).toHaveBeenCalledTimes(1))
+
+    await waitFor(() =>
+      expect(screen.queryByTestId('admin-author-hover-card-skeleton')).not.toBeInTheDocument()
+    )
+    expect(screen.queryByTestId('admin-author-hover-card-body')).not.toBeInTheDocument()
+    expect(screen.getByText('Ghost')).toBeInTheDocument()
+  })
+
+  it('navigates to the admin profile on trigger click', async () => {
+    getPublicUserProfileFn.mockResolvedValue(PROFILE)
+    getProfileTeamContextFn.mockResolvedValue(TEAM)
+    renderCard(
+      <AdminAuthorHoverCard principalId="principal_abc" displayName="Ada Lovelace">
+        Ada Lovelace
+      </AdminAuthorHoverCard>
+    )
+    fireEvent.click(screen.getByText('Ada Lovelace'))
+    expect(navigate).toHaveBeenCalledWith({
+      to: '/admin/users',
+      search: { selected: 'principal_abc' },
+    })
+  })
+})

--- a/apps/web/src/components/admin/__tests__/admin-author-hover-card.test.tsx
+++ b/apps/web/src/components/admin/__tests__/admin-author-hover-card.test.tsx
@@ -19,6 +19,11 @@ vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => navigate,
 }))
 
+let canViewPeople = true
+vi.mock('@/lib/client/use-permissions', () => ({
+  useHasPermission: () => canViewPeople,
+}))
+
 const getPublicUserProfileFn = vi.fn()
 const getProfileTeamContextFn = vi.fn()
 vi.mock('@/lib/server/functions/public-profile', () => ({
@@ -63,6 +68,7 @@ beforeEach(() => {
   navigate.mockReset()
   getPublicUserProfileFn.mockReset()
   getProfileTeamContextFn.mockReset()
+  canViewPeople = true
 })
 afterEach(cleanup)
 
@@ -172,6 +178,37 @@ describe('AdminAuthorHoverCard', () => {
     expect(navigate).toHaveBeenCalledWith({
       to: '/admin/users',
       search: { selected: 'principal_abc' },
+    })
+  })
+
+  it('does not fetch team context or expose email without people.view', async () => {
+    canViewPeople = false
+    getPublicUserProfileFn.mockResolvedValue(PROFILE)
+    renderCard(
+      <AdminAuthorHoverCard principalId="principal_abc" displayName="Ada Lovelace">
+        Ada Lovelace
+      </AdminAuthorHoverCard>
+    )
+
+    fireEvent.mouseEnter(screen.getByText('Ada Lovelace'))
+    const body = await screen.findByTestId('admin-author-hover-card-body')
+    expect(getProfileTeamContextFn).not.toHaveBeenCalled()
+    expect(body).not.toHaveTextContent('ada@example.com')
+    expect(body).not.toHaveTextContent('Open full profile')
+    expect(body).not.toHaveTextContent('Company')
+  })
+
+  it('falls back to the public profile when the caller lacks people.view', () => {
+    canViewPeople = false
+    renderCard(
+      <AdminAuthorHoverCard principalId="principal_abc" displayName="Ada Lovelace">
+        Ada Lovelace
+      </AdminAuthorHoverCard>
+    )
+    fireEvent.click(screen.getByText('Ada Lovelace'))
+    expect(navigate).toHaveBeenCalledWith({
+      to: '/u/$principalId',
+      params: { principalId: 'principal_abc' },
     })
   })
 })

--- a/apps/web/src/components/admin/admin-author-hover-card.tsx
+++ b/apps/web/src/components/admin/admin-author-hover-card.tsx
@@ -1,0 +1,296 @@
+/**
+ * AdminAuthorHoverCard
+ *
+ * Admin sibling of the portal author hover card. Same lazy 200ms open /
+ * fetch-on-open / null-payload = no card contract, plus people.view-gated
+ * team rows (email, company, last seen, segments) and a footer that opens
+ * the admin user profile (`/admin/users?selected=`).
+ *
+ * Anonymous and service principals never resolve a public profile, so they
+ * never get a card — same anti-enumeration contract as the portal.
+ */
+import { useRef, useState, type ReactNode } from 'react'
+import { useNavigate } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
+import { ArrowRightIcon, CheckCircleIcon } from '@heroicons/react/24/solid'
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
+import { Avatar } from '@/components/ui/avatar'
+import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
+import { TimeAgo } from '@/components/ui/time-ago'
+import { cn } from '@/lib/shared/utils'
+import {
+  getPublicUserProfileFn,
+  getProfileTeamContextFn,
+  type ProfileTeamContextView,
+} from '@/lib/server/functions/public-profile'
+
+const HOVER_OPEN_DELAY_MS = 200
+const HOVER_CLOSE_DELAY_MS = 150
+const MAX_VISIBLE_SEGMENTS = 2
+
+interface AdminAuthorHoverCardProps {
+  principalId: string
+  displayName: string | null
+  children: ReactNode
+  className?: string
+}
+
+export function AdminAuthorHoverCard({
+  principalId,
+  displayName,
+  children,
+  className,
+}: AdminAuthorHoverCardProps) {
+  const navigate = useNavigate()
+  const [open, setOpen] = useState(false)
+  const openTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const profileQuery = useQuery({
+    queryKey: ['portal', 'author-hover-card', principalId],
+    queryFn: () => getPublicUserProfileFn({ data: { principalId } }),
+    enabled: open,
+    staleTime: 60_000,
+  })
+  const teamQuery = useQuery({
+    queryKey: ['admin', 'author-hover-card-team', principalId],
+    queryFn: () => getProfileTeamContextFn({ data: { principalId } }),
+    enabled: open,
+    staleTime: 60_000,
+  })
+
+  function clearTimers() {
+    if (openTimer.current) clearTimeout(openTimer.current)
+    if (closeTimer.current) clearTimeout(closeTimer.current)
+    openTimer.current = null
+    closeTimer.current = null
+  }
+
+  function scheduleOpen() {
+    clearTimers()
+    openTimer.current = setTimeout(() => setOpen(true), HOVER_OPEN_DELAY_MS)
+  }
+
+  function scheduleClose() {
+    clearTimers()
+    closeTimer.current = setTimeout(() => setOpen(false), HOVER_CLOSE_DELAY_MS)
+  }
+
+  function goToProfile(e: { preventDefault: () => void; stopPropagation: () => void }) {
+    e.preventDefault()
+    e.stopPropagation()
+    void navigate({ to: '/admin/users', search: { selected: principalId } })
+  }
+
+  const profile = profileQuery.data ?? null
+  const hasCardContent = profileQuery.isLoading || !!profile
+
+  return (
+    <Popover open={open && hasCardContent} onOpenChange={setOpen}>
+      <PopoverAnchor asChild>
+        <span
+          role="link"
+          tabIndex={0}
+          data-principal-id={principalId}
+          onClick={goToProfile}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') goToProfile(e)
+          }}
+          onMouseEnter={scheduleOpen}
+          onMouseLeave={scheduleClose}
+          onFocus={scheduleOpen}
+          onBlur={scheduleClose}
+          className={cn(
+            'cursor-pointer rounded-sm hover:underline focus:outline-none focus-visible:underline',
+            className
+          )}
+        >
+          {children}
+        </span>
+      </PopoverAnchor>
+      <PopoverContent
+        className="w-72 p-3"
+        align="start"
+        sideOffset={6}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        onMouseEnter={scheduleOpen}
+        onMouseLeave={scheduleClose}
+      >
+        {profileQuery.isLoading ? (
+          <CardSkeleton />
+        ) : profile ? (
+          <div data-testid="admin-author-hover-card-body">
+            <div className="flex items-center gap-3">
+              <Avatar
+                src={profile.avatarUrl}
+                name={profile.displayName || displayName}
+                className="size-10"
+              />
+              <div className="min-w-0 flex-1">
+                <div className="flex min-w-0 items-center gap-1.5">
+                  <span className="min-w-0 truncate text-sm font-medium text-foreground">
+                    {profile.displayName || displayName || 'Anonymous'}
+                  </span>
+                  {teamQuery.data?.emailVerified && (
+                    <CheckCircleIcon className="size-3.5 shrink-0 text-primary" />
+                  )}
+                  {teamQuery.data?.blocked && (
+                    <Badge variant="destructive" size="sm" className="shrink-0">
+                      Blocked
+                    </Badge>
+                  )}
+                </div>
+                {teamQuery.data?.email ? (
+                  <div className="mt-0.5 truncate text-xs text-muted-foreground">
+                    {teamQuery.data.email}
+                  </div>
+                ) : teamQuery.isLoading ? (
+                  <Skeleton className="mt-0.5 h-3 w-32" />
+                ) : null}
+              </div>
+            </div>
+
+            <TeamInfoRows team={teamQuery.data ?? null} isLoading={teamQuery.isLoading} />
+
+            <div className="mt-3 flex items-center border-t border-border/50 pt-2.5">
+              <CardStat value={profile.postCount} label="Posts" />
+              <CardStat value={profile.commentCount} label="Comments" />
+              <CardStat value={profile.voteCount} label="Votes" />
+            </div>
+
+            <button
+              type="button"
+              onClick={goToProfile}
+              className="mt-3 flex w-full items-center justify-between border-t border-border/50 pt-2.5 text-primary"
+            >
+              <span className="text-xs font-medium">Open full profile</span>
+              <ArrowRightIcon className="size-3.5" />
+            </button>
+          </div>
+        ) : null}
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+function TeamInfoRows({
+  team,
+  isLoading,
+}: {
+  team: ProfileTeamContextView | null
+  isLoading: boolean
+}) {
+  if (isLoading && !team) {
+    return (
+      <div className="mt-3 space-y-[5px] border-t border-border/50 pt-2.5">
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-full" />
+      </div>
+    )
+  }
+  if (!team) return null
+
+  const segments = team.segments
+  // At most two chips in the row: two names, or one name plus a +N counter
+  // so the card height stays fixed however many segments the person is in.
+  const visibleCount = segments.length > MAX_VISIBLE_SEGMENTS ? 1 : segments.length
+  const visible = segments.slice(0, visibleCount)
+  const overflow = segments.length - visible.length
+
+  return (
+    <div className="mt-3 flex flex-col gap-[5px] border-t border-border/50 pt-2.5 text-xs leading-4">
+      <div className="flex items-center justify-between gap-2">
+        <span className="shrink-0 text-muted-foreground">Company</span>
+        <span className="min-w-0 truncate font-medium">
+          {team.company ? (
+            <>
+              {team.company.name}
+              {team.company.plan ? (
+                <span className="font-normal text-muted-foreground">
+                  {' '}
+                  &middot; {team.company.plan}
+                </span>
+              ) : null}
+            </>
+          ) : (
+            <span className="font-normal text-muted-foreground">—</span>
+          )}
+        </span>
+      </div>
+      <div className="flex items-center justify-between gap-2">
+        <span className="shrink-0 text-muted-foreground">Last seen</span>
+        <span className="min-w-0 truncate">
+          {team.lastSeenAt ? <TimeAgo date={team.lastSeenAt} /> : '—'}
+        </span>
+      </div>
+      {segments.length > 0 && (
+        <div className="flex items-center justify-between gap-2">
+          <span className="shrink-0 text-muted-foreground">Segments</span>
+          <span className="flex min-w-0 items-center justify-end gap-1 overflow-hidden">
+            {visible.map((seg) => (
+              <span
+                key={seg.id}
+                className="inline-flex shrink-0 items-center gap-1 rounded-full border border-border/60 px-1.5 py-px text-[11px] leading-[15px]"
+              >
+                <span
+                  className="size-1.5 shrink-0 rounded-full"
+                  style={{ backgroundColor: seg.color }}
+                />
+                {seg.name}
+              </span>
+            ))}
+            {overflow > 0 && (
+              <span className="inline-flex shrink-0 items-center rounded-full border border-border/60 px-1.5 py-px text-[11px] leading-[15px] text-muted-foreground">
+                +{overflow}
+              </span>
+            )}
+          </span>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function CardStat({ value, label }: { value: number; label: string }) {
+  return (
+    <div className="flex-1 text-center">
+      <div className="text-sm font-semibold tabular-nums text-foreground">{value}</div>
+      <div className="text-[11px] leading-[14px] text-muted-foreground">{label}</div>
+    </div>
+  )
+}
+
+function CardSkeleton() {
+  return (
+    <div data-testid="admin-author-hover-card-skeleton">
+      <div className="flex items-center gap-3">
+        <Skeleton className="size-10 shrink-0 rounded-full" />
+        <div className="flex-1 space-y-2 py-1">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-3 w-32" />
+        </div>
+      </div>
+      <div className="mt-3 space-y-[5px] border-t border-border/50 pt-2.5">
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-full" />
+      </div>
+      <div className="mt-3 flex items-center border-t border-border/50 pt-2.5">
+        <div className="flex flex-1 justify-center">
+          <Skeleton className="h-[34px] w-10" />
+        </div>
+        <div className="flex flex-1 justify-center">
+          <Skeleton className="h-[34px] w-10" />
+        </div>
+        <div className="flex flex-1 justify-center">
+          <Skeleton className="h-[34px] w-10" />
+        </div>
+      </div>
+      <div className="mt-3 border-t border-border/50 pt-2.5">
+        <Skeleton className="h-4 w-36" />
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/admin/admin-author-hover-card.tsx
+++ b/apps/web/src/components/admin/admin-author-hover-card.tsx
@@ -19,6 +19,8 @@ import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
 import { TimeAgo } from '@/components/ui/time-ago'
 import { cn } from '@/lib/shared/utils'
+import { PERMISSIONS } from '@/lib/shared/permissions'
+import { useHasPermission } from '@/lib/client/use-permissions'
 import {
   getPublicUserProfileFn,
   getProfileTeamContextFn,
@@ -43,6 +45,10 @@ export function AdminAuthorHoverCard({
   className,
 }: AdminAuthorHoverCardProps) {
   const navigate = useNavigate()
+  // Render-only: the team-context fn still requireAuth(people.view). Skip the
+  // request when the caller lacks it so a vote manager without people.view
+  // does not 403, matching the voters-stack / portal-profile pattern.
+  const canViewPeople = useHasPermission(PERMISSIONS.PEOPLE_VIEW)
   const [open, setOpen] = useState(false)
   const openTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -56,7 +62,7 @@ export function AdminAuthorHoverCard({
   const teamQuery = useQuery({
     queryKey: ['admin', 'author-hover-card-team', principalId],
     queryFn: () => getProfileTeamContextFn({ data: { principalId } }),
-    enabled: open,
+    enabled: open && canViewPeople,
     staleTime: 60_000,
   })
 
@@ -80,7 +86,12 @@ export function AdminAuthorHoverCard({
   function goToProfile(e: { preventDefault: () => void; stopPropagation: () => void }) {
     e.preventDefault()
     e.stopPropagation()
-    void navigate({ to: '/admin/users', search: { selected: principalId } })
+    if (canViewPeople) {
+      void navigate({ to: '/admin/users', search: { selected: principalId } })
+      return
+    }
+    // Without people.view the directory 403s; fall back to the public profile.
+    void navigate({ to: '/u/$principalId', params: { principalId } })
   }
 
   const profile = profileQuery.data ?? null
@@ -151,7 +162,10 @@ export function AdminAuthorHoverCard({
               </div>
             </div>
 
-            <TeamInfoRows team={teamQuery.data ?? null} isLoading={teamQuery.isLoading} />
+            <TeamInfoRows
+              team={canViewPeople ? (teamQuery.data ?? null) : null}
+              isLoading={canViewPeople && teamQuery.isLoading}
+            />
 
             <div className="mt-3 flex items-center border-t border-border/50 pt-2.5">
               <CardStat value={profile.postCount} label="Posts" />
@@ -159,14 +173,16 @@ export function AdminAuthorHoverCard({
               <CardStat value={profile.voteCount} label="Votes" />
             </div>
 
-            <button
-              type="button"
-              onClick={goToProfile}
-              className="mt-3 flex w-full items-center justify-between border-t border-border/50 pt-2.5 text-primary"
-            >
-              <span className="text-xs font-medium">Open full profile</span>
-              <ArrowRightIcon className="size-3.5" />
-            </button>
+            {canViewPeople && (
+              <button
+                type="button"
+                onClick={goToProfile}
+                className="mt-3 flex w-full items-center justify-between border-t border-border/50 pt-2.5 text-primary"
+              >
+                <span className="text-xs font-medium">Open full profile</span>
+                <ArrowRightIcon className="size-3.5" />
+              </button>
+            )}
           </div>
         ) : null}
       </PopoverContent>

--- a/apps/web/src/components/admin/users/__tests__/user-detail.test.tsx
+++ b/apps/web/src/components/admin/users/__tests__/user-detail.test.tsx
@@ -1,0 +1,199 @@
+// @vitest-environment happy-dom
+/**
+ * UserDetail — the reworked admin profile (identity header, facts strip,
+ * activity/conversations tabs, CRM rail).
+ *
+ * Covers layout contracts that the mockups pin:
+ *   - facts strip shows em dashes for missing last-seen / country
+ *   - destructive actions live in the overflow menu, not stacked buttons
+ *   - View public profile is present
+ *   - External ID is surfaced in Account and stripped from Attributes
+ *   - a lead with no email still renders Send message (disabled)
+ */
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import type { ReactElement, ReactNode } from 'react'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { PortalUserDetail } from '@/lib/shared/types'
+import type { PrincipalId } from '@quackback/ids'
+
+vi.mock('@tanstack/react-router', () => ({
+  useRouteContext: () => ({
+    settings: { featureFlags: { supportInbox: true } },
+  }),
+  Link: ({
+    children,
+    to,
+    ...props
+  }: {
+    children: ReactNode
+    to: string
+    [key: string]: unknown
+  }) => (
+    <a href={typeof to === 'string' ? to : '#'} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+vi.mock('@/lib/server/functions/conversation', () => ({
+  listConversationsForUserFn: vi.fn().mockResolvedValue({
+    conversations: [],
+    hasMore: false,
+    nextCursor: null,
+  }),
+  getConversationFn: vi.fn(),
+}))
+
+vi.mock('@/lib/server/functions/blocking', () => ({
+  getPersonBlockStatusFn: vi.fn().mockResolvedValue({ blockedAt: null }),
+  blockPersonFn: vi.fn(),
+  unblockPersonFn: vi.fn(),
+}))
+
+vi.mock('@/lib/server/functions/changelog-subscriptions', () => ({
+  getChangelogSubscriptionStatusFn: vi.fn().mockResolvedValue({ subscribed: true }),
+  setChangelogSubscriptionFn: vi.fn(),
+}))
+
+vi.mock('@/lib/server/functions/companies', () => ({
+  getCompanyForPrincipalFn: vi.fn().mockResolvedValue(null),
+  listCompaniesFn: vi.fn().mockResolvedValue([]),
+  createCompanyFn: vi.fn(),
+  attachPrincipalToCompanyFn: vi.fn(),
+  detachPrincipalFromCompanyFn: vi.fn(),
+}))
+
+vi.mock('@/lib/client/hooks/use-user-tags', () => ({
+  useUserTags: () => ({ data: [] }),
+  useUserTagsForPrincipal: () => ({ data: [] }),
+  useAssignUserTag: () => ({ mutate: vi.fn(), isPending: false }),
+  useRemoveUserTag: () => ({ mutate: vi.fn() }),
+}))
+
+vi.mock('@/lib/client/hooks/use-segments-queries', () => ({
+  useSegments: () => ({ data: [] }),
+}))
+
+vi.mock('@/lib/client/mutations', () => ({
+  useUpdatePortalUser: () => ({ mutate: vi.fn(), isPending: false }),
+  useRemoveUsersFromSegment: () => ({ mutateAsync: vi.fn() }),
+  useAssignUsersToSegment: () => ({ mutate: vi.fn(), mutateAsync: vi.fn() }),
+  useMergeLeadIntoUser: () => ({ mutate: vi.fn(), isPending: false }),
+}))
+
+vi.mock('../duplicate-users-warning', () => ({
+  DuplicateUsersWarning: () => null,
+}))
+
+vi.mock('@/components/admin/conversation/new-conversation-dialog', () => ({
+  NewConversationDialog: () => null,
+}))
+
+import { UserDetail } from '../user-detail'
+
+const BASE_USER: PortalUserDetail = {
+  principalId: 'principal_1' as PrincipalId,
+  userId: 'user_1',
+  name: 'Maya Chen',
+  email: 'maya@northwind.example',
+  image: null,
+  emailVerified: true,
+  joinedAt: new Date('2025-03-12T00:00:00.000Z'),
+  createdAt: new Date('2025-03-12T00:00:00.000Z'),
+  postCount: 12,
+  commentCount: 34,
+  voteCount: 87,
+  segments: [],
+  metadata: JSON.stringify({ plan_tier: 'growth', _externalUserId: 'usr_7f3a91' }),
+  isLead: false,
+  contactEmail: null,
+  lastSeenAt: new Date('2026-04-01T12:00:00.000Z'),
+  country: 'DE',
+  engagedPosts: [],
+}
+
+function renderDetail(ui: ReactElement) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+afterEach(cleanup)
+
+describe('UserDetail', () => {
+  it('renders the facts strip, public-profile link, and overflow actions', async () => {
+    renderDetail(
+      <UserDetail
+        user={BASE_USER}
+        isLoading={false}
+        onClose={vi.fn()}
+        onRemoveUser={vi.fn()}
+        isRemovePending={false}
+        currentMemberRole="admin"
+      />
+    )
+
+    expect(screen.getByText('Maya Chen')).toBeInTheDocument()
+    expect(screen.getByText('View public profile')).toBeInTheDocument()
+    expect(screen.getByText('Germany')).toBeInTheDocument()
+    expect(screen.getByText('Posts')).toBeInTheDocument()
+    expect(screen.getByText('12')).toBeInTheDocument()
+    expect(screen.getByText('Activity')).toBeInTheDocument()
+    expect(screen.getByText('No activity yet')).toBeInTheDocument()
+    expect(screen.getByText('Company')).toBeInTheDocument()
+    expect(screen.getByText('No company')).toBeInTheDocument()
+    expect(screen.getByText('usr_7f3a91')).toBeInTheDocument()
+    expect(screen.getByText('plan_tier')).toBeInTheDocument()
+    expect(screen.queryByText('_externalUserId')).not.toBeInTheDocument()
+
+    // Destructive actions are in the overflow menu, not stacked buttons.
+    expect(screen.queryByRole('button', { name: 'Remove from portal' })).not.toBeInTheDocument()
+    fireEvent.pointerDown(screen.getByLabelText('More actions'), { button: 0, ctrlKey: false })
+    expect(await screen.findByRole('menuitem', { name: 'Block' })).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: 'Remove from portal' })).toBeInTheDocument()
+  })
+
+  it('renders em dashes for missing last-seen and country', () => {
+    renderDetail(
+      <UserDetail
+        user={{ ...BASE_USER, lastSeenAt: null, country: null }}
+        isLoading={false}
+        onClose={vi.fn()}
+        onRemoveUser={vi.fn()}
+        isRemovePending={false}
+        currentMemberRole="admin"
+      />
+    )
+    const dashes = screen.getAllByText('—')
+    expect(dashes.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('keeps Send message visible but disabled for a lead with no email', async () => {
+    renderDetail(
+      <UserDetail
+        user={{
+          ...BASE_USER,
+          name: null,
+          email: null,
+          emailVerified: false,
+          isLead: true,
+          metadata: null,
+        }}
+        isLoading={false}
+        onClose={vi.fn()}
+        onRemoveUser={vi.fn()}
+        isRemovePending={false}
+        currentMemberRole="admin"
+      />
+    )
+    expect(screen.getByText('Unnamed user')).toBeInTheDocument()
+    expect(screen.getByText('Lead')).toBeInTheDocument()
+    expect(screen.getByText(/No email/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Send message/ })).toBeDisabled()
+    fireEvent.pointerDown(screen.getByLabelText('More actions'), { button: 0, ctrlKey: false })
+    expect(await screen.findByRole('menuitem', { name: 'Merge' })).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/admin/users/block-person-control.tsx
+++ b/apps/web/src/components/admin/users/block-person-control.tsx
@@ -4,6 +4,7 @@ import { NoSymbolIcon } from '@heroicons/react/24/outline'
 import { toast } from 'sonner'
 import type { PrincipalId } from '@quackback/ids'
 import { Button } from '@/components/ui/button'
+import { DropdownMenuItem } from '@/components/ui/dropdown-menu'
 import { ConfirmDialog } from '@/components/shared/confirm-dialog'
 import {
   blockPersonFn,
@@ -31,6 +32,43 @@ export function usePersonBlockStatus(principalId: PrincipalId | undefined) {
   return { blocked: query.data?.blockedAt != null, isLoading: query.isLoading }
 }
 
+/** Block / unblock mutations shared by the profile overflow menu and the button. */
+export function usePersonBlockActions(principalId: PrincipalId | undefined) {
+  const queryClient = useQueryClient()
+  const { blocked, isLoading } = usePersonBlockStatus(principalId)
+
+  const invalidate = () => {
+    if (!principalId) return Promise.resolve()
+    return queryClient.invalidateQueries({ queryKey: blockStatusKey(principalId) })
+  }
+
+  const blockMut = useMutation({
+    mutationFn: () => blockPersonFn({ data: { principalId: principalId as PrincipalId } }),
+    onSuccess: async () => {
+      await invalidate()
+      toast.success('Person blocked')
+    },
+    onError: (e) => toast.error(e instanceof Error ? e.message : 'Failed to block'),
+  })
+  const unblockMut = useMutation({
+    mutationFn: () => unblockPersonFn({ data: { principalId: principalId as PrincipalId } }),
+    onSuccess: async () => {
+      await invalidate()
+      toast.success('Person unblocked')
+    },
+    onError: (e) => toast.error(e instanceof Error ? e.message : 'Failed to unblock'),
+  })
+
+  return {
+    blocked,
+    isLoading,
+    busy: blockMut.isPending || unblockMut.isPending,
+    block: () => blockMut.mutate(),
+    unblock: () => unblockMut.mutate(),
+    blockPending: blockMut.isPending,
+  }
+}
+
 /**
  * Block / Unblock action for a person (support platform §4.6). Blocking rejects
  * their future messages and re-registration; unblocking restores them. Confirmed
@@ -42,51 +80,56 @@ export function BlockPersonControl({
   personName,
   className,
   size = 'sm',
+  mode = 'button',
+  open,
+  onOpenChange,
 }: {
   principalId: PrincipalId
   personName?: string | null
   className?: string
   size?: 'sm' | 'default'
+  /** `dialog` hides the trigger so a parent menu can own it. */
+  mode?: 'button' | 'menu-item' | 'dialog'
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
 }) {
-  const queryClient = useQueryClient()
-  const [confirmOpen, setConfirmOpen] = useState(false)
-  const { blocked, isLoading } = usePersonBlockStatus(principalId)
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false)
+  const confirmOpen = open ?? uncontrolledOpen
+  const setConfirmOpen = onOpenChange ?? setUncontrolledOpen
+  const { blocked, isLoading, busy, block, unblock, blockPending } =
+    usePersonBlockActions(principalId)
 
-  const invalidate = () => queryClient.invalidateQueries({ queryKey: blockStatusKey(principalId) })
+  if (isLoading && mode !== 'dialog') return null
 
-  const blockMut = useMutation({
-    mutationFn: () => blockPersonFn({ data: { principalId } }),
-    onSuccess: async () => {
-      await invalidate()
-      toast.success('Person blocked')
-    },
-    onError: (e) => toast.error(e instanceof Error ? e.message : 'Failed to block'),
-  })
-  const unblockMut = useMutation({
-    mutationFn: () => unblockPersonFn({ data: { principalId } }),
-    onSuccess: async () => {
-      await invalidate()
-      toast.success('Person unblocked')
-    },
-    onError: (e) => toast.error(e instanceof Error ? e.message : 'Failed to unblock'),
-  })
-  const busy = blockMut.isPending || unblockMut.isPending
-
-  if (isLoading) return null
+  function trigger() {
+    if (blocked) unblock()
+    else setConfirmOpen(true)
+  }
 
   return (
     <>
-      <Button
-        type="button"
-        variant={blocked ? 'outline' : 'destructive'}
-        size={size}
-        className={className}
-        disabled={busy}
-        onClick={() => (blocked ? unblockMut.mutate() : setConfirmOpen(true))}
-      >
-        <NoSymbolIcon className="h-4 w-4" />
-        {blocked ? 'Unblock' : 'Block'}
-      </Button>
+      {mode === 'menu-item' ? (
+        <DropdownMenuItem
+          variant={blocked ? 'default' : 'destructive'}
+          disabled={busy}
+          onSelect={() => trigger()}
+        >
+          <NoSymbolIcon className="h-4 w-4" />
+          {blocked ? 'Unblock' : 'Block'}
+        </DropdownMenuItem>
+      ) : mode === 'button' ? (
+        <Button
+          type="button"
+          variant={blocked ? 'outline' : 'destructive'}
+          size={size}
+          className={className}
+          disabled={busy}
+          onClick={trigger}
+        >
+          <NoSymbolIcon className="h-4 w-4" />
+          {blocked ? 'Unblock' : 'Block'}
+        </Button>
+      ) : null}
       <ConfirmDialog
         open={confirmOpen}
         onOpenChange={setConfirmOpen}
@@ -94,8 +137,8 @@ export function BlockPersonControl({
         description="They will not be able to send new messages or sign in again. Their existing activity stays, and you can unblock them at any time."
         confirmLabel="Block"
         variant="destructive"
-        isPending={blockMut.isPending}
-        onConfirm={() => blockMut.mutate()}
+        isPending={blockPending}
+        onConfirm={block}
       />
     </>
   )

--- a/apps/web/src/components/admin/users/merge-lead-control.tsx
+++ b/apps/web/src/components/admin/users/merge-lead-control.tsx
@@ -11,6 +11,7 @@ import { useQuery } from '@tanstack/react-query'
 import { ArrowPathIcon, ArrowsRightLeftIcon, MagnifyingGlassIcon } from '@heroicons/react/24/solid'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
+import { DropdownMenuItem } from '@/components/ui/dropdown-menu'
 import { Input } from '@/components/ui/input'
 import { Avatar } from '@/components/ui/avatar'
 import {
@@ -33,6 +34,10 @@ interface MergeLeadControlProps {
   /** Called after a successful merge so the parent can leave the deleted lead. */
   onMerged: () => void
   className?: string
+  /** `dialog` hides the trigger so a parent menu can own it. */
+  mode?: 'button' | 'menu-item' | 'dialog'
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
 }
 
 export function MergeLeadControl({
@@ -40,8 +45,13 @@ export function MergeLeadControl({
   leadName,
   onMerged,
   className,
+  mode = 'button',
+  open: openProp,
+  onOpenChange,
 }: MergeLeadControlProps) {
-  const [open, setOpen] = useState(false)
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false)
+  const open = openProp ?? uncontrolledOpen
+  const setOpen = onOpenChange ?? setUncontrolledOpen
   const [search, setSearch] = useState('')
   const [debouncedSearch, setDebouncedSearch] = useState('')
   const [targetId, setTargetId] = useState<PrincipalId | null>(null)
@@ -89,16 +99,23 @@ export function MergeLeadControl({
 
   return (
     <>
-      <Button
-        variant="outline"
-        size="sm"
-        className={className}
-        onClick={() => setOpen(true)}
-        title="Fold this lead's activity into an identified user"
-      >
-        <ArrowsRightLeftIcon className="h-4 w-4 mr-2" />
-        Merge into user…
-      </Button>
+      {mode === 'menu-item' ? (
+        <DropdownMenuItem onSelect={() => setOpen(true)}>
+          <ArrowsRightLeftIcon className="h-4 w-4" />
+          Merge
+        </DropdownMenuItem>
+      ) : mode === 'button' ? (
+        <Button
+          variant="outline"
+          size="sm"
+          className={className}
+          onClick={() => setOpen(true)}
+          title="Fold this lead's activity into an identified user"
+        >
+          <ArrowsRightLeftIcon className="h-4 w-4 mr-2" />
+          Merge into user…
+        </Button>
+      ) : null}
       <Dialog
         open={open}
         onOpenChange={(next) => {

--- a/apps/web/src/components/admin/users/user-company-control.tsx
+++ b/apps/web/src/components/admin/users/user-company-control.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { Link } from '@tanstack/react-router'
 import { BuildingOffice2Icon, CheckIcon, PlusIcon, XMarkIcon } from '@heroicons/react/24/outline'
 import type { CompanyId, PrincipalId } from '@quackback/ids'
 import {
@@ -11,6 +12,14 @@ import {
 } from '@/lib/server/functions/companies'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { cn } from '@/lib/shared/utils'
+
+function formatMrr(mrrCents: number): string {
+  return (mrrCents / 100).toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  })
+}
 
 /**
  * Attach / edit the company a person belongs to, from the People profile. The
@@ -91,82 +100,108 @@ export function UserCompanyControl({
   const matches = companies.filter((c) => c.name.toLowerCase().includes(query))
   const exactMatch = companies.some((c) => c.name.toLowerCase() === query)
 
-  if (!canManage) {
+  const mrr = current?.mrrCents != null ? formatMrr(current.mrrCents) : null
+  const planLine = [current?.plan, mrr ? `${mrr}/mo` : null].filter(Boolean).join(' · ')
+
+  const picker = (
+    <PopoverContent className="w-64 p-2" align="start" sideOffset={4}>
+      <input
+        type="text"
+        value={filter}
+        disabled={busy}
+        onChange={(e) => setFilter(e.target.value)}
+        placeholder="Search or create..."
+        className="mb-2 w-full rounded-md border border-border bg-background px-2 py-1 text-sm"
+      />
+      <div className="max-h-48 space-y-0.5 overflow-y-auto">
+        {matches.map((c) => (
+          <button
+            key={c.id}
+            type="button"
+            disabled={busy}
+            onClick={() => attach(c.id as CompanyId)}
+            className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-start text-[13px] font-medium text-foreground/80 hover:bg-muted/60 hover:text-foreground disabled:opacity-50"
+          >
+            <span className="flex-1 truncate">{c.name}</span>
+            {current?.id === c.id && <CheckIcon className="h-3.5 w-3.5 shrink-0 text-primary" />}
+          </button>
+        ))}
+        {query && !exactMatch && (
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => createAndAttach(filter.trim())}
+            className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-start text-[13px] font-medium text-primary hover:bg-muted/60 disabled:opacity-50"
+          >
+            <PlusIcon className="size-4 shrink-0" />
+            <span className="truncate">Create &ldquo;{filter.trim()}&rdquo;</span>
+          </button>
+        )}
+      </div>
+      {current && (
+        <button
+          type="button"
+          disabled={busy}
+          onClick={detach}
+          className="mt-2 flex w-full items-center gap-2 border-t border-border/40 px-2 pt-2 text-start text-[13px] text-muted-foreground hover:text-foreground disabled:opacity-50"
+        >
+          <XMarkIcon className="size-4 shrink-0" />
+          Remove from company
+        </button>
+      )}
+    </PopoverContent>
+  )
+
+  if (!current) {
     return (
-      <div className="flex items-center gap-2 text-sm">
-        <BuildingOffice2Icon className="h-4 w-4 text-muted-foreground" />
-        <span className={cn(current ? 'text-foreground' : 'text-muted-foreground/70')}>
-          {current?.name ?? 'No company'}
-        </span>
+      <div className="flex items-center gap-2">
+        <BuildingOffice2Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <span className="text-sm text-muted-foreground/70">No company</span>
+        <span className="flex-1" />
+        {canManage && (
+          <Popover open={open} onOpenChange={setOpen}>
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                disabled={busy}
+                className="inline-flex items-center rounded-full border border-dashed border-border/60 px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground disabled:opacity-50"
+              >
+                + Add
+              </button>
+            </PopoverTrigger>
+            {picker}
+          </Popover>
+        )}
       </div>
     )
   }
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          disabled={busy}
-          className={cn(
-            'flex w-full items-center gap-2 rounded-md border border-border/60 px-2.5 py-1.5 text-sm',
-            'hover:bg-muted/50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
-          )}
-        >
-          <BuildingOffice2Icon className="h-4 w-4 text-muted-foreground shrink-0" />
-          <span
-            className={cn('truncate', current ? 'text-foreground' : 'text-muted-foreground/70')}
-          >
-            {current?.name ?? 'Assign a company'}
-          </span>
-        </button>
-      </PopoverTrigger>
-      <PopoverContent className="w-64 p-2" align="start" sideOffset={4}>
-        <input
-          type="text"
-          value={filter}
-          disabled={busy}
-          onChange={(e) => setFilter(e.target.value)}
-          placeholder="Search or create..."
-          className="mb-2 w-full rounded-md border border-border bg-background px-2 py-1 text-sm"
-        />
-        <div className="max-h-48 space-y-0.5 overflow-y-auto">
-          {matches.map((c) => (
-            <button
-              key={c.id}
-              type="button"
-              disabled={busy}
-              onClick={() => attach(c.id as CompanyId)}
-              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-start text-[13px] font-medium text-foreground/80 hover:bg-muted/60 hover:text-foreground disabled:opacity-50"
-            >
-              <span className="flex-1 truncate">{c.name}</span>
-              {current?.id === c.id && <CheckIcon className="h-3.5 w-3.5 shrink-0 text-primary" />}
-            </button>
-          ))}
-          {query && !exactMatch && (
-            <button
-              type="button"
-              disabled={busy}
-              onClick={() => createAndAttach(filter.trim())}
-              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-start text-[13px] font-medium text-primary hover:bg-muted/60 disabled:opacity-50"
-            >
-              <PlusIcon className="size-4 shrink-0" />
-              <span className="truncate">Create &ldquo;{filter.trim()}&rdquo;</span>
-            </button>
-          )}
-        </div>
-        {current && (
+    <div>
+      <Popover open={canManage ? open : false} onOpenChange={canManage ? setOpen : undefined}>
+        <PopoverTrigger asChild disabled={!canManage || busy}>
           <button
             type="button"
-            disabled={busy}
-            onClick={detach}
-            className="mt-2 flex w-full items-center gap-2 border-t border-border/40 px-2 pt-2 text-start text-[13px] text-muted-foreground hover:text-foreground disabled:opacity-50"
+            disabled={!canManage || busy}
+            className={cn(
+              'flex w-full items-center gap-2 text-start',
+              canManage && 'rounded-md hover:bg-muted/40 disabled:opacity-50'
+            )}
           >
-            <XMarkIcon className="size-4 shrink-0" />
-            Remove from company
+            <BuildingOffice2Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <span className="truncate text-sm font-medium text-foreground">{current.name}</span>
           </button>
-        )}
-      </PopoverContent>
-    </Popover>
+        </PopoverTrigger>
+        {canManage && picker}
+      </Popover>
+      {planLine ? <p className="mt-1 ms-6 text-xs text-muted-foreground">{planLine}</p> : null}
+      <Link
+        to="/admin/users"
+        search={{ lifecycle: 'companies', company: current.id }}
+        className="mt-2 ms-6 inline-block text-xs font-medium text-primary hover:underline"
+      >
+        View company →
+      </Link>
+    </div>
   )
 }

--- a/apps/web/src/components/admin/users/user-detail.tsx
+++ b/apps/web/src/components/admin/users/user-detail.tsx
@@ -1,15 +1,13 @@
-import { useState } from 'react'
+import { useState, type ReactNode } from 'react'
 import { useQuery, useInfiniteQuery } from '@tanstack/react-query'
 import { Link, useRouteContext } from '@tanstack/react-router'
 import {
   ArrowLeftIcon,
+  ArrowTopRightOnSquareIcon,
   CheckCircleIcon,
-  DocumentTextIcon,
   ChatBubbleLeftIcon,
   HandThumbUpIcon,
   ArrowPathIcon,
-  CalendarIcon,
-  UserIcon,
   TrashIcon,
   ChevronUpIcon,
   ChevronDownIcon,
@@ -18,6 +16,9 @@ import {
   PencilIcon,
   XMarkIcon,
   CheckIcon,
+  EllipsisHorizontalIcon,
+  NoSymbolIcon,
+  ArrowsRightLeftIcon,
 } from '@heroicons/react/24/solid'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -26,12 +27,16 @@ import { Avatar } from '@/components/ui/avatar'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
 import { StatusBadge } from '@/components/ui/status-badge'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { contentPreview } from '@/lib/shared/utils/string'
 import { cn } from '@/lib/shared/utils'
+import { countryName } from '@/lib/shared/country'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { ChannelBadge } from '@/components/admin/conversation/channel-badge'
@@ -47,7 +52,7 @@ import { UserTagControl } from '@/components/admin/users/user-tag-control'
 import { UserCompanyControl } from '@/components/admin/users/user-company-control'
 import {
   BlockPersonControl,
-  usePersonBlockStatus,
+  usePersonBlockActions,
 } from '@/components/admin/users/block-person-control'
 import { ChangelogSubscriptionControl } from '@/components/admin/users/changelog-subscription-control'
 import { DuplicateUsersWarning } from '@/components/admin/users/duplicate-users-warning'
@@ -55,6 +60,24 @@ import { MergeLeadControl } from '@/components/admin/users/merge-lead-control'
 import { useUpdatePortalUser } from '@/lib/client/mutations'
 import { listConversationsForUserFn, getConversationFn } from '@/lib/server/functions/conversation'
 import type { PrincipalId } from '@quackback/ids'
+
+const EXTERNAL_ID_KEY = '_externalUserId'
+const EM_DASH = '—'
+
+function parseUserMetadata(metadata: string | null): {
+  attributes: [string, unknown][]
+  externalId: string | null
+} {
+  if (!metadata) return { attributes: [], externalId: null }
+  try {
+    const parsed = JSON.parse(metadata) as Record<string, unknown>
+    const externalId = typeof parsed[EXTERNAL_ID_KEY] === 'string' ? parsed[EXTERNAL_ID_KEY] : null
+    const attributes = Object.entries(parsed).filter(([key]) => !key.startsWith('_'))
+    return { attributes, externalId }
+  } catch {
+    return { attributes: [], externalId: null }
+  }
+}
 
 interface UserDetailProps {
   user: PortalUserDetail | null
@@ -77,31 +100,46 @@ function formatDate(date: Date | string): string {
 
 function DetailSkeleton() {
   return (
-    <div className="p-4 space-y-6">
-      {/* Profile Header */}
+    <div className="px-6 pb-6 space-y-5">
       <div className="flex items-start gap-4">
         <Skeleton className="h-16 w-16 rounded-full" />
         <div className="flex-1">
-          <Skeleton className="h-6 w-40 mb-2" />
-          <Skeleton className="h-4 w-48 mb-2" />
-          <Skeleton className="h-5 w-20 rounded-md" />
+          <Skeleton className="mb-2 h-6 w-40" />
+          <Skeleton className="h-4 w-48" />
         </div>
       </div>
-
-      {/* Activity Stats (3-column grid) */}
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-        {Array.from({ length: 3 }).map((_, i) => (
-          <Skeleton key={i} className="h-20 w-full rounded-lg" />
-        ))}
+      <Skeleton className="h-[52px] w-full rounded-lg" />
+      <div className="flex flex-col gap-6 lg:flex-row">
+        <div className="min-w-0 flex-1 space-y-3">
+          <Skeleton className="h-9 w-56 rounded-lg" />
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-16 w-full" />
+          ))}
+        </div>
+        <div className="w-full space-y-3 lg:w-[300px] lg:shrink-0">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-24 w-full rounded-lg" />
+          ))}
+        </div>
       </div>
+    </div>
+  )
+}
 
-      {/* Activity section */}
-      <div className="space-y-3">
-        <Skeleton className="h-4 w-16" />
-        {Array.from({ length: 3 }).map((_, i) => (
-          <Skeleton key={i} className="h-16 w-full" />
-        ))}
-      </div>
+function RailCard({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div className="rounded-lg border border-border/50 p-3.5">
+      <h3 className="mb-2 text-[13px] font-medium leading-[18px]">{title}</h3>
+      {children}
+    </div>
+  )
+}
+
+function KvRow({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-2 py-[3px] text-xs leading-4">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="min-w-0 truncate text-right">{children}</span>
     </div>
   )
 }
@@ -237,7 +275,13 @@ function ConversationPreview({ conversationId }: { conversationId: ConversationD
 }
 
 /** A user's support conversation history: filterable, paginated, with inline preview. */
-function UserConversations({ principalId }: { principalId: PrincipalId }) {
+function UserConversations({
+  principalId,
+  embedded = false,
+}: {
+  principalId: PrincipalId
+  embedded?: boolean
+}) {
   const { settings } = useRouteContext({ from: '__root__' })
   // Gated by the experimental supportInbox flag — when off, skip the fetch and
   // render nothing, so the profile shows no support history for a disabled feature.
@@ -266,9 +310,9 @@ function UserConversations({ principalId }: { principalId: PrincipalId }) {
   const conversations: ConversationDTO[] = query.data?.pages.flatMap((p) => p.conversations) ?? []
 
   return (
-    <div className="border-t border-border/50 pt-4">
+    <div className={cn(!embedded && 'border-t border-border/50 pt-4')}>
       <div className="mb-3 flex items-center justify-between">
-        <h3 className="text-sm font-medium">Support conversations</h3>
+        {embedded ? <span /> : <h3 className="text-sm font-medium">Support conversations</h3>}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <button
@@ -429,6 +473,8 @@ export function UserDetail({
   // and reads here as "no address" rather than as something writable.
   const displayEmail = user?.email ?? user?.contactEmail ?? null
   const [removeDialogOpen, setRemoveDialogOpen] = useState(false)
+  const [blockConfirmOpen, setBlockConfirmOpen] = useState(false)
+  const [mergeOpen, setMergeOpen] = useState(false)
   const [composeOpen, setComposeOpen] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
   const [editName, setEditName] = useState('')
@@ -439,7 +485,21 @@ export function UserDetail({
     (settings?.featureFlags as FeatureFlags | undefined)?.supportInbox ?? false
   // Check if current user can manage portal users
   const canManageUsers = currentMemberRole === 'admin'
-  const { blocked } = usePersonBlockStatus(user?.principalId as PrincipalId | undefined)
+  const { blocked, unblock } = usePersonBlockActions(user?.principalId as PrincipalId | undefined)
+  const conversationsQuery = useInfiniteQuery({
+    queryKey: ['admin', 'user-conversations', user?.principalId, 'all'],
+    enabled: supportInboxEnabled && !!user?.principalId,
+    initialPageParam: undefined as string | undefined,
+    queryFn: ({ pageParam }) =>
+      listConversationsForUserFn({
+        data: {
+          principalId: user!.principalId as PrincipalId,
+          before: pageParam,
+        },
+      }),
+    getNextPageParam: (last) => (last.hasMore ? (last.nextCursor ?? undefined) : undefined),
+  })
+  const conversationCount = conversationsQuery.data?.pages.flatMap((p) => p.conversations).length
 
   const startEditing = () => {
     if (!user) return
@@ -509,14 +569,16 @@ export function UserDetail({
     return null
   }
 
+  const { attributes, externalId } = parseUserMetadata(user.metadata)
+  const noEmailTooltip = 'This user has no email address to deliver a message to'
+
   return (
     <div className="max-w-5xl w-full">
       {backHeader}
-      <div className="p-4 space-y-6">
-        {/* Profile Header */}
-        <div className="flex items-start gap-4">
-          <Avatar src={user.image} name={user.name} className="h-16 w-16" />
-          <div className="flex-1 min-w-0">
+      <div className="px-6 pb-6">
+        <div className="flex flex-wrap items-start gap-4">
+          <Avatar src={user.image} name={user.name} className="h-16 w-16 shrink-0" />
+          <div className="min-w-0 flex-1">
             {isEditing ? (
               <div className="space-y-2">
                 <Input
@@ -554,18 +616,26 @@ export function UserDetail({
               </div>
             ) : (
               <>
-                <div className="flex items-center gap-2">
-                  <h2 className="font-semibold text-lg truncate">{user.name || 'Unnamed User'}</h2>
+                <div className="flex min-w-0 items-center gap-2">
+                  <h2 className="min-w-0 truncate text-lg font-semibold leading-7">
+                    {user.name || 'Unnamed user'}
+                  </h2>
                   {user.emailVerified && (
-                    <CheckCircleIcon className="h-4 w-4 text-primary shrink-0" />
+                    <CheckCircleIcon className="h-4 w-4 shrink-0 text-primary" />
                   )}
-                  {/* For a lead the form edits the captured contact email,
-                      never the placeholder account address. */}
+                  <Badge variant="secondary" className="shrink-0">
+                    {user.isLead ? 'Lead' : 'User'}
+                  </Badge>
+                  {blocked && (
+                    <Badge variant="destructive" className="shrink-0">
+                      Blocked
+                    </Badge>
+                  )}
                   {canManageUsers && (
                     <button
                       type="button"
                       onClick={startEditing}
-                      className="text-muted-foreground/50 hover:text-muted-foreground transition-colors"
+                      className="text-muted-foreground/50 transition-colors hover:text-muted-foreground"
                       title="Edit user details"
                     >
                       <PencilIcon className="h-3.5 w-3.5" />
@@ -573,40 +643,88 @@ export function UserDetail({
                   )}
                 </div>
                 {displayEmail ? (
-                  <p className="text-sm text-muted-foreground truncate">{displayEmail}</p>
+                  <p className="mt-0.5 truncate text-sm text-muted-foreground">{displayEmail}</p>
                 ) : (
-                  <p className="text-sm text-muted-foreground/50 italic">
+                  <p className="mt-0.5 text-sm italic text-muted-foreground/50">
                     No email &middot; cannot receive notifications
                   </p>
                 )}
-                <div className="mt-2 flex items-center gap-1.5">
-                  <Badge variant="secondary" className="text-xs">
-                    {user.isLead ? 'Lead' : 'User'}
-                  </Badge>
-                  {blocked && (
-                    <Badge variant="destructive" className="text-xs">
-                      Blocked
-                    </Badge>
-                  )}
-                </div>
               </>
             )}
           </div>
-          {supportInboxEnabled && !isEditing && (
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => setComposeOpen(true)}
-              disabled={!displayEmail}
-              title={
-                displayEmail ? undefined : 'This user has no email address to deliver a message to'
-              }
-            >
-              <ChatBubbleLeftIcon className="me-1.5 h-4 w-4" />
-              Send message
-            </Button>
+          {!isEditing && (
+            <div className="flex shrink-0 items-center gap-2">
+              {supportInboxEnabled && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        shape="default"
+                        onClick={() => setComposeOpen(true)}
+                        disabled={!displayEmail}
+                      >
+                        <ChatBubbleLeftIcon className="h-4 w-4" />
+                        Send message
+                      </Button>
+                    </span>
+                  </TooltipTrigger>
+                  {!displayEmail && <TooltipContent>{noEmailTooltip}</TooltipContent>}
+                </Tooltip>
+              )}
+              <Button size="sm" variant="outline" shape="default" asChild>
+                <Link to="/u/$principalId" params={{ principalId: user.principalId }}>
+                  <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5" />
+                  View public profile
+                </Link>
+              </Button>
+              {canManageUsers && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      size="icon-sm"
+                      variant="ghost"
+                      shape="default"
+                      aria-label="More actions"
+                    >
+                      <EllipsisHorizontalIcon className="h-4 w-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem
+                      variant={blocked ? 'default' : 'destructive'}
+                      onSelect={() => (blocked ? unblock() : setBlockConfirmOpen(true))}
+                    >
+                      <NoSymbolIcon className="h-4 w-4" />
+                      {blocked ? 'Unblock' : 'Block'}
+                    </DropdownMenuItem>
+                    {user.isLead && (
+                      <DropdownMenuItem onSelect={() => setMergeOpen(true)}>
+                        <ArrowsRightLeftIcon className="h-4 w-4" />
+                        Merge
+                      </DropdownMenuItem>
+                    )}
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      variant="destructive"
+                      disabled={isRemovePending}
+                      onSelect={() => setRemoveDialogOpen(true)}
+                    >
+                      {isRemovePending ? (
+                        <ArrowPathIcon className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <TrashIcon className="h-4 w-4" />
+                      )}
+                      Remove from portal
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
+            </div>
           )}
         </div>
+
         {supportInboxEnabled && (
           <NewConversationDialog
             open={composeOpen}
@@ -619,180 +737,25 @@ export function UserDetail({
             }}
           />
         )}
-
-        {/* Possible duplicates — renders nothing when the lookup is clean. */}
-        {!isEditing && (
-          <DuplicateUsersWarning
-            principalId={user.principalId as PrincipalId}
-            currentName={user.name}
-            canManage={canManageUsers}
-          />
-        )}
-
-        {/* Activity Stats */}
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-          <div className="text-center p-3 bg-muted/30 rounded-lg">
-            <div className="flex items-center justify-center gap-1.5 text-muted-foreground mb-1">
-              <DocumentTextIcon className="h-4 w-4" />
-            </div>
-            <div className="text-2xl font-semibold">{user.postCount}</div>
-            <div className="text-xs text-muted-foreground">Posts</div>
-          </div>
-          <div className="text-center p-3 bg-muted/30 rounded-lg">
-            <div className="flex items-center justify-center gap-1.5 text-muted-foreground mb-1">
-              <ChatBubbleLeftIcon className="h-4 w-4" />
-            </div>
-            <div className="text-2xl font-semibold">{user.commentCount}</div>
-            <div className="text-xs text-muted-foreground">Comments</div>
-          </div>
-          <div className="text-center p-3 bg-muted/30 rounded-lg">
-            <div className="flex items-center justify-center gap-1.5 text-muted-foreground mb-1">
-              <HandThumbUpIcon className="h-4 w-4" />
-            </div>
-            <div className="text-2xl font-semibold">{user.voteCount}</div>
-            <div className="text-xs text-muted-foreground">Votes</div>
-          </div>
-        </div>
-
-        {/* User Attributes */}
-        {user.metadata &&
-          (() => {
-            try {
-              const attrs = JSON.parse(user.metadata as string) as Record<string, unknown>
-              const entries = Object.entries(attrs).filter(([key]) => !key.startsWith('_'))
-              if (entries.length === 0) return null
-              return (
-                <div className="border-t border-border/50 pt-4">
-                  <h3 className="text-sm font-medium mb-3">Attributes</h3>
-                  <div className="space-y-1.5">
-                    {entries.map(([key, value]) => (
-                      <div key={key} className="flex items-center justify-between text-sm">
-                        <span className="text-muted-foreground">{key}</span>
-                        <span className="font-mono text-xs truncate max-w-[60%] text-right">
-                          {value === null ? (
-                            <span className="text-muted-foreground/50 italic">null</span>
-                          ) : (
-                            String(value)
-                          )}
-                        </span>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )
-            } catch {
-              return null
-            }
-          })()}
-
-        {/* Segments */}
-        {(user.segments.length > 0 || canManageUsers) && (
-          <div className="border-t border-border/50 pt-4">
-            <h3 className="text-sm font-medium mb-3">Segments</h3>
-            <UserSegmentBadges
-              principalId={user.principalId as PrincipalId}
-              segments={user.segments}
-              canManage={canManageUsers}
-            />
-          </div>
-        )}
-
-        {/* Tags */}
-        <div className="border-t border-border/50 pt-4">
-          <h3 className="text-sm font-medium mb-3">Tags</h3>
-          <UserTagControl
-            principalId={user.principalId as PrincipalId}
-            canManage={canManageUsers}
-          />
-        </div>
-
-        {/* Company */}
-        <div className="border-t border-border/50 pt-4">
-          <h3 className="text-sm font-medium mb-3">Company</h3>
-          <UserCompanyControl
-            principalId={user.principalId as PrincipalId}
-            canManage={canManageUsers}
-          />
-        </div>
-
-        {/* Changelog emails */}
         {canManageUsers && (
-          <div className="border-t border-border/50 pt-4">
-            <h3 className="text-sm font-medium mb-3">Notifications</h3>
-            <ChangelogSubscriptionControl principalId={user.principalId as PrincipalId} />
-          </div>
-        )}
-
-        {/* Support conversations */}
-        <UserConversations principalId={user.principalId as PrincipalId} />
-
-        {/* Engaged Posts */}
-        <div>
-          <h3 className="text-sm font-medium mb-3">Activity</h3>
-          {user.engagedPosts.length === 0 ? (
-            <EmptyMessage message="No activity yet" />
-          ) : (
-            <div className="border border-border/50 rounded-lg overflow-hidden">
-              {user.engagedPosts.map((post) => (
-                <EngagedPostCard key={post.id} post={post} />
-              ))}
-            </div>
-          )}
-        </div>
-
-        {/* Account Info */}
-        <div className="border-t border-border/50 pt-4">
-          <h3 className="text-sm font-medium mb-3">Account</h3>
-          <div className="space-y-2 text-sm">
-            <div className="flex items-center gap-2 text-muted-foreground">
-              <CalendarIcon className="h-4 w-4" />
-              <span>Joined portal {formatDate(user.joinedAt)}</span>
-            </div>
-            <div className="flex items-center gap-2 text-muted-foreground">
-              <UserIcon className="h-4 w-4" />
-              <span>Account created {formatDate(user.createdAt)}</span>
-            </div>
-          </div>
-        </div>
-
-        {/* Actions */}
-        {canManageUsers && (
-          <div className="border-t border-border/50 pt-4 space-y-3">
-            <h3 className="text-sm font-medium">Actions</h3>
-
-            {/* Block / Unblock — rejects future messages and re-registration. */}
+          <>
             <BlockPersonControl
+              mode="dialog"
               principalId={user.principalId as PrincipalId}
               personName={user.name}
-              className="w-full"
+              open={blockConfirmOpen}
+              onOpenChange={setBlockConfirmOpen}
             />
-
-            {/* Merge — leads only: fold the lead's activity into an identified
-                user and retire the anonymous identity. */}
             {user.isLead && (
               <MergeLeadControl
+                mode="dialog"
                 principalId={user.principalId as PrincipalId}
                 leadName={user.name}
                 onMerged={onClose}
-                className="w-full"
+                open={mergeOpen}
+                onOpenChange={setMergeOpen}
               />
             )}
-
-            {/* Remove User */}
-            <Button
-              variant="destructive"
-              size="sm"
-              className="w-full"
-              disabled={isRemovePending}
-              onClick={() => setRemoveDialogOpen(true)}
-            >
-              {isRemovePending ? (
-                <ArrowPathIcon className="h-4 w-4 animate-spin mr-2" />
-              ) : (
-                <TrashIcon className="h-4 w-4 mr-2" />
-              )}
-              Remove from portal
-            </Button>
             <ConfirmDialog
               open={removeDialogOpen}
               onOpenChange={setRemoveDialogOpen}
@@ -803,9 +766,144 @@ export function UserDetail({
               isPending={isRemovePending}
               onConfirm={onRemoveUser}
             />
-          </div>
+          </>
         )}
+
+        {!isEditing && (
+          <DuplicateUsersWarning
+            principalId={user.principalId as PrincipalId}
+            currentName={user.name}
+            canManage={canManageUsers}
+          />
+        )}
+
+        <div className="mt-4 flex overflow-hidden rounded-lg border border-border/50">
+          <FactCell value={user.postCount} label="Posts" numeric />
+          <FactCell value={user.commentCount} label="Comments" numeric />
+          <FactCell value={user.voteCount} label="Votes" numeric />
+          <FactCell
+            value={user.lastSeenAt ? <TimeAgo date={user.lastSeenAt} /> : EM_DASH}
+            label="Last seen"
+            muted={!user.lastSeenAt}
+          />
+          <FactCell value={formatDate(user.joinedAt)} label="Joined" />
+          <FactCell
+            value={user.country ? countryName(user.country) : EM_DASH}
+            label="Country"
+            muted={!user.country}
+          />
+        </div>
+
+        <div className="mt-5 flex flex-col items-start gap-6 lg:flex-row">
+          <div className="min-w-0 w-full flex-1">
+            <Tabs defaultValue="activity">
+              <TabsList>
+                <TabsTrigger value="activity">Activity</TabsTrigger>
+                {supportInboxEnabled && (
+                  <TabsTrigger value="conversations">
+                    {conversationCount != null
+                      ? `Conversations (${conversationCount})`
+                      : 'Conversations'}
+                  </TabsTrigger>
+                )}
+              </TabsList>
+              <TabsContent value="activity" className="mt-3">
+                {user.engagedPosts.length === 0 ? (
+                  <div className="rounded-lg border border-dashed border-border/60 px-4 py-6 text-center text-[13px] text-muted-foreground">
+                    No activity yet
+                  </div>
+                ) : (
+                  <div className="overflow-hidden rounded-lg border border-border/50">
+                    {user.engagedPosts.map((post) => (
+                      <EngagedPostCard key={post.id} post={post} />
+                    ))}
+                  </div>
+                )}
+              </TabsContent>
+              {supportInboxEnabled && (
+                <TabsContent value="conversations" className="mt-3">
+                  <UserConversations principalId={user.principalId as PrincipalId} embedded />
+                </TabsContent>
+              )}
+            </Tabs>
+          </div>
+
+          <div className="flex w-full shrink-0 flex-col gap-3 lg:w-[300px]">
+            <RailCard title="Company">
+              <UserCompanyControl
+                principalId={user.principalId as PrincipalId}
+                canManage={canManageUsers}
+              />
+            </RailCard>
+            <RailCard title="Segments">
+              <UserSegmentBadges
+                principalId={user.principalId as PrincipalId}
+                segments={user.segments}
+                canManage={canManageUsers}
+              />
+            </RailCard>
+            <RailCard title="Tags">
+              <UserTagControl
+                principalId={user.principalId as PrincipalId}
+                canManage={canManageUsers}
+              />
+            </RailCard>
+            <RailCard title="Attributes">
+              {attributes.length === 0 ? (
+                <p className="text-xs text-muted-foreground">No attributes</p>
+              ) : (
+                attributes.map(([key, value]) => (
+                  <KvRow key={key} label={key}>
+                    <span className="font-mono text-[11px]">
+                      {value === null ? (
+                        <span className="italic text-muted-foreground/50">null</span>
+                      ) : (
+                        String(value)
+                      )}
+                    </span>
+                  </KvRow>
+                ))
+              )}
+            </RailCard>
+            <RailCard title="Account">
+              <KvRow label="Account created">{formatDate(user.createdAt)}</KvRow>
+              <KvRow label="External ID">
+                {externalId ? <span className="font-mono text-[11px]">{externalId}</span> : EM_DASH}
+              </KvRow>
+              {canManageUsers && (
+                <ChangelogSubscriptionControl principalId={user.principalId as PrincipalId} />
+              )}
+            </RailCard>
+          </div>
+        </div>
       </div>
+    </div>
+  )
+}
+
+function FactCell({
+  value,
+  label,
+  numeric = false,
+  muted = false,
+}: {
+  value: ReactNode
+  label: string
+  numeric?: boolean
+  muted?: boolean
+}) {
+  return (
+    <div className="flex-1 border-border/50 px-2 py-2.5 text-center not-last:border-r">
+      <div
+        className={cn(
+          'leading-[22px]',
+          numeric ? 'text-base font-semibold tabular-nums' : 'text-sm font-medium',
+          muted && 'text-muted-foreground'
+        )}
+      >
+        {value}
+      </div>
+      <div className="text-[11px] leading-[15px] text-muted-foreground">{label}</div>
     </div>
   )
 }

--- a/apps/web/src/components/public/__tests__/author-hover-card.test.tsx
+++ b/apps/web/src/components/public/__tests__/author-hover-card.test.tsx
@@ -101,12 +101,15 @@ describe('AuthorHoverCard', () => {
     await waitFor(() => expect(getPublicUserProfileFn).toHaveBeenCalledTimes(1))
     expect(getPublicUserProfileFn).toHaveBeenCalledWith({ data: { principalId: 'principal_abc' } })
 
-    // Card body renders the fetched counts.
+    // Card body renders the fetched counts, evenly distributed.
     const body = await screen.findByTestId('author-hover-card-body')
     expect(body).toBeInTheDocument()
     expect(body).toHaveTextContent('7')
     expect(body).toHaveTextContent('12')
     expect(body).toHaveTextContent('42')
+    const statRow = body.querySelector('.flex.items-center.border-t')
+    expect(statRow?.className).not.toContain('gap-4')
+    expect(statRow?.querySelectorAll('.flex-1').length).toBe(3)
   })
 
   it('shows no card body when the payload resolves null', async () => {

--- a/apps/web/src/components/public/auth-comments-section.tsx
+++ b/apps/web/src/components/public/auth-comments-section.tsx
@@ -36,8 +36,10 @@ interface AuthCommentsSectionProps {
   currentStatusId?: string | null
   /** Whether the current user is a team member */
   isTeamMember?: boolean
-  /** Link comment authors to their public profile (portal only). */
+  /** Link comment authors to a profile behind a hover card. */
   linkAuthors?: boolean
+  /** Destination for author links. Admin uses the enriched hover card. */
+  authorLinkTo?: 'portal' | 'admin'
   /** Hide the comment form area entirely (for readonly previews) */
   hideCommentForm?: boolean
   /** Callback when a comment is deleted */
@@ -74,6 +76,7 @@ export function AuthCommentsSection({
   currentStatusId,
   isTeamMember,
   linkAuthors = false,
+  authorLinkTo = 'portal',
   hideCommentForm,
   onDeleteComment,
   deletingCommentId,
@@ -168,6 +171,7 @@ export function AuthCommentsSection({
       currentStatusId={currentStatusId}
       isTeamMember={isTeamMember}
       linkAuthors={linkAuthors}
+      authorLinkTo={authorLinkTo}
       hideCommentForm={hideCommentForm}
       onDeleteComment={onDeleteComment}
       deletingCommentId={deletingCommentId}

--- a/apps/web/src/components/public/author-hover-card.tsx
+++ b/apps/web/src/components/public/author-hover-card.tsx
@@ -143,7 +143,7 @@ export function AuthorHoverCard({
           <CardSkeleton />
         ) : profile ? (
           <div data-testid="author-hover-card-body">
-            <div className="flex items-start gap-3">
+            <div className="flex items-center gap-3">
               <Avatar
                 src={profile.avatarUrl}
                 name={profile.displayName || displayName}
@@ -199,7 +199,7 @@ export function AuthorHoverCard({
                 </div>
               </div>
             </div>
-            <div className="mt-3 flex items-center gap-4 border-t border-border/50 pt-2.5">
+            <div className="mt-3 flex items-center border-t border-border/50 pt-2.5">
               <CardStat
                 value={profile.postCount}
                 label={intl.formatMessage({
@@ -231,9 +231,9 @@ export function AuthorHoverCard({
 
 function CardStat({ value, label }: { value: number; label: string }) {
   return (
-    <div className="text-center">
+    <div className="flex-1 text-center">
       <div className="text-sm font-semibold tabular-nums text-foreground">{value}</div>
-      <div className="text-[11px] text-muted-foreground">{label}</div>
+      <div className="text-[11px] leading-[14px] text-muted-foreground">{label}</div>
     </div>
   )
 }
@@ -241,17 +241,23 @@ function CardStat({ value, label }: { value: number; label: string }) {
 function CardSkeleton() {
   return (
     <div data-testid="author-hover-card-skeleton">
-      <div className="flex items-start gap-3">
+      <div className="flex items-center gap-3">
         <Skeleton className="size-10 shrink-0 rounded-full" />
         <div className="flex-1 space-y-2 py-1">
           <Skeleton className="h-4 w-24" />
           <Skeleton className="h-3 w-32" />
         </div>
       </div>
-      <div className="mt-3 flex items-center gap-4 border-t border-border/50 pt-2.5">
-        <Skeleton className="h-7 w-10" />
-        <Skeleton className="h-7 w-10" />
-        <Skeleton className="h-7 w-10" />
+      <div className="mt-3 flex items-center border-t border-border/50 pt-2.5">
+        <div className="flex flex-1 justify-center">
+          <Skeleton className="h-[34px] w-10" />
+        </div>
+        <div className="flex flex-1 justify-center">
+          <Skeleton className="h-[34px] w-10" />
+        </div>
+        <div className="flex flex-1 justify-center">
+          <Skeleton className="h-[34px] w-10" />
+        </div>
       </div>
     </div>
   )

--- a/apps/web/src/components/public/comment-thread.tsx
+++ b/apps/web/src/components/public/comment-thread.tsx
@@ -28,6 +28,7 @@ import { cn, getInitials } from '@/lib/shared/utils'
 import { StatusBadge } from '@/components/ui/status-badge'
 import { CommentContent } from '@/components/public/comment-content'
 import { AuthorHoverCard } from '@/components/public/author-hover-card'
+import { AdminAuthorHoverCard } from '@/components/admin/admin-author-hover-card'
 import { CommentForm, type CreateCommentMutation } from './comment-form'
 import { RichTextEditor } from '@/components/ui/rich-text-editor'
 import { COMMENT_EDITOR_FEATURES } from './comment-editor-features'
@@ -141,8 +142,10 @@ interface CommentThreadProps {
   currentStatusId?: string | null
   /** Whether the current user is a team member */
   isTeamMember?: boolean
-  /** Link comment authors to their public profile (portal only). */
+  /** Link comment authors to a profile behind a hover card. */
   linkAuthors?: boolean
+  /** Destination for author links. Admin uses the enriched hover card. */
+  authorLinkTo?: 'portal' | 'admin'
   /** Hide the comment form area entirely (for readonly previews) */
   hideCommentForm?: boolean
   /** Callback when a comment is deleted */
@@ -178,6 +181,7 @@ export function CommentThread({
   currentStatusId,
   isTeamMember,
   linkAuthors = false,
+  authorLinkTo = 'portal',
   hideCommentForm = false,
   onDeleteComment,
   deletingCommentId,
@@ -279,6 +283,7 @@ export function CommentThread({
             isPinPending,
             isTeamMember,
             linkAuthors,
+            authorLinkTo,
             onDeleteComment,
             deletingCommentId,
             onRestoreComment,
@@ -309,8 +314,9 @@ interface CommentItemProps {
   isPinPending?: boolean
   /** Whether the current user is a team member */
   isTeamMember?: boolean
-  /** Link the author name to their public profile (portal only). */
+  /** Link the author name to a profile behind a hover card. */
   linkAuthors?: boolean
+  authorLinkTo?: 'portal' | 'admin'
   /** Callback when a comment is deleted */
   onDeleteComment?: (commentId: PostCommentId) => void
   /** ID of the comment currently being deleted */
@@ -343,6 +349,7 @@ function CommentItem({
   isPinPending = false,
   isTeamMember,
   linkAuthors = false,
+  authorLinkTo = 'portal',
   onDeleteComment,
   deletingCommentId,
   onRestoreComment,
@@ -517,6 +524,7 @@ function CommentItem({
                     isPinPending={isPinPending}
                     isTeamMember={isTeamMember}
                     linkAuthors={linkAuthors}
+                    authorLinkTo={authorLinkTo}
                     onDeleteComment={onDeleteComment}
                     deletingCommentId={deletingCommentId}
                     onRestoreComment={onRestoreComment}
@@ -571,17 +579,31 @@ function CommentItem({
               <AvatarFallback className="text-xs">{getInitials(comment.authorName)}</AvatarFallback>
             </Avatar>
             {linkAuthors && comment.principalId ? (
-              <AuthorHoverCard
-                principalId={comment.principalId}
-                displayName={comment.authorName}
-                className="font-medium text-sm"
-              >
-                {comment.authorName ||
-                  intl.formatMessage({
-                    id: 'portal.commentThread.authorFallback',
-                    defaultMessage: 'Anonymous',
-                  })}
-              </AuthorHoverCard>
+              authorLinkTo === 'admin' ? (
+                <AdminAuthorHoverCard
+                  principalId={comment.principalId}
+                  displayName={comment.authorName}
+                  className="font-medium text-sm"
+                >
+                  {comment.authorName ||
+                    intl.formatMessage({
+                      id: 'portal.commentThread.authorFallback',
+                      defaultMessage: 'Anonymous',
+                    })}
+                </AdminAuthorHoverCard>
+              ) : (
+                <AuthorHoverCard
+                  principalId={comment.principalId}
+                  displayName={comment.authorName}
+                  className="font-medium text-sm"
+                >
+                  {comment.authorName ||
+                    intl.formatMessage({
+                      id: 'portal.commentThread.authorFallback',
+                      defaultMessage: 'Anonymous',
+                    })}
+                </AuthorHoverCard>
+              )
             ) : (
               <span className="font-medium text-sm">
                 {comment.authorName ||
@@ -1018,6 +1040,7 @@ function CommentItem({
                   isPinPending={isPinPending}
                   isTeamMember={isTeamMember}
                   linkAuthors={linkAuthors}
+                  authorLinkTo={authorLinkTo}
                   onDeleteComment={onDeleteComment}
                   deletingCommentId={deletingCommentId}
                   onRestoreComment={onRestoreComment}

--- a/apps/web/src/components/public/post-detail/comments-section.tsx
+++ b/apps/web/src/components/public/post-detail/comments-section.tsx
@@ -178,9 +178,10 @@ export function CommentsSection({
         statuses={statuses}
         currentStatusId={currentStatusId}
         isTeamMember={effectiveIsTeamMember}
-        // Portal (no adminUser) links comment authors to their public profile;
-        // the admin post view keeps author names inert.
-        linkAuthors={!adminUser}
+        // Portal links to the public profile; admin uses the enriched hover
+        // card and navigates to /admin/users?selected=.
+        linkAuthors
+        authorLinkTo={adminUser ? 'admin' : 'portal'}
         onDeleteComment={onDeleteComment}
         deletingCommentId={deletingCommentId}
         onRestoreComment={onRestoreComment}

--- a/apps/web/src/components/public/post-detail/metadata-sidebar.tsx
+++ b/apps/web/src/components/public/post-detail/metadata-sidebar.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react'
 import { useIntl, FormattedMessage } from 'react-intl'
 import { useQuery } from '@tanstack/react-query'
-import { Link } from '@tanstack/react-router'
 import {
   CalendarIcon,
   ChevronUpIcon,
@@ -30,6 +29,7 @@ import { TimeAgo } from '@/components/ui/time-ago'
 import { Skeleton } from '@/components/ui/skeleton'
 import { AuthVoteButton } from '@/components/public/auth-vote-button'
 import { AuthorHoverCard } from '@/components/public/author-hover-card'
+import { AdminAuthorHoverCard } from '@/components/admin/admin-author-hover-card'
 import { AuthSubscriptionBell } from '@/components/public/auth-subscription-bell'
 import {
   VotersAvatarStack,
@@ -875,34 +875,32 @@ export function MetadataSidebar({
             </span>
           </div>
           {canEdit && authorPrincipalId ? (
-            <Link
-              to="/admin/users"
-              search={{ selected: authorPrincipalId }}
-              className="flex items-center gap-1.5 hover:opacity-80 transition-opacity"
-            >
-              <Avatar className="h-5 w-5">
-                {authorAvatarUrl && (
-                  <AvatarImage
-                    src={authorAvatarUrl}
-                    alt={
-                      authorName ||
-                      intl.formatMessage({
-                        id: 'portal.postDetail.metadata.authorFallback',
-                        defaultMessage: 'Anonymous',
-                      })
-                    }
-                  />
-                )}
-                <AvatarFallback className="text-xs">{getInitials(authorName)}</AvatarFallback>
-              </Avatar>
-              <span className="text-sm font-medium text-foreground underline decoration-muted-foreground/30 underline-offset-2">
-                {authorName ||
-                  intl.formatMessage({
-                    id: 'portal.postDetail.metadata.authorFallback',
-                    defaultMessage: 'Anonymous',
-                  })}
+            <AdminAuthorHoverCard principalId={authorPrincipalId} displayName={authorName}>
+              <span className="inline-flex items-center gap-1.5">
+                <Avatar className="h-5 w-5">
+                  {authorAvatarUrl && (
+                    <AvatarImage
+                      src={authorAvatarUrl}
+                      alt={
+                        authorName ||
+                        intl.formatMessage({
+                          id: 'portal.postDetail.metadata.authorFallback',
+                          defaultMessage: 'Anonymous',
+                        })
+                      }
+                    />
+                  )}
+                  <AvatarFallback className="text-xs">{getInitials(authorName)}</AvatarFallback>
+                </Avatar>
+                <span className="text-sm font-medium text-foreground underline decoration-muted-foreground/30 underline-offset-2">
+                  {authorName ||
+                    intl.formatMessage({
+                      id: 'portal.postDetail.metadata.authorFallback',
+                      defaultMessage: 'Anonymous',
+                    })}
+                </span>
               </span>
-            </Link>
+            </AdminAuthorHoverCard>
           ) : (
             (() => {
               const authorRow = (

--- a/apps/web/src/lib/server/domains/users/__tests__/user-public-profile.test.ts
+++ b/apps/web/src/lib/server/domains/users/__tests__/user-public-profile.test.ts
@@ -45,11 +45,13 @@ const TABLES = vi.hoisted(() => ({
     createdAt: 'principal.createdAt',
     contactEmail: 'principal.contactEmail',
     companyId: 'principal.companyId',
+    blockedAt: 'principal.blockedAt',
   },
   user: {
     id: 'user.id',
     name: 'user.name',
     email: 'user.email',
+    emailVerified: 'user.emailVerified',
     image: 'user.image',
     imageKey: 'user.imageKey',
   },
@@ -88,6 +90,14 @@ const TABLES = vi.hoisted(() => ({
     name: 'companies.name',
     plan: 'companies.plan',
     mrrCents: 'companies.mrrCents',
+  },
+  session: {
+    userId: 'session.userId',
+    updatedAt: 'session.updatedAt',
+  },
+  visitorDevices: {
+    principalId: 'visitorDevices.principalId',
+    lastSeenAt: 'visitorDevices.lastSeenAt',
   },
 }))
 
@@ -303,7 +313,10 @@ describe('getProfileTeamContext', () => {
       [
         {
           principalId: PRINCIPAL_ID,
+          userId: 'user_1',
           email: 'temp-abc123@anon.quackback.io',
+          emailVerified: false,
+          blockedAt: null,
           contactEmail: null,
           companyId: null,
           companyName: null,
@@ -311,19 +324,25 @@ describe('getProfileTeamContext', () => {
           companyMrrCents: null,
         },
       ],
-      [] // segments
+      [], // segments
+      [{ v: null }], // session last-seen
+      [{ v: null }] // device last-seen
     )
     const result = await getProfileTeamContext(PRINCIPAL_ID)
     expect(result).not.toBeNull()
     expect(result!.email).toBeNull()
   })
 
-  it('returns email, company, and segments for a full profile', async () => {
+  it('returns email, company, segments, lastSeenAt, and flags for a full profile', async () => {
+    const lastSeen = new Date('2026-04-01T12:00:00Z')
     hoisted.selectResults.push(
       [
         {
           principalId: PRINCIPAL_ID,
+          userId: 'user_1',
           email: 'alice@acme.com',
+          emailVerified: true,
+          blockedAt: null,
           contactEmail: null,
           companyId: 'company_1',
           companyName: 'Acme',
@@ -331,13 +350,18 @@ describe('getProfileTeamContext', () => {
           companyMrrCents: 129900,
         },
       ],
-      [{ id: 'segment_1', name: 'Beta users', color: '#f00' }]
+      [{ id: 'segment_1', name: 'Beta users', color: '#f00' }],
+      [{ v: lastSeen }],
+      [{ v: null }]
     )
     const result = await getProfileTeamContext(PRINCIPAL_ID)
     expect(result).toEqual({
       email: 'alice@acme.com',
       company: { id: 'company_1', name: 'Acme', plan: 'Scale', mrrCents: 129900 },
       segments: [{ id: 'segment_1', name: 'Beta users', color: '#f00' }],
+      lastSeenAt: lastSeen,
+      emailVerified: true,
+      blocked: false,
     })
   })
 })

--- a/apps/web/src/lib/server/domains/users/user.public-profile.ts
+++ b/apps/web/src/lib/server/domains/users/user.public-profile.ts
@@ -9,8 +9,8 @@
  * cannot see, and a principal with zero viewer-visible contributions
  * resolves to null (anti-enumeration: the route 404s).
  *
- * The team-only context strip (email / company / segments) is a separate
- * query, `getProfileTeamContext`, whose server fn is people.view-gated.
+ * The team-only context strip (email / company / segments / lastSeenAt) is a
+ * separate query, `getProfileTeamContext`, whose server fn is people.view-gated.
  */
 
 import {
@@ -23,6 +23,7 @@ import {
   sql,
   principal,
   user,
+  session,
   posts,
   postComments,
   postVotes,
@@ -31,6 +32,7 @@ import {
   userSegments,
   segments,
   companies,
+  visitorDevices,
   asc,
 } from '@/lib/server/db'
 import type { PrincipalId, SegmentId } from '@quackback/ids'
@@ -80,6 +82,11 @@ export interface PublicProfileTeamContext {
   email: string | null
   company: { id: string; name: string; plan: string | null; mrrCents: number | null } | null
   segments: { id: SegmentId; name: string; color: string }[]
+  /** Freshest activity signal: session touch or device beacon; null = none. */
+  lastSeenAt: Date | null
+  emailVerified: boolean
+  /** Whether this person is currently blocked. */
+  blocked: boolean
 }
 
 const ACTIVITY_LIMIT = 100
@@ -280,9 +287,10 @@ function normalizeItem(row: {
 
 /**
  * The team-only context for a profile: sanitized email, company summary,
- * segment chips. Same principal eligibility rules as the public profile,
- * but NO activity-visibility requirement — a team viewer with people.view
- * already sees this person in the admin directory.
+ * segment chips, last-seen, verified and blocked flags. Same principal
+ * eligibility rules as the public profile, but NO activity-visibility
+ * requirement — a team viewer with people.view already sees this person
+ * in the admin directory.
  */
 export async function getProfileTeamContext(
   principalId: PrincipalId
@@ -291,7 +299,10 @@ export async function getProfileTeamContext(
     const rows = await db
       .select({
         principalId: principal.id,
+        userId: user.id,
         email: user.email,
+        emailVerified: user.emailVerified,
+        blockedAt: principal.blockedAt,
         contactEmail: principal.contactEmail,
         companyId: companies.id,
         companyName: companies.name,
@@ -313,12 +324,28 @@ export async function getProfileTeamContext(
     const row = rows[0]
     if (!row) return null
 
-    const segmentRows = await db
-      .select({ id: segments.id, name: segments.name, color: segments.color })
-      .from(userSegments)
-      .innerJoin(segments, eq(userSegments.segmentId, segments.id))
-      .where(and(eq(userSegments.principalId, principalId), isNull(segments.deletedAt)))
-      .orderBy(asc(segments.name))
+    const [segmentRows, [sessionSeen], [deviceSeen]] = await Promise.all([
+      db
+        .select({ id: segments.id, name: segments.name, color: segments.color })
+        .from(userSegments)
+        .innerJoin(segments, eq(userSegments.segmentId, segments.id))
+        .where(and(eq(userSegments.principalId, principalId), isNull(segments.deletedAt)))
+        .orderBy(asc(segments.name)),
+      db
+        .select({ v: sql<Date | null>`max(${session.updatedAt})` })
+        .from(session)
+        .where(eq(session.userId, row.userId)),
+      db
+        .select({ v: sql<Date | null>`max(${visitorDevices.lastSeenAt})` })
+        .from(visitorDevices)
+        .where(eq(visitorDevices.principalId, principalId)),
+    ])
+
+    const seenDates = [sessionSeen?.v, deviceSeen?.v]
+      .filter((d): d is Date => d != null)
+      .map((d) => new Date(d))
+    const lastSeenAt =
+      seenDates.length > 0 ? new Date(Math.max(...seenDates.map((d) => d.getTime()))) : null
 
     return {
       // Synthetic anon placeholder must never surface.
@@ -332,6 +359,9 @@ export async function getProfileTeamContext(
           }
         : null,
       segments: segmentRows.map((s) => ({ id: s.id, name: s.name, color: s.color })),
+      lastSeenAt,
+      emailVerified: Boolean(row.emailVerified),
+      blocked: row.blockedAt != null,
     }
   } catch (error) {
     log.error({ err: error }, 'failed to get profile team context')

--- a/apps/web/src/lib/server/functions/__tests__/public-profile.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/public-profile.test.ts
@@ -107,6 +107,9 @@ beforeEach(() => {
     email: 'alice@acme.com',
     company: null,
     segments: [],
+    lastSeenAt: new Date('2026-04-01T12:00:00Z'),
+    emailVerified: true,
+    blocked: false,
   })
 })
 
@@ -177,6 +180,19 @@ describe('getProfileTeamContextFn', () => {
 
   it('returns the team context for a permitted caller', async () => {
     const result = await teamContextHandler({ data: { principalId: VALID_ID } })
-    expect(result).toEqual({ email: 'alice@acme.com', company: null, segments: [] })
+    expect(result).toEqual({
+      email: 'alice@acme.com',
+      company: null,
+      segments: [],
+      lastSeenAt: '2026-04-01T12:00:00.000Z',
+      emailVerified: true,
+      blocked: false,
+    })
+  })
+
+  it('returns null when the domain resolves no context', async () => {
+    hoisted.mockGetProfileTeamContext.mockResolvedValue(null)
+    const result = await teamContextHandler({ data: { principalId: VALID_ID } })
+    expect(result).toBeNull()
   })
 })

--- a/apps/web/src/lib/server/functions/public-profile.ts
+++ b/apps/web/src/lib/server/functions/public-profile.ts
@@ -10,9 +10,9 @@
  *    you".
  *
  *  - getProfileTeamContextFn: people.view-gated. Returns the team-only
- *    context strip (sanitized email, company, segments). Never called by
- *    the client unless the viewer holds the permission; enforced here
- *    regardless.
+ *    context strip (sanitized email, company, segments, lastSeenAt,
+ *    verified/blocked). Never called by the client unless the viewer holds
+ *    the permission; enforced here regardless.
  */
 import { z } from 'zod'
 import { createServerFn } from '@tanstack/react-start'
@@ -52,7 +52,15 @@ export interface PublicUserProfileView {
   upvotes: PublicProfileActivityItemView[]
 }
 
-export type ProfileTeamContextView = PublicProfileTeamContext
+/** Serialized team-context payload for the client (dates as ISO strings). */
+export interface ProfileTeamContextView {
+  email: PublicProfileTeamContext['email']
+  company: PublicProfileTeamContext['company']
+  segments: PublicProfileTeamContext['segments']
+  lastSeenAt: string | null
+  emailVerified: boolean
+  blocked: boolean
+}
 
 function serializeItem(item: PublicProfileActivityItem): PublicProfileActivityItemView {
   return {
@@ -110,9 +118,10 @@ export const getPublicUserProfileFn = createServerFn({ method: 'GET' })
 
 /**
  * Team-only context strip for a profile: sanitized email, company summary,
- * segment chips, for viewers holding people.view. The client only queries
- * this when `can('people.view')`; the permission is enforced server-side
- * here regardless. Returns null when the principal isn't profile-eligible.
+ * segment chips, lastSeenAt, verified/blocked flags, for viewers holding
+ * people.view. The client only queries this when `can('people.view')`; the
+ * permission is enforced server-side here regardless. Returns null when
+ * the principal isn't profile-eligible.
  */
 export const getProfileTeamContextFn = createServerFn({ method: 'GET' })
   .validator(profileParamsSchema)
@@ -122,5 +131,14 @@ export const getProfileTeamContextFn = createServerFn({ method: 'GET' })
     if (!isValidTypeId(data.principalId, 'principal')) return null
 
     const { getProfileTeamContext } = await import('@/lib/server/domains/users/user.public-profile')
-    return await getProfileTeamContext(data.principalId as PrincipalId)
+    const context = await getProfileTeamContext(data.principalId as PrincipalId)
+    if (!context) return null
+    return {
+      email: context.email,
+      company: context.company,
+      segments: context.segments,
+      lastSeenAt: context.lastSeenAt ? context.lastSeenAt.toISOString() : null,
+      emailVerified: context.emailVerified,
+      blocked: context.blocked,
+    }
   })


### PR DESCRIPTION
## Summary

Reworks the admin user profile into the information-rich layout from the approved artboards, and polishes both hover cards.

### Portal hover-card polish
- Stats trio is now `flex-1 text-center` across the card (no left-clustered `gap-4`).
- Skeleton mirrors the loaded layout (three centered bars).
- Header row uses `items-center` so the avatar sits against the two-line name/member-since block.
- Delays, fetch-on-open, null-payload = no card, and `role="link"` trigger are unchanged.

### Enriched admin author hover card
- New `AdminAuthorHoverCard` (288px) adds email, company · plan, last seen, capped segments (two chips max, then `+N`), Posts / Comments / **Votes**, and an “Open full profile” footer.
- Reuses `getPublicUserProfileFn` for the public payload. `getProfileTeamContextFn` (still `people.view`-gated) now also returns `lastSeenAt`, `emailVerified`, and `blocked`.
- Wired onto the admin post-detail author row and admin-mode comment authors. Anonymous/service principals still never link and never get a card.

### Admin user detail rework
- Identity header: 64px avatar, name + verified + User/Lead/Blocked badges, email (or the italic no-email fallback). Actions: Send message (existing compose flow), **View public profile** (`/u/:id`), and a `⋯` menu for Block/Unblock, Merge (leads), and Remove from portal.
- Facts strip: Posts · Comments · Votes · Last seen · Joined · Country. Missing values render an em dash.
- Two-column body: pill tabs (Activity / Conversations with count; Conversations tab hidden when `supportInbox` is off) + 300px CRM rail (Company, Segments, Tags, Attributes, Account).
- External ID is surfaced in Account and excluded from the generic Attributes list. Joined lives only in the facts strip.
- Empty sections stay visible with an inline empty state + action. Leads use the same layout, with email-dependent actions disabled (tooltip) rather than hidden.

## Deliberate deviations from the mockups
- Changelog emails keeps the existing switch control rather than a static “Subscribed” badge, so admins can still change the setting in place.
- Segment/tag add affordances keep the existing picker controls (not restyled as dashed chips) so manage/remove behaviour stays intact.
- The Blocked badge uses the design-system `destructive` token (`bg-destructive/20`) rather than a solid red fill.
- Hover-card segment overflow shows one named chip + `+N` when there are more than two, matching the EdgeCases board’s two-chip cap (one name, one counter).

## How verified
- Unit tests: portal hover card, admin hover card, user detail (facts strip, overflow menu, lead/no-email), `getProfileTeamContext` domain + fn serialization. 30 tests passing.
- Lint on the touched files (oxlint clean).
- Visual: worktree dev server at `:3010`.
  - Member profile (Sarah Taylor): identity header, facts strip, Activity tab, CRM rail, overflow menu (Block / Remove).
  - No-email user (Pat Nomail): italic fallback, Send message disabled, still visible.
  - Lead: Lead badge, last-seen populated, Merge in the `⋯` menu, Send message disabled.
  - Empty CRM: “No company” + Add, empty segments/tags/attributes stay on the rail.
  - Admin post author hover: email, company/last-seen em dashes, Votes, Open full profile.
  - Portal author hover: Member since + evenly distributed Posts/Comments/Upvotes.
  - Narrow admin viewport (~900px): two-column body stacks; rail sits under activity.
  - Light theme verified in the browser. Dark mode uses the same token classes (`text-primary`, `border-border/50`, `text-muted-foreground`) and was not separately restyled.

`/admin/users?selected=<id>` still opens the detail; list selection and back behaviour are unchanged. No migrations.