### PR TITLE
fix(auth): redeem Visit handoffs that arrive from the control plane

### DIFF
--- a/apps/web/src/lib/server/functions/__tests__/open-handoff.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/open-handoff.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { consumeOpenHandoff } from '../origin-transfer'
+import { consumeOpenHandoff, ottVerifyRequest } from '../origin-transfer'
 
 const hoisted = vi.hoisted(() => {
   const snapshotRows: { value: string; expiresAt: Date }[][] = []
@@ -37,6 +37,25 @@ vi.mock('@/lib/server/db', () => ({
   eq: () => true,
 }))
 
+describe('ottVerifyRequest', () => {
+  it('verifies as the workspace, not the control-plane referrer', () => {
+    const request = ottVerifyRequest(
+      'token-1',
+      new Headers({
+        host: 'ws-abc.quackback.io',
+        cookie: 'cf_clearance=x',
+        referer: 'https://app.quackback.io/dashboard',
+        origin: 'https://app.quackback.io',
+        'x-forwarded-proto': 'https',
+      })
+    )
+    expect(request.url).toBe('https://ws-abc.quackback.io/api/auth/one-time-token/verify')
+    expect(request.headers.get('origin')).toBe('https://ws-abc.quackback.io')
+    expect(request.headers.get('referer')).toBeNull()
+    expect(request.headers.get('cookie')).toBe('cf_clearance=x')
+  })
+})
+
 describe('consumeOpenHandoff', () => {
   beforeEach(() => {
     hoisted.handler.mockReset()
@@ -53,13 +72,22 @@ describe('consumeOpenHandoff', () => {
         get: () => null,
       },
     })
-    const result = await consumeOpenHandoff({ ott: 'token-1' })
+    const headers = new Headers({
+      host: 'ws-abc.quackback.io',
+      cookie: 'cf_clearance=x',
+      referer: 'https://app.quackback.io/',
+    })
+    const result = await consumeOpenHandoff({ ott: 'token-1', headers })
     expect(result).toEqual({
       kind: 'redirect',
       to: '/',
       cookies: ['session=abc; Path=/; HttpOnly'],
     })
     expect(hoisted.handler).toHaveBeenCalledOnce()
+    const verifyRequest = hoisted.handler.mock.calls[0]?.[0] as Request
+    expect(verifyRequest.url).toBe('https://ws-abc.quackback.io/api/auth/one-time-token/verify')
+    expect(verifyRequest.headers.get('origin')).toBe('https://ws-abc.quackback.io')
+    expect(verifyRequest.headers.get('referer')).toBeNull()
     expect(hoisted.getSession).not.toHaveBeenCalled()
   })
 

--- a/apps/web/src/lib/server/functions/__tests__/origin-transfer.db.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/origin-transfer.db.test.ts
@@ -152,6 +152,7 @@ describe.skipIf(!fixture.available)('rename-transfer OTT consume', () => {
     const auth = betterAuth({
       baseURL: CANONICAL,
       secret: 'test-secret-not-used-for-anything-real',
+      trustedOrigins: [CANONICAL, `https://${SYSTEM_HOST}`, `https://${FRIENDLY_HOST}`],
       database: drizzleAdapter(testDb, {
         provider: 'pg',
         schema: { user, session, account, verification },
@@ -242,6 +243,22 @@ describe.skipIf(!fixture.available)('rename-transfer OTT consume', () => {
     expect(result).toEqual({ kind: 'error', status: 'invalid' })
     expect(await ottRowCount(token)).toBe(1)
     expect(hoisted.handler).not.toHaveBeenCalled()
+  })
+
+  it('redeems a Visit handoff that arrived from the control plane', async () => {
+    const { sessionToken } = await seedSessionUser()
+    const token = await seedOtt({ sessionToken, expiresAt: future() })
+    const headers = new Headers({
+      host: SYSTEM_HOST,
+      cookie: 'cf_clearance=edge',
+      referer: 'https://app.quackback.io/',
+    })
+
+    const result = await consumeOpenHandoff({ ott: token, headers })
+
+    expect(result).toMatchObject({ kind: 'redirect', to: '/' })
+    if (result.kind !== 'redirect') return
+    expect(result.cookies.some((cookie) => cookie.toLowerCase().includes('session'))).toBe(true)
   })
 
   it('lets Visit replay the Open token until it expires', async () => {

--- a/apps/web/src/lib/server/functions/origin-transfer.ts
+++ b/apps/web/src/lib/server/functions/origin-transfer.ts
@@ -17,6 +17,34 @@ function responseCookies(response: Response): string[] {
   return single ? [single] : []
 }
 
+/**
+ * Internal verify Request for a browser GET that arrived from another origin.
+ *
+ * Visit workspace is a control-plane POST that 302s here. The GET keeps
+ * `Referer: https://app.quackback.io/…` and often a Cookie (CDN, prior
+ * visit). Better Auth CSRF treats Referer as Origin when Origin is
+ * absent, and refuses anything not on the workspace allowlist — so a
+ * freshly minted OTT looks expired. Verify as this workspace instead.
+ */
+export function ottVerifyRequest(ott: string, headers?: Headers): Request {
+  const requestHeaders = new Headers(headers)
+  requestHeaders.delete('content-length')
+  requestHeaders.delete('referer')
+  requestHeaders.delete('origin')
+  requestHeaders.set('content-type', 'application/json')
+
+  const host = headers?.get('host')?.trim()
+  const proto = (headers?.get('x-forwarded-proto') ?? 'https').split(',')[0]?.trim() || 'https'
+  const origin = host ? `${proto}://${host}` : 'http://auth.local'
+  requestHeaders.set('origin', origin)
+
+  return new Request(`${origin}/api/auth/one-time-token/verify`, {
+    method: 'POST',
+    headers: requestHeaders,
+    body: JSON.stringify({ token: ott }),
+  })
+}
+
 async function verifyOttCookies(
   ott: string,
   returnTo: string,
@@ -24,16 +52,7 @@ async function verifyOttCookies(
 ): Promise<OriginTransferResult> {
   try {
     const { auth } = await import('@/lib/server/auth')
-    const requestHeaders = new Headers(headers)
-    requestHeaders.delete('content-length')
-    requestHeaders.set('content-type', 'application/json')
-    const response = await auth.handler(
-      new Request('http://auth.local/api/auth/one-time-token/verify', {
-        method: 'POST',
-        headers: requestHeaders,
-        body: JSON.stringify({ token: ott }),
-      })
-    )
+    const response = await auth.handler(ottVerifyRequest(ott, headers))
     if (!response.ok) return { kind: 'error', status: 'invalid' }
     const cookies = responseCookies(response)
     if (cookies.length === 0) return { kind: 'error', status: 'error' }


### PR DESCRIPTION
Visit workspace already mints a fresh one-time token. The customer still landed on “This sign-in link is no longer valid” because `/auth/open-handoff` copied the control-plane `Referer` (`https://app.quackback.io/`) onto Better Auth’s verify POST. CSRF treats Referer as Origin when Origin is absent, and a CDN cookie is enough to turn that check on, so a token minted a second earlier is refused as an invalid origin.

This verifies as the workspace host instead of `auth.local`, drops the control-plane Referer, and sets Origin to the request Host.

## Test plan
- [x] `open-handoff.test.ts` asserts the verify Request uses the workspace origin and drops the CP Referer
- [x] `origin-transfer.db.test.ts` redeems an OTT with `Cookie` + `Referer: https://app.quackback.io/` against a trusted-origin-restricted Better Auth
- [ ] Click Visit workspace from app.quackback.io and land signed in, not on the expired-link page