### PR TITLE
fix(settings): drop Preview and Current from the Quackback URL field

### DIFF
--- a/apps/web/src/lib/shared/__tests__/platform-label.test.ts
+++ b/apps/web/src/lib/shared/__tests__/platform-label.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import {
   friendlyPlatformLabel,
+  hostnameRegistrableSuffix,
   isGeneratedSystemLabel,
   platformLabelFromHostname,
+  platformUrlSuffix,
 } from '../platform-label'
 
 describe('platform-label', () => {
@@ -21,5 +23,28 @@ describe('platform-label', () => {
     expect(friendlyPlatformLabel('ws-4a048e07941c5e7840e986c0.quackback.co.uk')).toBe('')
     expect(friendlyPlatformLabel('awesome.quackback.co.uk')).toBe('awesome')
     expect(friendlyPlatformLabel(null)).toBe('')
+  })
+
+  it('strips the first label for the registrable suffix', () => {
+    expect(hostnameRegistrableSuffix('awesome.quackback.co.uk')).toBe('quackback.co.uk')
+    expect(hostnameRegistrableSuffix('acme.quackback.io')).toBe('quackback.io')
+  })
+
+  it('takes the URL-field suffix from the platform host, not a custom-primary origin', () => {
+    expect(
+      platformUrlSuffix({
+        platformHostname: 'acme.quackback.co.uk',
+        canonicalOrigin: 'https://feedback.example.com',
+      })
+    ).toBe('quackback.co.uk')
+  })
+
+  it('falls back to the canonical host when no platform hostname is chosen yet', () => {
+    expect(
+      platformUrlSuffix({
+        platformHostname: null,
+        canonicalOrigin: 'https://ws-4a048e07941c5e7840e986c0.quackback.co.uk',
+      })
+    ).toBe('quackback.co.uk')
   })
 })

--- a/apps/web/src/lib/shared/platform-label.ts
+++ b/apps/web/src/lib/shared/platform-label.ts
@@ -16,3 +16,21 @@ export function friendlyPlatformLabel(hostname: string | null | undefined): stri
   const label = platformLabelFromHostname(hostname)
   return isGeneratedSystemLabel(label) ? '' : label
 }
+
+/** Registrable suffix of a hostname (`acme.quackback.co.uk` → `quackback.co.uk`). */
+export function hostnameRegistrableSuffix(hostname: string): string {
+  return hostname.split('.').slice(1).join('.')
+}
+
+/**
+ * Suffix shown next to the friendly Quackback URL field.
+ * Always taken from `platformHostname` when one exists — `canonicalOrigin`
+ * becomes a custom domain after that domain is made primary.
+ */
+export function platformUrlSuffix(identity: {
+  platformHostname: string | null
+  canonicalOrigin: string
+}): string {
+  const host = identity.platformHostname ?? new URL(identity.canonicalOrigin).hostname
+  return hostnameRegistrableSuffix(host)
+}

--- a/apps/web/src/routes/admin/__tests__/settings.domains.test.tsx
+++ b/apps/web/src/routes/admin/__tests__/settings.domains.test.tsx
@@ -69,7 +69,6 @@ describe('Quackback URL card', () => {
       <QuackbackUrlCard
         platformLabel=""
         domainSuffix="quackback.co.uk"
-        currentOrigin="https://south63792f.quackback.co.uk"
         pending={false}
         error={null}
         onPlatformLabelChange={vi.fn()}
@@ -80,13 +79,12 @@ describe('Quackback URL card', () => {
     expect(screen.queryByDisplayValue(/ws-/)).not.toBeInTheDocument()
   })
 
-  it('shows preview, current origin, and one save action', () => {
+  it('shows the suffix in the field and one save action, not preview or current lines', () => {
     const save = vi.fn()
     render(
       <QuackbackUrlCard
         platformLabel="ws-generated"
         domainSuffix="quackback.co.uk"
-        currentOrigin="https://ws-generated.quackback.co.uk"
         pending={false}
         error={null}
         onPlatformLabelChange={vi.fn()}
@@ -95,7 +93,9 @@ describe('Quackback URL card', () => {
     )
 
     expect(screen.getByLabelText('Quackback URL')).toHaveValue('ws-generated')
-    expect(screen.getByText(/Preview:/)).toHaveTextContent('https://ws-generated.quackback.co.uk')
+    expect(screen.getByText('.quackback.co.uk')).toBeInTheDocument()
+    expect(screen.queryByText(/Preview:/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Current:/)).not.toBeInTheDocument()
     const buttons = screen.getAllByRole('button')
     expect(buttons).toHaveLength(1)
     fireEvent.click(buttons[0]!)

--- a/apps/web/src/routes/admin/settings.domains.tsx
+++ b/apps/web/src/routes/admin/settings.domains.tsx
@@ -22,6 +22,7 @@ import {
   updateCloudIdentityFn,
 } from '@/lib/server/functions/cloud-identity'
 import type { CustomDomainInstruction } from '@/lib/server/control-plane/client'
+import { platformUrlSuffix } from '@/lib/shared/platform-label'
 
 export const Route = createFileRoute('/admin/settings/domains')({
   loader: async ({ context }) => {
@@ -133,10 +134,7 @@ function DomainsSettingsPage() {
           {cloudIdentity && (
             <QuackbackUrlCard
               platformLabel={platformLabel}
-              domainSuffix={new URL(cloudIdentity.canonicalOrigin).hostname
-                .split('.')
-                .slice(1)
-                .join('.')}
+              domainSuffix={platformUrlSuffix(cloudIdentity)}
               pending={identityMutation.isPending}
               error={identityMutation.error}
               onPlatformLabelChange={setPlatformLabel}

--- a/apps/web/src/routes/admin/settings.domains.tsx
+++ b/apps/web/src/routes/admin/settings.domains.tsx
@@ -137,7 +137,6 @@ function DomainsSettingsPage() {
                 .split('.')
                 .slice(1)
                 .join('.')}
-              currentOrigin={cloudIdentity.canonicalOrigin}
               pending={identityMutation.isPending}
               error={identityMutation.error}
               onPlatformLabelChange={setPlatformLabel}
@@ -165,13 +164,11 @@ function DomainsSettingsPage() {
 export function QuackbackUrlCard(props: {
   platformLabel: string
   domainSuffix: string
-  currentOrigin: string
   pending: boolean
   error: Error | null
   onPlatformLabelChange: (value: string) => void
   onSubmit: () => void
 }) {
-  const preview = `https://${props.platformLabel || 'workspace'}.${props.domainSuffix}`
   return (
     <SettingsCard title="Quackback URL" description="The address customers use for this workspace">
       <form
@@ -185,12 +182,12 @@ export function QuackbackUrlCard(props: {
           <Label htmlFor="platform-label" className="text-xs text-muted-foreground">
             Quackback URL
           </Label>
-          <div className="flex items-center rounded-md border bg-background focus-within:ring-2 focus-within:ring-ring">
+          <div className="flex h-9 items-center border border-input bg-transparent shadow-xs transition-[color,box-shadow] outline-none focus-within:border-ring focus-within:ring-ring/50 focus-within:ring-[3px] dark:bg-input/30 [border-radius:calc(var(--radius)*0.8)]">
             <Input
               id="platform-label"
               value={props.platformLabel}
               onChange={(event) => props.onPlatformLabelChange(event.target.value)}
-              className="border-0 focus-visible:ring-0"
+              className="h-full rounded-none border-0 bg-transparent shadow-none focus-visible:ring-0 dark:bg-transparent"
               maxLength={63}
               autoCapitalize="none"
               autoCorrect="off"
@@ -200,12 +197,6 @@ export function QuackbackUrlCard(props: {
               .{props.domainSuffix}
             </span>
           </div>
-          <p className="text-xs text-muted-foreground">
-            Preview: <span className="font-mono">{preview}</span>
-          </p>
-          <p className="text-xs text-muted-foreground">
-            Current: <span className="font-mono">{props.currentOrigin}</span>
-          </p>
         </div>
         {props.error && (
           <p role="alert" className="text-sm text-destructive">

--- a/apps/web/src/routes/onboarding/__tests__/cloud-details-goal.test.tsx
+++ b/apps/web/src/routes/onboarding/__tests__/cloud-details-goal.test.tsx
@@ -66,6 +66,22 @@ describe('cloud post-handoff onboarding', () => {
     expect(screen.queryByText(/ws-4a048e07941c5e7840e986c0/)).not.toBeInTheDocument()
   })
 
+  it('keeps the Quackback suffix when a custom domain is canonical', () => {
+    render(
+      <CloudWorkspaceDetailsForm
+        identity={{
+          ...IDENTITY,
+          canonicalOrigin: 'https://feedback.example.com',
+          platformHostname: 'awesome.quackback.co.uk',
+        }}
+        onSave={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('.quackback.co.uk')).toBeInTheDocument()
+    expect(screen.queryByText('.example.com')).not.toBeInTheDocument()
+  })
+
   it('keeps the outcome screen to one primary action', async () => {
     const save = vi.fn().mockResolvedValue(undefined)
     render(

--- a/apps/web/src/routes/onboarding/_layout.workspace.tsx
+++ b/apps/web/src/routes/onboarding/_layout.workspace.tsx
@@ -10,7 +10,7 @@ import {
   markCloudWorkspaceDetailsSeenFn,
   updateCloudIdentityFn,
 } from '@/lib/server/functions/cloud-identity'
-import { friendlyPlatformLabel } from '@/lib/shared/platform-label'
+import { friendlyPlatformLabel, platformUrlSuffix } from '@/lib/shared/platform-label'
 import { checkOnboardingState } from '@/lib/server/functions/admin'
 import { UseCaseSelector } from '@/components/onboarding/use-case-selector'
 import { pickOnboardingStep } from './-onboarding-step'
@@ -110,10 +110,7 @@ export function CloudWorkspaceDetailsForm(props: {
   )
   const [isSaving, setIsSaving] = useState(false)
   const [error, setError] = useState('')
-  const domainSuffix = new URL(props.identity.canonicalOrigin).hostname
-    .split('.')
-    .slice(1)
-    .join('.')
+  const domainSuffix = platformUrlSuffix(props.identity)
 
   async function run(action: () => Promise<void>, fallback: string): Promise<void> {
     setIsSaving(true)


### PR DESCRIPTION
## Summary

The Quackback URL field on Settings → Domains already shows the hostname and suffix in the input, so the Preview and Current lines underneath are redundant. Drop them, and give the suffix the same fill as the input so it no longer sits on a darker background.

## Test plan

- [ ] Cloud workspace: Settings → Domains → Quackback URL has no Preview/Current copy
- [ ] Suffix shares the input background in light and dark
- [ ] Saving a new label still works