### PR TITLE
feat(fleet): run enrol+reconcile on the always-on worker

### DIFF
--- a/apps/web/src/lib/server/cron/__tests__/fleet-jobs.test.ts
+++ b/apps/web/src/lib/server/cron/__tests__/fleet-jobs.test.ts
@@ -40,7 +40,7 @@ describe('the sweep inventory', () => {
   const jobsSource = read('cron/fleet-jobs.ts')
   const startupSource = read('startup.ts')
 
-  it('is exactly the eleven locks the fleet has, all defined in one module', () => {
+  it('is exactly the twelve locks the fleet has, all defined in one module', () => {
     const names = sweepLockNames(jobsSource)
     // Written out rather than derived, so a sweep deleted from the module makes
     // this fail instead of quietly shrinking both sides of a comparison.
@@ -49,6 +49,7 @@ describe('the sweep inventory', () => {
       'changelog_notify',
       'daily_cycle',
       'events_prune',
+      'fleet_migrator',
       'invite_sweep',
       'kv_sweep',
       'logs_retention',

--- a/apps/web/src/lib/server/cron/fleet-jobs.ts
+++ b/apps/web/src/lib/server/cron/fleet-jobs.ts
@@ -154,33 +154,44 @@ export async function runStatusMaintenanceSweep(): Promise<void> {
  * lease — enrol and reconcile claim through that table, so this pass and a
  * control-plane spawn cannot migrate the same workspace at once.
  */
-async function runMigratorConvergence(): Promise<void> {
-  const [{ enrolActiveWorkspaces, runReconcilePass }, { hostname }, { randomUUID }] =
-    await Promise.all([
-      import('@/lib/server/fleet/migrator'),
-      import('node:os'),
-      import('node:crypto'),
-    ])
-  const enrolled = await enrolActiveWorkspaces()
-  const result = await runReconcilePass({
-    workerId: `${hostname()}:${process.pid}:${randomUUID().slice(0, 8)}`,
-    concurrency: 4,
-    leaseMs: 900_000,
+/**
+ * Enrol missing intent rows, then one reconcile pass.
+ *
+ * Armed on the always-on worker. The dedicated migrator cron calls the same
+ * body via `housekeeping` until that container is retired. The schema-state
+ * lease is what stops two passes migrating one workspace; the sweep lock
+ * stops two replicas from both enumerating the fleet at once.
+ */
+export async function runFleetMigratorPass(): Promise<void> {
+  const { withSweepLock } = await import('@/lib/server/sweep-lock')
+  await withSweepLock('fleet_migrator', ONE_HOUR, async () => {
+    const [{ enrolActiveWorkspaces, runReconcilePass }, { hostname }, { randomUUID }] =
+      await Promise.all([
+        import('@/lib/server/fleet/migrator'),
+        import('node:os'),
+        import('node:crypto'),
+      ])
+    const enrolled = await enrolActiveWorkspaces()
+    const result = await runReconcilePass({
+      workerId: `${hostname()}:${process.pid}:${randomUUID().slice(0, 8)}`,
+      concurrency: 4,
+      leaseMs: 900_000,
+    })
+    log.info(
+      {
+        enrolled,
+        claimed: result.claimed,
+        reconciled: result.reconciled,
+        failed: result.failed,
+        already_current: result.alreadyCurrent,
+        healed: result.healed,
+      },
+      'fleet migrator pass complete'
+    )
+    if (result.failed > 0) {
+      throw new Error(`fleet migrator failed ${result.failed} workspace(s)`)
+    }
   })
-  log.info(
-    {
-      enrolled,
-      claimed: result.claimed,
-      reconciled: result.reconciled,
-      failed: result.failed,
-      already_current: result.alreadyCurrent,
-      healed: result.healed,
-    },
-    'fleet migrator pass complete'
-  )
-  if (result.failed > 0) {
-    throw new Error(`fleet migrator failed ${result.failed} workspace(s)`)
-  }
 }
 
 /**
@@ -217,7 +228,7 @@ export const FLEET_CRON_JOBS = {
     await withSweepLock('daily_cycle', TWENTY_THREE_HOURS, () => FLEET_CRON_JOBS.daily(), {
       keepUntilExpiry: true,
     })
-    await runMigratorConvergence()
+    await runFleetMigratorPass()
   },
 } as const
 

--- a/apps/web/src/lib/server/startup.ts
+++ b/apps/web/src/lib/server/startup.ts
@@ -318,6 +318,9 @@ function startBackgroundProcessing(): void {
       setTimeout(() => void jobs.runStatusMaintenanceSweep(), 31_000)
       setInterval(() => void jobs.runStatusMaintenanceSweep(), 5 * 60 * 1000)
 
+      setTimeout(() => void jobs.runFleetMigratorPass(), 90_000)
+      setInterval(() => void jobs.runFleetMigratorPass(), 60 * 60 * 1000)
+
       log.info({ event: 'sweeps.armed' }, 'scheduled sweeps armed')
     })
     .catch((err) => log.error({ err }, 'failed to init the scheduled sweeps'))


### PR DESCRIPTION
## Why

`housekeeping` already enrolled missing intent rows and ran one reconcile pass, but only the dedicated Railway migrator cron (`QUACKBACK_CRON_JOB=housekeeping`) called it. The always-on worker never did.

## Changes

- Export `runFleetMigratorPass` (enrol + reconcile, `fleet_migrator` sweep lock).
- Arm it on the worker: first pass at 90s, then hourly.
- `housekeeping` calls the same function, so the nightly container stays correct until it is removed.