### PR TITLE
feat(settings): fold status publish and branding identity into General

### DIFF
--- a/apps/web/e2e/tests/admin/settings-general.spec.ts
+++ b/apps/web/e2e/tests/admin/settings-general.spec.ts
@@ -14,6 +14,6 @@ test.describe('Admin General Settings', () => {
     }
 
     const productsCard = page.locator('#product-feedback').locator('xpath=ancestor::section[1]')
-    await expect(productsCard.locator('button[role="switch"]')).toHaveCount(5)
+    await expect(productsCard.locator('button[role="switch"]')).toHaveCount(4)
   })
 })

--- a/apps/web/src/components/admin/settings/logo-uploader.tsx
+++ b/apps/web/src/components/admin/settings/logo-uploader.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useRef, useState } from 'react'
+import { ArrowPathIcon, CameraIcon } from '@heroicons/react/24/solid'
+import { toast } from 'sonner'
+import { ImageCropper } from '@/components/ui/image-cropper'
+import { useSettingsLogo } from '@/lib/client/hooks/use-settings-queries'
+import { useUploadWorkspaceLogo, useDeleteWorkspaceLogo } from '@/lib/client/mutations/settings'
+
+const RASTER_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp']
+
+interface LogoUploaderProps {
+  workspaceName: string
+  onLogoChange?: (url: string | null) => void
+}
+
+export function LogoUploader({ workspaceName, onLogoChange }: LogoUploaderProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [showCropper, setShowCropper] = useState(false)
+  const [cropImageSrc, setCropImageSrc] = useState<string | null>(null)
+
+  const { data: logoData } = useSettingsLogo()
+  const uploadMutation = useUploadWorkspaceLogo()
+  const deleteMutation = useDeleteWorkspaceLogo()
+
+  const logoUrl = logoData?.url ?? null
+  const hasCustomLogo = !!logoUrl
+
+  useEffect(() => {
+    onLogoChange?.(logoUrl)
+  }, [logoUrl, onLogoChange])
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    if (!RASTER_IMAGE_TYPES.includes(file.type)) {
+      toast.error('Invalid file type. Allowed: JPEG, PNG, GIF, WebP')
+      return
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      toast.error('File too large. Maximum size is 5MB')
+      return
+    }
+
+    setCropImageSrc(URL.createObjectURL(file))
+    setShowCropper(true)
+    if (fileInputRef.current) fileInputRef.current.value = ''
+  }
+
+  const handleCropComplete = async (croppedBlob: Blob) => {
+    if (cropImageSrc) {
+      URL.revokeObjectURL(cropImageSrc)
+      setCropImageSrc(null)
+    }
+    uploadMutation.mutate(croppedBlob, {
+      onSuccess: () => toast.success('Logo updated'),
+      onError: (error) =>
+        toast.error(error instanceof Error ? error.message : 'Failed to upload logo'),
+    })
+  }
+
+  const handleCropperClose = (open: boolean) => {
+    if (!open && cropImageSrc) {
+      URL.revokeObjectURL(cropImageSrc)
+      setCropImageSrc(null)
+    }
+    setShowCropper(open)
+  }
+
+  return (
+    <div className="flex shrink-0 flex-col items-center gap-1.5">
+      <button
+        type="button"
+        onClick={() => fileInputRef.current?.click()}
+        disabled={uploadMutation.isPending}
+        className="relative group cursor-pointer"
+        aria-label="Change workspace logo"
+      >
+        {logoUrl ? (
+          <img
+            src={logoUrl}
+            alt={workspaceName}
+            className="h-14 w-14 rounded-xl object-cover border border-border transition-opacity group-hover:opacity-80"
+          />
+        ) : (
+          <div className="h-14 w-14 rounded-xl bg-primary flex items-center justify-center text-primary-foreground text-xl font-semibold border border-border transition-opacity group-hover:opacity-80">
+            {workspaceName.charAt(0).toUpperCase() || 'W'}
+          </div>
+        )}
+        {uploadMutation.isPending ? (
+          <div className="absolute inset-0 flex items-center justify-center rounded-xl bg-black/50">
+            <ArrowPathIcon className="h-5 w-5 animate-spin text-white" />
+          </div>
+        ) : (
+          <div className="absolute inset-0 flex items-center justify-center rounded-xl bg-black/50 opacity-0 transition-opacity group-hover:opacity-100">
+            <CameraIcon className="h-5 w-5 text-white" />
+          </div>
+        )}
+      </button>
+      {hasCustomLogo && (
+        <button
+          type="button"
+          onClick={() =>
+            deleteMutation.mutate(undefined, {
+              onSuccess: () => {
+                toast.success('Logo removed')
+                onLogoChange?.(null)
+              },
+              onError: (error) =>
+                toast.error(error instanceof Error ? error.message : 'Failed to remove logo'),
+            })
+          }
+          disabled={deleteMutation.isPending}
+          className="text-xs text-muted-foreground hover:text-destructive transition-colors"
+        >
+          {deleteMutation.isPending ? 'Removing…' : 'Remove'}
+        </button>
+      )}
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/jpeg,image/png,image/gif,image/webp"
+        onChange={handleFileChange}
+        className="hidden"
+      />
+
+      {cropImageSrc && (
+        <ImageCropper
+          imageSrc={cropImageSrc}
+          open={showCropper}
+          onOpenChange={handleCropperClose}
+          onCropComplete={handleCropComplete}
+          aspectRatio={1}
+          maxOutputSize={512}
+          title="Crop your logo"
+        />
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/admin/settings/status/status-general-card.tsx
+++ b/apps/web/src/components/admin/settings/status/status-general-card.tsx
@@ -1,5 +1,4 @@
 import { SettingsCard } from '@/components/admin/settings/settings-card'
-import { Switch } from '@/components/ui/switch'
 import { Label } from '@/components/ui/label'
 import { Input } from '@/components/ui/input'
 import type { StatusSettings } from '@/lib/shared/status-settings'
@@ -9,53 +8,28 @@ interface StatusGeneralCardProps {
   onChange: (patch: Partial<StatusSettings>) => void
   /** Flush any debounced text save immediately (input blur). */
   onFlushText?: () => void
-  disabled?: boolean
 }
 
-export function StatusGeneralCard({
-  settings,
-  onChange,
-  onFlushText,
-  disabled,
-}: StatusGeneralCardProps) {
+export function StatusGeneralCard({ settings, onChange, onFlushText }: StatusGeneralCardProps) {
   return (
     <SettingsCard
       title="General"
-      description="Publish the status page. Hide or rename the portal tab in Branding → Navigation."
+      description="The status page publishes from the Status toggle on Settings → General. Hide or rename the portal tab in Portal → Navigation."
     >
-      <div className="space-y-5">
-        <div className="flex items-center justify-between gap-4 py-1">
-          <div className="pr-4">
-            <Label htmlFor="status-enabled" className="text-sm font-medium cursor-pointer">
-              Publish status page
-            </Label>
-            <p className="mt-0.5 text-xs text-muted-foreground">
-              Makes the page public and starts recording uptime history.
-            </p>
-          </div>
-          <Switch
-            id="status-enabled"
-            checked={settings.enabled}
-            onCheckedChange={(checked) => onChange({ enabled: checked })}
-            disabled={disabled}
-          />
-        </div>
-
-        <div className="space-y-2">
-          <Label htmlFor="status-description" className="text-sm font-medium">
-            Page description
-          </Label>
-          {/* Not disabled while a save is pending: debounced saves fire mid-typing
-              and a disabled input would drop keystrokes. */}
-          <Input
-            id="status-description"
-            value={settings.pageDescription ?? ''}
-            onChange={(e) => onChange({ pageDescription: e.target.value || null })}
-            onBlur={onFlushText}
-            placeholder="Live status for our services. Subscribe to get notified about incidents."
-            maxLength={500}
-          />
-        </div>
+      <div className="space-y-2">
+        <Label htmlFor="status-description" className="text-sm font-medium">
+          Page description
+        </Label>
+        {/* Not disabled while a save is pending: debounced saves fire mid-typing
+            and a disabled input would drop keystrokes. */}
+        <Input
+          id="status-description"
+          value={settings.pageDescription ?? ''}
+          onChange={(e) => onChange({ pageDescription: e.target.value || null })}
+          onBlur={onFlushText}
+          placeholder="Live status for our services. Subscribe to get notified about incidents."
+          maxLength={500}
+        />
       </div>
     </SettingsCard>
   )

--- a/apps/web/src/components/admin/settings/status/status-notifications-card.tsx
+++ b/apps/web/src/components/admin/settings/status/status-notifications-card.tsx
@@ -19,41 +19,22 @@ export function StatusNotificationsCard({
       title="Notifications"
       description="How subscribers hear about incidents and maintenance."
     >
-      <div className="space-y-5">
-        <div className="flex items-center justify-between gap-4 py-1">
-          <div className="pr-4">
-            <Label htmlFor="status-emails" className="text-sm font-medium cursor-pointer">
-              Email notifications
-            </Label>
-            <p className="mt-0.5 text-xs text-muted-foreground">
-              Email subscribers once, when a new incident is published or maintenance is scheduled.
-              Updates and resolves appear on the page and in-app, not by email.
-            </p>
-          </div>
-          <Switch
-            id="status-emails"
-            checked={!settings.emailsDisabled}
-            onCheckedChange={(checked) => onChange({ emailsDisabled: !checked })}
-            disabled={disabled}
-          />
+      <div className="flex items-center justify-between gap-4 py-1">
+        <div className="pr-4">
+          <Label htmlFor="status-emails" className="text-sm font-medium cursor-pointer">
+            Email notifications
+          </Label>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            Email subscribers once, when a new incident is published or maintenance is scheduled.
+            Updates and resolves appear on the page and in-app, not by email.
+          </p>
         </div>
-
-        <div className="flex items-center justify-between gap-4 py-1">
-          <div className="pr-4">
-            <Label htmlFor="status-auto-subscribe" className="text-sm font-medium cursor-pointer">
-              Auto-subscribe portal members
-            </Label>
-            <p className="mt-0.5 text-xs text-muted-foreground">
-              New portal sign-ups are subscribed to the whole page. They can unsubscribe anytime.
-            </p>
-          </div>
-          <Switch
-            id="status-auto-subscribe"
-            checked={settings.autoSubscribe}
-            onCheckedChange={(checked) => onChange({ autoSubscribe: checked })}
-            disabled={disabled}
-          />
-        </div>
+        <Switch
+          id="status-emails"
+          checked={!settings.emailsDisabled}
+          onCheckedChange={(checked) => onChange({ emailsDisabled: !checked })}
+          disabled={disabled}
+        />
       </div>
     </SettingsCard>
   )

--- a/apps/web/src/components/public/portal-header.tsx
+++ b/apps/web/src/components/public/portal-header.tsx
@@ -4,6 +4,7 @@ import { useTheme } from 'next-themes'
 import { resolvePortalNavItems } from './portal-header-nav'
 import { usePreviewDraft } from './preview-draft-context'
 import { isProductEnabled } from '@/lib/shared/types/settings'
+import { isStatusPagePublished } from '@/lib/shared/status-settings'
 import { useIntl, FormattedMessage } from 'react-intl'
 import { cn } from '@/lib/shared/utils'
 import { isTeamMember, Role } from '@/lib/shared/roles'
@@ -74,12 +75,11 @@ export function PortalHeader({
   // Status tab: product flag + published. A non-public audience still needs
   // a signed-in viewer to bother showing the tab; the route enforces the
   // real per-viewer segment gate (settings here are workspace-global, not
-  // per-viewer). Hide or reorder the tab in Branding → Navigation.
+  // per-viewer). Hide or reorder the tab in Portal → Navigation.
   const statusAudience = settings?.statusConfig?.audience ?? 'public'
   const statusLoggedIn = !!session?.user && session.user.principalType !== 'anonymous'
   const statusEnabled =
-    isProductEnabled(flags, 'status') &&
-    !!settings?.statusConfig?.enabled &&
+    isStatusPagePublished(flags, settings?.statusConfig) &&
     (statusAudience === 'public' || statusLoggedIn)
   const onHelpPages = pathname === '/hc' || pathname.startsWith('/hc/')
   // Admin-configured help center links render beside the built-in nav on help

--- a/apps/web/src/lib/client/downscale-square-image.ts
+++ b/apps/web/src/lib/client/downscale-square-image.ts
@@ -1,0 +1,20 @@
+/**
+ * Rasterize a square image blob down to `size`×`size` PNG. Used to derive a
+ * favicon from the cropped workspace logo (already square, ≤512px).
+ */
+export async function downscaleSquareImage(blob: Blob, size: number): Promise<Blob> {
+  const bitmap = await createImageBitmap(blob)
+  try {
+    const canvas = document.createElement('canvas')
+    canvas.width = size
+    canvas.height = size
+    const ctx = canvas.getContext('2d')
+    if (!ctx) throw new Error('Could not get canvas context')
+    ctx.drawImage(bitmap, 0, 0, size, size)
+    const out = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, 'image/png'))
+    if (!out) throw new Error('Failed to encode image')
+    return out
+  } finally {
+    bitmap.close()
+  }
+}

--- a/apps/web/src/lib/client/hooks/use-settings-queries.ts
+++ b/apps/web/src/lib/client/hooks/use-settings-queries.ts
@@ -25,10 +25,3 @@ export function useSettingsHeaderLogo() {
     enabled: false, // Use SSR data, don't auto-fetch
   })
 }
-
-export function useSettingsFavicon() {
-  return useQuery({
-    ...settingsQueries.favicon(),
-    enabled: false, // Use SSR data, don't auto-fetch
-  })
-}

--- a/apps/web/src/lib/client/mutations/settings.ts
+++ b/apps/web/src/lib/client/mutations/settings.ts
@@ -13,10 +13,7 @@ import {
   updateHeaderDisplayNameFn,
   saveLogoKeyFn,
   saveHeaderLogoKeyFn,
-  savePortalOgImageKeyFn,
-  deletePortalOgImageFn,
   saveFaviconKeyFn,
-  deleteFaviconFn,
   saveWidgetHeroImageKeyFn,
   deleteWidgetHeroImageFn,
   updatePortalConfigFn,
@@ -49,11 +46,11 @@ import {
 import {
   getLogoUploadUrlFn,
   getHeaderLogoUploadUrlFn,
-  getPortalOgImageUploadUrlFn,
   getWidgetHeroUploadUrlFn,
   getFaviconUploadUrlFn,
 } from '@/lib/server/functions/uploads'
 import { settingsQueries } from '@/lib/client/queries/settings'
+import { downscaleSquareImage } from '@/lib/client/downscale-square-image'
 
 // ============================================================================
 // Logo Mutation Hooks
@@ -64,30 +61,45 @@ export function useUploadWorkspaceLogo() {
 
   return useMutation({
     mutationFn: async (file: Blob) => {
-      // 1. Get presigned URL from server
-      const { uploadUrl, key } = await getLogoUploadUrlFn({
-        data: {
-          filename: (file as File).name || 'logo.png',
-          contentType: file.type,
-          fileSize: file.size,
-        },
-      })
+      const logoType = file.type || 'image/png'
+      const faviconBlob = await downscaleSquareImage(file, 64)
 
-      // 2. Upload directly to S3
-      const uploadResponse = await fetch(uploadUrl, {
-        method: 'PUT',
-        body: file,
-        headers: {
-          'Content-Type': file.type,
-        },
-      })
+      const [logoUpload, faviconUpload] = await Promise.all([
+        getLogoUploadUrlFn({
+          data: {
+            filename: (file as File).name || 'logo.png',
+            contentType: logoType,
+            fileSize: file.size,
+          },
+        }),
+        getFaviconUploadUrlFn({
+          data: {
+            filename: 'favicon.png',
+            contentType: 'image/png',
+            fileSize: faviconBlob.size,
+          },
+        }),
+      ])
 
-      if (!uploadResponse.ok) {
+      const [logoResponse, faviconResponse] = await Promise.all([
+        fetch(logoUpload.uploadUrl, {
+          method: 'PUT',
+          body: file,
+          headers: { 'Content-Type': logoType },
+        }),
+        fetch(faviconUpload.uploadUrl, {
+          method: 'PUT',
+          body: faviconBlob,
+          headers: { 'Content-Type': 'image/png' },
+        }),
+      ])
+
+      if (!logoResponse.ok || !faviconResponse.ok) {
         throw new Error('Failed to upload logo to storage')
       }
 
-      // 3. Save the S3 key to the database
-      await saveLogoKeyFn({ data: { key } })
+      await saveLogoKeyFn({ data: { key: logoUpload.key } })
+      await saveFaviconKeyFn({ data: { key: faviconUpload.key } })
     },
     onSuccess: () => {
       queryClient.refetchQueries({ queryKey: settingsQueries.logo().queryKey })
@@ -102,108 +114,6 @@ export function useDeleteWorkspaceLogo() {
     mutationFn: () => deleteLogoFn(),
     onSuccess: () => {
       queryClient.refetchQueries({ queryKey: settingsQueries.logo().queryKey })
-    },
-  })
-}
-
-// ============================================================================
-// Portal OG Image Mutation Hooks
-// ============================================================================
-
-export function useUploadPortalOgImage() {
-  const queryClient = useQueryClient()
-
-  return useMutation({
-    mutationFn: async (file: Blob) => {
-      // 1. Get presigned URL from server
-      const { uploadUrl, key } = await getPortalOgImageUploadUrlFn({
-        data: {
-          filename: (file as File).name || 'og-image.png',
-          contentType: file.type,
-          fileSize: file.size,
-        },
-      })
-
-      // 2. Upload directly to S3
-      const uploadResponse = await fetch(uploadUrl, {
-        method: 'PUT',
-        body: file,
-        headers: {
-          'Content-Type': file.type,
-        },
-      })
-
-      if (!uploadResponse.ok) {
-        throw new Error('Failed to upload social image to storage')
-      }
-
-      // 3. Save the S3 key to the database
-      await savePortalOgImageKeyFn({ data: { key } })
-    },
-    onSuccess: () => {
-      queryClient.refetchQueries({ queryKey: settingsQueries.portalOgImage().queryKey })
-    },
-  })
-}
-
-export function useDeletePortalOgImage() {
-  const queryClient = useQueryClient()
-
-  return useMutation({
-    mutationFn: () => deletePortalOgImageFn(),
-    onSuccess: () => {
-      queryClient.refetchQueries({ queryKey: settingsQueries.portalOgImage().queryKey })
-    },
-  })
-}
-
-// ============================================================================
-// Favicon Mutation Hooks
-// ============================================================================
-
-export function useUploadFavicon() {
-  const queryClient = useQueryClient()
-
-  return useMutation({
-    mutationFn: async (file: Blob) => {
-      // 1. Get presigned URL from server
-      const { uploadUrl, key } = await getFaviconUploadUrlFn({
-        data: {
-          filename: (file as File).name || 'favicon.png',
-          contentType: file.type,
-          fileSize: file.size,
-        },
-      })
-
-      // 2. Upload directly to S3
-      const uploadResponse = await fetch(uploadUrl, {
-        method: 'PUT',
-        body: file,
-        headers: {
-          'Content-Type': file.type,
-        },
-      })
-
-      if (!uploadResponse.ok) {
-        throw new Error('Failed to upload favicon to storage')
-      }
-
-      // 3. Save the S3 key to the database
-      await saveFaviconKeyFn({ data: { key } })
-    },
-    onSuccess: () => {
-      queryClient.refetchQueries({ queryKey: settingsQueries.favicon().queryKey })
-    },
-  })
-}
-
-export function useDeleteFavicon() {
-  const queryClient = useQueryClient()
-
-  return useMutation({
-    mutationFn: () => deleteFaviconFn(),
-    onSuccess: () => {
-      queryClient.refetchQueries({ queryKey: settingsQueries.favicon().queryKey })
     },
   })
 }

--- a/apps/web/src/lib/client/queries/settings.ts
+++ b/apps/web/src/lib/client/queries/settings.ts
@@ -34,8 +34,6 @@ import { listRolesFn } from '@/lib/server/functions/roles'
 import {
   fetchSettingsLogoData,
   fetchSettingsHeaderLogoData,
-  fetchSettingsPortalOgImageData,
-  fetchSettingsFaviconData,
 } from '@/lib/server/functions/settings-utils'
 
 const STALE_TIME_SHORT = 30 * 1000
@@ -89,20 +87,6 @@ export const settingsQueries = {
     queryOptions({
       queryKey: ['settings', 'headerLogo'],
       queryFn: fetchSettingsHeaderLogoData,
-      staleTime: STALE_TIME_LONG,
-    }),
-
-  portalOgImage: () =>
-    queryOptions({
-      queryKey: ['settings', 'portalOgImage'],
-      queryFn: fetchSettingsPortalOgImageData,
-      staleTime: STALE_TIME_LONG,
-    }),
-
-  favicon: () =>
-    queryOptions({
-      queryKey: ['settings', 'favicon'],
-      queryFn: fetchSettingsFaviconData,
       staleTime: STALE_TIME_LONG,
     }),
 

--- a/apps/web/src/lib/server/domains/settings/__tests__/lab-sections.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/lab-sections.test.ts
@@ -30,6 +30,9 @@ describe('feature flag settings layout', () => {
     expect(isProductEnabled(DEFAULT_FEATURE_FLAGS, 'support')).toBe(false)
     expect(isProductEnabled(DEFAULT_FEATURE_FLAGS, 'helpCenter')).toBe(false)
     expect(isProductEnabled(DEFAULT_FEATURE_FLAGS, 'status')).toBe(false)
+    expect(PRODUCT_DEFINITIONS.find((product) => product.id === 'status')?.description).toBe(
+      'Publish a status page with live service status, incidents, maintenance, and uptime history.'
+    )
   })
 
   it('updates both Support capabilities from its single product toggle', () => {
@@ -85,6 +88,11 @@ describe('resolveFeatureFlags', () => {
   it('does not resurrect a disabled inbox from a stored linkPreviews value', () => {
     const flags = resolveFeatureFlags(JSON.stringify({ supportInbox: false, linkPreviews: true }))
     expect(flags.supportInbox).toBe(false)
+  })
+
+  it('forces feedback true even when stored false', () => {
+    const flags = resolveFeatureFlags(JSON.stringify({ feedback: false }))
+    expect(flags.feedback).toBe(true)
   })
 })
 

--- a/apps/web/src/lib/server/domains/settings/__tests__/portal-og-image.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/portal-og-image.test.ts
@@ -1,12 +1,8 @@
 /**
  * Portal OG image settings tests.
  *
- * Verifies:
- * - savePortalOgImageKey stores the key, removes the replaced S3 object, and
- *   invalidates the workspace settings cache
- * - deletePortalOgImageKey clears the key, removes the S3 object, and
- *   invalidates the cache
- * - getWorkspaceSettings resolves brandingData.ogImageUrl from the stored key
+ * The stored `portal_og_image_key` column is leftover and unread.
+ * Social share resolves to the workspace logo (then `/logo.png`).
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
@@ -121,7 +117,6 @@ function makeSettingsRow(overrides: Record<string, unknown> = {}) {
 
 // Import after mocks
 const { getWorkspaceSettings } = await import('../settings.service')
-const { savePortalOgImageKey, deletePortalOgImageKey } = await import('../settings.media')
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -136,56 +131,13 @@ beforeEach(() => {
   mockUpdate.mockReturnValue({ set: mockSet })
 })
 
-describe('savePortalOgImageKey', () => {
-  beforeEach(() => {
-    mockFindFirst.mockResolvedValue(makeSettingsRow())
-  })
-
-  it('stores the key and invalidates the workspace settings cache', async () => {
-    const result = await savePortalOgImageKey('portal-og/og.png')
-
-    expect(result).toEqual({ success: true, key: 'portal-og/og.png' })
-    expect(mockSet).toHaveBeenCalledWith({ portalOgImageKey: 'portal-og/og.png' })
-    expect(mockCacheDel).toHaveBeenCalledWith('settings:workspace', 'auth:registered-providers')
-  })
-
-  it('deletes the replaced S3 object', async () => {
-    mockFindFirst.mockResolvedValue(makeSettingsRow({ portalOgImageKey: 'portal-og/old.png' }))
-
-    await savePortalOgImageKey('portal-og/new.png')
-
-    expect(mockDeleteObject).toHaveBeenCalledWith('portal-og/old.png')
-  })
-})
-
-describe('deletePortalOgImageKey', () => {
-  it('clears the key, deletes the S3 object, and invalidates the cache', async () => {
-    mockFindFirst.mockResolvedValue(makeSettingsRow({ portalOgImageKey: 'portal-og/og.png' }))
-
-    const result = await deletePortalOgImageKey()
-
-    expect(result).toEqual({ success: true })
-    expect(mockDeleteObject).toHaveBeenCalledWith('portal-og/og.png')
-    expect(mockSet).toHaveBeenCalledWith({ portalOgImageKey: null })
-    expect(mockCacheDel).toHaveBeenCalledWith('settings:workspace', 'auth:registered-providers')
-  })
-
-  it('does not touch S3 when no image is set', async () => {
-    mockFindFirst.mockResolvedValue(makeSettingsRow())
-
-    await deletePortalOgImageKey()
-
-    expect(mockDeleteObject).not.toHaveBeenCalled()
-  })
-})
-
 describe('getWorkspaceSettings brandingData.ogImageUrl', () => {
-  it('resolves the public URL from the stored key', async () => {
+  it('does not read a leftover stored portal_og_image_key', async () => {
     mockFindFirst.mockResolvedValue(makeSettingsRow({ portalOgImageKey: 'portal-og/og.png' }))
 
     const result = await getWorkspaceSettings()
 
-    expect(result?.brandingData.ogImageUrl).toBe('https://cdn.test/portal-og/og.png')
+    expect(result?.brandingData.ogImageUrl).toBeNull()
   })
 
   it('is null when no OG image is set', async () => {

--- a/apps/web/src/lib/server/domains/settings/__tests__/settings-cache.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/settings-cache.test.ts
@@ -123,8 +123,13 @@ function makeSettingsRow(overrides: Record<string, unknown> = {}) {
 }
 
 // Import after mocks
-const { getWorkspaceSettings, updateAuthConfig, updatePortalConfig, updateDeveloperConfig } =
-  await import('../settings.service')
+const {
+  getWorkspaceSettings,
+  updateAuthConfig,
+  updatePortalConfig,
+  updateDeveloperConfig,
+  updateFeatureFlags,
+} = await import('../settings.service')
 const { invalidateSettingsCache } = await import('../settings.helpers')
 const {
   updateBrandingConfig,
@@ -367,6 +372,14 @@ describe('settings write functions invalidate cache', () => {
     expect(mockCacheDel).toHaveBeenCalledWith('settings:workspace', 'auth:registered-providers')
   })
 
+  it('deleteLogoKey clears the derived favicon too', async () => {
+    mockFindFirst.mockResolvedValue(
+      makeSettingsRow({ logoKey: 'logos/a.png', faviconKey: 'favicons/a.png' })
+    )
+    await deleteLogoKey()
+    expect(mockSet).toHaveBeenCalledWith({ logoKey: null, faviconKey: null })
+  })
+
   it('saveFaviconKey invalidates cache', async () => {
     await saveFaviconKey('favicons/new.ico')
     expect(mockCacheDel).toHaveBeenCalledWith('settings:workspace', 'auth:registered-providers')
@@ -390,5 +403,70 @@ describe('settings write functions invalidate cache', () => {
   it('regenerateWidgetSecret invalidates cache', async () => {
     await regenerateWidgetSecret()
     expect(mockCacheDel).toHaveBeenCalledWith('settings:workspace', 'auth:registered-providers')
+  })
+})
+
+describe('updateFeatureFlags', () => {
+  beforeEach(() => {
+    mockFindFirst.mockResolvedValue(
+      makeSettingsRow({
+        featureFlags: JSON.stringify({
+          feedback: true,
+          changelog: true,
+          helpCenter: false,
+          supportInbox: false,
+          supportTickets: false,
+          statusPage: false,
+        }),
+        metadata: null,
+      })
+    )
+  })
+
+  it('refuses to persist feedback: false', async () => {
+    const result = await updateFeatureFlags({ feedback: false })
+    expect(result.feedback).toBe(true)
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        featureFlags: expect.stringMatching(/"feedback":true/),
+      })
+    )
+    const written = JSON.parse(
+      (
+        mockSet.mock.calls.find((call) => call[0] && 'featureFlags' in call[0]) as
+          [{ featureFlags: string }] | undefined
+      )?.[0].featureFlags ?? '{}'
+    ) as { feedback?: boolean }
+    expect(written.feedback).toBe(true)
+  })
+
+  it('writes statusSettings.enabled true when turning Status on', async () => {
+    await updateFeatureFlags({ statusPage: true })
+    const metadataCall = mockSet.mock.calls.find((call) => call[0] && 'metadata' in call[0]) as
+      [{ metadata: string }] | undefined
+    expect(metadataCall).toBeTruthy()
+    const meta = JSON.parse(metadataCall![0].metadata) as {
+      statusSettings?: { enabled?: boolean }
+    }
+    expect(meta.statusSettings?.enabled).toBe(true)
+  })
+
+  it('does not write statusSettings.enabled when turning Status off', async () => {
+    mockFindFirst.mockResolvedValue(
+      makeSettingsRow({
+        featureFlags: JSON.stringify({
+          feedback: true,
+          changelog: true,
+          helpCenter: false,
+          supportInbox: false,
+          supportTickets: false,
+          statusPage: true,
+        }),
+        metadata: JSON.stringify({ statusSettings: { enabled: true } }),
+      })
+    )
+    await updateFeatureFlags({ statusPage: false })
+    const metadataCall = mockSet.mock.calls.find((call) => call[0] && 'metadata' in call[0])
+    expect(metadataCall).toBeUndefined()
   })
 })

--- a/apps/web/src/lib/server/domains/settings/settings.media.ts
+++ b/apps/web/src/lib/server/domains/settings/settings.media.ts
@@ -125,7 +125,8 @@ export async function saveLogoKey(key: string): Promise<{ success: true; key: st
 }
 
 /**
- * Delete logo from S3 and clear the key.
+ * Delete logo from S3 and clear the key. The favicon is derived from the
+ * logo at upload, so removing the logo clears both keys.
  */
 export async function deleteLogoKey(): Promise<{ success: true }> {
   log.info('delete logo key')
@@ -139,8 +140,18 @@ export async function deleteLogoKey(): Promise<{ success: true }> {
         log.warn({ err, logo_key: org.logoKey }, 'failed to delete logo s3 object')
       }
     }
+    if (org.faviconKey) {
+      try {
+        await deleteObject(org.faviconKey)
+      } catch (err) {
+        log.warn({ err, favicon_key: org.faviconKey }, 'failed to delete favicon s3 object')
+      }
+    }
 
-    await db.update(settings).set({ logoKey: null }).where(eq(settings.id, org.id))
+    await db
+      .update(settings)
+      .set({ logoKey: null, faviconKey: null })
+      .where(eq(settings.id, org.id))
     await invalidateSettingsCache()
 
     return { success: true }
@@ -257,64 +268,6 @@ export async function deleteHeaderLogoKey(): Promise<{ success: true }> {
   } catch (error) {
     log.error({ err: error }, 'delete header logo key failed')
     wrapDbError('delete header logo key', error)
-  }
-}
-
-/**
- * Save portal OG image S3 key and delete old image if exists.
- */
-export async function savePortalOgImageKey(key: string): Promise<{ success: true; key: string }> {
-  log.info('save portal og image key')
-  try {
-    const org = await requireSettings()
-
-    if (org.portalOgImageKey) {
-      try {
-        await deleteObject(org.portalOgImageKey)
-      } catch (err) {
-        log.warn(
-          { err, portal_og_image_key: org.portalOgImageKey },
-          'failed to delete old portal og image s3 object'
-        )
-      }
-    }
-
-    await db.update(settings).set({ portalOgImageKey: key }).where(eq(settings.id, org.id))
-    await invalidateSettingsCache()
-
-    return { success: true, key }
-  } catch (error) {
-    log.error({ err: error }, 'save portal og image key failed')
-    wrapDbError('save portal og image key', error)
-  }
-}
-
-/**
- * Delete portal OG image from S3 and clear the key.
- */
-export async function deletePortalOgImageKey(): Promise<{ success: true }> {
-  log.info('delete portal og image key')
-  try {
-    const org = await requireSettings()
-
-    if (org.portalOgImageKey) {
-      try {
-        await deleteObject(org.portalOgImageKey)
-      } catch (err) {
-        log.warn(
-          { err, portal_og_image_key: org.portalOgImageKey },
-          'failed to delete portal og image s3 object'
-        )
-      }
-    }
-
-    await db.update(settings).set({ portalOgImageKey: null }).where(eq(settings.id, org.id))
-    await invalidateSettingsCache()
-
-    return { success: true }
-  } catch (error) {
-    log.error({ err: error }, 'delete portal og image key failed')
-    wrapDbError('delete portal og image key', error)
   }
 }
 

--- a/apps/web/src/lib/server/domains/settings/settings.service.ts
+++ b/apps/web/src/lib/server/domains/settings/settings.service.ts
@@ -52,7 +52,7 @@ import { signupOpenFor } from '@/lib/shared/signup-open'
 import { publicHomeConfig, publicMessengerConfig } from './settings.widget'
 import { getSetupState, isOnboardingComplete } from '@/lib/shared/db-types'
 import { resolveChangelogSettings } from './settings.changelog'
-import { resolveStatusSettings } from './settings.status'
+import { resolveStatusSettings, updateStatusSettings } from './settings.status'
 import {
   parseJsonConfig,
   parseJsonOrNull,
@@ -928,7 +928,7 @@ export async function getWorkspaceSettings(): Promise<WorkspaceSettings | null> 
       logoUrl: offHostPublicUrl(org.logoKey),
       faviconUrl: getPublicUrlOrNull(org.faviconKey),
       headerLogoUrl: getPublicUrlOrNull(org.headerLogoKey),
-      ogImageUrl: offHostPublicUrl(org.portalOgImageKey),
+      ogImageUrl: null,
       headerDisplayMode: org.headerDisplayMode,
       headerDisplayName: org.headerDisplayName,
     }
@@ -1061,6 +1061,15 @@ export async function updateFeatureFlags(input: Partial<FeatureFlags>): Promise<
   // them into their umbrella flag), so this write persists a clean shape.
   const current = resolveFeatureFlags(org.featureFlags)
   const updated = { ...current, ...input }
+  // The public portal homepage is the feedback board — never persist off.
+  updated.feedback = true
+  // General Status ON is the single publish control: clear a legacy
+  // unpublished bit so the page actually goes live. OFF only flips the flag;
+  // workspaces that stored statusPage:true with enabled:false stay unpublished
+  // until that toggle is flipped on.
+  if (input.statusPage === true) {
+    await updateStatusSettings({ enabled: true })
+  }
   await db
     .update(settings)
     .set({ featureFlags: JSON.stringify(updated) })

--- a/apps/web/src/lib/server/domains/settings/settings.service.ts
+++ b/apps/web/src/lib/server/domains/settings/settings.service.ts
@@ -52,7 +52,7 @@ import { signupOpenFor } from '@/lib/shared/signup-open'
 import { publicHomeConfig, publicMessengerConfig } from './settings.widget'
 import { getSetupState, isOnboardingComplete } from '@/lib/shared/db-types'
 import { resolveChangelogSettings } from './settings.changelog'
-import { resolveStatusSettings, updateStatusSettings } from './settings.status'
+import { resolveStatusSettings } from './settings.status'
 import {
   parseJsonConfig,
   parseJsonOrNull,
@@ -1057,23 +1057,25 @@ export async function isCopilotCapabilityEnabled(
  */
 export async function updateFeatureFlags(input: Partial<FeatureFlags>): Promise<FeatureFlags> {
   const org = await requireSettings()
-  // resolveFeatureFlags drops legacy pre-consolidation keys (after coalescing
-  // them into their umbrella flag), so this write persists a clean shape.
+  // Unknown stored keys (retired Labs flags) drop here; the next write
+  // persists a clean shape.
   const current = resolveFeatureFlags(org.featureFlags)
-  const updated = { ...current, ...input }
-  // The public portal homepage is the feedback board — never persist off.
-  updated.feedback = true
+  const updated = { ...current, ...input, feedback: true }
   // General Status ON is the single publish control: clear a legacy
   // unpublished bit so the page actually goes live. OFF only flips the flag;
   // workspaces that stored statusPage:true with enabled:false stay unpublished
-  // until that toggle is flipped on.
-  if (input.statusPage === true) {
-    await updateStatusSettings({ enabled: true })
+  // until that toggle is flipped on. Written with the flags so a crash
+  // between the two cannot leave one side published and the other not.
+  const patch: { featureFlags: string; metadata?: string } = {
+    featureFlags: JSON.stringify(updated),
   }
-  await db
-    .update(settings)
-    .set({ featureFlags: JSON.stringify(updated) })
-    .where(eq(settings.id, org.id))
+  if (input.statusPage === true) {
+    const existing = resolveStatusSettings(org.metadata)
+    const meta = parseJsonOrNull<Record<string, unknown>>(org.metadata) ?? {}
+    meta.statusSettings = { ...existing, enabled: true }
+    patch.metadata = JSON.stringify(meta)
+  }
+  await db.update(settings).set(patch).where(eq(settings.id, org.id))
   await invalidateSettingsCache()
   return updated
 }

--- a/apps/web/src/lib/server/domains/settings/settings.status.ts
+++ b/apps/web/src/lib/server/domains/settings/settings.status.ts
@@ -1,7 +1,8 @@
 /**
  * Status page settings family (Status Product Spec §3): enablement, the
  * page visibility ladder (public / authenticated / segments), and the
- * email switches. Portal chrome lives in Branding → Navigation.
+ * email switches. Portal chrome lives in Portal → Navigation. The page
+ * publishes from the Status toggle on Settings → General.
  *
  * Storage: like changelog and office-hours settings, these ride in the
  * generic `settings.metadata` JSON bag (no dedicated column, no migration).

--- a/apps/web/src/lib/server/domains/settings/settings.types.ts
+++ b/apps/web/src/lib/server/domains/settings/settings.types.ts
@@ -1002,7 +1002,11 @@ export interface SettingsBrandingData {
   logoUrl: string | null
   faviconUrl: string | null
   headerLogoUrl: string | null
-  /** Custom portal social share (OG) image; null falls back to the logo. */
+  /**
+   * @deprecated Unread. Social share resolves to the workspace logo
+   * (`resolvePortalOgImageUrl`); the stored `portal_og_image_key` column is
+   * left in place but no longer populated or read.
+   */
   ogImageUrl: string | null
   headerDisplayMode: string | null
   headerDisplayName: string | null
@@ -1207,7 +1211,8 @@ export const PRODUCT_DEFINITIONS = [
   {
     id: 'status',
     label: 'Status',
-    description: 'Share live service status, incidents, maintenance, and uptime history.',
+    description:
+      'Publish a status page with live service status, incidents, maintenance, and uptime history.',
     featureFlags: ['statusPage'],
     adminPath: '/admin/status',
   },

--- a/apps/web/src/lib/server/functions/__tests__/favicon-settings.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/favicon-settings.test.ts
@@ -1,8 +1,7 @@
 /**
- * Favicon server functions — the admin upload flow ends at saveFaviconKeyFn
- * (persists the storage key) and deleteFaviconFn (clears it). Both are gated
- * on the branding permission; the portal <link rel="icon"> already reads the
- * key through WorkspaceSettings.faviconData.
+ * Favicon server functions — logo upload derives a 64px favicon and
+ * persist it via saveFaviconKeyFn. deleteLogoKey clears both keys.
+ * Gated on settings.manage (the logo lives on Settings → General).
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { PERMISSIONS } from '@/lib/shared/permissions'
@@ -53,10 +52,10 @@ beforeEach(() => {
 })
 
 describe('saveFaviconKeyFn', () => {
-  it('requires the branding permission and persists the key', async () => {
+  it('requires settings.manage and persists the key', async () => {
     const result = await saveFaviconKey({ data: { key: 'favicons/a.png' } })
     expect(hoisted.mockRequireAuth).toHaveBeenCalledWith({
-      permission: PERMISSIONS.SETTINGS_BRANDING,
+      permission: PERMISSIONS.SETTINGS_MANAGE,
     })
     expect(hoisted.mockSaveFaviconKey).toHaveBeenCalledWith('favicons/a.png')
     expect(result).toEqual({ success: true, key: 'favicons/a.png' })
@@ -70,10 +69,10 @@ describe('saveFaviconKeyFn', () => {
 })
 
 describe('deleteFaviconFn', () => {
-  it('requires the branding permission and clears the key', async () => {
+  it('requires settings.manage and clears the key', async () => {
     const result = await deleteFavicon()
     expect(hoisted.mockRequireAuth).toHaveBeenCalledWith({
-      permission: PERMISSIONS.SETTINGS_BRANDING,
+      permission: PERMISSIONS.SETTINGS_MANAGE,
     })
     expect(hoisted.mockDeleteFaviconKey).toHaveBeenCalled()
     expect(result).toEqual({ success: true })

--- a/apps/web/src/lib/server/functions/settings-utils.ts
+++ b/apps/web/src/lib/server/functions/settings-utils.ts
@@ -2,12 +2,7 @@ import { createServerFn } from '@tanstack/react-start'
 import { logger } from '@/lib/server/logger'
 
 const log = logger.child({ component: 'settings-utils' })
-import {
-  getSettingsLogoData,
-  getSettingsHeaderLogoData,
-  getSettingsPortalOgImageData,
-  getSettingsFaviconData,
-} from '@/lib/server/settings-utils'
+import { getSettingsLogoData, getSettingsHeaderLogoData } from '@/lib/server/settings-utils'
 
 /**
  * Server functions for settings utilities (logo/branding data).
@@ -31,27 +26,5 @@ export const fetchSettingsHeaderLogoData = createServerFn({ method: 'GET' }).han
   log.debug('fetching settings header logo data')
   const data = await getSettingsHeaderLogoData()
   log.debug({ has_header_logo: !!data }, 'settings header logo data fetched')
-  return data
-})
-
-/**
- * Fetch portal OG image data for settings
- */
-export const fetchSettingsPortalOgImageData = createServerFn({ method: 'GET' }).handler(
-  async () => {
-    log.debug('fetching settings portal og image data')
-    const data = await getSettingsPortalOgImageData()
-    log.debug({ has_og_image: !!data }, 'settings portal og image data fetched')
-    return data
-  }
-)
-
-/**
- * Fetch favicon data for settings
- */
-export const fetchSettingsFaviconData = createServerFn({ method: 'GET' }).handler(async () => {
-  log.debug('fetching settings favicon data')
-  const data = await getSettingsFaviconData()
-  log.debug({ has_favicon: !!data }, 'settings favicon data fetched')
   return data
 })

--- a/apps/web/src/lib/server/functions/settings.ts
+++ b/apps/web/src/lib/server/functions/settings.ts
@@ -23,8 +23,6 @@ import {
   deleteLogoKey,
   saveHeaderLogoKey,
   deleteHeaderLogoKey,
-  savePortalOgImageKey,
-  deletePortalOgImageKey,
   saveFaviconKey,
   deleteFaviconKey,
   updateHeaderDisplayMode,
@@ -609,13 +607,13 @@ export const saveLogoKeyFn = createServerFn({ method: 'POST' })
   .validator(saveLogoKeySchema)
   .handler(async ({ data }) => {
     log.info({ key: data.key }, 'save logo key')
-    await requireAuth({ permission: PERMISSIONS.SETTINGS_BRANDING })
+    await requireAuth({ permission: PERMISSIONS.SETTINGS_MANAGE })
     return await saveLogoKey(data.key)
   })
 
 export const deleteLogoFn = createServerFn({ method: 'POST' }).handler(async () => {
   log.info('delete logo')
-  await requireAuth({ permission: PERMISSIONS.SETTINGS_BRANDING })
+  await requireAuth({ permission: PERMISSIONS.SETTINGS_MANAGE })
   return await deleteLogoKey()
 })
 
@@ -633,31 +631,17 @@ export const deleteHeaderLogoFn = createServerFn({ method: 'POST' }).handler(asy
   return await deleteHeaderLogoKey()
 })
 
-export const savePortalOgImageKeyFn = createServerFn({ method: 'POST' })
-  .validator(saveLogoKeySchema)
-  .handler(async ({ data }) => {
-    log.info({ key: data.key }, 'save portal og image key')
-    await requireAuth({ permission: PERMISSIONS.SETTINGS_BRANDING })
-    return await savePortalOgImageKey(data.key)
-  })
-
-export const deletePortalOgImageFn = createServerFn({ method: 'POST' }).handler(async () => {
-  log.info('delete portal og image')
-  await requireAuth({ permission: PERMISSIONS.SETTINGS_BRANDING })
-  return await deletePortalOgImageKey()
-})
-
 export const saveFaviconKeyFn = createServerFn({ method: 'POST' })
   .validator(saveLogoKeySchema)
   .handler(async ({ data }) => {
     log.info({ key: data.key }, 'save favicon key')
-    await requireAuth({ permission: PERMISSIONS.SETTINGS_BRANDING })
+    await requireAuth({ permission: PERMISSIONS.SETTINGS_MANAGE })
     return await saveFaviconKey(data.key)
   })
 
 export const deleteFaviconFn = createServerFn({ method: 'POST' }).handler(async () => {
   log.info('delete favicon')
-  await requireAuth({ permission: PERMISSIONS.SETTINGS_BRANDING })
+  await requireAuth({ permission: PERMISSIONS.SETTINGS_MANAGE })
   return await deleteFaviconKey()
 })
 

--- a/apps/web/src/lib/server/functions/status.ts
+++ b/apps/web/src/lib/server/functions/status.ts
@@ -71,6 +71,7 @@ import { enforceStatusComponentLimit } from '@/lib/server/domains/settings/tier-
 import {
   statusSettingsSchema,
   DEFAULT_STATUS_SETTINGS,
+  isStatusPagePublished,
   type StatusSettings,
 } from '@/lib/shared/status-settings'
 import type { Actor } from '@/lib/server/policy/types'
@@ -743,9 +744,10 @@ interface StatusPageGateResult {
  *
  *   1. Portal access (a private portal must not leak status data to a caller
  *      the portal-access resolver denies — same outer gate as changelog).
- *   2. `statusSettings.enabled` — the workspace's own master switch.
- *   3. The `statusPage` feature flag.
- *   4. The status audience ladder (§4): public / authenticated / segments.
+ *   2. Published state via `isStatusPagePublished` (`statusPage` flag AND
+ *      `statusSettings.enabled !== false`, so a legacy unpublished page
+ *      stays dark until the General Status toggle is flipped).
+ *   3. The status audience ladder (§4): public / authenticated / segments.
  *
  * Never throws; callers translate `available: false` into the shape their
  * endpoint contract expects (404 for a single-entity read, empty list/array
@@ -761,12 +763,8 @@ async function resolveStatusPageGate(): Promise<StatusPageGateResult> {
   const authCtx = await getOptionalAuth()
   const actor = await policyActorFromAuth(authCtx)
 
-  if (!settings.enabled) {
-    return { available: false, actor, settings }
-  }
-
   const { isFeatureEnabled } = await import('@/lib/server/domains/settings/settings.service')
-  if (!(await isFeatureEnabled('statusPage'))) {
+  if (!isStatusPagePublished({ statusPage: await isFeatureEnabled('statusPage') }, settings)) {
     return { available: false, actor, settings }
   }
 

--- a/apps/web/src/lib/server/functions/uploads.ts
+++ b/apps/web/src/lib/server/functions/uploads.ts
@@ -218,16 +218,6 @@ export const getHeaderLogoUploadUrlFn = createServerFn({ method: 'POST' })
   })
 
 /**
- * Get a presigned URL for uploading the portal social share (OG) image.
- */
-export const getPortalOgImageUploadUrlFn = createServerFn({ method: 'POST' })
-  .validator(imageUploadSchema)
-  .handler(async ({ data }) => {
-    await requireAuth({ permission: PERMISSIONS.SETTINGS_MANAGE })
-    return presignedImageUpload(data, { label: 'portal og image', prefix: 'portal-og' })
-  })
-
-/**
  * Get a presigned URL for uploading the widget Home hero image.
  */
 export const getWidgetHeroUploadUrlFn = createServerFn({ method: 'POST' })

--- a/apps/web/src/lib/server/policy/authz-matrix/MATRIX.md
+++ b/apps/web/src/lib/server/policy/authz-matrix/MATRIX.md
@@ -100,7 +100,7 @@ Profiles: **Owner** = admin class + an admin-owned full API key (scoped keys hol
 
 ## 2. Surfaces and their enforced authorization
 
-### Server functions (`requireAuth`) — 669 surfaces
+### Server functions (`requireAuth`) — 666 surfaces
 
 | Surface | Enforces |
 | --- | --- |
@@ -558,14 +558,12 @@ Profiles: **Owner** = admin class + an admin-owned full API key (scoped keys hol
 | `lib/server/functions/settings.ts`::updateThemeFn | settings.branding |
 | `lib/server/functions/settings.ts`::updatePortalConfigFn | settings.manage |
 | `lib/server/functions/settings.ts`::updateAuthConfigFn | auth.manage |
-| `lib/server/functions/settings.ts`::saveLogoKeyFn | settings.branding |
-| `lib/server/functions/settings.ts`::deleteLogoFn | settings.branding |
+| `lib/server/functions/settings.ts`::saveLogoKeyFn | settings.manage |
+| `lib/server/functions/settings.ts`::deleteLogoFn | settings.manage |
 | `lib/server/functions/settings.ts`::saveHeaderLogoKeyFn | settings.branding |
 | `lib/server/functions/settings.ts`::deleteHeaderLogoFn | settings.branding |
-| `lib/server/functions/settings.ts`::savePortalOgImageKeyFn | settings.branding |
-| `lib/server/functions/settings.ts`::deletePortalOgImageFn | settings.branding |
-| `lib/server/functions/settings.ts`::saveFaviconKeyFn | settings.branding |
-| `lib/server/functions/settings.ts`::deleteFaviconFn | settings.branding |
+| `lib/server/functions/settings.ts`::saveFaviconKeyFn | settings.manage |
+| `lib/server/functions/settings.ts`::deleteFaviconFn | settings.manage |
 | `lib/server/functions/settings.ts`::updateHeaderDisplayModeFn | settings.branding |
 | `lib/server/functions/settings.ts`::updateHeaderDisplayNameFn | settings.branding |
 | `lib/server/functions/settings.ts`::updateWorkspaceNameFn | settings.branding |
@@ -746,7 +744,6 @@ Profiles: **Owner** = admin class + an admin-owned full API key (scoped keys hol
 | `lib/server/functions/uploads.ts`::getLogoUploadUrlFn | settings.manage |
 | `lib/server/functions/uploads.ts`::getFaviconUploadUrlFn | settings.manage |
 | `lib/server/functions/uploads.ts`::getHeaderLogoUploadUrlFn | settings.manage |
-| `lib/server/functions/uploads.ts`::getPortalOgImageUploadUrlFn | settings.manage |
 | `lib/server/functions/uploads.ts`::getWidgetHeroUploadUrlFn | settings.manage |
 | `lib/server/functions/uploads.ts`::getAvatarUploadUrlFn | END_USER (any authenticated) |
 | `lib/server/functions/uploads.ts`::getAssistantAvatarUploadUrlFn | assistant.manage |
@@ -979,7 +976,7 @@ Key scopes are enforced: an API key holds exactly its stored scopes (owner permi
 
 ## 4. Entry points without a requireAuth/key gate
 
-190 of 970 entry points hold no `requireAuth` / `withApiKeyAuth` / `requireTeamAuth` gate.
+188 of 965 entry points hold no `requireAuth` / `withApiKeyAuth` / `requireTeamAuth` gate.
 Each is expected to be intentionally public, a pre-auth flow, a signature-verified webhook, or a handler that delegates auth (e.g. the MCP route).
 **Adding a row here is an access-control change** — confirm the new entry point is meant to be reachable without a gate.
 
@@ -1061,10 +1058,8 @@ Each is expected to be intentionally public, a pre-auth flow, a signature-verifi
 | `lib/server/functions/public-posts.ts`::listPublicRoadmapsFn | server-fn |
 | `lib/server/functions/public-profile.ts`::getPublicUserProfileFn | server-fn |
 | `lib/server/functions/recovery-codes-consume.ts`::consumeRecoveryCodeFn | server-fn |
-| `lib/server/functions/settings-utils.ts`::fetchSettingsFaviconData | server-fn |
 | `lib/server/functions/settings-utils.ts`::fetchSettingsHeaderLogoData | server-fn |
 | `lib/server/functions/settings-utils.ts`::fetchSettingsLogoData | server-fn |
-| `lib/server/functions/settings-utils.ts`::fetchSettingsPortalOgImageData | server-fn |
 | `lib/server/functions/settings.ts`::fetchBrandingConfig | server-fn |
 | `lib/server/functions/settings.ts`::fetchCustomCssFn | server-fn |
 | `lib/server/functions/settings.ts`::fetchPublicAuthConfig | server-fn |

--- a/apps/web/src/lib/server/settings-utils.ts
+++ b/apps/web/src/lib/server/settings-utils.ts
@@ -47,19 +47,6 @@ export async function getSettingsLogoData(): Promise<LogoData | null> {
   return { url }
 }
 
-/**
- * Get portal OG image data for the settings.
- */
-export async function getSettingsPortalOgImageData(): Promise<LogoData | null> {
-  const record = await getSettingsRecord()
-  if (!record) return null
-
-  const url = offHostPublicUrl(record.portalOgImageKey)
-  if (!url) return null
-
-  return { url }
-}
-
 export interface HeaderLogoData {
   url: string | null
   displayMode: string | null

--- a/apps/web/src/lib/shared/__tests__/portal-og-image.test.ts
+++ b/apps/web/src/lib/shared/__tests__/portal-og-image.test.ts
@@ -2,39 +2,30 @@ import { describe, it, expect } from 'vitest'
 import { resolvePortalOgImageUrl } from '../portal-og-image'
 
 describe('resolvePortalOgImageUrl', () => {
-  it('prefers the custom OG image when set', () => {
-    expect(
-      resolvePortalOgImageUrl({
-        ogImageUrl: 'https://cdn.test/portal-og/og.png',
-        logoUrl: 'https://cdn.test/logos/logo.png',
-      })
-    ).toBe('https://cdn.test/portal-og/og.png')
+  it('uses the workspace logo when set', () => {
+    expect(resolvePortalOgImageUrl({ logoUrl: 'https://cdn.test/logos/logo.png' })).toBe(
+      'https://cdn.test/logos/logo.png'
+    )
   })
 
-  it('falls back to the workspace logo when no OG image is set', () => {
-    expect(
-      resolvePortalOgImageUrl({ ogImageUrl: null, logoUrl: 'https://cdn.test/logos/logo.png' })
-    ).toBe('https://cdn.test/logos/logo.png')
-  })
-
-  it('falls back to the default logo when neither is set', () => {
-    expect(resolvePortalOgImageUrl({ ogImageUrl: null, logoUrl: null })).toBe('/logo.png')
+  it('falls back to the default logo when no logo is set', () => {
+    expect(resolvePortalOgImageUrl({ logoUrl: null })).toBe('/logo.png')
     expect(resolvePortalOgImageUrl(null)).toBe('/logo.png')
     expect(resolvePortalOgImageUrl(undefined)).toBe('/logo.png')
   })
 
   it('joins a relative fallback to the supplied origin', () => {
-    expect(
-      resolvePortalOgImageUrl({ ogImageUrl: null, logoUrl: null }, 'https://ws-abc.quackback.co.uk')
-    ).toBe('https://ws-abc.quackback.co.uk/logo.png')
+    expect(resolvePortalOgImageUrl({ logoUrl: null }, 'https://ws-abc.quackback.co.uk')).toBe(
+      'https://ws-abc.quackback.co.uk/logo.png'
+    )
   })
 
-  it('keeps an already-absolute system-host OG URL', () => {
+  it('keeps an already-absolute logo URL', () => {
     expect(
       resolvePortalOgImageUrl(
-        { ogImageUrl: 'https://ws-abc.quackback.co.uk/api/storage/portal-og/og.png' },
+        { logoUrl: 'https://ws-abc.quackback.co.uk/api/storage/logos/logo.png' },
         'https://acme.quackback.co.uk'
       )
-    ).toBe('https://ws-abc.quackback.co.uk/api/storage/portal-og/og.png')
+    ).toBe('https://ws-abc.quackback.co.uk/api/storage/logos/logo.png')
   })
 })

--- a/apps/web/src/lib/shared/__tests__/status-publish.test.ts
+++ b/apps/web/src/lib/shared/__tests__/status-publish.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_STATUS_SETTINGS, isStatusPagePublished } from '../status-settings'
+import { DEFAULT_FEATURE_FLAGS } from '@/lib/server/domains/settings/settings.types'
+
+describe('isStatusPagePublished', () => {
+  it('stays unpublished when the flag is on but enabled is false', () => {
+    expect(isStatusPagePublished({ statusPage: true }, { enabled: false })).toBe(false)
+  })
+
+  it('publishes when the flag is on and enabled is true', () => {
+    expect(isStatusPagePublished({ statusPage: true }, { enabled: true })).toBe(true)
+  })
+
+  it('stays unpublished when the flag is off', () => {
+    expect(isStatusPagePublished({ statusPage: false }, { enabled: true })).toBe(false)
+    expect(isStatusPagePublished({ statusPage: false }, { enabled: false })).toBe(false)
+    expect(isStatusPagePublished(DEFAULT_FEATURE_FLAGS, DEFAULT_STATUS_SETTINGS)).toBe(false)
+  })
+})

--- a/apps/web/src/lib/shared/portal-og-image.ts
+++ b/apps/web/src/lib/shared/portal-og-image.ts
@@ -1,16 +1,15 @@
 /**
  * Portal social share (OG) image resolution.
  *
- * Priority: a custom uploaded OG image beats the workspace logo, which beats
- * the bundled default logo. The portal root's head() uses this so link
- * unfurls show the richest image the workspace has configured. Relative
+ * Always the workspace logo, then the bundled default. A stored custom OG
+ * image is no longer read (`portal_og_image_key` is leftover). Relative
  * fallbacks are joined to `origin` so crawlers receive an absolute URL.
  */
 export function resolvePortalOgImageUrl(
-  branding: { ogImageUrl?: string | null; logoUrl?: string | null } | null | undefined,
+  branding: { logoUrl?: string | null } | null | undefined,
   origin?: string | null
 ): string {
-  const src = branding?.ogImageUrl || branding?.logoUrl || '/logo.png'
+  const src = branding?.logoUrl || '/logo.png'
   if (!origin) return src
   try {
     return new URL(src, origin.endsWith('/') ? origin : `${origin}/`).toString()

--- a/apps/web/src/lib/shared/status-settings.ts
+++ b/apps/web/src/lib/shared/status-settings.ts
@@ -15,10 +15,15 @@ import { z } from 'zod'
 export type StatusAudience = 'public' | 'authenticated' | 'segments'
 
 export interface StatusSettings {
-  /** Master switch: publishes the page and starts recording uptime history. */
+  /**
+   * Legacy publish bit. The General Status product toggle is the single
+   * publish control: ON writes this true (clearing a stored false); OFF
+   * only flips `featureFlags.statusPage`. Effective published state is
+   * {@link isStatusPagePublished}.
+   */
   enabled: boolean
   /**
-   * @deprecated Ignored at read time. Portal chrome is Branding → Navigation.
+   * @deprecated Ignored at read time. Portal chrome is Portal → Navigation.
    */
   portalTabEnabled: boolean
   audience: StatusAudience
@@ -26,8 +31,6 @@ export interface StatusSettings {
   allowedSegmentIds: string[]
   /** Workspace-wide kill switch for all status emails. */
   emailsDisabled: boolean
-  /** Auto-subscribe new/identified end-users to the whole page. */
-  autoSubscribe: boolean
   /** Optional blurb under the public page header. */
   pageDescription: string | null
 }
@@ -38,8 +41,20 @@ export const DEFAULT_STATUS_SETTINGS: StatusSettings = {
   audience: 'public',
   allowedSegmentIds: [],
   emailsDisabled: false,
-  autoSubscribe: false,
   pageDescription: null,
+}
+
+/**
+ * Effective status-page publish state: the General product flag AND the
+ * legacy `statusSettings.enabled` bit. `enabled !== false` keeps a
+ * workspace that stored the flag on but the page unpublished from going
+ * live on upgrade until the General toggle is flipped (which writes both).
+ */
+export function isStatusPagePublished(
+  flags: { statusPage?: boolean } | null | undefined,
+  statusSettings: { enabled?: boolean } | null | undefined
+): boolean {
+  return !!flags?.statusPage && statusSettings?.enabled !== false
 }
 
 export const statusSettingsSchema = z
@@ -49,7 +64,6 @@ export const statusSettingsSchema = z
     audience: z.enum(['public', 'authenticated', 'segments']),
     allowedSegmentIds: z.array(z.string()),
     emailsDisabled: z.boolean(),
-    autoSubscribe: z.boolean(),
     pageDescription: z.string().max(500).nullable(),
   })
   .partial()

--- a/apps/web/src/routes/_portal.tsx
+++ b/apps/web/src/routes/_portal.tsx
@@ -287,7 +287,7 @@ export const Route = createFileRoute('/_portal')({
 
     const workspaceName = loaderData?.workspaceName ?? 'Quackback'
     const description = `Share feedback, vote on feature requests, and track the ${workspaceName} roadmap.`
-    // Social share image: custom OG upload > workspace logo > bundled default.
+    // Social share image: workspace logo, then the bundled default.
     const ogImageUrl = resolvePortalOgImageUrl(loaderData?.brandingData, loaderData?.baseUrl)
 
     const meta: Array<Record<string, string>> = [

--- a/apps/web/src/routes/_portal/index.tsx
+++ b/apps/web/src/routes/_portal/index.tsx
@@ -10,6 +10,7 @@ import { PortalWelcomeCard } from '@/components/public/feedback/portal-welcome-c
 import { usePreviewDraft } from '@/components/public/preview-draft-context'
 import { portalQueries } from '@/lib/client/queries/portal'
 import { isProductEnabled } from '@/lib/shared/types/settings'
+import { isStatusPagePublished } from '@/lib/shared/status-settings'
 
 const searchSchema = z.object({
   board: z.string().optional(),
@@ -73,7 +74,7 @@ export const Route = createFileRoute('/_portal/')({
       if (isProductEnabled(org.featureFlags, 'changelog')) {
         throw redirect({ to: '/changelog' })
       }
-      if (isProductEnabled(org.featureFlags, 'status') && org.statusConfig.enabled) {
+      if (isStatusPagePublished(org.featureFlags, org.statusConfig)) {
         throw redirect({ to: '/status' })
       }
       throw notFound()

--- a/apps/web/src/routes/admin/__tests__/settings-general-identity.test.tsx
+++ b/apps/web/src/routes/admin/__tests__/settings-general-identity.test.tsx
@@ -2,39 +2,34 @@
 import '@testing-library/jest-dom/vitest'
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
-import { CloudWorkspaceDetails, LocalWorkspaceNameCard } from '../settings.general'
+import { WorkspaceIdentityCard } from '../settings.general'
+
+vi.mock('@/components/admin/settings/logo-uploader', () => ({
+  LogoUploader: ({ workspaceName }: { workspaceName: string }) => (
+    <button type="button" aria-label="Change workspace logo">
+      {workspaceName.charAt(0).toUpperCase() || 'W'}
+    </button>
+  ),
+}))
 
 describe('General workspace identity', () => {
-  it('self-host name card has no cloud URL field', () => {
+  it('shows logo and name with no Quackback URL field', () => {
     render(
-      <LocalWorkspaceNameCard
+      <WorkspaceIdentityCard
         workspaceName="Acme"
         saving={false}
         managed={false}
         onWorkspaceNameChange={vi.fn()}
       />
     )
+    expect(screen.getByRole('heading', { name: 'Workspace' })).toBeInTheDocument()
+    expect(
+      screen.getByText('Your logo and name, shown across the portal, widget, and emails')
+    ).toBeInTheDocument()
     expect(screen.getByLabelText('Workspace Name')).toHaveValue('Acme')
+    expect(screen.getByRole('button', { name: 'Change workspace logo' })).toBeInTheDocument()
     expect(screen.queryByLabelText('Quackback URL')).not.toBeInTheDocument()
     expect(screen.queryByText(/Friendly Quackback URL/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/ws-/)).not.toBeInTheDocument()
-  })
-
-  it('cloud details do not prefill a generated host into the URL field', () => {
-    render(
-      <CloudWorkspaceDetails
-        workspaceName="Track1 Alpha"
-        platformLabel=""
-        domainSuffix="quackback.co.uk"
-        currentOrigin="https://south63792f.quackback.co.uk"
-        pending={false}
-        error={null}
-        onWorkspaceNameChange={vi.fn()}
-        onPlatformLabelChange={vi.fn()}
-        onSubmit={vi.fn()}
-      />
-    )
-    expect(screen.getByLabelText('Quackback URL')).toHaveValue('')
-    expect(screen.queryByDisplayValue(/ws-/)).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/routes/admin/__tests__/settings.domains.test.tsx
+++ b/apps/web/src/routes/admin/__tests__/settings.domains.test.tsx
@@ -7,7 +7,7 @@ vi.mock('@/components/admin/upgrade', () => ({
   UpgradeNotice: () => <p>Custom domains are a Growth feature. Upgrade to Growth to enable it.</p>,
 }))
 
-const { DomainsCard } = await import('../settings.domains')
+const { DomainsCard, QuackbackUrlCard } = await import('../settings.domains')
 
 const PENDING = {
   hostname: 'feedback.acme.test',
@@ -60,5 +60,45 @@ describe('domains card', () => {
     expect(screen.queryByText(/ch_/)).not.toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Check status' }))
     expect(refresh).toHaveBeenCalledWith('feedback.acme.test')
+  })
+})
+
+describe('Quackback URL card', () => {
+  it('does not prefill a generated host into the URL field', () => {
+    render(
+      <QuackbackUrlCard
+        platformLabel=""
+        domainSuffix="quackback.co.uk"
+        currentOrigin="https://south63792f.quackback.co.uk"
+        pending={false}
+        error={null}
+        onPlatformLabelChange={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    )
+    expect(screen.getByLabelText('Quackback URL')).toHaveValue('')
+    expect(screen.queryByDisplayValue(/ws-/)).not.toBeInTheDocument()
+  })
+
+  it('shows preview, current origin, and one save action', () => {
+    const save = vi.fn()
+    render(
+      <QuackbackUrlCard
+        platformLabel="ws-generated"
+        domainSuffix="quackback.co.uk"
+        currentOrigin="https://ws-generated.quackback.co.uk"
+        pending={false}
+        error={null}
+        onPlatformLabelChange={vi.fn()}
+        onSubmit={save}
+      />
+    )
+
+    expect(screen.getByLabelText('Quackback URL')).toHaveValue('ws-generated')
+    expect(screen.getByText(/Preview:/)).toHaveTextContent('https://ws-generated.quackback.co.uk')
+    const buttons = screen.getAllByRole('button')
+    expect(buttons).toHaveLength(1)
+    fireEvent.click(buttons[0]!)
+    expect(save).toHaveBeenCalledOnce()
   })
 })

--- a/apps/web/src/routes/admin/__tests__/settings.general-cloud.test.tsx
+++ b/apps/web/src/routes/admin/__tests__/settings.general-cloud.test.tsx
@@ -1,32 +1,32 @@
 // @vitest-environment happy-dom
 import '@testing-library/jest-dom/vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
-import { CloudWorkspaceDetails } from '../settings.general'
+import { WorkspaceIdentityCard } from '../settings.general'
 
-describe('cloud workspace details', () => {
-  it('shows one primary action with name and Quackback URL controls', () => {
-    const save = vi.fn()
+vi.mock('@/components/admin/settings/logo-uploader', () => ({
+  LogoUploader: () => (
+    <button type="button" aria-label="Change workspace logo">
+      W
+    </button>
+  ),
+}))
+
+describe('cloud workspace identity on General', () => {
+  it('keeps only name and logo — no URL controls or save button', () => {
     render(
-      <CloudWorkspaceDetails
+      <WorkspaceIdentityCard
         workspaceName="Untitled workspace"
-        platformLabel="ws-generated"
-        domainSuffix="quackback.co.uk"
-        currentOrigin="https://ws-generated.quackback.co.uk"
-        pending={false}
-        error={null}
+        saving={false}
+        managed={false}
         onWorkspaceNameChange={vi.fn()}
-        onPlatformLabelChange={vi.fn()}
-        onSubmit={save}
+        maxLength={80}
       />
     )
 
-    expect(screen.getByLabelText('Workspace name')).toBeInTheDocument()
-    expect(screen.getByLabelText('Quackback URL')).toBeInTheDocument()
-    expect(screen.getByText(/Preview:/)).toHaveTextContent('https://ws-generated.quackback.co.uk')
-    const buttons = screen.getAllByRole('button')
-    expect(buttons).toHaveLength(1)
-    fireEvent.click(buttons[0]!)
-    expect(save).toHaveBeenCalledOnce()
+    expect(screen.getByLabelText('Workspace Name')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Quackback URL')).not.toBeInTheDocument()
+    expect(screen.queryByText(/Preview:/)).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /save/i })).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/routes/admin/settings.branding.tsx
+++ b/apps/web/src/routes/admin/settings.branding.tsx
@@ -9,7 +9,6 @@ import {
   SunIcon,
   MoonIcon,
   ArrowPathIcon,
-  CameraIcon,
   PaintBrushIcon,
   ComputerDesktopIcon,
   DevicePhoneMobileIcon,
@@ -31,7 +30,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { ImageCropper } from '@/components/ui/image-cropper'
 import { RichTextEditor } from '@/components/ui/rich-text-editor'
 import { cn } from '@/lib/shared/utils'
 import { BackLink } from '@/components/ui/back-link'
@@ -59,16 +57,7 @@ import {
   type ThemeConfig,
   type ThemeMode,
 } from '@/lib/shared/theme'
-import { useSettingsLogo, useSettingsFavicon } from '@/lib/client/hooks/use-settings-queries'
-import {
-  useUploadWorkspaceLogo,
-  useDeleteWorkspaceLogo,
-  useUploadPortalOgImage,
-  useDeletePortalOgImage,
-  useUploadFavicon,
-  useDeleteFavicon,
-  useUpdatePortalConfig,
-} from '@/lib/client/mutations/settings'
+import { useUpdatePortalConfig } from '@/lib/client/mutations/settings'
 import { useImageUpload } from '@/lib/client/hooks/use-image-upload'
 import { UpgradeModal } from '@/components/admin/upgrade'
 import { describePlanUpgrade, isPlanRefusal } from '@/lib/shared/describe-upgrade'
@@ -77,6 +66,7 @@ import {
   PORTAL_WELCOME_CARD_TITLE_MAX,
   isProductEnabled,
 } from '@/lib/shared/types/settings'
+import { isStatusPagePublished } from '@/lib/shared/status-settings'
 import type {
   PortalConfig,
   PortalNavItemConfig,
@@ -115,8 +105,6 @@ export const Route = createFileRoute('/admin/settings/branding')({
     await Promise.all([
       context.queryClient.ensureQueryData(settingsQueries.branding()),
       context.queryClient.ensureQueryData(settingsQueries.logo()),
-      context.queryClient.ensureQueryData(settingsQueries.portalOgImage()),
-      context.queryClient.ensureQueryData(settingsQueries.favicon()),
       context.queryClient.ensureQueryData(settingsQueries.customCss()),
       context.queryClient.ensureQueryData(settingsQueries.portalConfig()),
       ensureBillingCatalogue(context.queryClient, context.billingEnabled),
@@ -127,7 +115,7 @@ export const Route = createFileRoute('/admin/settings/branding')({
 
 function BrandingPage() {
   const router = useRouter()
-  const { settings } = Route.useRouteContext()
+  const { settings, session } = Route.useRouteContext()
   const [, startTransition] = useTransition()
   // Display-only: the name is edited on Workspace > General.
   const workspaceName = settings?.name || ''
@@ -269,6 +257,8 @@ function BrandingPage() {
   // editor keeps their rows but renders them inert. Mirrors portal-header.
   const gatedTypes = useMemo(() => {
     const flags = settings?.featureFlags
+    const statusAudience = settings?.statusConfig?.audience ?? 'public'
+    const statusLoggedIn = !!session?.user && session.user.principalType !== 'anonymous'
     const gates: Record<PortalBuiltInNavType, boolean> = {
       feedback: isProductEnabled(flags, 'feedback'),
       roadmap: isProductEnabled(flags, 'feedback'),
@@ -277,12 +267,14 @@ function BrandingPage() {
       support:
         !!flags?.supportTickets ||
         (!!flags?.supportInbox && !!settings?.portalConfig?.support?.enabled),
-      status: isProductEnabled(flags, 'status') && !!settings?.statusConfig?.enabled,
+      status:
+        isStatusPagePublished(flags, settings?.statusConfig) &&
+        (statusAudience === 'public' || statusLoggedIn),
     }
     return new Set(
       (Object.keys(gates) as PortalBuiltInNavType[]).filter((type) => !gates[type])
     ) as ReadonlySet<string>
-  }, [settings])
+  }, [settings, session])
 
   // Structural drafts pushed into the preview iframe (postMessage, no reload).
   const previewDraft = useMemo<PortalPreviewDraft>(
@@ -317,23 +309,6 @@ function BrandingPage() {
       {/* Controls left, live portal preview right (sticky). */}
       <div className="grid grid-cols-1 xl:grid-cols-[minmax(360px,460px)_minmax(0,1fr)] gap-6 items-start">
         <div className="space-y-4 min-w-0">
-          <SettingsCard
-            title="Identity"
-            description="The portal header shows your logo and workspace name; the name is edited under General settings"
-          >
-            <div className="flex flex-wrap items-start gap-6">
-              <LogoUploader workspaceName={workspaceName} onLogoChange={state.setLogoUrl} />
-              <FaviconUploader workspaceName={workspaceName} />
-            </div>
-          </SettingsCard>
-
-          <SettingsCard
-            title="Social share image"
-            description="Shown when your portal link is shared on social media or in chat apps. Falls back to your logo. Recommended 1200×630"
-          >
-            <OgImageUploader />
-          </SettingsCard>
-
           <SettingsCard title="Appearance" description="Theme mode, color palette, and typography">
             <div className="space-y-4">
               <div className="space-y-1.5">
@@ -661,349 +636,6 @@ function WelcomeBodyEditor({
       }}
       onImageUpload={uploadImage}
     />
-  )
-}
-
-// ==============================================
-// Identity uploaders
-// ==============================================
-
-const RASTER_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp']
-
-interface LogoUploaderProps {
-  workspaceName: string
-  onLogoChange?: (url: string | null) => void
-}
-
-function LogoUploader({ workspaceName, onLogoChange }: LogoUploaderProps) {
-  const fileInputRef = useRef<HTMLInputElement>(null)
-  const [showCropper, setShowCropper] = useState(false)
-  const [cropImageSrc, setCropImageSrc] = useState<string | null>(null)
-
-  const { data: logoData } = useSettingsLogo()
-  const uploadMutation = useUploadWorkspaceLogo()
-  const deleteMutation = useDeleteWorkspaceLogo()
-
-  const logoUrl = logoData?.url ?? null
-  const hasCustomLogo = !!logoUrl
-
-  // Sync logo changes to parent
-  useEffect(() => {
-    onLogoChange?.(logoUrl)
-  }, [logoUrl, onLogoChange])
-
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0]
-    if (!file) return
-
-    if (!RASTER_IMAGE_TYPES.includes(file.type)) {
-      toast.error('Invalid file type. Allowed: JPEG, PNG, GIF, WebP')
-      return
-    }
-    if (file.size > 5 * 1024 * 1024) {
-      toast.error('File too large. Maximum size is 5MB')
-      return
-    }
-
-    setCropImageSrc(URL.createObjectURL(file))
-    setShowCropper(true)
-    if (fileInputRef.current) fileInputRef.current.value = ''
-  }
-
-  const handleCropComplete = async (croppedBlob: Blob) => {
-    if (cropImageSrc) {
-      URL.revokeObjectURL(cropImageSrc)
-      setCropImageSrc(null)
-    }
-    uploadMutation.mutate(croppedBlob, {
-      onSuccess: () => toast.success('Logo updated'),
-      onError: (error) =>
-        toast.error(error instanceof Error ? error.message : 'Failed to upload logo'),
-    })
-  }
-
-  const handleCropperClose = (open: boolean) => {
-    if (!open && cropImageSrc) {
-      URL.revokeObjectURL(cropImageSrc)
-      setCropImageSrc(null)
-    }
-    setShowCropper(open)
-  }
-
-  return (
-    <div className="flex flex-col items-center gap-1.5">
-      <button
-        type="button"
-        onClick={() => fileInputRef.current?.click()}
-        disabled={uploadMutation.isPending}
-        className="relative group cursor-pointer"
-        aria-label="Change workspace logo"
-      >
-        {logoUrl ? (
-          <img
-            src={logoUrl}
-            alt={workspaceName}
-            className="h-14 w-14 rounded-xl object-cover border border-border transition-opacity group-hover:opacity-80"
-          />
-        ) : (
-          <div className="h-14 w-14 rounded-xl bg-primary flex items-center justify-center text-primary-foreground text-xl font-semibold border border-border transition-opacity group-hover:opacity-80">
-            {workspaceName.charAt(0).toUpperCase() || 'W'}
-          </div>
-        )}
-        <UploaderOverlay busy={uploadMutation.isPending} />
-      </button>
-      <span className="text-[11px] text-muted-foreground">Logo</span>
-      {hasCustomLogo && (
-        <RemoveAssetButton
-          pending={deleteMutation.isPending}
-          onClick={() =>
-            deleteMutation.mutate(undefined, {
-              onSuccess: () => {
-                toast.success('Logo removed')
-                onLogoChange?.(null)
-              },
-              onError: (error) =>
-                toast.error(error instanceof Error ? error.message : 'Failed to remove logo'),
-            })
-          }
-        />
-      )}
-
-      <input
-        ref={fileInputRef}
-        type="file"
-        accept="image/jpeg,image/png,image/gif,image/webp"
-        onChange={handleFileChange}
-        className="hidden"
-      />
-
-      {cropImageSrc && (
-        <ImageCropper
-          imageSrc={cropImageSrc}
-          open={showCropper}
-          onOpenChange={handleCropperClose}
-          onCropComplete={handleCropComplete}
-          aspectRatio={1}
-          maxOutputSize={512}
-          title="Crop your logo"
-        />
-      )}
-    </div>
-  )
-}
-
-// Wide (1200×630) social share image for the portal's og:image meta tag.
-function OgImageUploader() {
-  const fileInputRef = useRef<HTMLInputElement>(null)
-  const [showCropper, setShowCropper] = useState(false)
-  const [cropImageSrc, setCropImageSrc] = useState<string | null>(null)
-
-  const { data: ogImageData } = useSuspenseQuery(settingsQueries.portalOgImage())
-  const uploadMutation = useUploadPortalOgImage()
-  const deleteMutation = useDeletePortalOgImage()
-
-  const ogImageUrl = ogImageData?.url ?? null
-
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0]
-    if (!file) return
-
-    if (!RASTER_IMAGE_TYPES.includes(file.type)) {
-      toast.error('Invalid file type. Allowed: JPEG, PNG, GIF, WebP')
-      return
-    }
-    if (file.size > 5 * 1024 * 1024) {
-      toast.error('File too large. Maximum size is 5MB')
-      return
-    }
-
-    setCropImageSrc(URL.createObjectURL(file))
-    setShowCropper(true)
-    if (fileInputRef.current) fileInputRef.current.value = ''
-  }
-
-  const handleCropComplete = async (croppedBlob: Blob) => {
-    if (cropImageSrc) {
-      URL.revokeObjectURL(cropImageSrc)
-      setCropImageSrc(null)
-    }
-    uploadMutation.mutate(croppedBlob, {
-      onSuccess: () => toast.success('Social share image updated'),
-      onError: (error) =>
-        toast.error(error instanceof Error ? error.message : 'Failed to upload social share image'),
-    })
-  }
-
-  const handleCropperClose = (open: boolean) => {
-    if (!open && cropImageSrc) {
-      URL.revokeObjectURL(cropImageSrc)
-      setCropImageSrc(null)
-    }
-    setShowCropper(open)
-  }
-
-  return (
-    <div className="flex flex-col items-start gap-1.5">
-      <button
-        type="button"
-        onClick={() => fileInputRef.current?.click()}
-        disabled={uploadMutation.isPending}
-        className="relative group cursor-pointer w-full max-w-[320px]"
-        aria-label="Change social share image"
-      >
-        {ogImageUrl ? (
-          <img
-            src={ogImageUrl}
-            alt="Social share image preview"
-            className="w-full aspect-[1200/630] rounded-xl object-cover border border-border transition-opacity group-hover:opacity-80"
-          />
-        ) : (
-          <div className="w-full aspect-[1200/630] rounded-xl border border-dashed border-border bg-muted/30 flex items-center justify-center text-xs text-muted-foreground transition-colors group-hover:border-primary/50">
-            1200 × 630
-          </div>
-        )}
-        <UploaderOverlay busy={uploadMutation.isPending} />
-      </button>
-      {ogImageUrl && (
-        <RemoveAssetButton
-          pending={deleteMutation.isPending}
-          onClick={() =>
-            deleteMutation.mutate(undefined, {
-              onSuccess: () => toast.success('Social share image removed'),
-              onError: (error) =>
-                toast.error(
-                  error instanceof Error ? error.message : 'Failed to remove social share image'
-                ),
-            })
-          }
-        />
-      )}
-
-      <input
-        ref={fileInputRef}
-        type="file"
-        accept="image/jpeg,image/png,image/gif,image/webp"
-        onChange={handleFileChange}
-        className="hidden"
-      />
-
-      {cropImageSrc && (
-        <ImageCropper
-          imageSrc={cropImageSrc}
-          open={showCropper}
-          onOpenChange={handleCropperClose}
-          onCropComplete={handleCropComplete}
-          aspectRatio={1200 / 630}
-          maxOutputSize={1200}
-          cropShape="rect"
-          title="Crop your social share image"
-        />
-      )}
-    </div>
-  )
-}
-
-function FaviconUploader({ workspaceName }: { workspaceName: string }) {
-  const fileInputRef = useRef<HTMLInputElement>(null)
-
-  const { data: faviconData } = useSettingsFavicon()
-  const uploadMutation = useUploadFavicon()
-  const deleteMutation = useDeleteFavicon()
-
-  const faviconUrl = faviconData?.url ?? null
-  const hasCustomFavicon = !!faviconUrl
-
-  // Favicons render at 16–32px, so no cropper — the file uploads as picked.
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0]
-    if (!file) return
-
-    if (!RASTER_IMAGE_TYPES.includes(file.type)) {
-      toast.error('Invalid file type. Allowed: JPEG, PNG, GIF, WebP')
-      return
-    }
-    if (file.size > 5 * 1024 * 1024) {
-      toast.error('File too large. Maximum size is 5MB')
-      return
-    }
-
-    uploadMutation.mutate(file, {
-      onSuccess: () => toast.success('Favicon updated'),
-      onError: (error) =>
-        toast.error(error instanceof Error ? error.message : 'Failed to upload favicon'),
-    })
-    if (fileInputRef.current) fileInputRef.current.value = ''
-  }
-
-  return (
-    <div className="flex flex-col items-center gap-1.5">
-      <button
-        type="button"
-        onClick={() => fileInputRef.current?.click()}
-        disabled={uploadMutation.isPending}
-        className="relative group cursor-pointer"
-        aria-label="Change workspace favicon"
-      >
-        {faviconUrl ? (
-          <img
-            src={faviconUrl}
-            alt={`${workspaceName} favicon`}
-            className="h-14 w-14 rounded-xl object-contain border border-border p-2 transition-opacity group-hover:opacity-80"
-          />
-        ) : (
-          <div className="h-14 w-14 rounded-xl border border-dashed border-border flex items-center justify-center text-muted-foreground transition-opacity group-hover:opacity-80">
-            <CameraIcon className="h-5 w-5" />
-          </div>
-        )}
-        <UploaderOverlay busy={uploadMutation.isPending} />
-      </button>
-      <span className="text-[11px] text-muted-foreground">Favicon</span>
-      {hasCustomFavicon && (
-        <RemoveAssetButton
-          pending={deleteMutation.isPending}
-          onClick={() =>
-            deleteMutation.mutate(undefined, {
-              onSuccess: () => toast.success('Favicon removed'),
-              onError: (error) =>
-                toast.error(error instanceof Error ? error.message : 'Failed to remove favicon'),
-            })
-          }
-        />
-      )}
-
-      <input
-        ref={fileInputRef}
-        type="file"
-        accept="image/jpeg,image/png,image/gif,image/webp"
-        onChange={handleFileChange}
-        className="hidden"
-      />
-    </div>
-  )
-}
-
-function UploaderOverlay({ busy }: { busy: boolean }) {
-  return busy ? (
-    <div className="absolute inset-0 flex items-center justify-center rounded-xl bg-black/50">
-      <ArrowPathIcon className="h-5 w-5 animate-spin text-white" />
-    </div>
-  ) : (
-    <div className="absolute inset-0 flex items-center justify-center rounded-xl bg-black/50 opacity-0 transition-opacity group-hover:opacity-100">
-      <CameraIcon className="h-5 w-5 text-white" />
-    </div>
-  )
-}
-
-function RemoveAssetButton({ pending, onClick }: { pending: boolean; onClick: () => void }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={pending}
-      className="text-xs text-muted-foreground hover:text-destructive transition-colors"
-    >
-      {pending ? 'Removing…' : 'Remove'}
-    </button>
   )
 }
 

--- a/apps/web/src/routes/admin/settings.domains.tsx
+++ b/apps/web/src/routes/admin/settings.domains.tsx
@@ -3,7 +3,7 @@ import { PERMISSIONS } from '@/lib/shared/permissions'
 import { assertRoutePermission } from '@/lib/shared/route-permission'
 import { useMutation } from '@tanstack/react-query'
 import { createFileRoute, useRouteContext, useRouter } from '@tanstack/react-router'
-import { GlobeAltIcon } from '@heroicons/react/24/solid'
+import { ArrowPathIcon, GlobeAltIcon } from '@heroicons/react/24/solid'
 import { toast } from 'sonner'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -15,8 +15,11 @@ import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import {
   getCloudCustomDomainsFn,
+  getCloudIdentityFn,
   hasCustomDomainEntitlementFn,
   mutateCloudCustomDomainFn,
+  platformLabelFromHostname,
+  updateCloudIdentityFn,
 } from '@/lib/server/functions/cloud-identity'
 import type { CustomDomainInstruction } from '@/lib/server/control-plane/client'
 
@@ -25,24 +28,67 @@ export const Route = createFileRoute('/admin/settings/domains')({
     assertRoutePermission(context.permissions, PERMISSIONS.SETTINGS_CUSTOM_DOMAIN)
     const { cloudEnabled } = context
     if (!cloudEnabled)
-      return { allowed: false, entitled: false, domains: [] as CustomDomainInstruction[] }
+      return {
+        allowed: false,
+        entitled: false,
+        domains: [] as CustomDomainInstruction[],
+        cloudIdentity: null,
+      }
     const { ensureBillingCatalogue } = await import('@/lib/client/queries/billing')
-    const [entitled, domains] = await Promise.all([
+    const [entitled, domains, cloudIdentity] = await Promise.all([
       hasCustomDomainEntitlementFn(),
       getCloudCustomDomainsFn().catch(() => [] as CustomDomainInstruction[]),
+      getCloudIdentityFn().catch(() => null),
       ensureBillingCatalogue(context.queryClient, context.billingEnabled),
     ])
-    return { allowed: true, entitled, domains }
+    return { allowed: true, entitled, domains, cloudIdentity }
   },
   component: DomainsSettingsPage,
 })
 
 function DomainsSettingsPage() {
   const { cloudEnabled } = useRouteContext({ from: '__root__' })
-  const { allowed, entitled, domains: initialDomains } = Route.useLoaderData()
+  const {
+    allowed,
+    entitled,
+    domains: initialDomains,
+    cloudIdentity: initialCloudIdentity,
+  } = Route.useLoaderData()
   const [domains, setDomains] = useState(initialDomains)
   const [hostname, setHostname] = useState('')
+  const [cloudIdentity, setCloudIdentity] = useState(initialCloudIdentity)
+  const [platformLabel, setPlatformLabel] = useState(
+    initialCloudIdentity?.platformHostname
+      ? platformLabelFromHostname(initialCloudIdentity.platformHostname)
+      : ''
+  )
   const router = useRouter()
+
+  const identityMutation = useMutation({
+    mutationFn: () => {
+      const requestedLabel = platformLabel.trim()
+      return updateCloudIdentityFn({
+        data: requestedLabel ? { platformLabel: requestedLabel } : {},
+      })
+    },
+    onSuccess: async (result) => {
+      setCloudIdentity(result.projection)
+      setPlatformLabel(
+        result.projection.platformHostname
+          ? platformLabelFromHostname(result.projection.platformHostname)
+          : ''
+      )
+      if (result.transferToken) {
+        const target = new URL('/auth/origin-transfer', result.projection.canonicalOrigin)
+        target.searchParams.set('ott', result.transferToken)
+        target.searchParams.set('returnTo', '/admin/settings/domains')
+        window.location.assign(target)
+        return
+      }
+      toast.success('Quackback URL saved')
+      await router.invalidate()
+    },
+  })
 
   const mutation = useMutation({
     mutationFn: (input: {
@@ -83,20 +129,95 @@ function DomainsSettingsPage() {
           Custom domains are available only in a Quackback Cloud workspace.
         </p>
       ) : (
-        <DomainsCard
-          entitled={entitled}
-          domains={domains}
-          hostname={hostname}
-          pending={mutation.isPending}
-          error={mutation.error}
-          onHostnameChange={setHostname}
-          onAdd={() => mutation.mutate({ action: 'add', hostname })}
-          onRefresh={(value) => mutation.mutate({ action: 'refresh', hostname: value })}
-          onMakePrimary={(value) => mutation.mutate({ action: 'makePrimary', hostname: value })}
-          onRemove={(value) => mutation.mutate({ action: 'remove', hostname: value })}
-        />
+        <>
+          {cloudIdentity && (
+            <QuackbackUrlCard
+              platformLabel={platformLabel}
+              domainSuffix={new URL(cloudIdentity.canonicalOrigin).hostname
+                .split('.')
+                .slice(1)
+                .join('.')}
+              currentOrigin={cloudIdentity.canonicalOrigin}
+              pending={identityMutation.isPending}
+              error={identityMutation.error}
+              onPlatformLabelChange={setPlatformLabel}
+              onSubmit={() => identityMutation.mutate()}
+            />
+          )}
+          <DomainsCard
+            entitled={entitled}
+            domains={domains}
+            hostname={hostname}
+            pending={mutation.isPending}
+            error={mutation.error}
+            onHostnameChange={setHostname}
+            onAdd={() => mutation.mutate({ action: 'add', hostname })}
+            onRefresh={(value) => mutation.mutate({ action: 'refresh', hostname: value })}
+            onMakePrimary={(value) => mutation.mutate({ action: 'makePrimary', hostname: value })}
+            onRemove={(value) => mutation.mutate({ action: 'remove', hostname: value })}
+          />
+        </>
       )}
     </div>
+  )
+}
+
+export function QuackbackUrlCard(props: {
+  platformLabel: string
+  domainSuffix: string
+  currentOrigin: string
+  pending: boolean
+  error: Error | null
+  onPlatformLabelChange: (value: string) => void
+  onSubmit: () => void
+}) {
+  const preview = `https://${props.platformLabel || 'workspace'}.${props.domainSuffix}`
+  return (
+    <SettingsCard title="Quackback URL" description="The address customers use for this workspace">
+      <form
+        className="max-w-xl space-y-5"
+        onSubmit={(event) => {
+          event.preventDefault()
+          props.onSubmit()
+        }}
+      >
+        <div className="space-y-1.5">
+          <Label htmlFor="platform-label" className="text-xs text-muted-foreground">
+            Quackback URL
+          </Label>
+          <div className="flex items-center rounded-md border bg-background focus-within:ring-2 focus-within:ring-ring">
+            <Input
+              id="platform-label"
+              value={props.platformLabel}
+              onChange={(event) => props.onPlatformLabelChange(event.target.value)}
+              className="border-0 focus-visible:ring-0"
+              maxLength={63}
+              autoCapitalize="none"
+              autoCorrect="off"
+              disabled={props.pending}
+            />
+            <span className="shrink-0 pe-3 text-sm text-muted-foreground">
+              .{props.domainSuffix}
+            </span>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Preview: <span className="font-mono">{preview}</span>
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Current: <span className="font-mono">{props.currentOrigin}</span>
+          </p>
+        </div>
+        {props.error && (
+          <p role="alert" className="text-sm text-destructive">
+            {props.error.message || 'Could not save Quackback URL. Try again.'}
+          </p>
+        )}
+        <Button type="submit" disabled={props.pending || !props.platformLabel.trim()}>
+          {props.pending && <ArrowPathIcon className="h-4 w-4 animate-spin" />}
+          Save
+        </Button>
+      </form>
+    </SettingsCard>
   )
 }
 

--- a/apps/web/src/routes/admin/settings.general.tsx
+++ b/apps/web/src/routes/admin/settings.general.tsx
@@ -7,19 +7,17 @@ import { Cog6ToothIcon, ArrowPathIcon } from '@heroicons/react/24/solid'
 import { toast } from 'sonner'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Badge } from '@/components/ui/badge'
 import { BackLink } from '@/components/ui/back-link'
 import { PageHeader } from '@/components/shared/page-header'
 import { SettingsCard } from '@/components/admin/settings/settings-card'
-import { Button } from '@/components/ui/button'
+import { LogoUploader } from '@/components/admin/settings/logo-uploader'
 import { updateWorkspaceNameFn } from '@/lib/server/functions/settings'
-import {
-  getCloudIdentityFn,
-  platformLabelFromHostname,
-  updateCloudIdentityFn,
-} from '@/lib/server/functions/cloud-identity'
+import { getCloudIdentityFn, updateCloudIdentityFn } from '@/lib/server/functions/cloud-identity'
 import { updateFeatureFlagsFn } from '@/lib/server/functions/feature-flags'
 import { useDebouncedSave } from '@/lib/client/hooks/use-debounced-save'
 import { isPathManagedFromBootstrap, MANAGED_PATHS } from '@/lib/client/config-file'
+import { settingsQueries } from '@/lib/client/queries/settings'
 import {
   DEFAULT_FEATURE_FLAGS,
   PRODUCT_DEFINITIONS,
@@ -34,27 +32,25 @@ import { WorkspaceDangerCard } from '@/components/admin/settings/workspace-dange
 export const Route = createFileRoute('/admin/settings/general')({
   loader: async ({ context }) => {
     assertRoutePermission(context.permissions, PERMISSIONS.SETTINGS_MANAGE)
-    return { cloudIdentity: await getCloudIdentityFn() }
+    const [cloudIdentity] = await Promise.all([
+      getCloudIdentityFn(),
+      context.queryClient.ensureQueryData(settingsQueries.logo()),
+    ])
+    return { cloudIdentity }
   },
   component: GeneralSettingsPage,
 })
 
 function GeneralSettingsPage() {
   const { settings, managedFieldPaths } = Route.useRouteContext()
-  const { cloudIdentity: initialCloudIdentity } = Route.useLoaderData()
+  const { cloudIdentity } = Route.useLoaderData()
   const workspaceNameManaged = isPathManagedFromBootstrap(
     MANAGED_PATHS.WORKSPACE_NAME,
     managedFieldPaths ?? []
   )
 
-  const [cloudIdentity, setCloudIdentity] = useState(initialCloudIdentity)
   const [workspaceName, setWorkspaceName] = useState(
-    initialCloudIdentity?.displayName ?? settings?.name ?? ''
-  )
-  const [platformLabel, setPlatformLabel] = useState(
-    initialCloudIdentity?.platformHostname
-      ? platformLabelFromHostname(initialCloudIdentity.platformHostname)
-      : ''
+    cloudIdentity?.displayName ?? settings?.name ?? ''
   )
   const [isSavingName, setIsSavingName] = useState(false)
   const [localFlags, setLocalFlags] = useState<FeatureFlags>(
@@ -89,54 +85,31 @@ function GeneralSettingsPage() {
     },
   })
 
-  const identityMutation = useMutation({
-    mutationFn: () => {
-      const requestedLabel = platformLabel.trim()
-      return updateCloudIdentityFn({
-        data: {
-          displayName: workspaceName.trim(),
-          ...(requestedLabel ? { platformLabel: requestedLabel } : {}),
-        },
-      })
-    },
-    onSuccess: async (result) => {
-      setCloudIdentity(result.projection)
-      setWorkspaceName(result.projection.displayName)
-      setPlatformLabel(
-        result.projection.platformHostname
-          ? platformLabelFromHostname(result.projection.platformHostname)
-          : ''
-      )
-      if (result.transferToken) {
-        const target = new URL('/auth/origin-transfer', result.projection.canonicalOrigin)
-        target.searchParams.set('ott', result.transferToken)
-        target.searchParams.set('returnTo', '/admin/settings/general')
-        window.location.assign(target)
-        return
-      }
-      toast.success('Workspace details saved')
-      await router.invalidate()
-    },
-  })
-
   // Debounced workspace name save. `useDebouncedSave` flushes any pending
   // value on unmount, so navigating away mid-debounce no longer drops it.
   const { queue: queueNameSave } = useDebouncedSave<string>(async (value) => {
-    if (value.trim() && value !== settings?.name) {
-      setIsSavingName(true)
-      try {
-        await updateWorkspaceNameFn({ data: { name: value.trim() } })
-      } catch {
-        toast.error('Failed to update workspace name')
-      } finally {
-        setIsSavingName(false)
+    const trimmed = value.trim()
+    if (!trimmed) return
+    setIsSavingName(true)
+    try {
+      if (cloudIdentity) {
+        if (trimmed !== cloudIdentity.displayName) {
+          await updateCloudIdentityFn({ data: { displayName: trimmed } })
+          await router.invalidate()
+        }
+      } else if (trimmed !== settings?.name) {
+        await updateWorkspaceNameFn({ data: { name: trimmed } })
       }
+    } catch {
+      toast.error('Failed to update workspace name')
+    } finally {
+      setIsSavingName(false)
     }
   }, 800)
 
   const handleNameChange = (value: string) => {
     setWorkspaceName(value)
-    if (!cloudIdentity) queueNameSave(value)
+    queueNameSave(value)
   }
 
   const handleProductToggle = (productId: ProductId, enabled: boolean) => {
@@ -154,29 +127,13 @@ function GeneralSettingsPage() {
         description="Workspace identity and products"
       />
 
-      {cloudIdentity ? (
-        <CloudWorkspaceDetails
-          workspaceName={workspaceName}
-          platformLabel={platformLabel}
-          domainSuffix={new URL(cloudIdentity.canonicalOrigin).hostname
-            .split('.')
-            .slice(1)
-            .join('.')}
-          currentOrigin={cloudIdentity.canonicalOrigin}
-          pending={identityMutation.isPending}
-          error={identityMutation.error}
-          onWorkspaceNameChange={setWorkspaceName}
-          onPlatformLabelChange={setPlatformLabel}
-          onSubmit={() => identityMutation.mutate()}
-        />
-      ) : (
-        <LocalWorkspaceNameCard
-          workspaceName={workspaceName}
-          saving={isSavingName}
-          managed={workspaceNameManaged}
-          onWorkspaceNameChange={handleNameChange}
-        />
-      )}
+      <WorkspaceIdentityCard
+        workspaceName={workspaceName}
+        saving={isSavingName}
+        managed={!cloudIdentity && workspaceNameManaged}
+        onWorkspaceNameChange={handleNameChange}
+        maxLength={cloudIdentity ? 80 : undefined}
+      />
 
       <SettingsCard
         title="Products"
@@ -194,7 +151,7 @@ function GeneralSettingsPage() {
               >
                 <div className="min-w-0 space-y-0.5">
                   <Label
-                    htmlFor={`product-${product.id}`}
+                    htmlFor={alwaysOn ? undefined : `product-${product.id}`}
                     className={
                       alwaysOn ? 'text-sm font-medium' : 'cursor-pointer text-sm font-medium'
                     }
@@ -202,18 +159,19 @@ function GeneralSettingsPage() {
                     {product.label}
                   </Label>
                   <p className="text-xs text-muted-foreground">{product.description}</p>
-                  {alwaysOn && (
-                    <p className="text-xs text-muted-foreground">
-                      {product.label} is always enabled
-                    </p>
-                  )}
                 </div>
-                <Switch
-                  id={`product-${product.id}`}
-                  checked={alwaysOn || isProductEnabled(localFlags, product.id)}
-                  onCheckedChange={(checked) => handleProductToggle(product.id, checked)}
-                  disabled={alwaysOn || productMutation.isPending}
-                />
+                {alwaysOn ? (
+                  <Badge id={`product-${product.id}`} variant="outline">
+                    Always on
+                  </Badge>
+                ) : (
+                  <Switch
+                    id={`product-${product.id}`}
+                    checked={isProductEnabled(localFlags, product.id)}
+                    onCheckedChange={(checked) => handleProductToggle(product.id, checked)}
+                    disabled={productMutation.isPending}
+                  />
+                )}
               </div>
             )
           })}
@@ -225,113 +183,44 @@ function GeneralSettingsPage() {
   )
 }
 
-export function LocalWorkspaceNameCard(props: {
+export function WorkspaceIdentityCard(props: {
   workspaceName: string
   saving: boolean
   managed: boolean
   onWorkspaceNameChange: (value: string) => void
+  maxLength?: number
 }) {
-  return (
-    <SettingsCard title="Workspace" description="The name shown across the portal and emails">
-      <div className="max-w-md space-y-1.5">
-        <Label htmlFor="workspace-name" className="text-xs text-muted-foreground">
-          Workspace Name
-        </Label>
-        <div className="relative">
-          <Input
-            id="workspace-name"
-            value={props.workspaceName}
-            onChange={(e) => props.onWorkspaceNameChange(e.target.value)}
-            placeholder="My Workspace"
-            disabled={props.managed}
-          />
-          {props.saving && (
-            <ArrowPathIcon className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 animate-spin text-muted-foreground" />
-          )}
-        </div>
-        {props.managed && (
-          <p className="text-xs text-muted-foreground">
-            Managed by your administrator&apos;s config &mdash; edit there.
-          </p>
-        )}
-      </div>
-    </SettingsCard>
-  )
-}
-
-export function CloudWorkspaceDetails(props: {
-  workspaceName: string
-  platformLabel: string
-  domainSuffix: string
-  currentOrigin: string
-  pending: boolean
-  error: Error | null
-  onWorkspaceNameChange: (value: string) => void
-  onPlatformLabelChange: (value: string) => void
-  onSubmit: () => void
-}) {
-  const preview = `https://${props.platformLabel || 'workspace'}.${props.domainSuffix}`
   return (
     <SettingsCard
-      title="Workspace details"
-      description="The name and Quackback address customers use for this workspace"
+      title="Workspace"
+      description="Your logo and name, shown across the portal, widget, and emails"
     >
-      <form
-        className="max-w-xl space-y-5"
-        onSubmit={(event) => {
-          event.preventDefault()
-          props.onSubmit()
-        }}
-      >
-        <div className="space-y-1.5">
+      <div className="flex items-center gap-4">
+        <LogoUploader workspaceName={props.workspaceName} />
+        <div className="min-w-0 flex-1 max-w-md space-y-1.5">
           <Label htmlFor="workspace-name" className="text-xs text-muted-foreground">
-            Workspace name
+            Workspace Name
           </Label>
-          <Input
-            id="workspace-name"
-            value={props.workspaceName}
-            onChange={(event) => props.onWorkspaceNameChange(event.target.value)}
-            placeholder="Untitled workspace"
-            maxLength={80}
-            disabled={props.pending}
-          />
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="platform-label" className="text-xs text-muted-foreground">
-            Quackback URL
-          </Label>
-          <div className="flex items-center rounded-md border bg-background focus-within:ring-2 focus-within:ring-ring">
+          <div className="relative">
             <Input
-              id="platform-label"
-              value={props.platformLabel}
-              onChange={(event) => props.onPlatformLabelChange(event.target.value)}
-              className="border-0 focus-visible:ring-0"
-              maxLength={63}
-              autoCapitalize="none"
-              autoCorrect="off"
-              disabled={props.pending}
+              id="workspace-name"
+              value={props.workspaceName}
+              onChange={(e) => props.onWorkspaceNameChange(e.target.value)}
+              placeholder="My Workspace"
+              disabled={props.managed}
+              maxLength={props.maxLength}
             />
-            <span className="shrink-0 pe-3 text-sm text-muted-foreground">
-              .{props.domainSuffix}
-            </span>
+            {props.saving && (
+              <ArrowPathIcon className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 animate-spin text-muted-foreground" />
+            )}
           </div>
-          <p className="text-xs text-muted-foreground">
-            Preview: <span className="font-mono">{preview}</span>
-          </p>
-          <p className="text-xs text-muted-foreground">
-            Current: <span className="font-mono">{props.currentOrigin}</span>
-          </p>
+          {props.managed && (
+            <p className="text-xs text-muted-foreground">
+              Managed by your administrator&apos;s config &mdash; edit there.
+            </p>
+          )}
         </div>
-        {props.error && (
-          <p role="alert" className="text-sm text-destructive">
-            {props.error.message || 'Could not save workspace details. Try again.'}
-          </p>
-        )}
-        <Button type="submit" disabled={props.pending || !props.workspaceName.trim()}>
-          {props.pending && <ArrowPathIcon className="h-4 w-4 animate-spin" />}
-          Save workspace details
-        </Button>
-      </form>
+      </div>
     </SettingsCard>
   )
 }

--- a/apps/web/src/routes/admin/settings.status.tsx
+++ b/apps/web/src/routes/admin/settings.status.tsx
@@ -71,12 +71,7 @@ function StatusSettingsPage() {
         description="Public status page for your services: incidents, maintenance, and uptime history."
       />
 
-      <StatusGeneralCard
-        settings={settings}
-        onChange={onChange}
-        onFlushText={textSave.flush}
-        disabled={mutation.isPending}
-      />
+      <StatusGeneralCard settings={settings} onChange={onChange} onFlushText={textSave.flush} />
       <StatusVisibilityCard settings={settings} onChange={onChange} disabled={mutation.isPending} />
       <StatusNotificationsCard
         settings={settings}

--- a/apps/web/src/routes/status/feed.ts
+++ b/apps/web/src/routes/status/feed.ts
@@ -23,13 +23,13 @@ export const Route = createFileRoute('/status/feed')({
         const siteName = branding?.name || 'Status'
 
         // `listStatusHistoryFn` independently composes every status-page
-        // gate (portal access, `statusSettings.enabled`, the `statusPage`
-        // feature flag, and the audience ladder — see
-        // `resolveStatusPageGate` in `lib/server/functions/status.ts`) and
-        // returns an empty result rather than throwing when denied. A
-        // private/disabled/gated-out status page therefore still yields a
-        // valid, empty RSS document here — same contract as the changelog
-        // feed and sitemap.xml, never a data leak.
+        // gate (portal access, `isStatusPagePublished`, and the audience
+        // ladder — see `resolveStatusPageGate` in
+        // `lib/server/functions/status.ts`) and returns an empty result
+        // rather than throwing when denied. A private/disabled/gated-out
+        // status page therefore still yields a valid, empty RSS document
+        // here — same contract as the changelog feed and sitemap.xml,
+        // never a data leak.
         const history = await listStatusHistoryFn({ data: { limit: 50 } })
 
         // Same per-caller-portal-access reasoning as the changelog feed:


### PR DESCRIPTION
## Summary

Settings → General becomes the identity + products page. The workspace logo sits next to the name; favicon is derived from the logo at upload; the social share image is unread. The Status product toggle is the single publish control. Cloud Quackback URL moves to Domains.

## Migration

No SQL. Behavior on upgrade:

- `featureFlags.feedback: false` is overwritten to `true` on write (already repaired on read).
- Status: effective published state is `flags.statusPage && statusSettings.enabled !== false`. A workspace that has the flag on but the page unpublished stays unpublished until the General Status toggle is flipped (ON writes both `statusPage: true` and `statusSettings.enabled: true`; OFF writes `statusPage: false` only).
- Existing stored favicons are kept until the next logo upload overwrites them. Deleting the logo clears both.
- `portal_og_image_key` is left in the DB but unread. OG resolves to the logo, then `/logo.png`.

## What reviewers will see

- General: Workspace (logo + name, one row), Products (Feedback = Always on badge; four product switches), Danger zone
- Cloud: Quackback URL is on Domains, not General
- Status settings: description + visibility + notifications + danger — no publish switch, no auto-subscribe

## Test plan

- [ ] Upload a logo on General; confirm favicon updates on the portal
- [ ] Delete the logo; confirm favicon clears
- [ ] Feedback row shows Always on; toggling it off via API still stores true
- [ ] Status ON from General publishes; a legacy flag-on/unpublished workspace stays dark until the toggle is flipped
- [ ] Cloud: Quackback URL lives on Domains