### PR TITLE
fix(storage): re-sign private asset URLs at render time

### DIFF
--- a/apps/web/src/lib/server/content/__tests__/email-image-proxy.test.ts
+++ b/apps/web/src/lib/server/content/__tests__/email-image-proxy.test.ts
@@ -2,7 +2,17 @@ import { describe, expect, it, vi } from 'vitest'
 import type { JSONContent } from '@tiptap/core'
 
 vi.mock('@/lib/server/config', () => ({
-  config: { baseUrl: 'https://env-app.example.net', s3PublicUrl: undefined },
+  config: {
+    s3Bucket: 'env-bucket',
+    s3Region: 'env-region',
+    s3Endpoint: 'https://env-endpoint.example.net',
+    s3AccessKeyId: 'env-access-key',
+    s3SecretAccessKey: 'env-secret-key',
+    s3ForcePathStyle: true,
+    s3PublicUrl: undefined,
+    s3Proxy: false,
+    baseUrl: 'https://env-app.example.net',
+  },
 }))
 
 const { withEmailProxyHint } = await import('../email-image-proxy')
@@ -51,9 +61,37 @@ describe('withEmailProxyHint', () => {
       }
     )
 
-    expect(rewritten.content?.[0]?.attrs?.src).toBe(
-      'https://ws-abc123.quackback.co.uk/api/storage/chat-images/a.png?email=1'
+    const src = rewritten.content?.[0]?.attrs?.src as string
+    expect(
+      src.startsWith('https://ws-abc123.quackback.co.uk/api/storage/chat-images/a.png?read=')
+    ).toBe(true)
+    expect(src).toContain('email=1')
+  })
+
+  it('mints a current read token on a private storage src before tagging email', () => {
+    const rewritten = withWorkspace(
+      'workspace-alpha',
+      () =>
+        withEmailProxyHint(
+          doc([
+            {
+              type: 'image',
+              attrs: { src: 'https://old.example.com/api/storage/uploads/2026/07/logo.png' },
+            },
+          ])
+        ),
+      {
+        storage: { publicUrl: 'https://ws-abc123.quackback.co.uk/api/storage' },
+        baseUrl: 'https://acme.quackback.co.uk',
+        secrets: { storage: { accessKeyId: 'shared-key', secretAccessKey: 'shared-secret' } },
+      }
     )
+
+    const src = rewritten.content?.[0]?.attrs?.src as string
+    expect(
+      src.startsWith('https://ws-abc123.quackback.co.uk/api/storage/uploads/2026/07/logo.png?read=')
+    ).toBe(true)
+    expect(src).toContain('email=1')
   })
 
   it('leaves a foreign CDN src untouched', () => {

--- a/apps/web/src/lib/server/content/__tests__/storage-read-urls.test.ts
+++ b/apps/web/src/lib/server/content/__tests__/storage-read-urls.test.ts
@@ -38,7 +38,7 @@ describe('withCurrentStorageReadTokens', () => {
             {
               type: 'image',
               attrs: {
-                src: `https://nexus-mods.quackback.io/api/storage/${PRIVATE}`,
+                src: `https://old.example.com/api/storage/${PRIVATE}`,
                 alt: '',
                 width: 100,
                 height: 100,
@@ -67,6 +67,28 @@ describe('withCurrentStorageReadTokens', () => {
       secrets: SHARED_SECRET,
     })
     expect(JSON.stringify(input)).toBe(before)
+  })
+
+  it('contentJsonForClient passes null through and remints a stored doc', async () => {
+    const { contentJsonForClient } = await import('../storage-read-urls')
+    expect(contentJsonForClient(null)).toBeNull()
+    const rewritten = withWorkspace(
+      'workspace-alpha',
+      () =>
+        contentJsonForClient(
+          doc([
+            {
+              type: 'image',
+              attrs: { src: `https://old.example.com/api/storage/${PRIVATE}` },
+            },
+          ])
+        ),
+      { secrets: SHARED_SECRET }
+    )
+    const minted = withWorkspace('workspace-alpha', () => getPublicUrlOrNull(PRIVATE), {
+      secrets: SHARED_SECRET,
+    })
+    expect(rewritten?.content?.[0]?.attrs?.src).toBe(minted)
   })
 
   it('leaves a foreign CDN src untouched', () => {

--- a/apps/web/src/lib/server/content/__tests__/storage-read-urls.test.ts
+++ b/apps/web/src/lib/server/content/__tests__/storage-read-urls.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { JSONContent } from '@tiptap/core'
+
+vi.mock('@/lib/server/config', () => ({
+  config: {
+    s3Bucket: 'env-bucket',
+    s3Region: 'env-region',
+    s3Endpoint: 'https://env-endpoint.example.net',
+    s3AccessKeyId: 'env-access-key',
+    s3SecretAccessKey: 'env-secret-key',
+    s3ForcePathStyle: true,
+    s3PublicUrl: 'https://env-cdn.example.net',
+    s3Proxy: false,
+    baseUrl: 'https://env-app.example.net',
+  },
+}))
+
+const { withCurrentStorageReadTokens } = await import('../storage-read-urls')
+const { getPublicUrlOrNull } = await import('@/lib/server/storage/s3')
+const { withWorkspace } = await import('@/lib/server/__tests__/workspace-scope')
+
+const PRIVATE = 'uploads/2026/07/b260d4f8-nexus-logo.png'
+const SHARED_SECRET = {
+  storage: { accessKeyId: 'shared-key', secretAccessKey: 'shared-secret' },
+} as const
+
+function doc(nodes: JSONContent[]): JSONContent {
+  return { type: 'doc', content: nodes }
+}
+
+describe('withCurrentStorageReadTokens', () => {
+  it('mints a current read token on an unsigned private welcome-card image', () => {
+    const rewritten = withWorkspace(
+      'workspace-alpha',
+      () =>
+        withCurrentStorageReadTokens(
+          doc([
+            {
+              type: 'image',
+              attrs: {
+                src: `https://nexus-mods.quackback.io/api/storage/${PRIVATE}`,
+                alt: '',
+                width: 100,
+                height: 100,
+              },
+            },
+          ])
+        ),
+      { secrets: SHARED_SECRET }
+    )
+
+    const minted = withWorkspace('workspace-alpha', () => getPublicUrlOrNull(PRIVATE), {
+      secrets: SHARED_SECRET,
+    })
+    expect(rewritten.content?.[0]?.attrs?.src).toBe(minted)
+  })
+
+  it('does not mutate the input tree', () => {
+    const input = doc([
+      {
+        type: 'image',
+        attrs: { src: `https://old.example.com/api/storage/${PRIVATE}` },
+      },
+    ])
+    const before = JSON.stringify(input)
+    withWorkspace('workspace-alpha', () => withCurrentStorageReadTokens(input), {
+      secrets: SHARED_SECRET,
+    })
+    expect(JSON.stringify(input)).toBe(before)
+  })
+
+  it('leaves a foreign CDN src untouched', () => {
+    const rewritten = withCurrentStorageReadTokens(
+      doc([{ type: 'image', attrs: { src: 'https://cdn.example.com/b.png' } }])
+    )
+    expect(rewritten.content?.[0]?.attrs?.src).toBe('https://cdn.example.com/b.png')
+  })
+})

--- a/apps/web/src/lib/server/content/email-image-proxy.ts
+++ b/apps/web/src/lib/server/content/email-image-proxy.ts
@@ -10,6 +10,7 @@
  */
 import type { JSONContent } from '@tiptap/core'
 import { absolutizeOffHostAssetUrl, isStoredAssetPath } from '@/lib/server/storage/asset-url'
+import { resignStoredAssetUrl } from '@/lib/server/storage/s3'
 
 const IMAGE_NODE_TYPES = new Set(['image', 'resizableImage', 'chatImage'])
 
@@ -22,7 +23,10 @@ export function withEmailProxyHint(node: JSONContent): JSONContent {
       if (isStoredAssetPath(parsed.pathname) || src.startsWith('/api/storage/')) {
         next = {
           ...node,
-          attrs: { ...node.attrs, src: absolutizeOffHostAssetUrl(src, { email: true }) },
+          attrs: {
+            ...node.attrs,
+            src: absolutizeOffHostAssetUrl(resignStoredAssetUrl(src), { email: true }),
+          },
         }
       }
     } catch {

--- a/apps/web/src/lib/server/content/storage-read-urls.ts
+++ b/apps/web/src/lib/server/content/storage-read-urls.ts
@@ -25,3 +25,9 @@ export function withCurrentStorageReadTokens(node: JSONContent): JSONContent {
   if (!node.content) return next
   return { ...next, content: node.content.map(withCurrentStorageReadTokens) }
 }
+
+/** Null-preserving leave for stored `contentJson` sent to a browser. */
+export function contentJsonForClient<T extends JSONContent | null | undefined>(node: T): T {
+  if (!node) return node
+  return withCurrentStorageReadTokens(node) as T
+}

--- a/apps/web/src/lib/server/content/storage-read-urls.ts
+++ b/apps/web/src/lib/server/content/storage-read-urls.ts
@@ -1,0 +1,27 @@
+/**
+ * Read-time rewrite of stored image srcs inside TipTap content.
+ *
+ * Persist may hold a host-independent `/api/storage/<key>`, a legacy absolute
+ * URL, or a private ref whose `?read=` token was minted under a previous
+ * secret or binding. Leaves that send content to a browser mint a current
+ * capability here. The stored doc is not written back.
+ *
+ * Structural walk over a copy of the doc — never a string replace over
+ * serialized content.
+ */
+import type { JSONContent } from '@tiptap/core'
+import { resignStoredAssetUrl } from '@/lib/server/storage/s3'
+
+const IMAGE_NODE_TYPES = new Set(['image', 'resizableImage', 'chatImage'])
+
+export function withCurrentStorageReadTokens(node: JSONContent): JSONContent {
+  let next = node
+  if (IMAGE_NODE_TYPES.has(node.type ?? '') && typeof node.attrs?.src === 'string') {
+    const src = resignStoredAssetUrl(node.attrs.src)
+    if (src !== node.attrs.src) {
+      next = { ...node, attrs: { ...node.attrs, src } }
+    }
+  }
+  if (!node.content) return next
+  return { ...next, content: node.content.map(withCurrentStorageReadTokens) }
+}

--- a/apps/web/src/lib/server/domains/comments/comment.query.ts
+++ b/apps/web/src/lib/server/domains/comments/comment.query.ts
@@ -14,6 +14,7 @@ import { NotFoundError } from '@/lib/shared/errors'
 import { realEmail } from '@/lib/shared/anonymous-email'
 import type { CommentThread } from './comment.types'
 import { buildCommentTree, toStatusChange } from '@/lib/shared'
+import { contentJsonForClient } from '@/lib/server/content/storage-read-urls'
 
 /**
  * Get a comment by ID
@@ -125,7 +126,7 @@ export async function getCommentsByPost(
     principalId: comment.principalId,
     authorName: comment.author?.displayName ?? null,
     content: comment.content,
-    contentJson: comment.contentJson ?? null,
+    contentJson: contentJsonForClient(comment.contentJson ?? null),
     isTeamMember: comment.isTeamMember,
     isPrivate: comment.isPrivate,
     createdAt: comment.createdAt,

--- a/apps/web/src/lib/server/domains/settings/__tests__/settings-cache.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/settings-cache.test.ts
@@ -77,6 +77,8 @@ vi.mock('@/lib/server/auth', () => ({
 // --- S3 mock ---
 vi.mock('@/lib/server/storage/s3', () => ({
   getPublicUrlOrNull: (key: string | null) => (key ? `https://cdn.test/${key}` : null),
+  resignStoredAssetUrl: (src: string) =>
+    src.includes('/api/storage/') && !src.includes('read=') ? `${src}?read=live` : src,
   deleteObject: vi.fn(),
 }))
 
@@ -184,6 +186,50 @@ describe('getWorkspaceSettings', () => {
 
     expect(result).toEqual(cached)
     expect(mockCacheGet).toHaveBeenCalledWith('settings:workspace')
+    expect(mockFindFirst).not.toHaveBeenCalled()
+  })
+
+  it('remints welcome-card storage srcs on a cache hit without writing them back', async () => {
+    const unsigned = '/api/storage/uploads/logo.png'
+    const cached = {
+      name: 'Cached Workspace',
+      slug: 'cached',
+      settings: makeSettingsRow({
+        name: 'Cached Workspace',
+        setupState: JSON.stringify({
+          version: 2,
+          steps: {
+            core: true,
+            workspace: true,
+            startingPoint: {
+              outcome: 'product_feedback',
+              resourceType: 'none',
+              source: 'managed',
+              resolution: 'configured',
+              completedAt: '2026-08-13T00:00:00.000Z',
+            },
+          },
+        }),
+      }),
+      publicPortalConfig: {
+        welcomeCard: {
+          enabled: true,
+          title: 'Hi',
+          body: {
+            type: 'doc',
+            content: [{ type: 'image', attrs: { src: unsigned } }],
+          },
+        },
+      },
+    }
+    mockCacheGet.mockResolvedValue(cached)
+
+    const result = await getWorkspaceSettings()
+
+    expect(result?.publicPortalConfig.welcomeCard?.body.content?.[0]?.attrs?.src).toBe(
+      `${unsigned}?read=live`
+    )
+    expect(cached.publicPortalConfig.welcomeCard.body.content[0].attrs.src).toBe(unsigned)
     expect(mockFindFirst).not.toHaveBeenCalled()
   })
 

--- a/apps/web/src/lib/server/domains/settings/settings.helpers.ts
+++ b/apps/web/src/lib/server/domains/settings/settings.helpers.ts
@@ -6,6 +6,7 @@ import { db, eq, settings } from '@/lib/server/db'
 import { cacheDel, CACHE_KEYS } from '@/lib/server/cache'
 import { DomainException, InternalError, NotFoundError, ValidationError } from '@/lib/shared/errors'
 import { sanitizeTiptapContent } from '@/lib/server/sanitize-tiptap'
+import { withCurrentStorageReadTokens } from '@/lib/server/content/storage-read-urls'
 import { logger } from '@/lib/server/logger'
 import {
   DEFAULT_PORTAL_CONFIG,
@@ -154,7 +155,10 @@ export function publicWelcomeCard(
   card: PortalWelcomeCard | undefined
 ): PortalWelcomeCard | undefined {
   if (!card?.enabled) return undefined
-  return card
+  return {
+    ...card,
+    body: withCurrentStorageReadTokens(card.body) as PortalWelcomeCard['body'],
+  }
 }
 
 /**

--- a/apps/web/src/lib/server/domains/settings/settings.helpers.ts
+++ b/apps/web/src/lib/server/domains/settings/settings.helpers.ts
@@ -6,7 +6,6 @@ import { db, eq, settings } from '@/lib/server/db'
 import { cacheDel, CACHE_KEYS } from '@/lib/server/cache'
 import { DomainException, InternalError, NotFoundError, ValidationError } from '@/lib/shared/errors'
 import { sanitizeTiptapContent } from '@/lib/server/sanitize-tiptap'
-import { withCurrentStorageReadTokens } from '@/lib/server/content/storage-read-urls'
 import { logger } from '@/lib/server/logger'
 import {
   DEFAULT_PORTAL_CONFIG,
@@ -155,10 +154,7 @@ export function publicWelcomeCard(
   card: PortalWelcomeCard | undefined
 ): PortalWelcomeCard | undefined {
   if (!card?.enabled) return undefined
-  return {
-    ...card,
-    body: withCurrentStorageReadTokens(card.body) as PortalWelcomeCard['body'],
-  }
+  return card
 }
 
 /**

--- a/apps/web/src/lib/server/domains/settings/settings.service.ts
+++ b/apps/web/src/lib/server/domains/settings/settings.service.ts
@@ -36,6 +36,7 @@ import type {
   HelpCenterLocalesConfig,
   HelpCenterLocaleChromeStrings,
   VerifiedDomain,
+  PortalWelcomeCard,
 } from './settings.types'
 import {
   DEFAULT_AUTH_CONFIG,
@@ -63,8 +64,29 @@ import {
   mergeWelcomeCard,
   publicWelcomeCard,
 } from './settings.helpers'
+import { withCurrentStorageReadTokens } from '@/lib/server/content/storage-read-urls'
 
 const log = logger.child({ component: 'settings' })
+
+/** Mint current `?read=` tokens on a public welcome card. Persist stays unsigned. */
+function liveWelcomeCard(card: PortalWelcomeCard): PortalWelcomeCard {
+  return {
+    ...card,
+    body: withCurrentStorageReadTokens(card.body) as PortalWelcomeCard['body'],
+  }
+}
+
+function liveWorkspaceSettings(settings: WorkspaceSettings): WorkspaceSettings {
+  const welcome = settings.publicPortalConfig?.welcomeCard
+  if (!welcome) return settings
+  return {
+    ...settings,
+    publicPortalConfig: {
+      ...settings.publicPortalConfig,
+      welcomeCard: liveWelcomeCard(welcome),
+    },
+  }
+}
 
 function offHostPublicUrl(key: string | null | undefined): string | null {
   const stored = getPublicUrlOrNull(key)
@@ -832,7 +854,7 @@ export async function getPublicPortalConfig(): Promise<PublicPortalConfig> {
         showPublicEditHistory: portalConfig.features.showPublicEditHistory,
       },
       ...(oidcProviders.length > 0 && { oidcProviders }),
-      ...(welcome && { welcomeCard: welcome }),
+      ...(welcome && { welcomeCard: liveWelcomeCard(welcome) }),
       portalAccess: {
         isPrivate: portalConfig.access?.visibility === 'private',
         widgetSignIn: portalConfig.access?.widgetSignIn ?? false,
@@ -864,7 +886,7 @@ export async function getWorkspaceSettings(): Promise<WorkspaceSettings | null> 
         // before that rule existed still carries feedback:false and would keep
         // the portal dark for the hour the entry has left to live.
         if (cached.featureFlags) cached.featureFlags.feedback = true
-        return cached
+        return liveWorkspaceSettings(cached)
       }
     }
 
@@ -983,7 +1005,7 @@ export async function getWorkspaceSettings(): Promise<WorkspaceSettings | null> 
     // calls invalidateSettingsCache(), so a long TTL is safe and keeps
     // the per-request cost of getWorkspaceSettings to a single Redis GET.
     await cacheSet(CACHE_KEYS.WORKSPACE_SETTINGS, result, 3600)
-    return result
+    return liveWorkspaceSettings(result)
   } catch (error) {
     log.error({ err: error }, 'get workspace settings failed')
     wrapDbError('fetch settings with all configs', error)

--- a/apps/web/src/lib/server/messages/__tests__/message-core.test.ts
+++ b/apps/web/src/lib/server/messages/__tests__/message-core.test.ts
@@ -4,7 +4,13 @@
  * metadata.blockReply on the stored row project straight onto the DTO's
  * `block` / `blockReply` fields, defaulting to null when absent.
  */
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@/lib/server/storage/s3', () => ({
+  resignStoredAssetUrl: (src: string) =>
+    src.includes('/api/storage/') && !src.includes('read=') ? `${src}?read=live` : src,
+  getPublicUrlOrNull: vi.fn(),
+}))
 import type { ConversationMessage } from '@/lib/server/db'
 import { toMessageDTO } from '../message-core'
 
@@ -28,6 +34,34 @@ function message(overrides: Partial<ConversationMessage> = {}): ConversationMess
     ...overrides,
   } as ConversationMessage
 }
+
+describe('toMessageDTO — storage read tokens', () => {
+  it('mints a current read token on a private storage image in contentJson', () => {
+    const dto = toMessageDTO(
+      message({
+        contentJson: {
+          type: 'doc',
+          content: [
+            {
+              type: 'image',
+              attrs: { src: 'https://old.example.com/api/storage/chat-images/a.png' },
+            },
+          ],
+        },
+      }),
+      null
+    )
+    expect(dto.contentJson).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'image',
+          attrs: { src: 'https://old.example.com/api/storage/chat-images/a.png?read=live' },
+        },
+      ],
+    })
+  })
+})
 
 describe('toMessageDTO — block/blockReply projection', () => {
   it('projects metadata.block onto the DTO, null when absent', () => {

--- a/apps/web/src/lib/server/messages/message-core.ts
+++ b/apps/web/src/lib/server/messages/message-core.ts
@@ -10,6 +10,7 @@ import { ValidationError } from '@/lib/shared/errors'
 import { isTrustedAttachmentUrl } from '@/lib/server/storage/trusted-url'
 import { truncate } from '@/lib/shared/utils/string'
 import type { TiptapContent } from '@/lib/shared/db-types'
+import { contentJsonForClient } from '@/lib/server/content/storage-read-urls'
 import { tiptapJsonToText, hasTextLeaf } from '@/lib/server/markdown-tiptap'
 import type { PrincipalId } from '@quackback/ids'
 import {
@@ -136,7 +137,7 @@ export function toMessageDTO(
     citations: message.citations ?? [],
     isAssistant: assistantPrincipalId != null && message.principalId === assistantPrincipalId,
     isInternal: message.isInternal,
-    contentJson: message.contentJson ?? null,
+    contentJson: contentJsonForClient(message.contentJson ?? null),
     viaEmail: message.metadata?.source === 'email',
     systemEvent: message.metadata?.systemEvent ?? null,
     block: message.metadata?.block ?? null,

--- a/apps/web/src/lib/server/storage/__tests__/asset-url.test.ts
+++ b/apps/web/src/lib/server/storage/__tests__/asset-url.test.ts
@@ -14,6 +14,7 @@ const {
   absolutizeOffHostAssetUrl,
   getSystemAssetOrigin,
   isStoredAssetPath,
+  storedAssetKeyFromSrc,
   systemHostOriginFromPublicUrl,
 } = await import('../asset-url')
 const { withWorkspace } = await import('@/lib/server/__tests__/workspace-scope')
@@ -105,5 +106,20 @@ describe('absolutizeOffHostAssetUrl', () => {
     expect(isStoredAssetPath('/api/storage')).toBe(false)
     expect(isStoredAssetPath('/api/storage/')).toBe(false)
     expect(isStoredAssetPath(`/api/storage/${KEY}`)).toBe(true)
+  })
+})
+
+describe('storedAssetKeyFromSrc', () => {
+  it('reads the key from a relative persist ref, discarding a stale token', () => {
+    expect(storedAssetKeyFromSrc(`/api/storage/${KEY}?read=stale`)).toBe(KEY)
+  })
+
+  it('reads the key from a legacy absolute URL on any host', () => {
+    expect(storedAssetKeyFromSrc(`https://old.example.com/api/storage/${KEY}`)).toBe(KEY)
+  })
+
+  it('refuses a path that is not a stored asset', () => {
+    expect(storedAssetKeyFromSrc('https://cdn.example.com/logos/brand.png')).toBeNull()
+    expect(storedAssetKeyFromSrc('/api/storage/../secret')).toBeNull()
   })
 })

--- a/apps/web/src/lib/server/storage/__tests__/s3-tenant-placement.test.ts
+++ b/apps/web/src/lib/server/storage/__tests__/s3-tenant-placement.test.ts
@@ -69,6 +69,7 @@ const {
   getStorageSigningSecret,
   isS3Configured,
   isS3Usable,
+  resignStoredAssetUrl,
   StorageUnavailableError,
   uploadObject,
 } = await import('../s3')
@@ -185,6 +186,40 @@ describe('public URLs', () => {
       new URL(url!, 'https://placeholder.invalid').searchParams.get('read')
     expect(sigOf(alpha)).toBeTruthy()
     expect(sigOf(alpha)).not.toBe(sigOf(bravo))
+  })
+
+  it('resigns an unsigned legacy private URL with the current workspace token', () => {
+    const minted = withWorkspace('workspace-alpha', () => getPublicUrlOrNull(PRIVATE_KEY), {
+      secrets: SHARED_SECRET,
+    })
+    const resigned = withWorkspace(
+      'workspace-alpha',
+      () => resignStoredAssetUrl(`https://old.example.com/api/storage/${PRIVATE_KEY}`),
+      { secrets: SHARED_SECRET }
+    )
+    expect(resigned).toBe(minted)
+    expect(resigned).toContain(`?read=`)
+  })
+
+  it('replaces a stale private token rather than keeping it', () => {
+    const resigned = withWorkspace(
+      'workspace-alpha',
+      () =>
+        resignStoredAssetUrl(`/api/storage/${PRIVATE_KEY}?read=deadbeefdeadbeefdeadbeefdeadbeef`),
+      { secrets: SHARED_SECRET }
+    )
+    expect(resigned).not.toContain('deadbeef')
+    expect(resigned).toBe(
+      withWorkspace('workspace-alpha', () => getPublicUrlOrNull(PRIVATE_KEY), {
+        secrets: SHARED_SECRET,
+      })
+    )
+  })
+
+  it('leaves a foreign src untouched', () => {
+    expect(resignStoredAssetUrl('https://cdn.example.com/brand.png')).toBe(
+      'https://cdn.example.com/brand.png'
+    )
   })
 
   it('leaves the unscoped read signature byte-identical to the historical one', () => {

--- a/apps/web/src/lib/server/storage/asset-url.ts
+++ b/apps/web/src/lib/server/storage/asset-url.ts
@@ -18,6 +18,26 @@ export function isStoredAssetPath(pathname: string): boolean {
 }
 
 /**
+ * The stored object key a persist ref (or a legacy absolute `/api/storage`
+ * URL) names, or null if `src` is not one.
+ *
+ * Absolute srcs on an old hostname still name a key: the host is not the
+ * workspace boundary. `..` and undecodable escapes are refused the same way
+ * the storage route refuses them.
+ */
+export function storedAssetKeyFromSrc(src: string): string | null {
+  if (!src) return null
+  try {
+    const parsed = new URL(src, 'https://placeholder.invalid')
+    if (!isStoredAssetPath(parsed.pathname)) return null
+    const key = decodeURIComponent(parsed.pathname.slice('/api/storage/'.length))
+    return key && !key.includes('..') ? key : null
+  } catch {
+    return null
+  }
+}
+
+/**
  * Origin of the pinned system-host storage URL (`https://ws-…/api/storage`).
  * CDN-style publicUrl values are not a system host and are ignored.
  */

--- a/apps/web/src/lib/server/storage/s3.ts
+++ b/apps/web/src/lib/server/storage/s3.ts
@@ -51,14 +51,14 @@
  * ```
  *
  * The prefix is `fromUuid('workspace', settings.id)` (for example
- * `workspace_01kxddf1jaf6cr22gerxt7z9gg`), not the UUID spelling of
- * `settings.id`. Object names are composed from the TypeID; copying under the
- * UUID leaves every restored object unreadable.
+ * `workspace_01kxddf1jaf6cr22gerxt7z9gg`). `SELECT id FROM settings` returns
+ * the UUID spelling; copying under that UUID leaves every restored object
+ * unreadable. Convert the UUID before composing `w/<prefix>/`.
  *
  * It is a server-side copy: no bytes leave the bucket, the stored keys do not
  * change, and no content is rewritten, because the namespace appears in neither
  * the database nor any URL. Every affected install holds exactly one workspace
- * per bucket, so that TypeID is unambiguous — `SELECT id FROM settings`.
+ * per bucket, so that TypeID is unambiguous.
  *
  * **Note what this repository must NOT grow to make that convenient.** Listing
  * and deleting at the bucket root is correct against a bucket that holds one

--- a/apps/web/src/lib/server/storage/s3.ts
+++ b/apps/web/src/lib/server/storage/s3.ts
@@ -47,13 +47,18 @@
  * traffic:
  *
  * ```
- * aws s3 mv s3://<bucket>/ s3://<bucket>/w/<settings.id>/ --recursive --exclude 'w/*'
+ * aws s3 mv s3://<bucket>/ s3://<bucket>/w/<workspace TypeID>/ --recursive --exclude 'w/*'
  * ```
+ *
+ * The prefix is `fromUuid('workspace', settings.id)` (for example
+ * `workspace_01kxddf1jaf6cr22gerxt7z9gg`), not the UUID spelling of
+ * `settings.id`. Object names are composed from the TypeID; copying under the
+ * UUID leaves every restored object unreadable.
  *
  * It is a server-side copy: no bytes leave the bucket, the stored keys do not
  * change, and no content is rewritten, because the namespace appears in neither
  * the database nor any URL. Every affected install holds exactly one workspace
- * per bucket, so `<settings.id>` is unambiguous — `SELECT id FROM settings`.
+ * per bucket, so that TypeID is unambiguous — `SELECT id FROM settings`.
  *
  * **Note what this repository must NOT grow to make that convenient.** Listing
  * and deleting at the bucket root is correct against a bucket that holds one
@@ -77,7 +82,7 @@ import {
   currentWorkspaceNamespace,
   SINGLE_WORKSPACE_NAMESPACE,
 } from '@/lib/server/workspaces/workspace-keyed'
-import { absolutizeOffHostAssetUrl } from './asset-url'
+import { absolutizeOffHostAssetUrl, storedAssetKeyFromSrc } from './asset-url'
 import { composeNamespacedKey, workspaceNamespace } from './namespace'
 import { currentWorkspaceId } from './workspace-scope'
 
@@ -929,6 +934,20 @@ export function getPublicUrlOrNull(key: string | null | undefined): string | nul
   if (!isPublicStorageKey(key) && !isS3Usable()) return null
 
   return buildPublicUrl(getStoragePlacement(), key)
+}
+
+/**
+ * Mint a current-workspace persist ref for a stored `/api/storage` src.
+ *
+ * Private keys get a fresh `?read=` capability; public keys stay unsigned.
+ * Stale tokens, unbound K8s signatures, and unsigned legacy URLs are all
+ * replaced. Foreign srcs are returned unchanged. A workspace whose storage
+ * credentials do not resolve keeps the original src rather than a blank one.
+ */
+export function resignStoredAssetUrl(src: string): string {
+  const key = storedAssetKeyFromSrc(src)
+  if (!key) return src
+  return getPublicUrlOrNull(key) ?? src
 }
 
 /**


### PR DESCRIPTION
## Summary

Private `/api/storage` image srcs in welcome-card and email content 403 when they have no `?read=` token, or a token minted under a previous secret/binding (unsigned legacy refs, dedicated-install signatures). This mints a current-workspace read token when those docs are projected, without writing the token back to the stored JSON.

Also documents that restored objects must land under `w/<workspace TypeID>/` (`fromUuid('workspace', settings.id)`), not the UUID spelling of `settings.id`.

## Test plan

- [x] `bun run test --run` on asset-url, s3-tenant-placement, storage-read-urls, email-image-proxy, normalize-welcome-card-input (55 tests)
- [ ] After deploy, load a portal welcome card whose body still stores an unsigned `/api/storage/uploads/…` src and confirm the rendered `<img>` has a current `?read=` and returns 200
- [ ] Confirm a foreign CDN image src is left untouched
- [ ] Confirm outbound email still absolutizes storage srcs onto the system host and adds `?email=1`