### PR TITLE
feat(settings): consolidate messenger surfaces and portal access

### DIFF
--- a/apps/web/e2e/tests/admin/settings-permissions.spec.ts
+++ b/apps/web/e2e/tests/admin/settings-permissions.spec.ts
@@ -17,18 +17,13 @@ test.describe('Admin Moderation Settings', () => {
   test('page loads and shows moderation heading', async ({ page }) => {
     await expect(page.getByRole('heading', { name: 'Moderation' })).toBeVisible({ timeout: 10000 })
     await expect(
-      page.getByText('Anonymous access and approval rules for incoming posts.')
+      page.getByText('Approval rules and content review for incoming posts and comments.')
     ).toBeVisible({ timeout: 10000 })
   })
 
-  test('shows Anonymous access card with the master switch', async ({ page }) => {
-    // Card title is an <h2>; match by heading role so it doesn't collide with the
-    // page description ("Anonymous access and approval rules for incoming posts.").
-    await expect(page.getByRole('heading', { name: 'Anonymous access' })).toBeVisible({
-      timeout: 10000,
-    })
-    // Consolidated single master switch (replaces the old 3 per-action toggles).
-    await expect(page.getByRole('switch', { name: 'Allow anonymous interaction' })).toBeVisible()
+  test('does not show the anonymous-access card (moved to Portal access)', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Anonymous access' })).toHaveCount(0)
+    await expect(page.getByRole('switch', { name: 'Allow anonymous interaction' })).toHaveCount(0)
   })
 
   test('shows Approval rules card with per-axis approval switches', async ({ page }) => {
@@ -43,11 +38,24 @@ test.describe('Admin Moderation Settings', () => {
     ).toBeVisible()
   })
 
-  test('page shows the anonymous-access and approval-rules cards', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: 'Anonymous access' })).toBeVisible({
+  test('page shows the approval-rules and content-review cards', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Approval rules' })).toBeVisible({
       timeout: 10000,
     })
-    await expect(page.getByRole('heading', { name: 'Approval rules' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Content review' })).toBeVisible()
+  })
+})
+
+test.describe('Admin Portal access — anonymous interaction', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/admin/settings/security/authentication?tab=portal-access')
+    await page.waitForLoadState('networkidle')
+  })
+
+  test('shows the allow-anonymous master switch', async ({ page }) => {
+    await expect(page.getByRole('switch', { name: 'Allow anonymous interaction' })).toBeVisible({
+      timeout: 10000,
+    })
   })
 
   test('the allow-anonymous master switch is interactive', async ({ page }) => {

--- a/apps/web/src/components/admin/settings/boards/__tests__/board-access-form.test.tsx
+++ b/apps/web/src/components/admin/settings/boards/__tests__/board-access-form.test.tsx
@@ -33,17 +33,22 @@ import type { BoardId } from '@quackback/ids'
 vi.mock('@tanstack/react-router', () => ({
   Link: ({
     to,
+    search,
     children,
     className,
   }: {
     to: string
+    search?: { tab?: string }
     children: React.ReactNode
     className?: string
-  }) => (
-    <a href={to} className={className}>
-      {children}
-    </a>
-  ),
+  }) => {
+    const qs = search?.tab ? `?tab=${search.tab}` : ''
+    return (
+      <a href={`${to}${qs}`} className={className}>
+        {children}
+      </a>
+    )
+  },
 }))
 
 const mutate = vi.fn()
@@ -354,6 +359,11 @@ describe('<BoardAccessForm> workspace ceiling', () => {
       expect(banner.textContent).toMatch(/Submit/)
       expect(banner.textContent).not.toMatch(/\bView\b/)
     })
+    const link = screen.getByRole('link', { name: /Workspace access/i })
+    expect(link).toHaveAttribute(
+      'href',
+      '/admin/settings/security/authentication?tab=portal-access'
+    )
   })
 
   it('auto-bumps Anonymous cells on all three rows when the master switch flips off', async () => {

--- a/apps/web/src/components/admin/settings/boards/board-access-form.tsx
+++ b/apps/web/src/components/admin/settings/boards/board-access-form.tsx
@@ -427,7 +427,8 @@ export function BoardAccessForm({ board }: BoardAccessFormProps) {
               .
             </span>
             <Link
-              to="/admin/settings/moderation"
+              to="/admin/settings/security/authentication"
+              search={{ tab: 'portal-access' }}
               className="ml-auto whitespace-nowrap text-primary hover:underline"
             >
               Workspace access →
@@ -682,7 +683,7 @@ function MatrixRow({
         const isSegmentsCell = tier.id === 'segments'
 
         const tooltip = wsBlocked
-          ? 'Anonymous interaction is disabled workspace-wide. Manage in Workspace → Access.'
+          ? 'Anonymous interaction is disabled workspace-wide. Manage in Access & Security → Portal access.'
           : hierarchyBlocked
             ? `Can't be more open than View (${TIERS.find((x) => ACCESS_TIER_RANK[x.id] === minRank)?.label}).`
             : undefined

--- a/apps/web/src/components/admin/settings/security/__tests__/portal-auth-tab.test.tsx
+++ b/apps/web/src/components/admin/settings/security/__tests__/portal-auth-tab.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment happy-dom
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { DEFAULT_PORTAL_CONFIG, type PortalConfig } from '@/lib/shared/types/settings'
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+  useRouter: () => ({ invalidate: vi.fn() }),
+}))
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: () => ({ isLoading: false, isError: false, data: [] }),
+}))
+
+vi.mock('@/lib/server/functions/portal-access', () => ({
+  updatePortalAccessFn: vi.fn(),
+}))
+
+vi.mock('@/lib/server/functions/settings', () => ({
+  updatePortalConfigFn: vi.fn(),
+}))
+
+vi.mock('@/lib/server/functions/admin', () => ({
+  listSegmentsFn: vi.fn(),
+}))
+
+vi.mock('@/components/admin/users/use-portal-invites', () => ({
+  usePortalInvites: () => ({
+    invites: [],
+    isLoading: false,
+    pendingCount: 0,
+    acceptedCount: 0,
+    lastSentSummary: null,
+    dialogOpen: false,
+    openDialog: vi.fn(),
+    onOpenChange: vi.fn(),
+    emailsInput: '',
+    messageInput: '',
+    emailError: null,
+    batchResults: null,
+    sendBusy: false,
+    onEmailsChange: vi.fn(),
+    onMessageChange: vi.fn(),
+    onSend: vi.fn(),
+  }),
+}))
+
+vi.mock('@/components/admin/users/invite-people-dialog', () => ({
+  InvitePeopleDialog: () => null,
+}))
+
+vi.mock('@/components/admin/settings/portal-privacy-dialog', () => ({
+  PortalPrivacyDialog: () => null,
+}))
+
+const { PortalAuthTab } = await import('../portal-auth-tab')
+
+const portal: PortalConfig = {
+  ...DEFAULT_PORTAL_CONFIG,
+  features: { ...DEFAULT_PORTAL_CONFIG.features, allowAnonymous: true },
+}
+
+describe('PortalAuthTab — anonymous interaction', () => {
+  it('shows the allow-anonymous switch after visibility and before account signup', () => {
+    render(<PortalAuthTab portalConfig={portal} teamOpenSignup />)
+
+    const anonymous = screen.getByRole('switch', { name: 'Allow anonymous interaction' })
+    const signup = screen.getByRole('switch', {
+      name: 'Allow visitors to create their own portal account',
+    })
+    expect(anonymous).toBeInTheDocument()
+    expect(signup).toBeInTheDocument()
+    expect(
+      anonymous.compareDocumentPosition(signup) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+
+    expect(
+      screen.getByText(
+        'When off, all boards require sign-in for voting, commenting, and submitting posts.'
+      )
+    ).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/admin/settings/security/portal-auth-tab.tsx
+++ b/apps/web/src/components/admin/settings/security/portal-auth-tab.tsx
@@ -11,6 +11,7 @@ import {
 import { useQuery } from '@tanstack/react-query'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import { PortalPrivacyDialog } from '@/components/admin/settings/portal-privacy-dialog'
 import { SettingsCard } from '@/components/admin/settings/settings-card'
@@ -134,6 +135,30 @@ export function PortalAuthTab({ portalConfig, teamOpenSignup }: PortalAuthTabPro
   // writes an explicit portal answer, and the fallback stops applying.
   const [openSignup, setOpenSignup] = useState<boolean>(portalConfig.openSignup ?? teamOpenSignup)
   const [signupBusy, setSignupBusy] = useState(false)
+
+  // Workspace-wide master switch for anonymous interaction. Collapsed in
+  // migration 0084 from the legacy anonymousVoting / Commenting / Posting
+  // trio — per-board access tiers carry the finer-grained restrictions.
+  const [allowAnonymous, setAllowAnonymous] = useState<boolean>(
+    portalConfig.features?.allowAnonymous ?? true
+  )
+  const [anonBusy, setAnonBusy] = useState(false)
+
+  async function applyAllowAnonymous(next: boolean) {
+    const previous = allowAnonymous
+    setAllowAnonymous(next)
+    setAnonBusy(true)
+    try {
+      await updatePortalConfigFn({ data: { features: { allowAnonymous: next } } })
+      startTransition(() => {
+        router.invalidate()
+      })
+    } catch {
+      setAllowAnonymous(previous)
+    } finally {
+      setAnonBusy(false)
+    }
+  }
 
   async function applyOpenSignup(next: boolean) {
     const previous = openSignup
@@ -324,6 +349,24 @@ export function PortalAuthTab({ portalConfig, teamOpenSignup }: PortalAuthTabPro
             the cards below to authorize additional visitors.
           </p>
         )}
+
+        <div className="mt-4 flex items-center justify-between border-t border-border/40 pt-4">
+          <div className="pr-4">
+            <Label htmlFor="allow-anonymous" className="text-sm font-medium cursor-pointer">
+              Allow anonymous interaction
+            </Label>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              When off, all boards require sign-in for voting, commenting, and submitting posts.
+            </p>
+          </div>
+          <Switch
+            id="allow-anonymous"
+            checked={allowAnonymous}
+            onCheckedChange={(checked) => void applyAllowAnonymous(checked)}
+            disabled={anonBusy || isPending}
+            aria-label="Allow anonymous interaction"
+          />
+        </div>
       </SettingsCard>
 
       {/* Who may open an account, as opposed to who may look. Kept a peer of

--- a/apps/web/src/components/public/portal-header.tsx
+++ b/apps/web/src/components/public/portal-header.tsx
@@ -5,6 +5,7 @@ import { resolvePortalNavItems } from './portal-header-nav'
 import { usePreviewDraft } from './preview-draft-context'
 import { isProductEnabled } from '@/lib/shared/types/settings'
 import { isStatusPagePublished } from '@/lib/shared/status-settings'
+import { isPortalSupportSurfaceEnabled } from '@/lib/shared/support-surfaces'
 import { useIntl, FormattedMessage } from 'react-intl'
 import { cn } from '@/lib/shared/utils'
 import { isTeamMember, Role } from '@/lib/shared/roles'
@@ -69,8 +70,7 @@ export function PortalHeader({
   const flags = settings?.featureFlags
   const feedbackEnabled = isProductEnabled(flags, 'feedback')
   const helpCenterEnabled = isProductEnabled(flags, 'helpCenter')
-  const supportEnabled =
-    !!flags?.supportTickets || (!!flags?.supportInbox && !!settings?.portalConfig?.support?.enabled)
+  const supportEnabled = isPortalSupportSurfaceEnabled(flags, settings?.portalConfig)
   const changelogEnabled = isProductEnabled(flags, 'changelog')
   // Status tab: product flag + published. A non-public audience still needs
   // a signed-in viewer to bother showing the tab; the route enforces the

--- a/apps/web/src/lib/server/domains/settings/__tests__/support-gate.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/support-gate.test.ts
@@ -17,10 +17,54 @@ vi.mock('../settings.widget', () => ({
 
 import { isPortalSupportEnabled, isConversationsEnabled } from '../settings.support'
 import { DEFAULT_PORTAL_CONFIG } from '../settings.types'
+import {
+  isPortalSupportSurfaceEnabled,
+  isWidgetMessengerEnabled,
+} from '@/lib/shared/support-surfaces'
 
 describe('DEFAULT_PORTAL_CONFIG.support', () => {
   it('is disabled by default so shipping the gate changes nothing for existing workspaces', () => {
     expect(DEFAULT_PORTAL_CONFIG.support?.enabled).toBe(false)
+  })
+})
+
+describe('isPortalSupportSurfaceEnabled', () => {
+  it.each([
+    { tickets: false, inbox: true, enabled: true, expected: true },
+    { tickets: false, inbox: false, enabled: true, expected: false },
+    { tickets: false, inbox: true, enabled: false, expected: false },
+    { tickets: true, inbox: false, enabled: false, expected: true },
+    { tickets: true, inbox: true, enabled: false, expected: true },
+  ])(
+    'tickets=$tickets inbox=$inbox enabled=$enabled → $expected',
+    ({ tickets, inbox, enabled, expected }) => {
+      expect(
+        isPortalSupportSurfaceEnabled(
+          { supportTickets: tickets, supportInbox: inbox },
+          { support: { enabled } }
+        )
+      ).toBe(expected)
+    }
+  )
+})
+
+describe('isWidgetMessengerEnabled', () => {
+  it('requires the inbox flag, widget master, and Messages tab', () => {
+    expect(
+      isWidgetMessengerEnabled({ supportInbox: true }, { enabled: true, tabs: { messenger: true } })
+    ).toBe(true)
+    expect(
+      isWidgetMessengerEnabled(
+        { supportInbox: true },
+        { enabled: false, tabs: { messenger: true } }
+      )
+    ).toBe(false)
+    expect(
+      isWidgetMessengerEnabled(
+        { supportInbox: false },
+        { enabled: true, tabs: { messenger: true } }
+      )
+    ).toBe(false)
   })
 })
 
@@ -30,21 +74,28 @@ describe('isPortalSupportEnabled', () => {
   })
 
   it.each([
-    { flag: true, support: { enabled: true }, expected: true },
-    { flag: false, support: { enabled: true }, expected: false },
-    { flag: true, support: { enabled: false }, expected: false },
-    { flag: true, support: undefined, expected: false },
-  ])('flag=$flag support=$support → $expected', async ({ flag, support, expected }) => {
-    hoisted.mockIsFeatureEnabled.mockResolvedValue(flag)
-    hoisted.mockGetPortalConfig.mockResolvedValue({ support })
-    expect(await isPortalSupportEnabled()).toBe(expected)
-  })
+    { inbox: true, tickets: false, support: { enabled: true }, expected: true },
+    { inbox: false, tickets: false, support: { enabled: true }, expected: false },
+    { inbox: true, tickets: false, support: { enabled: false }, expected: false },
+    { inbox: true, tickets: false, support: undefined, expected: false },
+    { inbox: false, tickets: true, support: { enabled: false }, expected: true },
+  ])(
+    'inbox=$inbox tickets=$tickets support=$support → $expected',
+    async ({ inbox, tickets, support, expected }) => {
+      hoisted.mockIsFeatureEnabled.mockImplementation(async (flag: string) =>
+        flag === 'supportTickets' ? tickets : flag === 'supportInbox' ? inbox : false
+      )
+      hoisted.mockGetPortalConfig.mockResolvedValue({ support })
+      expect(await isPortalSupportEnabled()).toBe(expected)
+    }
+  )
 
-  it('checks the supportInbox feature flag specifically', async () => {
+  it('checks the supportInbox and supportTickets flags', async () => {
     hoisted.mockIsFeatureEnabled.mockResolvedValue(true)
     hoisted.mockGetPortalConfig.mockResolvedValue({ support: { enabled: true } })
     await isPortalSupportEnabled()
     expect(hoisted.mockIsFeatureEnabled).toHaveBeenCalledWith('supportInbox')
+    expect(hoisted.mockIsFeatureEnabled).toHaveBeenCalledWith('supportTickets')
   })
 })
 

--- a/apps/web/src/lib/server/domains/settings/__tests__/widget-config.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/widget-config.test.ts
@@ -270,7 +270,7 @@ describe('getPublicWidgetConfig — help tab projection', () => {
 })
 
 describe('getPublicWidgetConfig — tickets projection (converged Messages)', () => {
-  it('projects tabs.tickets from the supportTickets flag alone — no per-tab toggle', async () => {
+  it('projects tabs.tickets from the supportTickets flag alone — no stored tab', async () => {
     // The flag is set explicitly, and the stored tabs deliberately carry no
     // `tickets` key: that is the point of the assertion. DEFAULT_FEATURE_FLAGS
     // is core-only (Feedback + Changelog) since 0268, so relying on a default
@@ -294,6 +294,25 @@ describe('getPublicWidgetConfig — tickets projection (converged Messages)', ()
     const projected = await getPublicWidgetConfig()
     expect(projected.tabs?.tickets).toBe(false)
     expect(projected.enabled).toBe(false)
+  })
+})
+
+describe('getPublicWidgetConfig — translations', () => {
+  it('projects per-locale copy so the widget iframe sees Home and messenger strings', async () => {
+    settingsRow.current = fixtureRow({
+      enabled: true,
+      translations: {
+        de: { greeting: 'Hallo', welcomeMessage: 'Willkommen' },
+      },
+      launcherGreeting: 'Need a hand?',
+      launcherLabel: 'Chat',
+    })
+    const projected = await getPublicWidgetConfig()
+    expect(projected.translations).toEqual({
+      de: { greeting: 'Hallo', welcomeMessage: 'Willkommen' },
+    })
+    expect(projected.launcherGreeting).toBe('Need a hand?')
+    expect(projected.launcherLabel).toBe('Chat')
   })
 })
 

--- a/apps/web/src/lib/server/domains/settings/settings.service.ts
+++ b/apps/web/src/lib/server/domains/settings/settings.service.ts
@@ -42,13 +42,12 @@ import {
   DEFAULT_AUTH_CONFIG,
   DEFAULT_DEVELOPER_CONFIG,
   DEFAULT_WIDGET_CONFIG,
-  DEFAULT_MESSENGER_CONFIG,
   DEFAULT_FEATURE_FLAGS,
   DEFAULT_HELP_CENTER_CONFIG,
   resolveFeatureFlags,
 } from './settings.types'
 import { signupOpenFor } from '@/lib/shared/signup-open'
-import { publicHomeConfig, publicMessengerConfig } from './settings.widget'
+import { projectPublicWidgetConfig } from './settings.widget'
 import { getSetupState, isOnboardingComplete } from '@/lib/shared/db-types'
 import { resolveChangelogSettings } from './settings.changelog'
 import { resolveStatusSettings } from './settings.status'
@@ -964,36 +963,7 @@ export async function getWorkspaceSettings(): Promise<WorkspaceSettings | null> 
           },
         }
       })(),
-      publicWidgetConfig: {
-        enabled: widgetConfig.enabled,
-        defaultBoard: widgetConfig.defaultBoard,
-        position: widgetConfig.position,
-        tabs: {
-          ...widgetConfig.tabs,
-          feedback: (widgetConfig.tabs?.feedback ?? true) && featureFlags.feedback,
-          changelog: (widgetConfig.tabs?.changelog ?? false) && featureFlags.changelog,
-          help: (widgetConfig.tabs?.help ?? false) && featureFlags.helpCenter,
-          messenger: (widgetConfig.tabs?.messenger ?? false) && featureFlags.supportInbox,
-          // Fail-closed like its siblings: the Tickets tab is only ever exposed
-          // publicly when the experimental supportTickets flag is on (gate (a) of
-          // the triple gate), so no consumer can surface it with the flag off.
-          tickets: (widgetConfig.tabs?.tickets ?? false) && featureFlags.supportTickets,
-        },
-        // Identify is verified-only (backend-signed ssoToken; GH issue #300).
-        hmacRequired: true,
-        // Home customisation is client-safe (greeting, hero style, quick links);
-        // the stored hero-image key is resolved to a public URL.
-        home: publicHomeConfig(widgetConfig.home),
-        // Client-safe messenger config (routing stays agent-only). `enabled`
-        // mirrors the module flag — widget visibility is `tabs.messenger`.
-        messenger: {
-          ...publicMessengerConfig(
-            widgetConfig.messenger ?? DEFAULT_MESSENGER_CONFIG,
-            assistantIdentity
-          ),
-          enabled: featureFlags.supportInbox,
-        },
-      },
+      publicWidgetConfig: projectPublicWidgetConfig(widgetConfig, featureFlags, assistantIdentity),
       featureFlags,
       brandingData,
       faviconData: brandingData.faviconUrl ? { url: brandingData.faviconUrl } : null,

--- a/apps/web/src/lib/server/domains/settings/settings.support.ts
+++ b/apps/web/src/lib/server/domains/settings/settings.support.ts
@@ -5,15 +5,28 @@
  * stay alive when either surface is on.
  */
 
+import {
+  isPortalChatStartEnabled,
+  isPortalSupportSurfaceEnabled,
+  isWidgetMessengerEnabled,
+} from '@/lib/shared/support-surfaces'
+
+export { isPortalChatStartEnabled, isPortalSupportSurfaceEnabled, isWidgetMessengerEnabled }
+
 /**
- * Whether the portal Support tab is enabled: the experimental `supportInbox`
- * feature flag AND the explicit portal toggle. Fail-closed — an absent
- * `support` section means disabled, so existing workspaces are unaffected.
+ * Whether the portal Support tab is enabled: tickets-enabled workspaces, or
+ * the `supportInbox` flag plus the explicit portal chats toggle. Fail-closed
+ * — an absent `support` section means disabled, so existing workspaces are
+ * unaffected.
  */
 export async function isPortalSupportEnabled(): Promise<boolean> {
   const { isFeatureEnabled, getPortalConfig } = await import('./settings.service')
-  const [flagOn, portal] = await Promise.all([isFeatureEnabled('supportInbox'), getPortalConfig()])
-  return Boolean(flagOn && portal.support?.enabled === true)
+  const [inboxOn, ticketsOn, portal] = await Promise.all([
+    isFeatureEnabled('supportInbox'),
+    isFeatureEnabled('supportTickets'),
+    getPortalConfig(),
+  ])
+  return isPortalSupportSurfaceEnabled({ supportInbox: inboxOn, supportTickets: ticketsOn }, portal)
 }
 
 /**

--- a/apps/web/src/lib/server/domains/settings/settings.types.ts
+++ b/apps/web/src/lib/server/domains/settings/settings.types.ts
@@ -356,8 +356,9 @@ export interface PortalConfig {
 }
 
 /**
- * Portal Support tab configuration. Gated (with the `supportInbox` feature
- * flag) by `isPortalSupportEnabled`; independent of the widget Messages tab.
+ * Portal Support tab configuration. Gated by `isPortalSupportSurfaceEnabled`
+ * (`supportTickets` OR `supportInbox` plus this toggle); independent of the
+ * widget Messages tab.
  */
 export interface PortalSupportConfig {
   enabled: boolean
@@ -689,8 +690,6 @@ export interface WidgetConfig {
     help?: boolean
     /** Messenger (the "Messages" tab). */
     messenger?: boolean
-    /** Support tickets (the "Tickets" tab). */
-    tickets?: boolean
     /** Show the aggregated Home tab (defaults to on; only appears with 2+ sections) */
     home?: boolean
   }
@@ -707,21 +706,32 @@ export interface WidgetConfig {
  * Public subset of widget config — safe to include in WorkspaceSettings / bootstrap data
  * Does NOT include identifyVerification (admin-only concern)
  */
-export type PublicWidgetConfig = Pick<
-  WidgetConfig,
-  | 'enabled'
-  | 'defaultBoard'
-  | 'position'
-  | 'tabs'
-  | 'home'
-  | 'launcherGreeting'
-  | 'launcherLabel'
-  | 'translations'
+export type PublicWidgetConfig = Omit<
+  Pick<
+    WidgetConfig,
+    | 'enabled'
+    | 'defaultBoard'
+    | 'position'
+    | 'tabs'
+    | 'home'
+    | 'launcherGreeting'
+    | 'launcherLabel'
+    | 'translations'
+  >,
+  'tabs'
 > & {
   /** Always true: identify requires a backend-signed ssoToken (GH issue #300). */
   hmacRequired?: boolean
   /** Client-safe messenger config (no agent-only fields like routing). */
   messenger?: PublicMessengerConfig
+  tabs?: NonNullable<WidgetConfig['tabs']> & {
+    /**
+     * Computed from the `supportTickets` flag — not a stored tab. Ticket
+     * pairs surface through Messages; this bit still drives the requester's
+     * own-tickets list in the widget.
+     */
+    tickets?: boolean
+  }
 }
 
 export const DEFAULT_MESSENGER_CONFIG: MessengerConfig = {
@@ -759,7 +769,6 @@ export interface UpdateWidgetConfigInput {
     changelog?: boolean
     help?: boolean
     messenger?: boolean
-    tickets?: boolean
     home?: boolean
   }
   messenger?: Partial<MessengerConfig>

--- a/apps/web/src/lib/server/domains/settings/settings.widget.ts
+++ b/apps/web/src/lib/server/domains/settings/settings.widget.ts
@@ -23,6 +23,7 @@ import {
   DEFAULT_ASSISTANT_CONFIG,
   type AssistantIdentity,
 } from '@/lib/shared/assistant/config'
+import { isWidgetMessengerEnabled } from '@/lib/shared/support-surfaces'
 
 const log = logger.child({ component: 'settings-widget' })
 export const WIDGET_OBSERVATION_THROTTLE_MS = 15 * 60 * 1000
@@ -321,6 +322,53 @@ export async function updateWidgetAssistantDeployment(
   return result
 }
 
+/**
+ * Client-safe widget projection. Shared by `getPublicWidgetConfig` and the
+ * workspace-settings payload so the iframe and `/api/widget/config.json`
+ * cannot drift.
+ */
+export function projectPublicWidgetConfig(
+  config: WidgetConfig,
+  flags: ReturnType<typeof resolveFeatureFlags>,
+  identity: AssistantIdentity = DEFAULT_ASSISTANT_CONFIG.identity
+): PublicWidgetConfig {
+  const tabs = {
+    feedback: (config.tabs?.feedback ?? true) && flags.feedback,
+    changelog: (config.tabs?.changelog ?? false) && flags.changelog,
+    help: (config.tabs?.help ?? false) && flags.helpCenter,
+    messenger: (config.tabs?.messenger ?? false) && flags.supportInbox,
+    // Converged Messages: ticket pairs surface through the messenger tab,
+    // gated by the supportTickets flag alone (there is no stored Tickets tab).
+    tickets: flags.supportTickets,
+    home: config.tabs?.home,
+  }
+  return {
+    enabled:
+      config.enabled &&
+      [tabs.feedback, tabs.changelog, tabs.help, tabs.messenger, tabs.tickets].some(Boolean),
+    defaultBoard: config.defaultBoard,
+    position: config.position,
+    launcherGreeting: config.launcherGreeting,
+    launcherLabel: config.launcherLabel,
+    tabs,
+    // Identify is verified-only (backend-signed ssoToken; GH issue #300).
+    hmacRequired: true,
+    // Home customisation is client-safe (greeting, hero style, quick links);
+    // the stored hero-image key is resolved to a public URL.
+    home: publicHomeConfig(config.home),
+    // Project only client-safe messenger fields; routing is agent-only.
+    // `enabled` mirrors the module flag — there is no separate messenger
+    // master switch; widget visibility is `tabs.messenger`.
+    messenger: {
+      ...publicMessengerConfig(config.messenger ?? DEFAULT_MESSENGER_CONFIG, identity),
+      enabled: flags.supportInbox,
+    },
+    // Per-locale copy overrides — client-safe (customer-facing strings the
+    // widget resolves against its own locale for Home + messenger greetings).
+    translations: config.translations,
+  }
+}
+
 export async function getPublicWidgetConfig(): Promise<PublicWidgetConfig> {
   try {
     // Read-only + on public hot paths (config.json, widget SSR): cached row.
@@ -331,41 +379,7 @@ export async function getPublicWidgetConfig(): Promise<PublicWidgetConfig> {
       ? assistantConfig.data.identity
       : DEFAULT_ASSISTANT_CONFIG.identity
     const flags = resolveFeatureFlags(org.featureFlags)
-    const tabs = {
-      feedback: (config.tabs?.feedback ?? true) && flags.feedback,
-      changelog: (config.tabs?.changelog ?? false) && flags.changelog,
-      help: (config.tabs?.help ?? false) && flags.helpCenter,
-      messenger: (config.tabs?.messenger ?? false) && flags.supportInbox,
-      // Converged Messages: ticket pairs surface through the messenger tab,
-      // gated by the supportTickets flag alone (there is no Tickets tab).
-      tickets: flags.supportTickets,
-      home: config.tabs?.home,
-    }
-    return {
-      enabled:
-        config.enabled &&
-        [tabs.feedback, tabs.changelog, tabs.help, tabs.messenger, tabs.tickets].some(Boolean),
-      defaultBoard: config.defaultBoard,
-      position: config.position,
-      launcherGreeting: config.launcherGreeting,
-      launcherLabel: config.launcherLabel,
-      tabs,
-      // Identify is verified-only (backend-signed ssoToken; GH issue #300).
-      hmacRequired: true,
-      // Home customisation is client-safe (greeting, hero style, quick links);
-      // the stored hero-image key is resolved to a public URL.
-      home: publicHomeConfig(config.home),
-      // Project only client-safe messenger fields; routing is agent-only.
-      // `enabled` mirrors the module flag — there is no separate messenger
-      // master switch; widget visibility is `tabs.messenger`.
-      messenger: {
-        ...publicMessengerConfig(config.messenger ?? DEFAULT_MESSENGER_CONFIG, identity),
-        enabled: flags.supportInbox,
-      },
-      // Per-locale copy overrides — client-safe (customer-facing strings the
-      // widget resolves against its own locale for the Home surface).
-      translations: config.translations,
-    }
+    return projectPublicWidgetConfig(config, flags, identity)
   } catch (error) {
     log.error({ err: error }, 'get public widget config failed')
     wrapDbError('fetch public widget config', error)
@@ -393,7 +407,7 @@ export async function getMessengerConfig(): Promise<MessengerConfig> {
 export async function isMessengerEnabled(): Promise<boolean> {
   const { isFeatureEnabled } = await import('./settings.service')
   const [flagOn, widget] = await Promise.all([isFeatureEnabled('supportInbox'), getWidgetConfig()])
-  return Boolean(flagOn && widget.enabled && widget.tabs?.messenger)
+  return isWidgetMessengerEnabled({ supportInbox: flagOn }, widget)
 }
 
 /**

--- a/apps/web/src/lib/server/functions/settings.ts
+++ b/apps/web/src/lib/server/functions/settings.ts
@@ -829,7 +829,6 @@ const updateWidgetConfigSchema = z.object({
       changelog: z.boolean().optional(),
       help: z.boolean().optional(),
       messenger: z.boolean().optional(),
-      tickets: z.boolean().optional(),
       home: z.boolean().optional(),
     })
     .optional(),

--- a/apps/web/src/lib/shared/support-surfaces.ts
+++ b/apps/web/src/lib/shared/support-surfaces.ts
@@ -1,0 +1,36 @@
+/**
+ * Visitor-facing support surface gates. Shared by the portal header, portal
+ * Support routes, admin preview, and the async settings.support resolvers so
+ * the formula cannot drift.
+ */
+
+/** Signed-in visitors can start a new portal conversation. */
+export function isPortalChatStartEnabled(
+  flags: { supportInbox?: boolean } | null | undefined,
+  portal: { support?: { enabled?: boolean } } | null | undefined
+): boolean {
+  return Boolean(flags?.supportInbox && portal?.support?.enabled === true)
+}
+
+/**
+ * Whether the portal Support tab (and its routes) are on: tickets-enabled
+ * workspaces always list conversation pairs, otherwise the inbox flag plus
+ * the explicit portal chats toggle.
+ */
+export function isPortalSupportSurfaceEnabled(
+  flags: { supportTickets?: boolean; supportInbox?: boolean } | null | undefined,
+  portal: { support?: { enabled?: boolean } } | null | undefined
+): boolean {
+  return Boolean(flags?.supportTickets || isPortalChatStartEnabled(flags, portal))
+}
+
+/**
+ * Whether the widget Messages tab is live. Mirrors `isMessengerEnabled`
+ * (`supportInbox` + widget master + Messages tab).
+ */
+export function isWidgetMessengerEnabled(
+  flags: { supportInbox?: boolean } | null | undefined,
+  widget: { enabled?: boolean; tabs?: { messenger?: boolean } } | null | undefined
+): boolean {
+  return Boolean(flags?.supportInbox && widget?.enabled && widget?.tabs?.messenger)
+}

--- a/apps/web/src/lib/shared/widget/translations.ts
+++ b/apps/web/src/lib/shared/widget/translations.ts
@@ -14,6 +14,19 @@ export interface WidgetContentTranslation {
 /** Locale code -> overrides. Empty/absent means the base copy is used. */
 export type WidgetTranslations = Record<string, WidgetContentTranslation>
 
+/** Display names for admin translation pickers (widget Home + messenger). */
+export const WIDGET_LOCALE_LABELS: Record<string, string> = {
+  en: 'English',
+  de: 'German',
+  fr: 'French',
+  es: 'Spanish',
+  ar: 'Arabic',
+  ru: 'Russian',
+  'pt-br': 'Portuguese (Brazil)',
+  'zh-cn': 'Chinese (Simplified)',
+  'zh-tw': 'Chinese (Traditional)',
+}
+
 /**
  * The overrides that apply for `locale`: an exact match first, then the base
  * language (so `de-AT` falls back to `de`), then nothing. Callers apply the

--- a/apps/web/src/routes/_portal/hc/articles/$categorySlug/$articleSlug.tsx
+++ b/apps/web/src/routes/_portal/hc/articles/$categorySlug/$articleSlug.tsx
@@ -19,6 +19,7 @@ import {
 import { JsonLd } from '@/components/json-ld'
 import { buildArticleJsonLd, buildBreadcrumbJsonLd } from '@/lib/shared/json-ld'
 import { stripMarkdownPreview } from '@/lib/shared/utils'
+import { isPortalSupportSurfaceEnabled } from '@/lib/shared/support-surfaces'
 import type { JSONContent } from '@tiptap/react'
 
 const helpCenterApi = getRouteApi('/_portal/hc')
@@ -79,8 +80,10 @@ function ArticleDetailPage() {
   const { category, articles, allCategories } = categoryApi.useLoaderData()
   const { helpCenterConfig } = helpCenterApi.useLoaderData()
   const { baseUrl, settings } = Route.useRouteContext()
-  const supportEnabled =
-    !!settings?.featureFlags?.supportInbox && !!settings?.portalConfig?.support?.enabled
+  const supportEnabled = isPortalSupportSurfaceEnabled(
+    settings?.featureFlags,
+    settings?.portalConfig
+  )
 
   const breadcrumbs = buildCategoryBreadcrumbs({
     allCategories,

--- a/apps/web/src/routes/_portal/index.tsx
+++ b/apps/web/src/routes/_portal/index.tsx
@@ -11,6 +11,7 @@ import { usePreviewDraft } from '@/components/public/preview-draft-context'
 import { portalQueries } from '@/lib/client/queries/portal'
 import { isProductEnabled } from '@/lib/shared/types/settings'
 import { isStatusPagePublished } from '@/lib/shared/status-settings'
+import { isPortalSupportSurfaceEnabled } from '@/lib/shared/support-surfaces'
 
 const searchSchema = z.object({
   board: z.string().optional(),
@@ -63,10 +64,9 @@ export const Route = createFileRoute('/_portal/')({
 
     if (!isProductEnabled(org.featureFlags, 'feedback')) {
       if (isProductEnabled(org.featureFlags, 'support')) {
-        const supportPublished =
-          org.featureFlags.supportTickets ||
-          (org.featureFlags.supportInbox && org.portalConfig.support?.enabled === true)
-        if (supportPublished) throw redirect({ to: '/support' })
+        if (isPortalSupportSurfaceEnabled(org.featureFlags, org.portalConfig)) {
+          throw redirect({ to: '/support' })
+        }
       }
       if (isProductEnabled(org.featureFlags, 'helpCenter')) {
         throw redirect({ to: '/hc' })

--- a/apps/web/src/routes/_portal/support.$conversationId.tsx
+++ b/apps/web/src/routes/_portal/support.$conversationId.tsx
@@ -19,6 +19,7 @@ import {
   PORTAL_CONVERSATION_PRESENCE_QUERY_KEY,
   PORTAL_MY_CONVERSATIONS_QUERY_KEY,
 } from '@/lib/client/queries/portal-support'
+import { isPortalSupportSurfaceEnabled } from '@/lib/shared/support-surfaces'
 
 export const Route = createFileRoute('/_portal/support/$conversationId')({
   component: SupportThreadPage,
@@ -42,9 +43,10 @@ function SupportThreadPage() {
   // Converged Messages: ticket pairs open here too, so a tickets-enabled
   // workspace keeps this route alive even with the messenger/portal-support
   // toggle off (email-first workspaces reply to their ticket threads here).
-  const messengerEnabled =
-    !!settings?.featureFlags?.supportInbox && !!settings?.portalConfig?.support?.enabled
-  const supportEnabled = messengerEnabled || !!settings?.featureFlags?.supportTickets
+  const supportEnabled = isPortalSupportSurfaceEnabled(
+    settings?.featureFlags,
+    settings?.portalConfig
+  )
 
   const user = session?.user
   const isLoggedIn = !!user && user.principalType !== 'anonymous'

--- a/apps/web/src/routes/_portal/support.index.tsx
+++ b/apps/web/src/routes/_portal/support.index.tsx
@@ -10,6 +10,10 @@ import { StageChip } from '@/components/shared/ticket-stage'
 import { useAuthPopoverSafe } from '@/components/auth/auth-popover-context'
 import { getMyConversationsFn } from '@/lib/server/functions/conversation'
 import { PORTAL_MY_CONVERSATIONS_QUERY_KEY } from '@/lib/client/queries/portal-support'
+import {
+  isPortalChatStartEnabled,
+  isPortalSupportSurfaceEnabled,
+} from '@/lib/shared/support-surfaces'
 
 export const Route = createFileRoute('/_portal/support/')({
   component: SupportListPage,
@@ -65,10 +69,11 @@ function SupportListPage() {
   const { session, settings } = useRouteContext({ from: '__root__' })
   const authPopover = useAuthPopoverSafe()
 
-  const supportTicketsEnabled = !!settings?.featureFlags?.supportTickets
-  const messengerEnabled =
-    !!settings?.featureFlags?.supportInbox && !!settings?.portalConfig?.support?.enabled
-  const surfaceEnabled = messengerEnabled || supportTicketsEnabled
+  const messengerEnabled = isPortalChatStartEnabled(settings?.featureFlags, settings?.portalConfig)
+  const surfaceEnabled = isPortalSupportSurfaceEnabled(
+    settings?.featureFlags,
+    settings?.portalConfig
+  )
 
   const user = session?.user
   const isLoggedIn = !!user && user.principalType !== 'anonymous'

--- a/apps/web/src/routes/admin/__tests__/settings.messenger-surfaces.test.tsx
+++ b/apps/web/src/routes/admin/__tests__/settings.messenger-surfaces.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment happy-dom
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@tanstack/react-router', async () => {
+  const actual =
+    await vi.importActual<typeof import('@tanstack/react-router')>('@tanstack/react-router')
+  return {
+    ...actual,
+    useRouter: () => ({ invalidate: vi.fn() }),
+    Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+  }
+})
+
+vi.mock('@tanstack/react-query', () => ({
+  useSuspenseQuery: (opts: { queryKey: string[] }) => {
+    if (opts.queryKey.includes('widgetConfig')) {
+      return {
+        data: {
+          tabs: { messenger: true },
+          messenger: {
+            welcomeMessage: 'Hi',
+            offlineMessage: 'Away',
+            teamName: 'Support',
+            preventRepliesWhenClosed: false,
+          },
+          translations: {},
+        },
+      }
+    }
+    return { data: { support: { enabled: true } } }
+  },
+}))
+
+vi.mock('@/lib/client/queries/settings', () => ({
+  settingsQueries: {
+    widgetConfig: () => ({ queryKey: ['settings', 'widgetConfig'] }),
+    portalConfig: () => ({ queryKey: ['settings', 'portalConfig'] }),
+  },
+}))
+
+vi.mock('@/lib/client/mutations/settings', () => ({
+  useUpdateWidgetConfig: () => ({ mutateAsync: vi.fn() }),
+  useUpdatePortalConfig: () => ({ mutateAsync: vi.fn() }),
+}))
+
+const { MessengerChannelPage } = await import('../settings.channels_.messenger')
+
+describe('Messenger Surfaces', () => {
+  it('owns Widget and Portal chats switches', () => {
+    render(<MessengerChannelPage />)
+
+    expect(screen.getByRole('heading', { name: 'Surfaces' })).toBeInTheDocument()
+    expect(screen.getByRole('switch', { name: 'Widget' })).toBeInTheDocument()
+    expect(screen.getByRole('switch', { name: 'Portal chats' })).toBeInTheDocument()
+    expect(screen.getByText('Show the Messages tab in the widget.')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "Let signed-in customers start new conversations from the portal's Support tab."
+      )
+    ).toBeInTheDocument()
+    expect(screen.queryByText('Widget settings')).not.toBeInTheDocument()
+    expect(screen.queryByText('Portal Support')).not.toBeInTheDocument()
+    expect(screen.getByText('Translations')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/routes/admin/__tests__/settings.moderation.test.tsx
+++ b/apps/web/src/routes/admin/__tests__/settings.moderation.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment happy-dom
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@tanstack/react-router', async () => {
+  const actual =
+    await vi.importActual<typeof import('@tanstack/react-router')>('@tanstack/react-router')
+  return {
+    ...actual,
+    useRouter: () => ({ invalidate: vi.fn() }),
+    Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+  }
+})
+
+vi.mock('@tanstack/react-query', () => ({
+  useSuspenseQuery: () => ({
+    data: {
+      features: { allowAnonymous: true },
+      moderationDefault: { requireApproval: 'none', holdImages: false, holdLinks: false },
+    },
+  }),
+}))
+
+vi.mock('@/lib/client/mutations/settings', () => ({
+  useUpdateModerationDefault: () => ({ mutateAsync: vi.fn() }),
+}))
+
+vi.mock('@/lib/client/queries/settings', () => ({
+  settingsQueries: { portalConfig: () => ({ queryKey: ['portal'] }) },
+}))
+
+const { ModerationPage } = await import('../settings.moderation')
+
+describe('Moderation page', () => {
+  it('keeps approval and content-review cards and has no anonymous-access card', () => {
+    render(<ModerationPage />)
+
+    expect(
+      screen.getByText('Approval rules and content review for incoming posts and comments.')
+    ).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Approval rules' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Content review' })).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'Anonymous access' })).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('switch', { name: 'Allow anonymous interaction' })
+    ).not.toBeInTheDocument()
+
+    expect(screen.getByLabelText('Require approval for anonymous posts')).toBeInTheDocument()
+    expect(screen.getByLabelText('Require approval for signed-in posts')).toBeInTheDocument()
+    expect(screen.getByLabelText('Hold posts and comments that contain images')).toBeInTheDocument()
+    expect(screen.getByLabelText('Hold posts and comments that contain links')).toBeInTheDocument()
+    expect(
+      screen.queryByText(
+        'Posts from visitors without an account wait for review before they appear.'
+      )
+    ).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/routes/admin/__tests__/settings.widget-modules.test.tsx
+++ b/apps/web/src/routes/admin/__tests__/settings.widget-modules.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment happy-dom
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@tanstack/react-router', async () => {
+  const actual =
+    await vi.importActual<typeof import('@tanstack/react-router')>('@tanstack/react-router')
+  return {
+    ...actual,
+    useRouter: () => ({ invalidate: vi.fn() }),
+    Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+  }
+})
+
+vi.mock('@/lib/client/mutations/settings', () => ({
+  useUpdateWidgetConfig: () => ({ mutateAsync: vi.fn() }),
+}))
+
+const { ModulesCard } = await import('../settings.widget')
+
+const config = {
+  tabs: { home: true, messenger: true, feedback: true, changelog: true, help: true },
+}
+
+function renderModules(
+  flags: {
+    helpCenterFlagEnabled?: boolean
+    supportInboxFlagEnabled?: boolean
+    feedbackFlagEnabled?: boolean
+    changelogFlagEnabled?: boolean
+    supportTicketsFlagEnabled?: boolean
+  } = {}
+) {
+  return render(
+    <ModulesCard
+      config={config}
+      boards={[]}
+      position="bottom-right"
+      onPositionChange={vi.fn()}
+      launcherLabel=""
+      onLabelChange={vi.fn()}
+      helpCenterFlagEnabled={flags.helpCenterFlagEnabled ?? false}
+      supportInboxFlagEnabled={flags.supportInboxFlagEnabled ?? true}
+      feedbackFlagEnabled={flags.feedbackFlagEnabled ?? true}
+      changelogFlagEnabled={flags.changelogFlagEnabled ?? true}
+      supportTicketsFlagEnabled={flags.supportTicketsFlagEnabled ?? false}
+    />
+  )
+}
+
+describe('Widget Modules card', () => {
+  it('has no Messages row and lists Feedback and Changelog when those products are on', () => {
+    renderModules()
+    expect(screen.queryByRole('switch', { name: 'Messages tab' })).not.toBeInTheDocument()
+    expect(screen.getByRole('switch', { name: 'Feedback tab' })).toBeInTheDocument()
+    expect(screen.getByRole('switch', { name: 'Changelog tab' })).toBeInTheDocument()
+    expect(screen.queryByRole('switch', { name: 'Help tab' })).not.toBeInTheDocument()
+  })
+
+  it('hides Changelog when that product is off', () => {
+    renderModules({ changelogFlagEnabled: false })
+    expect(screen.getByRole('switch', { name: 'Feedback tab' })).toBeInTheDocument()
+    expect(screen.queryByRole('switch', { name: 'Changelog tab' })).not.toBeInTheDocument()
+  })
+
+  it('shows Help only while the help product is on', () => {
+    renderModules({ helpCenterFlagEnabled: true })
+    expect(screen.getByRole('switch', { name: 'Help tab' })).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/routes/admin/settings.channels.tsx
+++ b/apps/web/src/routes/admin/settings.channels.tsx
@@ -19,6 +19,10 @@ import {
 } from '@/lib/server/functions/settings'
 import { useQuery } from '@tanstack/react-query'
 import { getChannelDescriptor } from '@/lib/shared/channels'
+import {
+  isPortalSupportSurfaceEnabled,
+  isWidgetMessengerEnabled,
+} from '@/lib/shared/support-surfaces'
 
 export const Route = createFileRoute('/admin/settings/channels')({
   loader: async ({ context }) => {
@@ -40,6 +44,8 @@ function ChannelsHubRoute() {
 }
 
 function ChannelsHubPage() {
+  const { settings } = Route.useRouteContext()
+  const flags = settings?.featureFlags as FeatureFlags | undefined
   const widget = useSuspenseQuery(settingsQueries.widgetConfig())
   const portal = useSuspenseQuery(settingsQueries.portalConfig())
   const emailStatusQuery = useQuery({
@@ -57,7 +63,9 @@ function ChannelsHubPage() {
   const enabled = routingEnabled ?? routingQuery.data?.enabled ?? false
   const messenger = getChannelDescriptor('messenger')
   const email = getChannelDescriptor('email')
-  const messengerOn = widget.data.tabs?.messenger === true || portal.data?.support?.enabled === true
+  const messengerOn =
+    isWidgetMessengerEnabled(flags, widget.data) ||
+    isPortalSupportSurfaceEnabled(flags, portal.data)
   const receiving = emailStatusQuery.data?.inboundConfigured === true
   const sendingOnly = !receiving && !!emailStatusQuery.data?.fromAddress
   const emailStatus = receiving ? 'Receiving' : sendingOnly ? 'Sending only' : 'Set up'

--- a/apps/web/src/routes/admin/settings.channels_.messenger.tsx
+++ b/apps/web/src/routes/admin/settings.channels_.messenger.tsx
@@ -14,6 +14,9 @@ import { Switch } from '@/components/ui/switch'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
+import { cn } from '@/lib/shared/utils'
+import { SUPPORTED_LOCALES } from '@/lib/shared/i18n'
+import { WIDGET_LOCALE_LABELS, type WidgetTranslations } from '@/lib/shared/widget/translations'
 
 export const Route = createFileRoute('/admin/settings/channels_/messenger')({
   loader: async ({ context }) => {
@@ -34,7 +37,7 @@ function MessengerChannelRoute() {
   return <MessengerChannelPage />
 }
 
-function MessengerChannelPage() {
+export function MessengerChannelPage() {
   const router = useRouter()
   const updateWidgetConfig = useUpdateWidgetConfig()
   const updatePortalConfig = useUpdatePortalConfig()
@@ -44,6 +47,7 @@ function MessengerChannelPage() {
   const messengerConfig = config.messenger
   const [isPending, startTransition] = useTransition()
   const [savingField, setSavingField] = useState<string | null>(null)
+  const [widgetMessenger, setWidgetMessenger] = useState(config.tabs?.messenger ?? false)
   const [portalSupportEnabled, setPortalSupportEnabled] = useState(
     portalConfigQuery.data?.support?.enabled ?? false
   )
@@ -53,6 +57,8 @@ function MessengerChannelPage() {
   const [welcomeMessage, setWelcomeMessage] = useState(messengerConfig?.welcomeMessage ?? '')
   const [offlineMessage, setOfflineMessage] = useState(messengerConfig?.offlineMessage ?? '')
   const [teamName, setTeamName] = useState(messengerConfig?.teamName ?? '')
+  const [translations, setTranslations] = useState<WidgetTranslations>(config.translations ?? {})
+  const [translationLocale, setTranslationLocale] = useState<string>('en')
 
   async function persist(
     field: string,
@@ -83,25 +89,36 @@ function MessengerChannelPage() {
         description="Live chat in the widget and on the portal."
       />
 
-      <SettingsCard title="Surfaces" description="Where customers see their conversations.">
+      <SettingsCard title="Surfaces" description="Where customers can start conversations.">
         <div className="flex items-center justify-between py-1">
           <div className="pr-4">
-            <p className="text-sm font-medium">Widget</p>
+            <Label htmlFor="widget-messenger-tab" className="text-sm font-medium cursor-pointer">
+              Widget
+            </Label>
             <p className="mt-0.5 text-xs text-muted-foreground">
-              Show the Messages tab from Widget settings.
+              Show the Messages tab in the widget.
             </p>
           </div>
-          <Link to="/admin/settings/widget" className="text-sm font-medium text-primary">
-            Widget settings
-          </Link>
+          <Switch
+            id="widget-messenger-tab"
+            checked={widgetMessenger}
+            onCheckedChange={(checked) => {
+              setWidgetMessenger(checked)
+              persist('widgetMessenger', { tabs: { messenger: checked } }, () =>
+                setWidgetMessenger(!checked)
+              )
+            }}
+            disabled={isBusy}
+            aria-label="Widget"
+          />
         </div>
         <div className="mt-4 flex items-center justify-between border-t border-border/40 py-1 pt-4">
           <div className="pr-4">
             <Label htmlFor="portal-support-enabled" className="text-sm font-medium cursor-pointer">
-              Portal Support
+              Portal chats
             </Label>
             <p className="mt-0.5 text-xs text-muted-foreground">
-              Show a Support tab on the public portal for signed-in users.
+              Let signed-in customers start new conversations from the portal&apos;s Support tab.
             </p>
           </div>
           <Switch
@@ -120,6 +137,7 @@ function MessengerChannelPage() {
               }
             }}
             disabled={isBusy}
+            aria-label="Portal chats"
           />
         </div>
       </SettingsCard>
@@ -183,6 +201,17 @@ function MessengerChannelPage() {
               or when nobody is online.
             </p>
           </div>
+          <MessengerTranslations
+            translations={translations}
+            selectedLocale={translationLocale}
+            onSelectLocale={setTranslationLocale}
+            disabled={isBusy}
+            onCommit={(next) => {
+              const prev = translations
+              setTranslations(next)
+              persist('translations', { translations: next }, () => setTranslations(prev))
+            }}
+          />
         </div>
       </SettingsCard>
 
@@ -227,6 +256,96 @@ function MessengerChannelPage() {
           </Link>
         </div>
       </SettingsCard>
+    </div>
+  )
+}
+
+function MessengerTranslations({
+  translations,
+  selectedLocale,
+  onSelectLocale,
+  disabled,
+  onCommit,
+}: {
+  translations: WidgetTranslations
+  selectedLocale: string
+  onSelectLocale: (locale: string) => void
+  disabled: boolean
+  onCommit: (next: WidgetTranslations) => void
+}) {
+  const isDefault = selectedLocale === 'en'
+  const entry = translations[selectedLocale] ?? {}
+
+  function commitField(key: 'welcomeMessage' | 'offlineMessage', raw: string) {
+    const value = raw.trim()
+    if (value === (entry[key] ?? '')) return
+    const nextEntry = { ...entry, [key]: value || undefined }
+    const next = { ...translations, [selectedLocale]: nextEntry }
+    if (
+      !nextEntry.welcomeMessage &&
+      !nextEntry.offlineMessage &&
+      !nextEntry.greeting &&
+      !nextEntry.subtitle
+    ) {
+      const { [selectedLocale]: _removed, ...rest } = next
+      onCommit(rest)
+      return
+    }
+    onCommit(next)
+  }
+
+  return (
+    <div className="border-t border-border/40 pt-4 space-y-3">
+      <span className="text-sm font-medium">Translations</span>
+      <div className="flex flex-wrap gap-1.5">
+        {SUPPORTED_LOCALES.map((locale) => (
+          <button
+            key={locale}
+            type="button"
+            onClick={() => onSelectLocale(locale)}
+            disabled={disabled}
+            className={cn(
+              'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium',
+              selectedLocale === locale
+                ? 'border-primary/40 bg-primary/5 text-foreground'
+                : 'border-border/50 text-muted-foreground hover:text-foreground'
+            )}
+          >
+            {WIDGET_LOCALE_LABELS[locale] ?? locale}
+          </button>
+        ))}
+      </div>
+      <p className="text-xs text-muted-foreground">Welcome and offline messages per locale.</p>
+      {!isDefault && (
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="messenger-welcome-locale">Welcome message</Label>
+            <Textarea
+              id="messenger-welcome-locale"
+              defaultValue={entry.welcomeMessage ?? ''}
+              key={`${selectedLocale}-welcome`}
+              maxLength={500}
+              rows={2}
+              placeholder="Hi! How can we help you today?"
+              disabled={disabled}
+              onBlur={(e) => commitField('welcomeMessage', e.target.value)}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="messenger-offline-locale">Offline message</Label>
+            <Textarea
+              id="messenger-offline-locale"
+              defaultValue={entry.offlineMessage ?? ''}
+              key={`${selectedLocale}-offline`}
+              maxLength={500}
+              rows={2}
+              placeholder="We're away right now. Leave a message and we'll get back to you by email."
+              disabled={disabled}
+              onBlur={(e) => commitField('offlineMessage', e.target.value)}
+            />
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/web/src/routes/admin/settings.moderation.tsx
+++ b/apps/web/src/routes/admin/settings.moderation.tsx
@@ -4,7 +4,7 @@ import { assertRoutePermission } from '@/lib/shared/route-permission'
 import { createFileRoute, redirect, useRouter } from '@tanstack/react-router'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { settingsQueries } from '@/lib/client/queries/settings'
-import { useUpdatePortalConfig, useUpdateModerationDefault } from '@/lib/client/mutations/settings'
+import { useUpdateModerationDefault } from '@/lib/client/mutations/settings'
 import { ShieldCheckIcon, ArrowPathIcon } from '@heroicons/react/24/solid'
 import { BackLink } from '@/components/ui/back-link'
 import { PageHeader } from '@/components/shared/page-header'
@@ -36,7 +36,6 @@ export const Route = createFileRoute('/admin/settings/moderation')({
 interface PermissionToggleProps {
   id: string
   label: string
-  description: string
   checked: boolean
   saving?: boolean
   onCheckedChange: (checked: boolean) => void
@@ -46,7 +45,6 @@ interface PermissionToggleProps {
 function PermissionToggle({
   id,
   label,
-  description,
   checked,
   saving,
   onCheckedChange,
@@ -58,7 +56,6 @@ function PermissionToggle({
         <label htmlFor={id} className="text-sm font-medium cursor-pointer">
           {label}
         </label>
-        <p className="mt-0.5 text-xs text-muted-foreground">{description}</p>
       </div>
       <div className="flex items-center gap-2">
         {saving && <ArrowPathIcon className="h-3.5 w-3.5 animate-spin text-muted-foreground" />}
@@ -68,20 +65,11 @@ function PermissionToggle({
   )
 }
 
-function ModerationPage() {
+export function ModerationPage() {
   const router = useRouter()
-  const updatePortalConfig = useUpdatePortalConfig()
   const updateModerationDefault = useUpdateModerationDefault()
   const portalConfigQuery = useSuspenseQuery(settingsQueries.portalConfig())
   const [isPending, startTransition] = useTransition()
-
-  const features = portalConfigQuery.data.features
-
-  // Workspace-wide master switch for anonymous interaction. Collapsed
-  // in migration 0084 from the legacy anonymousVoting / Commenting /
-  // Posting trio — per-board access tiers carry the finer-grained
-  // restrictions now (see BoardAccessForm).
-  const [allowAnonymous, setAllowAnonymous] = useState(features?.allowAnonymous ?? true)
 
   // Moderation toggles
   const [moderationToggles, setModerationToggles] = useState<ApprovalToggles>(() =>
@@ -95,20 +83,6 @@ function ModerationPage() {
   )
 
   const [savingField, setSavingField] = useState<string | null>(null)
-
-  async function updateFeature(key: string, value: boolean, revert: () => void) {
-    setSavingField(key)
-    try {
-      await updatePortalConfig.mutateAsync({ features: { [key]: value } })
-      startTransition(() => {
-        router.invalidate()
-      })
-    } catch {
-      revert()
-    } finally {
-      setSavingField(null)
-    }
-  }
 
   async function updateModeration(key: keyof ApprovalToggles, checked: boolean) {
     const prev = moderationToggles
@@ -154,28 +128,8 @@ function ModerationPage() {
       <PageHeader
         icon={ShieldCheckIcon}
         title="Moderation"
-        description="Anonymous access and approval rules for incoming posts."
+        description="Approval rules and content review for incoming posts and comments."
       />
-
-      <SettingsCard
-        title="Anonymous access"
-        description="Control whether visitors without an account can interact with your portal."
-      >
-        <div className="divide-y divide-border/50">
-          <PermissionToggle
-            id="allow-anonymous"
-            label="Allow anonymous interaction"
-            description="When off, all boards require sign-in for voting, commenting, and submitting posts."
-            checked={allowAnonymous}
-            saving={savingField === 'allowAnonymous'}
-            onCheckedChange={(checked) => {
-              setAllowAnonymous(checked)
-              updateFeature('allowAnonymous', checked, () => setAllowAnonymous(!checked))
-            }}
-            disabled={isBusy}
-          />
-        </div>
-      </SettingsCard>
 
       <SettingsCard
         title="Approval rules"
@@ -185,7 +139,6 @@ function ModerationPage() {
           <PermissionToggle
             id="moderate-anonymous"
             label="Require approval for anonymous posts"
-            description="Posts from visitors without an account wait for review before they appear."
             checked={moderationToggles.anonymous}
             saving={savingField === 'moderation-anonymous'}
             onCheckedChange={(checked) => updateModeration('anonymous', checked)}
@@ -194,7 +147,6 @@ function ModerationPage() {
           <PermissionToggle
             id="moderate-authenticated"
             label="Require approval for signed-in posts"
-            description="Posts from signed-in portal users wait for review before they appear."
             checked={moderationToggles.authenticated}
             saving={savingField === 'moderation-authenticated'}
             onCheckedChange={(checked) => updateModeration('authenticated', checked)}
@@ -205,13 +157,12 @@ function ModerationPage() {
 
       <SettingsCard
         title="Content review"
-        description="Hold submissions that include media or outbound links, regardless of who authored them."
+        description="Hold submissions that include media or outbound links for review."
       >
         <div className="divide-y divide-border/50">
           <PermissionToggle
             id="moderate-images"
             label="Hold posts and comments that contain images"
-            description="Submissions with an attached or embedded image wait for review before they appear."
             checked={holdImages}
             saving={savingField === 'moderation-holdImages'}
             onCheckedChange={(checked) => updateContentHold('holdImages', checked)}
@@ -220,7 +171,6 @@ function ModerationPage() {
           <PermissionToggle
             id="moderate-links"
             label="Hold posts and comments that contain links"
-            description="Submissions with an external link wait for review before they appear."
             checked={holdLinks}
             saving={savingField === 'moderation-holdLinks'}
             onCheckedChange={(checked) => updateContentHold('holdLinks', checked)}

--- a/apps/web/src/routes/admin/settings.portal.tsx
+++ b/apps/web/src/routes/admin/settings.portal.tsx
@@ -61,6 +61,7 @@ import { UpgradeModal } from '@/components/admin/upgrade'
 import { describePlanUpgrade, isPlanRefusal } from '@/lib/shared/describe-upgrade'
 import { DEFAULT_PORTAL_CONFIG, isProductEnabled } from '@/lib/shared/types/settings'
 import { isStatusPagePublished } from '@/lib/shared/status-settings'
+import { isPortalSupportSurfaceEnabled } from '@/lib/shared/support-surfaces'
 import type {
   PortalConfig,
   PortalNavItemConfig,
@@ -237,9 +238,7 @@ function PortalPage() {
       roadmap: isProductEnabled(flags, 'feedback'),
       changelog: isProductEnabled(flags, 'changelog'),
       help: isProductEnabled(flags, 'helpCenter'),
-      support:
-        !!flags?.supportTickets ||
-        (!!flags?.supportInbox && !!settings?.portalConfig?.support?.enabled),
+      support: isPortalSupportSurfaceEnabled(flags, settings?.portalConfig),
       status:
         isStatusPagePublished(flags, settings?.statusConfig) &&
         (statusAudience === 'public' || statusLoggedIn),

--- a/apps/web/src/routes/admin/settings.widget.install.tsx
+++ b/apps/web/src/routes/admin/settings.widget.install.tsx
@@ -89,7 +89,7 @@ function WidgetInstallPage() {
         queryClient.invalidateQueries({ queryKey: ['settings', 'widgetConfig'] }),
         queryClient.invalidateQueries({ queryKey: ['admin', 'onboarding'] }),
       ])
-      toast.success(mode === 'messenger' ? 'Messenger enabled' : 'Feedback widget enabled')
+      toast.success(mode === 'messenger' ? 'Messages tab turned on' : 'Feedback widget enabled')
     },
     onError: (error) =>
       toast.error(error instanceof Error ? error.message : 'Couldn’t configure the widget'),
@@ -122,7 +122,7 @@ function WidgetInstallPage() {
       />
 
       <SettingsCard
-        title="1. Enable the channel"
+        title={mode === 'messenger' ? '1. Messages tab' : '1. Enable the channel'}
         description={
           mode === 'messenger'
             ? 'Turns on the widget and the Messages tab together.'
@@ -136,7 +136,7 @@ function WidgetInstallPage() {
         ) : (
           <Button onClick={() => configure.mutate()} disabled={configure.isPending}>
             {configure.isPending && <ArrowPathIcon className="h-4 w-4 animate-spin" />}
-            {mode === 'messenger' ? 'Enable Messenger' : 'Enable feedback widget'}
+            {mode === 'messenger' ? 'Turn on the Messages tab' : 'Enable feedback widget'}
           </Button>
         )}
       </SettingsCard>

--- a/apps/web/src/routes/admin/settings.widget.tsx
+++ b/apps/web/src/routes/admin/settings.widget.tsx
@@ -73,7 +73,11 @@ import type {
   WidgetHomeConfig,
 } from '@/lib/shared/types/settings'
 import { SUPPORTED_LOCALES } from '@/lib/shared/i18n'
-import type { WidgetContentTranslation, WidgetTranslations } from '@/lib/shared/widget/translations'
+import {
+  WIDGET_LOCALE_LABELS,
+  type WidgetContentTranslation,
+  type WidgetTranslations,
+} from '@/lib/shared/widget/translations'
 import { widgetOriginVerifiedLabel } from '@/lib/shared/widget/widget-origin'
 import { DEFAULT_WIDGET_HOME_CARDS } from '@/lib/shared/types/settings'
 import { WIDGET_HERO_PATTERNS, heroBackdropStyle } from '@/lib/shared/widget/hero-style'
@@ -113,6 +117,9 @@ function WidgetSettingsPage() {
 
   const helpCenterFlagEnabled = flags?.helpCenter ?? false
   const supportInboxFlagEnabled = flags?.supportInbox ?? false
+  const feedbackFlagEnabled = flags?.feedback ?? true
+  const changelogFlagEnabled = flags?.changelog ?? true
+  const supportTicketsFlagEnabled = flags?.supportTickets ?? false
 
   // Lifted editor state: position drives the preview's launcher chrome.
   const [position, setPosition] = useState<'bottom-right' | 'bottom-left'>(
@@ -168,6 +175,9 @@ function WidgetSettingsPage() {
             onLabelChange={setLauncherLabel}
             helpCenterFlagEnabled={helpCenterFlagEnabled}
             supportInboxFlagEnabled={supportInboxFlagEnabled}
+            feedbackFlagEnabled={feedbackFlagEnabled}
+            changelogFlagEnabled={changelogFlagEnabled}
+            supportTicketsFlagEnabled={supportTicketsFlagEnabled}
           />
 
           <HomeCustomizationCard
@@ -300,7 +310,7 @@ function WidgetToggle({ initialEnabled }: { initialEnabled: boolean }) {
   )
 }
 
-function ModulesCard({
+export function ModulesCard({
   config,
   boards,
   position,
@@ -309,6 +319,9 @@ function ModulesCard({
   onLabelChange,
   helpCenterFlagEnabled,
   supportInboxFlagEnabled,
+  feedbackFlagEnabled,
+  changelogFlagEnabled,
+  supportTicketsFlagEnabled,
 }: {
   config: {
     defaultBoard?: string
@@ -329,6 +342,9 @@ function ModulesCard({
   onLabelChange: (val: string) => void
   helpCenterFlagEnabled: boolean
   supportInboxFlagEnabled: boolean
+  feedbackFlagEnabled: boolean
+  changelogFlagEnabled: boolean
+  supportTicketsFlagEnabled: boolean
 }) {
   const router = useRouter()
   const updateWidgetConfig = useUpdateWidgetConfig()
@@ -344,6 +360,22 @@ function ModulesCard({
   })
 
   const showHelpToggle = helpCenterFlagEnabled
+  const bothContentProductsOn = feedbackFlagEnabled && changelogFlagEnabled
+  const contentSectionCount = [
+    feedbackFlagEnabled && tabs.feedback,
+    changelogFlagEnabled && tabs.changelog,
+    helpCenterFlagEnabled && tabs.help,
+    supportInboxFlagEnabled && tabs.messenger,
+    supportTicketsFlagEnabled,
+  ].filter(Boolean).length
+  const lastSectionLock = contentSectionCount <= 1
+  const lockFeedbackOff =
+    tabs.feedback && (bothContentProductsOn ? !tabs.changelog : lastSectionLock)
+  const lockChangelogOff =
+    tabs.changelog && (bothContentProductsOn ? !tabs.feedback : lastSectionLock)
+  const pairLockHint = (other: string) =>
+    `At least one of Feedback or Changelog stays on — enable ${other} to turn this off.`
+  const lastSectionHint = 'The widget needs at least one section.'
 
   const isBusy = saving || isPending
 
@@ -388,31 +420,21 @@ function ModulesCard({
           onChange={(checked) => void saveTab('home', checked)}
         />
 
-        {supportInboxFlagEnabled && (
+        {feedbackFlagEnabled && (
           <TabRow
-            id="tab-messages"
-            label="Messages"
-            description="Conversations with your team and assistant"
-            checked={tabs.messenger}
-            disabled={isBusy}
+            id="tab-feedback"
+            label="Feedback"
+            description="Search, vote, and submit ideas"
+            checked={tabs.feedback}
+            disabled={isBusy || lockFeedbackOff}
+            disabledHint={bothContentProductsOn ? pairLockHint('Changelog') : lastSectionHint}
             saving={saving}
-            onChange={(checked) => void saveTab('messenger', checked)}
+            onChange={(checked) => {
+              if (!checked && lockFeedbackOff) return
+              void saveTab('feedback', checked)
+            }}
           />
         )}
-
-        <TabRow
-          id="tab-feedback"
-          label="Feedback"
-          description="Search, vote, and submit ideas"
-          checked={tabs.feedback}
-          disabled={isBusy || (tabs.feedback && !tabs.changelog)}
-          disabledHint="At least one of Feedback or Changelog stays on — enable Changelog to turn this off."
-          saving={saving}
-          onChange={(checked) => {
-            if (!checked && !tabs.changelog) return
-            void saveTab('feedback', checked)
-          }}
-        />
 
         {showHelpToggle && (
           <TabRow
@@ -420,25 +442,31 @@ function ModulesCard({
             label="Help"
             description="Browse and search help center articles"
             checked={tabs.help}
-            disabled={isBusy}
+            disabled={isBusy || (tabs.help && lastSectionLock)}
+            disabledHint={lastSectionHint}
             saving={saving}
-            onChange={(checked) => void saveTab('help', checked)}
+            onChange={(checked) => {
+              if (!checked && lastSectionLock) return
+              void saveTab('help', checked)
+            }}
           />
         )}
 
-        <TabRow
-          id="tab-changelog"
-          label="Changelog"
-          description="Show product updates and shipped features"
-          checked={tabs.changelog}
-          disabled={isBusy || (tabs.changelog && !tabs.feedback)}
-          disabledHint="At least one of Feedback or Changelog stays on — enable Feedback to turn this off."
-          saving={saving}
-          onChange={(checked) => {
-            if (!checked && !tabs.feedback) return
-            void saveTab('changelog', checked)
-          }}
-        />
+        {changelogFlagEnabled && (
+          <TabRow
+            id="tab-changelog"
+            label="Changelog"
+            description="Show product updates and shipped features"
+            checked={tabs.changelog}
+            disabled={isBusy || lockChangelogOff}
+            disabledHint={bothContentProductsOn ? pairLockHint('Feedback') : lastSectionHint}
+            saving={saving}
+            onChange={(checked) => {
+              if (!checked && lockChangelogOff) return
+              void saveTab('changelog', checked)
+            }}
+          />
+        )}
       </div>
 
       <div className="mt-5 space-y-2">
@@ -1207,19 +1235,7 @@ function SortableHomeCardShell({
 
 /** Cross-link to the AI & Automation page (assistant identity lives there). */
 const TRANSLATABLE_LOCALES = SUPPORTED_LOCALES.filter((l) => l !== 'en')
-const LOCALE_LABEL: Record<string, string> = {
-  de: 'German',
-  fr: 'French',
-  es: 'Spanish',
-  ar: 'Arabic',
-  ru: 'Russian',
-  'pt-br': 'Portuguese (Brazil)',
-  'zh-cn': 'Chinese (Simplified)',
-  'zh-tw': 'Chinese (Traditional)',
-}
 const TRANSLATION_FIELDS: { key: keyof WidgetContentTranslation; placeholder: string }[] = [
-  { key: 'welcomeMessage', placeholder: 'Welcome message' },
-  { key: 'offlineMessage', placeholder: 'Offline message' },
   { key: 'greeting', placeholder: 'Home greeting' },
   { key: 'subtitle', placeholder: 'Home subtitle' },
 ]
@@ -1253,7 +1269,7 @@ function WidgetTranslationsCard({ translations }: { translations?: WidgetTransla
         {configured.map((locale) => (
           <div key={locale} className="space-y-2 rounded-lg border border-border/50 p-3">
             <div className="flex items-center justify-between">
-              <span className="text-sm font-medium">{LOCALE_LABEL[locale] ?? locale}</span>
+              <span className="text-sm font-medium">{WIDGET_LOCALE_LABELS[locale] ?? locale}</span>
               <Button
                 type="button"
                 variant="ghost"
@@ -1302,7 +1318,7 @@ function WidgetTranslationsCard({ translations }: { translations?: WidgetTransla
             <SelectContent>
               {available.map((l) => (
                 <SelectItem key={l} value={l}>
-                  {LOCALE_LABEL[l] ?? l}
+                  {WIDGET_LOCALE_LABELS[l] ?? l}
                 </SelectItem>
               ))}
             </SelectContent>


### PR DESCRIPTION
## Summary

Anonymous interaction moves to Access & Security → Portal access. Messenger Surfaces owns both messenger switches (Widget + Portal chats). Widget Modules drops Messages and only lists enabled products. Messenger translations edit on the Messenger page and actually reach the widget iframe via a unified public widget projection.

## Migration

No data change for the moved switches (same keys). `WidgetConfig.tabs.tickets` is no longer stored or writable; the public projection still computes tickets from the `supportTickets` flag for the widget iframe.

## What reviewers will see

- Moderation: Approval rules + Content review only (no anonymous-access card, no row sublines)
- Portal access tab: Allow anonymous interaction after visibility, before Account signup
- Board Access banner links to Portal access
- Messenger Surfaces: Widget switch + Portal chats switch
- Widget Modules: no Messages row; Feedback/Changelog rows only while those products are on
- Messenger Messaging card includes Translations locale chips

## Test plan

- [ ] Toggle anonymous interaction from Portal access; board Access banner points there
- [ ] Messenger Widget switch writes the Messages tab; Widget Modules has no Messages row
- [ ] Help Center off → no Help row on Widget Modules
- [ ] Edit messenger welcome translation; confirm the widget iframe receives it