### PR TITLE
fix(tenancy): refuse registry rows whose pooled and direct hosts match

### DIFF
--- a/apps/web/src/lib/server/workspaces/__tests__/registry.test.ts
+++ b/apps/web/src/lib/server/workspaces/__tests__/registry.test.ts
@@ -187,6 +187,19 @@ describe('interpretRow', () => {
     expect(result.kind).toBe('invalid')
   })
 
+  it('refuses pooled and direct URLs that only differ by application_name', () => {
+    const result = interpretRow(
+      row({
+        db_pooled_url: 'postgresql://qb_ws_t1@db.example.com/qb_ws_t1?application_name=web',
+        db_direct_url: 'postgresql://qb_ws_t1@db.example.com/qb_ws_t1?application_name=migrator',
+      }),
+      't1.localhost'
+    )
+    expect(result.kind).toBe('invalid')
+    if (result.kind !== 'invalid') return
+    expect(result.problems.join(' ')).toMatch(/host:port/)
+  })
+
   it('refuses a direct endpoint that is really a pooler', () => {
     // LISTEN registration is lost through a transaction pooler in proportion to
     // contention, so this fails silently under load rather than at deploy.

--- a/apps/web/src/lib/server/workspaces/__tests__/vendor-digest.test.ts
+++ b/apps/web/src/lib/server/workspaces/__tests__/vendor-digest.test.ts
@@ -19,11 +19,12 @@ import { describe, expect, it } from 'vitest'
 const VENDOR_DIR = join(import.meta.dirname, '..', 'vendor')
 
 const EXPECTED: Record<string, string> = {
-  'contract.ts': '84b46f322c054b884838376d54b884e84b14acfdcf587ab274b0ecb077992d68',
+  'contract.ts': '59d16295b3f1d4a0379a8e0c65838f531afbbb96a600379494637fecb3b5cf13',
   'fleet-secrets.ts': '8c2337ea138a5185fac7244829220360000bd6df12d53ddc1f7502be97505e4a',
   'mail-slug-pattern.ts': 'f64fdfdcc164bae1a58656e8335042a9620c85d802e5bc8c7018fbfe5e2fb310',
   'secret-ref.ts': '4f4cba2a5fdc4d3d690bd655367fab31a5fb5daad4a5791931edaa674fa1b902',
-  'workspace-secret-resolution.ts': 'd02b7e7033437226506c107b28937378ca9bcc84f37ec2738ccc2066d25c74c0',
+  'workspace-secret-resolution.ts':
+    'd02b7e7033437226506c107b28937378ca9bcc84f37ec2738ccc2066d25c74c0',
 }
 
 function digest(file: string): string {

--- a/apps/web/src/lib/server/workspaces/__tests__/vendor-parity.test.ts
+++ b/apps/web/src/lib/server/workspaces/__tests__/vendor-parity.test.ts
@@ -35,7 +35,7 @@ const vendorDir = join(here, '..', 'vendor')
  * here too — which is the point.
  */
 const VENDORED = {
-  'contract.ts': '84b46f322c054b884838376d54b884e84b14acfdcf587ab274b0ecb077992d68',
+  'contract.ts': '59d16295b3f1d4a0379a8e0c65838f531afbbb96a600379494637fecb3b5cf13',
   // The mail slug vocabulary, which `contract.ts` imports and re-exports. It is
   // a separate module on the control plane so the edge mail Worker can apply the
   // same rule without pulling zod and the record schema into a workerd bundle;

--- a/apps/web/src/lib/server/workspaces/vendor/contract.ts
+++ b/apps/web/src/lib/server/workspaces/vendor/contract.ts
@@ -422,6 +422,18 @@ export function checkWorkspaceRecordInvariants(record: WorkspaceRecord): string[
   if (record.database.pooledUrl === record.database.directUrl) {
     problems.push('pooled and direct endpoints are identical — session-mode consumers would run through the pooler')
   }
+  const pooledParts = parseDsnParts(record.database.pooledUrl)
+  const directParts = parseDsnParts(record.database.directUrl)
+  if (
+    pooledParts &&
+    directParts &&
+    pooledParts.host === directParts.host &&
+    pooledParts.port === directParts.port
+  ) {
+    problems.push(
+      'pooled and direct endpoints share host:port — session-mode consumers would run through the pooler',
+    )
+  }
   if (record.database.directUrl.includes('-pooler.')) {
     problems.push('direct endpoint points at a pooler host — LISTEN would be silently dropped')
   }
@@ -447,20 +459,31 @@ export function checkWorkspaceRecordInvariants(record: WorkspaceRecord): string[
   return problems
 }
 
-/** `scheme://role@host[:port]/db[?params]`, password-less. */
+/** `scheme://role@host[:port]/db[?params]`, password-less. Port defaults to 5432. */
 export function parseDsnParts(
   dsn: string,
-): { role: string; host: string; database: string } | null {
+): { role: string; host: string; port: number; database: string } | null {
   if (!DSN_RE.test(dsn)) return null
   const afterScheme = dsn.slice(dsn.indexOf('://') + 3)
   const at = afterScheme.indexOf('@')
   const role = afterScheme.slice(0, at)
   const rest = afterScheme.slice(at + 1)
   const slash = rest.indexOf('/')
-  const host = rest.slice(0, slash)
+  const hostPort = rest.slice(0, slash)
   const database = rest.slice(slash + 1).split('?')[0] ?? ''
-  if (!role || !host || !database) return null
-  return { role, host, database }
+  if (!role || !hostPort || !database) return null
+  const colon = hostPort.lastIndexOf(':')
+  let host = hostPort
+  let port = 5432
+  if (colon > 0) {
+    const parsedPort = Number(hostPort.slice(colon + 1))
+    if (Number.isInteger(parsedPort) && parsedPort > 0) {
+      host = hostPort.slice(0, colon)
+      port = parsedPort
+    }
+  }
+  if (!host) return null
+  return { role, host, port, database }
 }
 
 /**


### PR DESCRIPTION
## Why
The registry contract treated pooled and direct DSNs as distinct if `application_name` differed, even when both hit the same Postgres host. That is how LISTEN and web traffic shared one connection budget.

## What
Compare host:port. Same host with only `application_name` different is invalid.

**Merge after** control-plane registry rows are rewritten onto `pgbouncer.railway.internal` (already done in production; CP PR https://github.com/QuackbackIO/quackback-cp/pull/133). Shipping this first would 503 every current tenant.