### PR TITLE
feat(onboarding): launch plan treats the goal as configuration

### DIFF
--- a/apps/web/e2e/tests/admin/getting-started.spec.ts
+++ b/apps/web/e2e/tests/admin/getting-started.spec.ts
@@ -50,29 +50,47 @@ test.describe('Launch plan (Getting Started)', () => {
     await expect.poll(() => viewport.evaluate((element) => element.scrollTop)).toBeGreaterThan(0)
   })
 
-  test('offers an action for the next available setup step', async ({ page }) => {
-    const essentials = page
-      .getByRole('heading', { name: 'Set up the essentials' })
-      .locator('xpath=ancestor::section[1]')
-    const actionableLinks = essentials.locator('ul a')
-    const nextStep = page.getByRole('heading', { name: 'Next step' })
-
-    if ((await actionableLinks.count()) === 0 && (await nextStep.count()) === 0) {
+  test('emphasizes the current setup step with its action', async ({ page }) => {
+    const upNext = page.getByText('Up next')
+    if ((await upNext.count()) === 0) {
       test.skip(true, 'The seeded workspace has no available setup steps')
       return
     }
 
-    if ((await nextStep.count()) > 0) {
-      await expect(
-        page
-          .getByRole('link')
-          .filter({ hasText: /board|article|Messenger|teammate/i })
-          .first()
-      ).toBeVisible()
+    await expect(upNext).toBeVisible()
+    const essentials = page
+      .getByRole('heading', { name: 'Set up the essentials' })
+      .locator('xpath=ancestor::section[1]')
+    await expect(
+      essentials
+        .getByRole('link')
+        .or(essentials.getByRole('button', { name: /Write|Create|Connect|Copy|Turn on/i }))
+        .first()
+    ).toBeVisible()
+  })
+
+  test('skip moves a step into Skipped steps and Add back restores the count', async ({ page }) => {
+    const progress = page.getByRole('progressbar', { name: 'Setup progress' })
+    if ((await progress.count()) === 0) {
+      test.skip(true, 'All essentials are already skipped')
       return
     }
 
-    await expect(actionableLinks.first()).toBeVisible()
+    const skip = page.getByRole('button', { name: 'Skip' }).first()
+    if ((await skip.count()) === 0) {
+      test.skip(true, 'No skippable setup step is on the page')
+      return
+    }
+
+    const maxBefore = await progress.getAttribute('aria-valuemax')
+    await skip.click()
+    await expect(page.getByRole('heading', { name: 'Skipped steps' })).toBeVisible()
+    await page.getByRole('heading', { name: 'Skipped steps' }).click()
+    await page.getByRole('button', { name: 'Add back' }).click()
+    await expect(page.getByRole('progressbar', { name: 'Setup progress' })).toHaveAttribute(
+      'aria-valuemax',
+      maxBefore ?? ''
+    )
   })
 
   test('changing the goal to Help Center turns the product on', async ({ page }) => {

--- a/apps/web/e2e/tests/admin/getting-started.spec.ts
+++ b/apps/web/e2e/tests/admin/getting-started.spec.ts
@@ -55,13 +55,50 @@ test.describe('Launch plan (Getting Started)', () => {
       .getByRole('heading', { name: 'Set up the essentials' })
       .locator('xpath=ancestor::section[1]')
     const actionableLinks = essentials.locator('ul a')
+    const nextStep = page.getByRole('heading', { name: 'Next step' })
 
-    if ((await actionableLinks.count()) === 0) {
+    if ((await actionableLinks.count()) === 0 && (await nextStep.count()) === 0) {
       test.skip(true, 'The seeded workspace has no available setup steps')
       return
     }
 
+    if ((await nextStep.count()) > 0) {
+      await expect(
+        page
+          .getByRole('link')
+          .filter({ hasText: /board|article|Messenger|teammate/i })
+          .first()
+      ).toBeVisible()
+      return
+    }
+
     await expect(actionableLinks.first()).toBeVisible()
+  })
+
+  test('changing the goal to Help Center turns the product on', async ({ page }) => {
+    const changeGoal = page.getByRole('button', { name: 'Change goal' })
+    if ((await changeGoal.count()) === 0 || (await changeGoal.isDisabled())) {
+      test.skip(true, 'This workspace does not let the admin change the goal')
+      return
+    }
+
+    const previous =
+      (await page.locator('#activation-goal + h2').textContent()) ?? 'Product feedback'
+
+    await changeGoal.click()
+    await page.getByRole('radio', { name: /Help Center/i }).click()
+    await page.getByRole('button', { name: 'Use this goal' }).click()
+    await expect(page.locator('#activation-goal + h2')).toHaveText('Help Center')
+    await expect(page.getByRole('link', { name: 'Help Center' }).first()).toBeVisible()
+    await expect(page.getByRole('progressbar', { name: 'Setup progress' })).toHaveAttribute(
+      'aria-valuemax',
+      /[1-9]\d*/
+    )
+
+    await changeGoal.click()
+    await page.getByRole('radio', { name: new RegExp(previous.trim(), 'i') }).click()
+    await page.getByRole('button', { name: 'Use this goal' }).click()
+    await expect(page.locator('#activation-goal + h2')).toHaveText(previous.trim())
   })
 
   test('is accessible from the admin sidebar through the launch plan link', async ({ page }) => {

--- a/apps/web/e2e/tests/admin/getting-started.spec.ts
+++ b/apps/web/e2e/tests/admin/getting-started.spec.ts
@@ -3,6 +3,10 @@ import { expect, test } from '@playwright/test'
 // Admin project uses stored auth state (e2e/.auth/admin.json) — no manual login needed.
 
 test.describe('Launch plan (Getting Started)', () => {
+  // Goal change and skip write the singleton seeded workspace. Parallel
+  // workers would see Help Center or a skipped essential mid-file.
+  test.describe.configure({ mode: 'serial' })
+
   test.beforeEach(async ({ page }) => {
     await page.goto('/admin/getting-started')
     await page.waitForLoadState('networkidle')
@@ -100,23 +104,33 @@ test.describe('Launch plan (Getting Started)', () => {
       return
     }
 
-    const previous =
-      (await page.locator('#activation-goal + h2').textContent()) ?? 'Product feedback'
+    const seededGoal = 'Product feedback'
+    const goalHeading = page.locator('#activation-goal + h2')
 
-    await changeGoal.click()
-    await page.getByRole('radio', { name: /Help Center/i }).click()
-    await page.getByRole('button', { name: 'Use this goal' }).click()
-    await expect(page.locator('#activation-goal + h2')).toHaveText('Help Center')
-    await expect(page.getByRole('link', { name: 'Help Center' }).first()).toBeVisible()
-    await expect(page.getByRole('progressbar', { name: 'Setup progress' })).toHaveAttribute(
-      'aria-valuemax',
-      /[1-9]\d*/
-    )
+    async function selectGoal(label: string): Promise<void> {
+      const current = (await goalHeading.textContent())?.trim()
+      if (current === label) return
+      await page.getByRole('button', { name: 'Change goal' }).click()
+      await page.getByRole('radio', { name: label }).click()
+      await page.getByRole('button', { name: 'Use this goal' }).click()
+      await expect(goalHeading).toHaveText(label)
+    }
 
-    await changeGoal.click()
-    await page.getByRole('radio', { name: new RegExp(previous.trim(), 'i') }).click()
-    await page.getByRole('button', { name: 'Use this goal' }).click()
-    await expect(page.locator('#activation-goal + h2')).toHaveText(previous.trim())
+    try {
+      await selectGoal('Help Center')
+      await expect(page.getByRole('link', { name: 'Help Center' }).first()).toBeVisible()
+      await expect(page.getByRole('progressbar', { name: 'Setup progress' })).toHaveAttribute(
+        'aria-valuemax',
+        /[1-9]\d*/
+      )
+    } finally {
+      await page.goto('/admin/getting-started')
+      await page.waitForLoadState('networkidle')
+      const restore = page.getByRole('button', { name: 'Change goal' })
+      if ((await restore.count()) > 0 && (await restore.isEnabled())) {
+        await selectGoal(seededGoal)
+      }
+    }
   })
 
   test('is accessible from the admin sidebar through the launch plan link', async ({ page }) => {

--- a/apps/web/src/components/admin/admin-sidebar.tsx
+++ b/apps/web/src/components/admin/admin-sidebar.tsx
@@ -172,8 +172,9 @@ export function AdminSidebar({ initialUserData, latestVersion }: AdminSidebarPro
   const canManageWorkflows = usePermission(PERMISSIONS.WORKFLOW_MANAGE)
   const canOpenAutomation = canManageAssistant || canManageWorkflows
   // Launch-plan progress for the shell badge (admins only). The query stays
-  // enabled until the first-win milestone so a quiet dot can clear; skip
-  // and complete actions invalidate ['admin', 'onboarding'] explicitly.
+  // enabled and polls until the first-win milestone so a quiet dot can clear
+  // when the win happens off this page; skip and complete actions also
+  // invalidate ['admin', 'onboarding'] explicitly.
   const queryClient = useQueryClient()
   const onboardingQueryOptions = adminQueries.onboardingStatus()
   const cachedOnboardingStatus = queryClient.getQueryData<LaunchStatus>(
@@ -185,6 +186,10 @@ export function AdminSidebar({ initialUserData, latestVersion }: AdminSidebarPro
   const onboardingQuery = useQuery({
     ...onboardingQueryOptions,
     enabled: isAdmin && !cachedFirstWin,
+    refetchInterval: (query) => {
+      const data = query.state.data
+      return data && launchChecklistSummary(data).firstWinComplete ? false : 15_000
+    },
   })
   const launchSummary = onboardingQuery.data ? launchChecklistSummary(onboardingQuery.data) : null
   const showLaunchNav = isAdmin && (!launchSummary || !launchSummary.firstWinComplete)

--- a/apps/web/src/components/admin/admin-sidebar.tsx
+++ b/apps/web/src/components/admin/admin-sidebar.tsx
@@ -107,6 +107,7 @@ function NavItem({
   isActive,
   onClick,
   badge,
+  dot,
 }: {
   href: string
   icon: typeof ChatBubbleLeftIcon
@@ -115,6 +116,8 @@ function NavItem({
   onClick?: () => void
   /** Optional count or short mark (e.g. remaining launch steps) */
   badge?: string | number | null
+  /** Quiet marker while the plan is resolved but the first win is still open */
+  dot?: boolean
 }) {
   return (
     <Tooltip>
@@ -141,6 +144,12 @@ function NavItem({
               {badge}
             </span>
           )}
+          {dot && (badge == null || badge === '') && (
+            <span
+              className="absolute top-0.5 right-0.5 size-2 rounded-full bg-primary"
+              aria-hidden="true"
+            />
+          )}
           <span className="sr-only">{label}</span>
         </Link>
       </TooltipTrigger>
@@ -162,30 +171,28 @@ export function AdminSidebar({ initialUserData, latestVersion }: AdminSidebarPro
   const canManageAssistant = usePermission(PERMISSIONS.ASSISTANT_MANAGE)
   const canManageWorkflows = usePermission(PERMISSIONS.WORKFLOW_MANAGE)
   const canOpenAutomation = canManageAssistant || canManageWorkflows
-  // Launch-plan progress for the shell badge (admins only). Once the
-  // checklist is complete there's nothing left to watch for, so the query
-  // stops refetching — read the last-known result straight from the cache
-  // (rather than from `onboardingQuery.data`, which isn't declared yet) to
-  // decide whether to keep it enabled. Skip/complete actions invalidate
-  // ['admin', 'onboarding'] explicitly, so this can't go stale forever.
+  // Launch-plan progress for the shell badge (admins only). The query stays
+  // enabled until the first-win milestone so a quiet dot can clear; skip
+  // and complete actions invalidate ['admin', 'onboarding'] explicitly.
   const queryClient = useQueryClient()
   const onboardingQueryOptions = adminQueries.onboardingStatus()
   const cachedOnboardingStatus = queryClient.getQueryData<LaunchStatus>(
     onboardingQueryOptions.queryKey
   )
-  const cachedAllComplete = cachedOnboardingStatus
-    ? launchChecklistSummary(cachedOnboardingStatus).resolved
+  const cachedFirstWin = cachedOnboardingStatus
+    ? launchChecklistSummary(cachedOnboardingStatus).firstWinComplete
     : false
   const onboardingQuery = useQuery({
     ...onboardingQueryOptions,
-    enabled: isAdmin && !cachedAllComplete,
+    enabled: isAdmin && !cachedFirstWin,
   })
   const launchSummary = onboardingQuery.data ? launchChecklistSummary(onboardingQuery.data) : null
-  const showLaunchNav = isAdmin && (!launchSummary || !launchSummary.resolved)
+  const showLaunchNav = isAdmin && (!launchSummary || !launchSummary.firstWinComplete)
   const launchRemaining =
     launchSummary && !launchSummary.resolved && launchSummary.remaining > 0
       ? launchSummary.remaining
       : null
+  const launchQuietDot = Boolean(launchSummary?.resolved && !launchSummary.firstWinComplete)
   const launchPlanLabel =
     launchRemaining != null
       ? intl.formatMessage(
@@ -288,6 +295,7 @@ export function AdminSidebar({ initialUserData, latestVersion }: AdminSidebarPro
                   label={launchPlanLabel}
                   isActive={isNavActive(pathname, '/admin/getting-started')}
                   badge={launchRemaining}
+                  dot={launchQuietDot}
                 />
               )}
               {filteredNavItems.map((item) => (

--- a/apps/web/src/components/admin/admin-sidebar.tsx
+++ b/apps/web/src/components/admin/admin-sidebar.tsx
@@ -42,7 +42,11 @@ import {
   openOwnerWorkspaceFn,
 } from '@/lib/server/functions/owner-workspaces'
 import { friendlySiblingAddress, WorkspaceSwitcher } from '@/components/admin/workspace-switcher'
-import { launchChecklistSummary, type LaunchStatus } from '@/lib/shared/launch-checklist'
+import {
+  isLaunchPlanActive,
+  launchChecklistSummary,
+  type LaunchStatus,
+} from '@/lib/shared/launch-checklist'
 import { useIntl } from 'react-intl'
 import { usePermission } from '@/lib/client/hooks/use-permission'
 import { PERMISSIONS } from '@/lib/shared/permissions'
@@ -171,28 +175,29 @@ export function AdminSidebar({ initialUserData, latestVersion }: AdminSidebarPro
   const canManageAssistant = usePermission(PERMISSIONS.ASSISTANT_MANAGE)
   const canManageWorkflows = usePermission(PERMISSIONS.WORKFLOW_MANAGE)
   const canOpenAutomation = canManageAssistant || canManageWorkflows
-  // Launch-plan progress for the shell badge (admins only). The query stays
-  // enabled and polls until the first-win milestone so a quiet dot can clear
-  // when the win happens off this page; skip and complete actions also
+  // Launch-plan progress for the shell badge (admins only). Stay visible and
+  // polling until essentials resolve *and* the first win lands — a first win
+  // can arrive while invite-team is still open. Skip/complete actions also
   // invalidate ['admin', 'onboarding'] explicitly.
   const queryClient = useQueryClient()
   const onboardingQueryOptions = adminQueries.onboardingStatus()
   const cachedOnboardingStatus = queryClient.getQueryData<LaunchStatus>(
     onboardingQueryOptions.queryKey
   )
-  const cachedFirstWin = cachedOnboardingStatus
-    ? launchChecklistSummary(cachedOnboardingStatus).firstWinComplete
+  const cachedLaunchSettled = cachedOnboardingStatus
+    ? !isLaunchPlanActive(launchChecklistSummary(cachedOnboardingStatus))
     : false
   const onboardingQuery = useQuery({
     ...onboardingQueryOptions,
-    enabled: isAdmin && !cachedFirstWin,
+    enabled: isAdmin && !cachedLaunchSettled,
     refetchInterval: (query) => {
       const data = query.state.data
-      return data && launchChecklistSummary(data).firstWinComplete ? false : 15_000
+      if (!data) return 15_000
+      return isLaunchPlanActive(launchChecklistSummary(data)) ? 15_000 : false
     },
   })
   const launchSummary = onboardingQuery.data ? launchChecklistSummary(onboardingQuery.data) : null
-  const showLaunchNav = isAdmin && (!launchSummary || !launchSummary.firstWinComplete)
+  const showLaunchNav = isAdmin && (!launchSummary || isLaunchPlanActive(launchSummary))
   const launchRemaining =
     launchSummary && !launchSummary.resolved && launchSummary.remaining > 0
       ? launchSummary.remaining

--- a/apps/web/src/components/onboarding/use-case-selector.tsx
+++ b/apps/web/src/components/onboarding/use-case-selector.tsx
@@ -21,6 +21,8 @@ interface OutcomeOption {
   description: string
   /** Who this is for — ICP cue, not jargon */
   forWhom: string
+  /** What picking this goal turns on or uses */
+  whatYouGet: string
   icon: ComponentType<{ className?: string }>
 }
 
@@ -42,6 +44,7 @@ const OUTCOME_OPTIONS: OutcomeOption[] = [
     label: 'Product feedback',
     description: 'Collect ideas, prioritize requests, and share what’s coming next',
     forWhom: 'Product teams',
+    whatYouGet: 'Uses the Feedback product that’s already on',
     icon: LightBulbIcon,
   },
   {
@@ -49,6 +52,7 @@ const OUTCOME_OPTIONS: OutcomeOption[] = [
     label: 'Customer support',
     description: 'Talk with customers and manage conversations in a shared inbox',
     forWhom: 'Support teams',
+    whatYouGet: 'Turns on the Support inbox',
     icon: ChatBubbleLeftRightIcon,
   },
   {
@@ -56,6 +60,7 @@ const OUTCOME_OPTIONS: OutcomeOption[] = [
     label: 'Help Center',
     description: 'Publish answers customers can find whenever they need them',
     forWhom: 'Support & content',
+    whatYouGet: 'Turns on the Help Center product',
     icon: BookOpenIcon,
   },
   {
@@ -63,6 +68,7 @@ const OUTCOME_OPTIONS: OutcomeOption[] = [
     label: 'Internal feedback',
     description: 'Give teammates a private place to share ideas and improvements',
     forWhom: 'Your team',
+    whatYouGet: 'Uses the Feedback product for a private team board',
     icon: UserGroupIcon,
   },
 ]
@@ -145,6 +151,12 @@ export function UseCaseSelector({ value, onChange, disabled }: UseCaseSelectorPr
                 <FormattedMessage
                   id={`onboarding.goal.${option.id}.description`}
                   defaultMessage={option.description}
+                />
+              </div>
+              <div className="mt-1 text-xs text-muted-foreground/80">
+                <FormattedMessage
+                  id={`onboarding.goal.${option.id}.whatYouGet`}
+                  defaultMessage={option.whatYouGet}
                 />
               </div>
             </div>

--- a/apps/web/src/lib/client/__tests__/enabled-modules-toast.test.ts
+++ b/apps/web/src/lib/client/__tests__/enabled-modules-toast.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const success = vi.fn()
+vi.mock('sonner', () => ({ toast: { success } }))
+
+const { toastEnabledModules } = await import('../enabled-modules-toast')
+
+describe('toastEnabledModules', () => {
+  beforeEach(() => success.mockClear())
+
+  it('is silent when nothing new turned on', () => {
+    toastEnabledModules([])
+    expect(success).not.toHaveBeenCalled()
+  })
+
+  it('names a single newly enabled product', () => {
+    toastEnabledModules(['Help Center'])
+    expect(success).toHaveBeenCalledWith('Help Center turned on')
+  })
+
+  it('lists several newly enabled products', () => {
+    toastEnabledModules(['Help Center', 'Support'])
+    expect(success).toHaveBeenCalledWith('Turned on Help Center, Support')
+  })
+})

--- a/apps/web/src/lib/client/enabled-modules-toast.ts
+++ b/apps/web/src/lib/client/enabled-modules-toast.ts
@@ -1,0 +1,12 @@
+import { toast } from 'sonner'
+
+/** State a public-surface change. No-op when the goal turned nothing new on. */
+export function toastEnabledModules(modules: readonly string[]): void {
+  if (modules.length === 1) {
+    toast.success(`${modules[0]} turned on`)
+    return
+  }
+  if (modules.length > 1) {
+    toast.success(`Turned on ${modules.join(', ')}`)
+  }
+}

--- a/apps/web/src/lib/server/domains/settings/__tests__/lab-sections.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/lab-sections.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_FEATURE_FLAGS,
   PRODUCT_DEFINITIONS,
   enableFlagsForUseCase,
+  flagsForGoal,
   newlyEnabledProductLabels,
   featureFlagsForUseCase,
   getFirstEnabledAdminProductPath,
@@ -131,17 +132,18 @@ describe('featureFlagsForUseCase', () => {
   })
 
   it('names only the products that this goal change newly turned on', () => {
+    expect(flagsForGoal(DEFAULT_FEATURE_FLAGS, 'help_center')).toEqual({
+      flags: featureFlagsForUseCase('help_center'),
+      enabledModules: ['Help Center'],
+    })
+    expect(flagsForGoal(DEFAULT_FEATURE_FLAGS, 'customer_support').enabledModules).toEqual([
+      'Support',
+    ])
+    expect(
+      flagsForGoal(featureFlagsForUseCase('help_center'), 'help_center').enabledModules
+    ).toEqual([])
     expect(
       newlyEnabledProductLabels(DEFAULT_FEATURE_FLAGS, featureFlagsForUseCase('help_center'))
     ).toEqual(['Help Center'])
-    expect(
-      newlyEnabledProductLabels(DEFAULT_FEATURE_FLAGS, featureFlagsForUseCase('customer_support'))
-    ).toEqual(['Support'])
-    expect(
-      newlyEnabledProductLabels(
-        featureFlagsForUseCase('help_center'),
-        enableFlagsForUseCase(featureFlagsForUseCase('help_center'), 'help_center')
-      )
-    ).toEqual([])
   })
 })

--- a/apps/web/src/lib/server/domains/settings/__tests__/lab-sections.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/lab-sections.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_FEATURE_FLAGS,
   PRODUCT_DEFINITIONS,
   enableFlagsForUseCase,
+  newlyEnabledProductLabels,
   featureFlagsForUseCase,
   getFirstEnabledAdminProductPath,
   getProductFlagUpdate,
@@ -127,5 +128,20 @@ describe('featureFlagsForUseCase', () => {
     const merged = enableFlagsForUseCase(current, 'customer_support')
     expect(isProductEnabled(merged, 'helpCenter')).toBe(true)
     expect(isProductEnabled(merged, 'support')).toBe(true)
+  })
+
+  it('names only the products that this goal change newly turned on', () => {
+    expect(
+      newlyEnabledProductLabels(DEFAULT_FEATURE_FLAGS, featureFlagsForUseCase('help_center'))
+    ).toEqual(['Help Center'])
+    expect(
+      newlyEnabledProductLabels(DEFAULT_FEATURE_FLAGS, featureFlagsForUseCase('customer_support'))
+    ).toEqual(['Support'])
+    expect(
+      newlyEnabledProductLabels(
+        featureFlagsForUseCase('help_center'),
+        enableFlagsForUseCase(featureFlagsForUseCase('help_center'), 'help_center')
+      )
+    ).toEqual([])
   })
 })

--- a/apps/web/src/lib/server/domains/settings/settings.types.ts
+++ b/apps/web/src/lib/server/domains/settings/settings.types.ts
@@ -1223,6 +1223,13 @@ export const PRODUCT_DEFINITIONS = [
   },
 ] as const satisfies readonly ProductDefinition[]
 
+/** Product labels that this flag change newly turned on. Additive diffs only. */
+export function newlyEnabledProductLabels(before: FeatureFlags, after: FeatureFlags): string[] {
+  return PRODUCT_DEFINITIONS.filter((product) =>
+    product.featureFlags.some((flag) => before[flag] !== true && after[flag] === true)
+  ).map((product) => product.label)
+}
+
 function getProductDefinition(productId: ProductId): ProductDefinition {
   return PRODUCT_DEFINITIONS.find((product) => product.id === productId)!
 }

--- a/apps/web/src/lib/server/domains/settings/settings.types.ts
+++ b/apps/web/src/lib/server/domains/settings/settings.types.ts
@@ -1230,6 +1230,15 @@ export function newlyEnabledProductLabels(before: FeatureFlags, after: FeatureFl
   ).map((product) => product.label)
 }
 
+/** Merge a goal onto current flags and name what this change newly turned on. */
+export function flagsForGoal(
+  current: FeatureFlags,
+  useCase?: FeatureFlagUseCase | null
+): { flags: FeatureFlags; enabledModules: string[] } {
+  const flags = enableFlagsForUseCase(current, useCase)
+  return { flags, enabledModules: newlyEnabledProductLabels(current, flags) }
+}
+
 function getProductDefinition(productId: ProductId): ProductDefinition {
   return PRODUCT_DEFINITIONS.find((product) => product.id === productId)!
 }

--- a/apps/web/src/lib/server/functions/__tests__/activation-goal-flags.fn.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/activation-goal-flags.fn.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { FeatureFlags } from '@/lib/server/domains/settings/settings.types'
+import {
+  DEFAULT_FEATURE_FLAGS,
+  resolveFeatureFlags,
+} from '@/lib/server/domains/settings/settings.types'
+import type { SetupState } from '@/lib/server/db'
+
+const hoisted = vi.hoisted(() => ({
+  requireAuth: vi.fn(),
+  emitPlgEvent: vi.fn(async () => undefined),
+  isPathManaged: vi.fn((path: string, paths: string[] | null | undefined) =>
+    (paths ?? []).includes(path)
+  ),
+  row: {
+    id: 'ws_1',
+    name: 'Acme',
+    slug: 'acme',
+    managedFieldPaths: [] as string[],
+    featureFlags: JSON.stringify({
+      feedback: true,
+      changelog: true,
+      helpCenter: false,
+      supportInbox: false,
+      supportTickets: false,
+      statusPage: false,
+    }),
+  },
+  flagWrites: [] as Record<string, unknown>[],
+  state: {
+    version: 2,
+    steps: { core: true, workspace: true, startingPoint: null },
+    useCase: 'product_feedback',
+  } as SetupState,
+}))
+
+vi.mock('@tanstack/react-start', () => ({
+  createServerFn: () => {
+    const chain = {
+      validator: () => chain,
+      handler: (fn: (args: unknown) => unknown) => fn,
+    }
+    return chain
+  },
+}))
+
+vi.mock('@/lib/server/functions/auth-helpers', () => ({
+  requireAuth: hoisted.requireAuth,
+}))
+
+vi.mock('@/lib/server/plg-events', () => ({ emitPlgEvent: hoisted.emitPlgEvent }))
+
+vi.mock('@/lib/server/config-file/managed-paths', () => ({
+  isPathManaged: hoisted.isPathManaged,
+}))
+
+vi.mock('@/lib/server/logger', () => ({
+  logger: { child: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }) },
+}))
+
+vi.mock('@/lib/server/domains/settings/tier-limits.service', () => ({
+  getTierLimits: vi.fn(async () => ({ maxBoards: null })),
+}))
+
+vi.mock('@/lib/server/db', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/server/db')>()),
+  db: {
+    query: { settings: { findFirst: vi.fn() }, boards: { findFirst: vi.fn() } },
+    select: () => ({ from: () => ({ where: async () => [{ count: 0 }] }) }),
+  },
+}))
+
+vi.mock('@/lib/server/setup-state', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/server/setup-state')>()),
+  mutateSetupStateAtomic: async (
+    mutate: (
+      current: SetupState,
+      row: typeof hoisted.row,
+      tx: {
+        update: (table: unknown) => {
+          set: (values: Record<string, unknown>) => { where: () => Promise<void> }
+        }
+      }
+    ) => Promise<{ state: SetupState; value: unknown }> | { state: SetupState; value: unknown }
+  ) => {
+    const tx = {
+      update: () => ({
+        set: (values: Record<string, unknown>) => {
+          hoisted.flagWrites.push(values)
+          return { where: async () => undefined }
+        },
+      }),
+    }
+    return mutate(hoisted.state, hoisted.row, tx)
+  },
+}))
+
+const { setActivationGoalFn } = await import('../activation')
+
+beforeEach(() => {
+  hoisted.flagWrites = []
+  hoisted.row.managedFieldPaths = []
+  hoisted.row.featureFlags = JSON.stringify(DEFAULT_FEATURE_FLAGS)
+  hoisted.state = {
+    version: 2,
+    steps: { core: true, workspace: true, startingPoint: null },
+    useCase: 'product_feedback',
+  }
+  hoisted.requireAuth.mockResolvedValue({
+    user: { id: 'usr_1' },
+    principal: { id: 'prn_1', role: 'admin' },
+    settings: { id: 'ws_1' },
+  })
+  hoisted.emitPlgEvent.mockClear()
+})
+
+describe('setActivationGoalFn enables the goal modules', () => {
+  it('turns Help Center on when the launch-plan goal changes to Help Center', async () => {
+    const result = await setActivationGoalFn({ data: { outcome: 'help_center' } } as never)
+
+    expect(result).toEqual({ outcome: 'help_center', enabledModules: ['Help Center'] })
+    const written = hoisted.flagWrites.find((values) => typeof values.featureFlags === 'string')
+    const flags = resolveFeatureFlags(written!.featureFlags as string)
+    expect(flags.helpCenter).toBe(true)
+    expect(flags.supportInbox).toBe(false)
+  })
+
+  it('returns no newly-enabled modules when the needed flags are already on', async () => {
+    hoisted.row.featureFlags = JSON.stringify({
+      ...DEFAULT_FEATURE_FLAGS,
+      helpCenter: true,
+    } satisfies FeatureFlags)
+
+    const result = await setActivationGoalFn({ data: { outcome: 'help_center' } } as never)
+
+    expect(result).toEqual({ outcome: 'help_center', enabledModules: [] })
+  })
+
+  it('refuses a managed goal without writing flags', async () => {
+    hoisted.row.managedFieldPaths = ['workspace.useCase']
+
+    await expect(
+      setActivationGoalFn({ data: { outcome: 'help_center' } } as never)
+    ).rejects.toThrow(/managed/i)
+    expect(hoisted.flagWrites).toEqual([])
+  })
+})

--- a/apps/web/src/lib/server/functions/__tests__/onboarding-admin-promotion.fn.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/onboarding-admin-promotion.fn.test.ts
@@ -245,6 +245,7 @@ describe('saveWorkspaceAndGoalFn bootstrap authorization', () => {
         name: 'Acme Inc',
         slug: 'acme-inc',
         useCase: 'customer_support',
+        enabledModules: ['Support'],
       })
     )
   })
@@ -329,6 +330,23 @@ describe('saveWorkspaceAndGoalFn bootstrap authorization', () => {
     expect(result.name).toBe('Acme Labs')
     expect(result.slug).toBe('fixed-portal')
     expect(result.managed).toEqual({ name: false, slug: true, useCase: false })
+    expect(result.enabledModules).toEqual([])
+  })
+
+  it('enables Help Center when an existing workspace picks that goal', async () => {
+    hoisted.getSettings.mockResolvedValue({
+      ...STAMPED_SETTINGS,
+      featureFlags: JSON.stringify(DEFAULT_FEATURE_FLAGS),
+    })
+    hoisted.principalFindFirst.mockResolvedValue({ id: 'principal_1', role: 'admin' })
+
+    const result = await saveWorkspaceAndGoalFn({
+      data: { workspaceName: 'Acme', useCase: 'help_center' },
+    })
+
+    expect(result.enabledModules).toEqual(['Help Center'])
+    const written = hoisted.flagWrites.find((values) => typeof values.featureFlags === 'string')
+    expect(resolveFeatureFlags(written!.featureFlags as string).helpCenter).toBe(true)
   })
 
   it.each([

--- a/apps/web/src/lib/server/functions/__tests__/onboarding-admin-promotion.fn.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/onboarding-admin-promotion.fn.test.ts
@@ -24,6 +24,7 @@ const hoisted = vi.hoisted(() => ({
   setPrincipalRole: vi.fn(),
   settingsInsert: vi.fn(),
   invalidateSettingsCache: vi.fn(),
+  flagWrites: [] as Record<string, unknown>[],
   /** What `settings.cloud_workspace_key` holds — null on an install, a key on a
    *  workspace a control plane created. Read by the tx `execute` double below. */
   stamp: { value: null as string | null },
@@ -74,11 +75,14 @@ vi.mock('@/lib/server/setup-state', async (importOriginal) => ({
       const row = await hoisted.getSettings()
       const tx = {
         update: vi.fn(() => ({
-          set: vi.fn((values: Record<string, unknown>) => ({
-            where: vi.fn(() => ({
-              returning: vi.fn(async () => [{ ...row, ...values }]),
-            })),
-          })),
+          set: vi.fn((values: Record<string, unknown>) => {
+            hoisted.flagWrites.push(values)
+            return {
+              where: vi.fn(() => ({
+                returning: vi.fn(async () => [{ ...row, ...values }]),
+              })),
+            }
+          }),
         })),
       }
       return mutate(JSON.parse(row.setupState), row, tx)
@@ -123,11 +127,14 @@ vi.mock('@/lib/server/db', async (importOriginal) => {
   }
 })
 
-const { saveWorkspaceAndGoalFn } = await import('../onboarding')
+const { saveWorkspaceAndGoalFn, saveCloudOnboardingGoalFn } = await import('../onboarding')
+const { DEFAULT_FEATURE_FLAGS, resolveFeatureFlags } =
+  await import('@/lib/server/domains/settings/settings.types')
 const { bootstrapAdminLock } = await import('@/lib/server/domains/principals/bootstrap-admin')
 
 beforeEach(() => {
   vi.clearAllMocks()
+  hoisted.flagWrites = []
   hoisted.getSession.mockResolvedValue({ user: { id: 'user_caller' } })
   hoisted.postStatusesFindFirst.mockResolvedValue({ id: 'status_existing' })
   hoisted.stamp.value = null
@@ -350,5 +357,66 @@ describe('saveWorkspaceAndGoalFn bootstrap authorization', () => {
     hoisted.principalFindFirst.mockResolvedValue({ id: 'principal_1', role: 'admin' })
 
     await expect(saveWorkspaceAndGoalFn({ data: example.data })).rejects.toThrow(example.message)
+  })
+})
+
+const CLOUD_IDENTITY = {
+  version: 4,
+  displayName: 'Acme',
+  canonicalOrigin: 'https://acme.example.com',
+  platformHostname: 'acme.example.com',
+  customDomains: [],
+  updatedAt: '2026-08-14T12:00:00.000Z',
+}
+
+describe('saveCloudOnboardingGoalFn enables the goal modules', () => {
+  function cloudRow(overrides: Record<string, unknown> = {}) {
+    return {
+      id: 'workspace_1',
+      name: 'Acme',
+      slug: 'acme',
+      managedFieldPaths: [],
+      cloudIdentity: CLOUD_IDENTITY,
+      featureFlags: JSON.stringify(DEFAULT_FEATURE_FLAGS),
+      setupState: JSON.stringify({
+        version: 2,
+        steps: { core: true, workspace: true, startingPoint: null },
+        useCase: null,
+        workspaceDetailsSeenAt: '2026-08-14T11:00:00.000Z',
+      }),
+      ...overrides,
+    }
+  }
+
+  it('turns Help Center on when a cloud workspace picks that goal', async () => {
+    hoisted.getSettings.mockResolvedValue(cloudRow())
+    hoisted.principalFindFirst.mockResolvedValue({ id: 'principal_1', role: 'admin' })
+
+    const result = await saveCloudOnboardingGoalFn({ data: { useCase: 'help_center' } })
+
+    expect(result).toEqual({ useCase: 'help_center', enabledModules: ['Help Center'] })
+    const written = hoisted.flagWrites.find((values) => typeof values.featureFlags === 'string')
+    expect(written).toBeDefined()
+    const flags = resolveFeatureFlags(written!.featureFlags as string)
+    expect(flags.helpCenter).toBe(true)
+    expect(flags.supportInbox).toBe(false)
+  })
+
+  it('turns Support on for customer support without turning Help Center off', async () => {
+    hoisted.getSettings.mockResolvedValue(
+      cloudRow({
+        featureFlags: JSON.stringify({ ...DEFAULT_FEATURE_FLAGS, helpCenter: true }),
+      })
+    )
+    hoisted.principalFindFirst.mockResolvedValue({ id: 'principal_1', role: 'admin' })
+
+    const result = await saveCloudOnboardingGoalFn({ data: { useCase: 'customer_support' } })
+
+    expect(result.enabledModules).toEqual(['Support'])
+    const written = hoisted.flagWrites.find((values) => typeof values.featureFlags === 'string')
+    const flags = resolveFeatureFlags(written!.featureFlags as string)
+    expect(flags.supportInbox).toBe(true)
+    expect(flags.supportTickets).toBe(true)
+    expect(flags.helpCenter).toBe(true)
   })
 })

--- a/apps/web/src/lib/server/functions/__tests__/open-handoff.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/open-handoff.test.ts
@@ -65,6 +65,7 @@ describe('consumeOpenHandoff', () => {
   })
 
   it('does not require an identity projection', async () => {
+    hoisted.snapshotRows.push([{ value: 'sess', expiresAt: new Date(Date.now() + 60_000) }])
     hoisted.handler.mockResolvedValue({
       ok: true,
       headers: {
@@ -114,6 +115,7 @@ describe('consumeOpenHandoff', () => {
   })
 
   it('lands on the workspace root even if a wizard returnTo is supplied', async () => {
+    hoisted.snapshotRows.push([{ value: 'sess', expiresAt: new Date(Date.now() + 60_000) }])
     hoisted.handler.mockResolvedValue({
       ok: true,
       headers: {
@@ -129,21 +131,19 @@ describe('consumeOpenHandoff', () => {
   it('retries when a parallel GET consumed the token before snapshot', async () => {
     const live = { value: 'sess', expiresAt: new Date(Date.now() + 60_000) }
     hoisted.snapshotRows.push([], [live])
-    hoisted.handler
-      .mockResolvedValueOnce(new Response('no', { status: 400 }))
-      .mockResolvedValueOnce({
-        ok: true,
-        headers: {
-          getSetCookie: () => ['session=abc; Path=/; HttpOnly'],
-          get: () => null,
-        },
-      })
+    hoisted.handler.mockResolvedValue({
+      ok: true,
+      headers: {
+        getSetCookie: () => ['session=abc; Path=/; HttpOnly'],
+        get: () => null,
+      },
+    })
 
     await expect(consumeOpenHandoff({ ott: 'token-1' })).resolves.toEqual({
       kind: 'redirect',
       to: '/',
       cookies: ['session=abc; Path=/; HttpOnly'],
     })
-    expect(hoisted.handler).toHaveBeenCalledTimes(2)
+    expect(hoisted.handler).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/src/lib/server/functions/activation.ts
+++ b/apps/web/src/lib/server/functions/activation.ts
@@ -30,6 +30,8 @@ import { getTierLimits } from '@/lib/server/domains/settings/tier-limits.service
 import {
   DEFAULT_MESSENGER_CONFIG,
   DEFAULT_WIDGET_CONFIG,
+  enableFlagsForUseCase,
+  newlyEnabledProductLabels,
   resolveFeatureFlags,
 } from '@/lib/server/domains/settings/settings.types'
 import { parseJsonConfig } from '@/lib/server/domains/settings/settings.helpers'
@@ -233,20 +235,26 @@ export const setActivationGoalFn = createServerFn({ method: 'POST' })
   .validator(z.object({ outcome: outcomeSchema }))
   .handler(async ({ data }) => {
     const auth = await requireAuth({ permission: PERMISSIONS.SETTINGS_MANAGE })
-    const { state } = await mutateSetupStateAtomic((current, row) => {
+    const { state, value } = await mutateSetupStateAtomic(async (current, row, tx) => {
       if (isPathManaged('workspace.useCase', row.managedFieldPaths)) {
         throw new Error('Workspace goal is managed by your workspace admin')
       }
+      const currentFlags = resolveFeatureFlags(row.featureFlags)
+      const nextFlags = enableFlagsForUseCase(currentFlags, data.outcome)
+      await tx
+        .update(settings)
+        .set({ featureFlags: JSON.stringify(nextFlags) })
+        .where(eq(settings.id, row.id))
       return {
         state: { ...current, useCase: data.outcome },
-        value: undefined,
+        value: { enabledModules: newlyEnabledProductLabels(currentFlags, nextFlags) },
       }
     })
     await emitPlgEvent(
       { name: 'onboarding_goal_saved', outcome: state.useCase! },
       { workspaceId: auth.settings.id, principalId: auth.principal.id }
     )
-    return { outcome: state.useCase! }
+    return { outcome: state.useCase!, enabledModules: value.enabledModules }
   })
 
 export interface CompleteStartingPointResult {

--- a/apps/web/src/lib/server/functions/activation.ts
+++ b/apps/web/src/lib/server/functions/activation.ts
@@ -30,8 +30,7 @@ import { getTierLimits } from '@/lib/server/domains/settings/tier-limits.service
 import {
   DEFAULT_MESSENGER_CONFIG,
   DEFAULT_WIDGET_CONFIG,
-  enableFlagsForUseCase,
-  newlyEnabledProductLabels,
+  flagsForGoal,
   resolveFeatureFlags,
 } from '@/lib/server/domains/settings/settings.types'
 import { parseJsonConfig } from '@/lib/server/domains/settings/settings.helpers'
@@ -239,15 +238,17 @@ export const setActivationGoalFn = createServerFn({ method: 'POST' })
       if (isPathManaged('workspace.useCase', row.managedFieldPaths)) {
         throw new Error('Workspace goal is managed by your workspace admin')
       }
-      const currentFlags = resolveFeatureFlags(row.featureFlags)
-      const nextFlags = enableFlagsForUseCase(currentFlags, data.outcome)
+      const { flags, enabledModules } = flagsForGoal(
+        resolveFeatureFlags(row.featureFlags),
+        data.outcome
+      )
       await tx
         .update(settings)
-        .set({ featureFlags: JSON.stringify(nextFlags) })
+        .set({ featureFlags: JSON.stringify(flags) })
         .where(eq(settings.id, row.id))
       return {
         state: { ...current, useCase: data.outcome },
-        value: { enabledModules: newlyEnabledProductLabels(currentFlags, nextFlags) },
+        value: { enabledModules },
       }
     })
     await emitPlgEvent(

--- a/apps/web/src/lib/server/functions/admin.ts
+++ b/apps/web/src/lib/server/functions/admin.ts
@@ -455,8 +455,9 @@ export const fetchOnboardingStatus = createServerFn({ method: 'GET' }).handler(a
   }
 })
 
-/** Save or clear a launch-plan task preference. Required steps can be moved
- * later; only optional customisation can be hidden. */
+/** Save or clear a launch-plan skip. Any incomplete non-milestone task can
+ *  be skipped; storage is always `dismissed`. Legacy clients may still send
+ *  `deferred`, which is accepted and normalized. */
 const taskResolutionSchema = z.object({
   outcome: z.enum(['product_feedback', 'customer_support', 'help_center', 'internal']),
   taskId: z.string().min(1),
@@ -474,14 +475,14 @@ export const setLaunchTaskResolutionFn = createServerFn({ method: 'POST' })
       (candidate) => candidate.id === data.taskId
     )
     if (!task) throw new Error('Unknown launch task')
-    if (data.resolution === 'deferred' && task.classification !== 'prerequisite') {
-      throw new Error('Only setup steps can be moved later')
+    if (task.classification === 'first_win' && data.resolution) {
+      throw new Error('The milestone cannot be skipped')
     }
-    if (data.resolution === 'dismissed' && task.classification !== 'polish') {
-      throw new Error('Only optional customization can be skipped')
+    if (task.isCompleted && data.resolution) {
+      throw new Error('Completed tasks cannot be skipped')
     }
-    if (task.isCompleted && data.resolution)
-      throw new Error('Completed tasks cannot be deferred or dismissed')
+
+    const storedResolution = data.resolution === 'deferred' ? 'dismissed' : data.resolution
 
     const { mutateSetupStateAtomic } = await import('@/lib/server/setup-state')
     const { state } = await mutateSetupStateAtomic((current) => {
@@ -489,9 +490,9 @@ export const setLaunchTaskResolutionFn = createServerFn({ method: 'POST' })
         throw new Error('Task outcome does not match the workspace goal')
       const taskResolutions = { ...(current.taskResolutions ?? {}) }
       const outcomeTasks = { ...(taskResolutions[data.outcome] ?? {}) }
-      if (data.resolution) {
+      if (storedResolution) {
         outcomeTasks[data.taskId] = {
-          resolution: data.resolution,
+          resolution: storedResolution,
           resolvedAt: new Date().toISOString(),
         }
       } else {
@@ -508,7 +509,7 @@ export const setLaunchTaskResolutionFn = createServerFn({ method: 'POST' })
       }
     })
 
-    log.info({ task_id: data.taskId, resolution: data.resolution }, 'launch task resolution saved')
+    log.info({ task_id: data.taskId, resolution: storedResolution }, 'launch task resolution saved')
     return { taskResolutions: state.taskResolutions ?? {} }
   })
 

--- a/apps/web/src/lib/server/functions/onboarding.ts
+++ b/apps/web/src/lib/server/functions/onboarding.ts
@@ -28,6 +28,7 @@ import { DEFAULT_AUTH_CONFIG, DEFAULT_PORTAL_CONFIG } from '@/lib/server/domains
 import {
   enableFlagsForUseCase,
   featureFlagsForUseCase,
+  newlyEnabledProductLabels,
   resolveFeatureFlags,
 } from '@/lib/server/domains/settings/settings.types'
 import { isPathManaged } from '@/lib/server/config-file/managed-paths'
@@ -350,16 +351,22 @@ export const saveCloudOnboardingGoalFn = createServerFn({ method: 'POST' })
     })
     if (!caller || !isAdmin(caller.role)) throw new Error('Only admin can change setup')
 
-    const { state } = await mutateSetupStateAtomic((current, row) => {
+    const { state, value } = await mutateSetupStateAtomic(async (current, row, tx) => {
       if (!parseIdentityProjection(row.cloudIdentity)) {
         throw new Error('Cloud workspace identity is not enabled')
       }
       if (!current.workspaceDetailsSeenAt) {
         throw new Error('Set your workspace name and URL first')
       }
+      const currentFlags = resolveFeatureFlags(row.featureFlags)
+      const nextFlags = enableFlagsForUseCase(currentFlags, data.useCase)
+      await tx
+        .update(settings)
+        .set({ featureFlags: JSON.stringify(nextFlags) })
+        .where(eq(settings.id, row.id))
       return {
         state: applyDeferredLaunchStartingPoint(current, data.useCase),
-        value: undefined,
+        value: { enabledModules: newlyEnabledProductLabels(currentFlags, nextFlags) },
       }
     })
 
@@ -373,7 +380,7 @@ export const saveCloudOnboardingGoalFn = createServerFn({ method: 'POST' })
         }))
       )
     }
-    return { useCase: state.useCase! }
+    return { useCase: state.useCase!, enabledModules: value.enabledModules }
   })
 
 /**

--- a/apps/web/src/lib/server/functions/onboarding.ts
+++ b/apps/web/src/lib/server/functions/onboarding.ts
@@ -26,9 +26,8 @@ import { isOnboardingComplete } from '@/lib/shared/db-types'
 import { invalidateSettingsCache } from '@/lib/server/domains/settings/settings.helpers'
 import { DEFAULT_AUTH_CONFIG, DEFAULT_PORTAL_CONFIG } from '@/lib/server/domains/settings'
 import {
-  enableFlagsForUseCase,
-  featureFlagsForUseCase,
-  newlyEnabledProductLabels,
+  DEFAULT_FEATURE_FLAGS,
+  flagsForGoal,
   resolveFeatureFlags,
 } from '@/lib/server/domains/settings/settings.types'
 import { isPathManaged } from '@/lib/server/config-file/managed-paths'
@@ -185,6 +184,7 @@ export interface SaveWorkspaceAndGoalResult {
   slug: string
   useCase: OnboardingOutcome
   managed: { name: boolean; slug: boolean; useCase: boolean }
+  enabledModules: string[]
 }
 
 // ============================================
@@ -253,6 +253,7 @@ export const saveWorkspaceAndGoalFn = createServerFn({ method: 'POST' })
             data.useCase
           ),
         }
+        const { flags, enabledModules } = flagsForGoal(DEFAULT_FEATURE_FLAGS, data.useCase)
         const [created] = await db
           .insert(settings)
           .values({
@@ -263,7 +264,7 @@ export const saveWorkspaceAndGoalFn = createServerFn({ method: 'POST' })
             portalConfig: JSON.stringify(DEFAULT_PORTAL_CONFIG),
             authConfig: JSON.stringify({ ...DEFAULT_AUTH_CONFIG, openSignup: true }),
             setupState: JSON.stringify(initialState),
-            featureFlags: JSON.stringify(featureFlagsForUseCase(data.useCase)),
+            featureFlags: JSON.stringify(flags),
           })
           .returning()
         await invalidateSettingsCache()
@@ -273,6 +274,7 @@ export const saveWorkspaceAndGoalFn = createServerFn({ method: 'POST' })
           slug: created.slug,
           useCase: data.useCase,
           managed: { name: false, slug: false, useCase: false },
+          enabledModules,
         }
       } else {
         const { value } = await mutateSetupStateAtomic(async (current, row, tx) => {
@@ -285,16 +287,16 @@ export const saveWorkspaceAndGoalFn = createServerFn({ method: 'POST' })
           if (useCaseManaged && data.useCase !== current.useCase) {
             throw new Error('Workspace goal is managed by your workspace admin')
           }
+          const goal = useCaseManaged ? (current.useCase ?? data.useCase) : data.useCase
+          const { flags, enabledModules } = flagsForGoal(
+            resolveFeatureFlags(row.featureFlags),
+            goal
+          )
           const updatePayload: Record<string, unknown> = {
             portalConfig: row.portalConfig ?? JSON.stringify(DEFAULT_PORTAL_CONFIG),
             authConfig:
               row.authConfig ?? JSON.stringify({ ...DEFAULT_AUTH_CONFIG, openSignup: true }),
-            featureFlags: JSON.stringify(
-              enableFlagsForUseCase(
-                resolveFeatureFlags(row.featureFlags),
-                useCaseManaged ? (current.useCase ?? data.useCase) : data.useCase
-              )
-            ),
+            featureFlags: JSON.stringify(flags),
           }
           if (!nameManaged) updatePayload.name = workspaceName
           if (!slugManaged) updatePayload.slug = slug
@@ -303,13 +305,13 @@ export const saveWorkspaceAndGoalFn = createServerFn({ method: 'POST' })
             .set(updatePayload)
             .where(eq(settings.id, row.id))
             .returning()
-          const goal = useCaseManaged ? (current.useCase ?? data.useCase) : data.useCase
           return {
             state: applyDeferredLaunchStartingPoint(current, goal),
             value: {
               updated,
               goal,
               managed: { name: nameManaged, slug: slugManaged, useCase: useCaseManaged },
+              enabledModules,
             },
           }
         })
@@ -319,6 +321,7 @@ export const saveWorkspaceAndGoalFn = createServerFn({ method: 'POST' })
           slug: value.updated.slug,
           useCase: value.goal,
           managed: value.managed,
+          enabledModules: value.enabledModules,
         }
       }
 
@@ -358,15 +361,17 @@ export const saveCloudOnboardingGoalFn = createServerFn({ method: 'POST' })
       if (!current.workspaceDetailsSeenAt) {
         throw new Error('Set your workspace name and URL first')
       }
-      const currentFlags = resolveFeatureFlags(row.featureFlags)
-      const nextFlags = enableFlagsForUseCase(currentFlags, data.useCase)
+      const { flags, enabledModules } = flagsForGoal(
+        resolveFeatureFlags(row.featureFlags),
+        data.useCase
+      )
       await tx
         .update(settings)
-        .set({ featureFlags: JSON.stringify(nextFlags) })
+        .set({ featureFlags: JSON.stringify(flags) })
         .where(eq(settings.id, row.id))
       return {
         state: applyDeferredLaunchStartingPoint(current, data.useCase),
-        value: { enabledModules: newlyEnabledProductLabels(currentFlags, nextFlags) },
+        value: { enabledModules },
       }
     })
 

--- a/apps/web/src/lib/server/functions/origin-transfer.ts
+++ b/apps/web/src/lib/server/functions/origin-transfer.ts
@@ -145,21 +145,23 @@ type OpenHandoffAttempt =
 
 async function consumeOpenHandoffOnce(ott: string, headers?: Headers): Promise<OpenHandoffAttempt> {
   const snapshot = await snapshotOpenHandoffOtt(ott)
+  if (!snapshot) {
+    const existing = await continueIfAlreadySignedIn('/', headers)
+    if (existing.kind === 'redirect') return existing
+    return { kind: 'error', status: 'invalid', missedSnapshot: true }
+  }
   const first = await consumeOrContinueExistingSession(ott, '/', headers)
   if (first.kind === 'redirect') {
-    if (snapshot) await restoreOpenHandoffOtt(snapshot)
+    await restoreOpenHandoffOtt(snapshot)
     return first
   }
-  if (snapshot) {
+  await restoreOpenHandoffOtt(snapshot)
+  const retry = await verifyOttCookies(ott, '/', headers)
+  if (retry.kind === 'redirect') {
     await restoreOpenHandoffOtt(snapshot)
-    const retry = await verifyOttCookies(ott, '/', headers)
-    if (retry.kind === 'redirect') {
-      await restoreOpenHandoffOtt(snapshot)
-      return retry
-    }
-    return { ...first, missedSnapshot: false }
+    return retry
   }
-  return { ...first, missedSnapshot: true }
+  return { ...first, missedSnapshot: false }
 }
 
 /**

--- a/apps/web/src/lib/shared/__tests__/launch-checklist.test.ts
+++ b/apps/web/src/lib/shared/__tests__/launch-checklist.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { buildLaunchTasks, launchChecklistSummary, normalizeOutcome } from '../launch-checklist'
+import {
+  buildLaunchTasks,
+  isLaunchPlanActive,
+  launchChecklistSummary,
+  normalizeOutcome,
+} from '../launch-checklist'
 import type { LaunchStatus } from '../launch-checklist'
 
 const base: LaunchStatus = {
@@ -151,6 +156,13 @@ describe('buildLaunchTasks V2', () => {
     expect(summary.allComplete).toBe(true)
     expect(summary.firstWinComplete).toBe(false)
     expect(summary.resolved).toBe(true)
+  })
+
+  it('keeps the launch-plan nav until essentials resolve, even if the first win arrived early', () => {
+    expect(isLaunchPlanActive({ resolved: false, firstWinComplete: true })).toBe(true)
+    expect(isLaunchPlanActive({ resolved: true, firstWinComplete: false })).toBe(true)
+    expect(isLaunchPlanActive({ resolved: false, firstWinComplete: false })).toBe(true)
+    expect(isLaunchPlanActive({ resolved: true, firstWinComplete: true })).toBe(false)
   })
 
   it('resolves an all-skipped essentials list and hides it from the count', () => {

--- a/apps/web/src/lib/shared/__tests__/launch-checklist.test.ts
+++ b/apps/web/src/lib/shared/__tests__/launch-checklist.test.ts
@@ -36,12 +36,35 @@ describe('buildLaunchTasks V2', () => {
     expect(configured.filter((task) => task.classification === 'prerequisite')).toHaveLength(1)
   })
 
-  it('blocks an unavailable board without adding it to the readiness denominator', () => {
+  it('counts a blocked board step in the readiness denominator', () => {
     const status = { ...base, boardCount: 1, maxBoards: 1 }
     const board = buildLaunchTasks(status).find((task) => task.id === 'create-board')
     expect(board?.availability).toBe('blocked')
+    expect(board?.blocked?.kind).toBe('plan-limit')
     expect(board?.blockedReason).toMatch(/board limit/i)
-    expect(launchChecklistSummary(status).denominator).toBe(0)
+    const summary = launchChecklistSummary(status)
+    expect(summary.denominator).toBeGreaterThan(0)
+    expect(summary.doneCount).toBe(0)
+  })
+
+  it('counts a blocked Help Center step as 0/1, never 0/0', () => {
+    const summary = launchChecklistSummary({
+      ...base,
+      useCase: 'help_center',
+      features: {
+        supportInbox: false,
+        helpCenter: false,
+        statusPage: false,
+        integrations: true,
+      },
+    })
+    const article = summary.tasks.find((task) => task.id === 'help-article')
+    expect(article?.availability).toBe('blocked')
+    expect(article?.blocked).toEqual({ kind: 'module-off', productId: 'helpCenter' })
+    expect(summary.denominator).toBe(1)
+    expect(summary.doneCount).toBe(0)
+    expect(summary.blockedCount).toBe(1)
+    expect(summary.remaining).toBe(1)
   })
 
   it('removes action links when the caller lacks the responsible permission', () => {

--- a/apps/web/src/lib/shared/__tests__/launch-checklist.test.ts
+++ b/apps/web/src/lib/shared/__tests__/launch-checklist.test.ts
@@ -83,7 +83,7 @@ describe('buildLaunchTasks V2', () => {
     expect(tasks.find((task) => task.id === 'create-board')?.availability).toBe('blocked')
   })
 
-  it('keeps deferred prerequisites pending without bypassing their dependency', () => {
+  it('reads legacy deferred rows as skipped without bypassing their dependency', () => {
     const tasks = buildLaunchTasks({
       ...base,
       taskResolutions: {
@@ -96,12 +96,32 @@ describe('buildLaunchTasks V2', () => {
       },
     })
     const board = tasks.find((task) => task.id === 'create-board')!
-    expect(board.isDeferred).toBe(true)
+    expect(board.isSkipped).toBe(true)
     expect(board.isCompleted).toBe(false)
     expect(tasks.find((task) => task.id === 'distribute-feedback')?.availability).toBe('blocked')
   })
 
-  it('honors dismissal only as excluded optional polish', () => {
+  it('excludes skipped essentials from numerator and denominator', () => {
+    const summary = launchChecklistSummary({
+      ...base,
+      taskResolutions: {
+        product_feedback: {
+          'create-board': {
+            resolution: 'dismissed',
+            resolvedAt: '2026-07-13T10:00:00.000Z',
+          },
+        },
+      },
+    })
+    const board = summary.tasks.find((task) => task.id === 'create-board')!
+    expect(board.isSkipped).toBe(true)
+    expect(summary.skippedTasks.map((task) => task.id)).toContain('create-board')
+    expect(summary.denominator).toBe(1)
+    expect(summary.doneCount).toBe(0)
+    expect(summary.resolved).toBe(false)
+  })
+
+  it('treats polish dismissal as skipped without changing the essentials count', () => {
     const summary = launchChecklistSummary({
       ...base,
       hasBoards: true,
@@ -116,13 +136,13 @@ describe('buildLaunchTasks V2', () => {
       },
     })
     const branding = summary.tasks.find((task) => task.id === 'customize-branding')!
-    expect(branding.isDismissed).toBe(true)
+    expect(branding.isSkipped).toBe(true)
     expect(branding.isCompleted).toBe(false)
     expect(summary.denominator).toBe(2)
     expect(summary.doneCount).toBe(2)
   })
 
-  it('keeps first win independent of readiness completion', () => {
+  it('resolves once every prerequisite is done or skipped, without waiting for the first win', () => {
     const summary = launchChecklistSummary({
       ...base,
       hasBoards: true,
@@ -130,7 +150,49 @@ describe('buildLaunchTasks V2', () => {
     })
     expect(summary.allComplete).toBe(true)
     expect(summary.firstWinComplete).toBe(false)
-    expect(summary.resolved).toBe(false)
+    expect(summary.resolved).toBe(true)
+  })
+
+  it('resolves an all-skipped essentials list and hides it from the count', () => {
+    const summary = launchChecklistSummary({
+      ...base,
+      useCase: 'help_center',
+      features: {
+        supportInbox: false,
+        helpCenter: true,
+        statusPage: false,
+        integrations: true,
+      },
+      taskResolutions: {
+        help_center: {
+          'help-article': {
+            resolution: 'deferred',
+            resolvedAt: '2026-07-13T10:00:00.000Z',
+          },
+        },
+      },
+    })
+    expect(summary.denominator).toBe(0)
+    expect(summary.doneCount).toBe(0)
+    expect(summary.skippedTasks).toHaveLength(1)
+    expect(summary.resolved).toBe(true)
+    expect(summary.firstWinComplete).toBe(false)
+  })
+
+  it('uses the write-article copy for the Help Center essential', () => {
+    const task = buildLaunchTasks({
+      ...base,
+      useCase: 'help_center',
+      features: {
+        supportInbox: false,
+        helpCenter: true,
+        statusPage: false,
+        integrations: true,
+      },
+    }).find((row) => row.id === 'help-article')
+    expect(task?.title).toBe('Write your first article')
+    expect(task?.description).toMatch(/first answer/i)
+    expect(task?.actionLabel).toBe('Write article')
   })
 
   it('uses only the current goal task set', () => {

--- a/apps/web/src/lib/shared/__tests__/launch-checklist.test.ts
+++ b/apps/web/src/lib/shared/__tests__/launch-checklist.test.ts
@@ -52,6 +52,40 @@ describe('buildLaunchTasks V2', () => {
     expect(summary.doneCount).toBe(0)
   })
 
+  it('keeps a Help Center article blocked when the product is later turned off', () => {
+    const summary = launchChecklistSummary({
+      ...base,
+      useCase: 'help_center',
+      hasHelpArticle: true,
+      features: {
+        supportInbox: false,
+        helpCenter: false,
+        statusPage: false,
+        integrations: true,
+      },
+    })
+    const article = summary.tasks.find((task) => task.id === 'help-article')
+    expect(article?.isCompleted).toBe(false)
+    expect(article?.blocked).toEqual({ kind: 'module-off', productId: 'helpCenter' })
+    expect(summary.resolved).toBe(false)
+  })
+
+  it('keeps Connect Messenger blocked when Support is later turned off', () => {
+    const task = buildLaunchTasks({
+      ...base,
+      useCase: 'customer_support',
+      hasWidgetInstalled: true,
+      features: {
+        supportInbox: false,
+        helpCenter: false,
+        statusPage: false,
+        integrations: true,
+      },
+    }).find((row) => row.id === 'connect-messenger')
+    expect(task?.isCompleted).toBe(false)
+    expect(task?.blocked).toEqual({ kind: 'module-off', productId: 'support' })
+  })
+
   it('counts a blocked Help Center step as 0/1, never 0/0', () => {
     const summary = launchChecklistSummary({
       ...base,

--- a/apps/web/src/lib/shared/activation-action.ts
+++ b/apps/web/src/lib/shared/activation-action.ts
@@ -1,9 +1,5 @@
 import type { OnboardingOutcome, StartingPointState } from '@/lib/shared/db-types'
-import {
-  buildLaunchTasks,
-  normalizeOutcome,
-  type LaunchStatus,
-} from '@/lib/shared/launch-checklist'
+import { normalizeOutcome, type LaunchStatus } from '@/lib/shared/launch-checklist'
 
 export type ActivationSurface =
   'onboarding_handoff' | 'feedback_empty' | 'conversation_empty' | 'launch_plan'
@@ -37,7 +33,7 @@ export interface ActivationActionContext {
   startingPoint?: StartingPointState | null
 }
 
-function copyBoardAction(
+export function copyBoardLinkAction(
   outcome: OnboardingOutcome,
   status: LaunchStatus
 ): ActivationAction | null {
@@ -81,7 +77,7 @@ export function selectActivationAction({
     }
     if (!status.publicBoardLinkCopiedAt && !status.hasWidgetInstalled && !status.hasFirstWin) {
       if (status.permissions?.boardManage === false) return null
-      return copyBoardAction(outcome, status)
+      return copyBoardLinkAction(outcome, status)
     }
     return null
   }
@@ -123,7 +119,7 @@ export function selectActivationAction({
     }
     if (outcome === 'product_feedback') {
       return (
-        copyBoardAction(outcome, status) ?? {
+        copyBoardLinkAction(outcome, status) ?? {
           id: 'open-feedback-board',
           outcome,
           label: 'Open your board',
@@ -168,23 +164,7 @@ export function selectActivationAction({
     }
   }
 
-  const nextTask = buildLaunchTasks(status, outcome).find(
-    (task) =>
-      task.classification === 'prerequisite' &&
-      !task.isCompleted &&
-      !task.isDeferred &&
-      task.availability === 'available'
-  )
-  if (!nextTask) return null
-  if (nextTask.id === 'distribute-feedback') return copyBoardAction(outcome, status)
-  if (!nextTask.href) return null
-  return {
-    id: nextTask.id,
-    outcome,
-    label: nextTask.actionLabel ?? nextTask.title,
-    kind: 'link',
-    destination: nextTask.href,
-  }
+  return null
 }
 
 /**

--- a/apps/web/src/lib/shared/admin-home.ts
+++ b/apps/web/src/lib/shared/admin-home.ts
@@ -1,10 +1,11 @@
 import { getFirstEnabledAdminProductPath, type FeatureFlags } from '@/lib/shared/types/settings'
 
 /**
- * Admin landing destination. While an admin still has Getting Started
- * work, that page is home. Once the launch plan is done, the first
- * enabled product is home — Feedback, then Support, then Help Center,
- * Changelog, Status, or Analytics if every product is off.
+ * Admin landing destination. While an admin still has unskipped
+ * essentials, Getting Started is home. Once every prerequisite is done
+ * or skipped, the first enabled product is home — Feedback, then Support,
+ * then Help Center, Changelog, Status, or Analytics if every product is
+ * off. The first-win milestone no longer holds this page.
  */
 export function resolveAdminHomePath(input: {
   isAdmin: boolean

--- a/apps/web/src/lib/shared/launch-checklist.ts
+++ b/apps/web/src/lib/shared/launch-checklist.ts
@@ -70,8 +70,7 @@ export interface LaunchTask {
   availability: LaunchTaskAvailability
   classification: LaunchTaskClassification
   isCompleted: boolean
-  isDeferred: boolean
-  isDismissed: boolean
+  isSkipped: boolean
   blocked?: LaunchTaskBlocked
   blockedReason?: string
   href?: LaunchTaskHref
@@ -81,7 +80,7 @@ export interface LaunchTask {
 
 interface LaunchTaskInput extends Omit<
   LaunchTask,
-  'availability' | 'isCompleted' | 'isDeferred' | 'isDismissed' | 'blocked' | 'blockedReason'
+  'availability' | 'isCompleted' | 'isSkipped' | 'blocked' | 'blockedReason'
 > {
   completed: boolean
   canAct?: boolean
@@ -123,6 +122,13 @@ export const OUTCOME_HOME: Record<OnboardingOutcome, { label: string; href: Laun
   internal: { label: 'Open feedback', href: '/admin/feedback' },
 }
 
+export const FIRST_WIN_NOUN: Record<OnboardingOutcome, string> = {
+  product_feedback: 'customer post or vote',
+  customer_support: 'customer conversation',
+  help_center: 'published article',
+  internal: 'team idea',
+}
+
 const ALLOW_ALL: LaunchPermissions = {
   settingsManage: true,
   boardManage: true,
@@ -138,11 +144,10 @@ function materializeTask(
   resolutions: OutcomeTaskResolutions | undefined
 ): LaunchTask {
   const stored = resolutions?.[outcome]?.[task.id]
-  const isDeferred = !task.completed && stored?.resolution === 'deferred'
-  const isDismissed =
-    !task.completed && task.classification === 'polish' && stored?.resolution === 'dismissed'
+  const isSkipped =
+    !task.completed && (stored?.resolution === 'dismissed' || stored?.resolution === 'deferred')
   const blocked: LaunchTaskBlocked | undefined =
-    !task.completed && !isDismissed
+    !task.completed && !isSkipped
       ? (task.blocked ?? (task.canAct === false ? { kind: 'permission' } : undefined))
       : undefined
   const blockedReason = blocked ? (task.unavailableReason ?? blockedReasonFrom(blocked)) : undefined
@@ -153,8 +158,7 @@ function materializeTask(
     classification: task.classification,
     availability: task.completed ? 'complete' : blockedReason ? 'blocked' : 'available',
     isCompleted: task.completed,
-    isDeferred,
-    isDismissed,
+    isSkipped,
     ...(blocked ? { blocked } : {}),
     ...(blockedReason ? { blockedReason } : {}),
     ...(task.href && task.canAct !== false ? { href: task.href } : {}),
@@ -241,8 +245,8 @@ export function buildLaunchTasks(
   }
   const helpDraft: LaunchTaskInput = {
     id: 'help-article',
-    title: 'Prepare your first article',
-    description: 'Turn your draft into a useful answer for customers.',
+    title: 'Write your first article',
+    description: 'Draft the first answer your customers should find.',
     completed: Boolean(status.hasHelpArticle),
     canAct: permissions.helpCenterManage,
     ...(features.helpCenter
@@ -250,7 +254,7 @@ export function buildLaunchTasks(
       : { blocked: { kind: 'module-off' as const, productId: 'helpCenter' as const } }),
     classification: 'prerequisite',
     href: '/admin/help-center',
-    actionLabel: 'Continue article',
+    actionLabel: 'Write article',
     completedLabel: 'Open article',
   }
   const invite: LaunchTaskInput = {
@@ -325,21 +329,7 @@ export function buildLaunchTasks(
       break
   }
 
-  const tasks = inputs.map((task) => materializeTask(task, outcome, status.taskResolutions))
-  const hasOtherActionablePrerequisite = tasks.some(
-    (task) =>
-      task.classification === 'prerequisite' &&
-      task.availability === 'available' &&
-      !task.isDeferred
-  )
-  if (!hasOtherActionablePrerequisite) return tasks
-
-  const prerequisites = tasks.filter((task) => task.classification === 'prerequisite')
-  return [
-    ...prerequisites.filter((task) => !task.isDeferred),
-    ...prerequisites.filter((task) => task.isDeferred),
-    ...tasks.filter((task) => task.classification !== 'prerequisite'),
-  ]
+  return inputs.map((task) => materializeTask(task, outcome, status.taskResolutions))
 }
 
 export function launchChecklistSummary(
@@ -347,6 +337,7 @@ export function launchChecklistSummary(
   outcomeOverride?: OnboardingOutcome
 ): {
   tasks: LaunchTask[]
+  skippedTasks: LaunchTask[]
   outcome: OnboardingOutcome
   doneCount: number
   denominator: number
@@ -360,29 +351,36 @@ export function launchChecklistSummary(
   const outcome = outcomeOverride ?? normalizeOutcome(status.useCase)
   const tasks = buildLaunchTasks(status, outcome)
   const prerequisites = tasks.filter((task) => task.classification === 'prerequisite')
-  const doneCount = prerequisites.filter((task) => task.isCompleted).length
-  const remaining = prerequisites.filter((task) => !task.isCompleted).length
-  const blockedCount = prerequisites.filter((task) => task.availability === 'blocked').length
+  const skippedTasks = tasks.filter((task) => task.isSkipped && task.classification !== 'first_win')
+  const counted = prerequisites.filter((task) => !task.isSkipped)
+  const doneCount = counted.filter((task) => task.isCompleted).length
+  const remaining = counted.filter((task) => !task.isCompleted).length
+  const blockedCount = counted.filter((task) => task.availability === 'blocked').length
   const firstWinComplete = tasks.some(
     (task) => task.classification === 'first_win' && task.isCompleted
   )
+  const hasAvailable = counted.some(
+    (task) => task.availability === 'available' && !task.isCompleted
+  )
   const allComplete = remaining === 0
+  const winNoun = FIRST_WIN_NOUN[outcome]
   return {
     tasks,
+    skippedTasks,
     outcome,
     doneCount,
-    denominator: prerequisites.length,
+    denominator: counted.length,
     remaining,
     blockedCount,
     allComplete,
     firstWinComplete,
-    resolved: allComplete && firstWinComplete,
+    resolved: allComplete,
     headline: firstWinComplete
       ? 'You’re up and running'
-      : blockedCount > 0 && remaining === 0
-        ? 'Your workspace needs attention before you can launch'
-        : allComplete
-          ? 'Everything is ready for your first result'
-          : `${remaining} setup step${remaining === 1 ? '' : 's'} to go`,
+      : blockedCount > 0 && !hasAvailable
+        ? 'One thing needs attention before you can launch'
+        : remaining === 0
+          ? `You’re ready for your first ${winNoun}`
+          : `${remaining} step${remaining === 1 ? '' : 's'} to your first ${winNoun}`,
   }
 }

--- a/apps/web/src/lib/shared/launch-checklist.ts
+++ b/apps/web/src/lib/shared/launch-checklist.ts
@@ -233,7 +233,7 @@ export function buildLaunchTasks(
       : status.hasMessengerEnabled
         ? 'Messenger is configured. Add the SDK to your website to connect it.'
         : 'Turn on the Messages tab and add the SDK to your website.',
-    completed: status.hasWidgetInstalled === true,
+    completed: status.hasWidgetInstalled === true && features.supportInbox,
     canAct: permissions.settingsManage,
     ...(features.supportInbox
       ? {}
@@ -247,7 +247,7 @@ export function buildLaunchTasks(
     id: 'help-article',
     title: 'Write your first article',
     description: 'Draft the first answer your customers should find.',
-    completed: Boolean(status.hasHelpArticle),
+    completed: Boolean(status.hasHelpArticle) && features.helpCenter,
     canAct: permissions.helpCenterManage,
     ...(features.helpCenter
       ? {}

--- a/apps/web/src/lib/shared/launch-checklist.ts
+++ b/apps/web/src/lib/shared/launch-checklist.ts
@@ -384,3 +384,11 @@ export function launchChecklistSummary(
           : `${remaining} step${remaining === 1 ? '' : 's'} to your first ${winNoun}`,
   }
 }
+
+/** Sidebar still shows Getting Started until essentials resolve and the first win lands. */
+export function isLaunchPlanActive(summary: {
+  resolved: boolean
+  firstWinComplete: boolean
+}): boolean {
+  return !summary.resolved || !summary.firstWinComplete
+}

--- a/apps/web/src/lib/shared/launch-checklist.ts
+++ b/apps/web/src/lib/shared/launch-checklist.ts
@@ -4,6 +4,7 @@ import {
   type OutcomeTaskResolutions,
   type UseCaseType,
 } from '@/lib/shared/db-types'
+import type { ProductId } from '@/lib/shared/types/settings'
 
 export interface LaunchPermissions {
   settingsManage: boolean
@@ -57,6 +58,11 @@ export type LaunchTaskHref =
 export type LaunchTaskAvailability = 'available' | 'blocked' | 'complete'
 export type LaunchTaskClassification = 'prerequisite' | 'polish' | 'first_win'
 
+export interface LaunchTaskBlocked {
+  kind: 'module-off' | 'plan-limit' | 'permission'
+  productId?: ProductId
+}
+
 export interface LaunchTask {
   id: string
   title: string
@@ -66,6 +72,7 @@ export interface LaunchTask {
   isCompleted: boolean
   isDeferred: boolean
   isDismissed: boolean
+  blocked?: LaunchTaskBlocked
   blockedReason?: string
   href?: LaunchTaskHref
   actionLabel?: string
@@ -74,11 +81,28 @@ export interface LaunchTask {
 
 interface LaunchTaskInput extends Omit<
   LaunchTask,
-  'availability' | 'isCompleted' | 'isDeferred' | 'isDismissed' | 'blockedReason'
+  'availability' | 'isCompleted' | 'isDeferred' | 'isDismissed' | 'blocked' | 'blockedReason'
 > {
   completed: boolean
   canAct?: boolean
   unavailableReason?: string
+  blocked?: LaunchTaskBlocked
+}
+
+function blockedReasonFrom(blocked: LaunchTaskBlocked): string {
+  if (blocked.kind === 'module-off') {
+    const label =
+      blocked.productId === 'helpCenter'
+        ? 'Help Center'
+        : blocked.productId === 'support'
+          ? 'Customer support'
+          : 'This product'
+    return `${label} is turned off for this workspace. Ask a workspace admin to enable it in Settings → General.`
+  }
+  if (blocked.kind === 'plan-limit') {
+    return "You've reached the board limit for your plan. Remove a board or upgrade to continue."
+  }
+  return 'Ask a workspace admin to complete this step.'
 }
 
 export function normalizeOutcome(useCase?: UseCaseType | null): OnboardingOutcome {
@@ -117,11 +141,11 @@ function materializeTask(
   const isDeferred = !task.completed && stored?.resolution === 'deferred'
   const isDismissed =
     !task.completed && task.classification === 'polish' && stored?.resolution === 'dismissed'
-  const blockedReason =
+  const blocked: LaunchTaskBlocked | undefined =
     !task.completed && !isDismissed
-      ? (task.unavailableReason ??
-        (task.canAct === false ? 'Ask a workspace admin to complete this step.' : undefined))
+      ? (task.blocked ?? (task.canAct === false ? { kind: 'permission' } : undefined))
       : undefined
+  const blockedReason = blocked ? (task.unavailableReason ?? blockedReasonFrom(blocked)) : undefined
   return {
     id: task.id,
     title: task.title,
@@ -131,6 +155,7 @@ function materializeTask(
     isCompleted: task.completed,
     isDeferred,
     isDismissed,
+    ...(blocked ? { blocked } : {}),
     ...(blockedReason ? { blockedReason } : {}),
     ...(task.href && task.canAct !== false ? { href: task.href } : {}),
     ...(task.actionLabel ? { actionLabel: task.actionLabel } : {}),
@@ -165,9 +190,13 @@ export function buildLaunchTasks(
         : 'Give customers a place to submit and vote on ideas.',
     completed: hasGoalBoard,
     canAct: permissions.boardManage,
-    unavailableReason: boardCapacityBlocked
-      ? "You've reached the board limit for your plan. Remove a board or upgrade to continue."
-      : undefined,
+    ...(boardCapacityBlocked
+      ? {
+          blocked: { kind: 'plan-limit' as const },
+          unavailableReason:
+            "You've reached the board limit for your plan. Remove a board or upgrade to continue.",
+        }
+      : {}),
     classification: 'prerequisite',
     href: '/admin/settings/boards',
     actionLabel: 'Create board',
@@ -202,9 +231,9 @@ export function buildLaunchTasks(
         : 'Turn on the Messages tab and add the SDK to your website.',
     completed: status.hasWidgetInstalled === true,
     canAct: permissions.settingsManage,
-    unavailableReason: features.supportInbox
-      ? undefined
-      : 'Customer support is turned off for this workspace. Ask a workspace admin to enable it in Settings → General.',
+    ...(features.supportInbox
+      ? {}
+      : { blocked: { kind: 'module-off' as const, productId: 'support' as const } }),
     classification: 'prerequisite',
     href: '/admin/settings/widget/install',
     actionLabel: 'Connect Messenger',
@@ -216,9 +245,9 @@ export function buildLaunchTasks(
     description: 'Turn your draft into a useful answer for customers.',
     completed: Boolean(status.hasHelpArticle),
     canAct: permissions.helpCenterManage,
-    unavailableReason: features.helpCenter
-      ? undefined
-      : 'Help Center is turned off for this workspace. Ask a workspace admin to enable it in Settings → General.',
+    ...(features.helpCenter
+      ? {}
+      : { blocked: { kind: 'module-off' as const, productId: 'helpCenter' as const } }),
     classification: 'prerequisite',
     href: '/admin/help-center',
     actionLabel: 'Continue article',
@@ -252,9 +281,12 @@ export function buildLaunchTasks(
     description: 'Keep Quackback in sync with the tools your team already uses.',
     completed: Boolean(status.hasIntegration),
     canAct: permissions.integrationManage,
-    unavailableReason: features.integrations
-      ? undefined
-      : 'Integrations are not included in your current plan.',
+    ...(features.integrations
+      ? {}
+      : {
+          blocked: { kind: 'plan-limit' as const },
+          unavailableReason: 'Integrations are not included in your current plan.',
+        }),
     classification: 'polish',
     href: '/admin/settings/integrations',
     actionLabel: 'Connect',
@@ -327,14 +359,10 @@ export function launchChecklistSummary(
 } {
   const outcome = outcomeOverride ?? normalizeOutcome(status.useCase)
   const tasks = buildLaunchTasks(status, outcome)
-  const availableSteps = tasks.filter(
-    (task) => task.classification === 'prerequisite' && task.availability !== 'blocked'
-  )
-  const doneCount = availableSteps.filter((task) => task.isCompleted).length
-  const remaining = availableSteps.filter((task) => !task.isCompleted).length
-  const blockedCount = tasks.filter(
-    (task) => task.classification === 'prerequisite' && task.availability === 'blocked'
-  ).length
+  const prerequisites = tasks.filter((task) => task.classification === 'prerequisite')
+  const doneCount = prerequisites.filter((task) => task.isCompleted).length
+  const remaining = prerequisites.filter((task) => !task.isCompleted).length
+  const blockedCount = prerequisites.filter((task) => task.availability === 'blocked').length
   const firstWinComplete = tasks.some(
     (task) => task.classification === 'first_win' && task.isCompleted
   )
@@ -343,7 +371,7 @@ export function launchChecklistSummary(
     tasks,
     outcome,
     doneCount,
-    denominator: availableSteps.length,
+    denominator: prerequisites.length,
     remaining,
     blockedCount,
     allComplete,

--- a/apps/web/src/routes/admin/getting-started.tsx
+++ b/apps/web/src/routes/admin/getting-started.tsx
@@ -26,14 +26,16 @@ import { setLaunchTaskResolutionFn } from '@/lib/server/functions/admin'
 import { setActivationGoalFn } from '@/lib/server/functions/activation'
 import { updateFeatureFlagsFn } from '@/lib/server/functions/feature-flags'
 import {
+  FIRST_WIN_NOUN,
   launchChecklistSummary,
   OUTCOME_HOME,
   OUTCOME_TAB_LABEL,
+  type LaunchStatus,
   type LaunchTask,
 } from '@/lib/shared/launch-checklist'
 import { normalizeOnboardingOutcome, type OnboardingOutcome } from '@/lib/shared/db-types'
 import { cn } from '@/lib/shared/utils'
-import { selectActivationAction } from '@/lib/shared/activation-action'
+import { copyBoardLinkAction } from '@/lib/shared/activation-action'
 import {
   getProductFlagUpdate,
   PRODUCT_DEFINITIONS,
@@ -53,7 +55,7 @@ function GettingStartedPage() {
     ...adminQueries.onboardingStatus(),
     refetchInterval: (query) => {
       const data = query.state.data
-      return data && launchChecklistSummary(data).resolved ? false : 15_000
+      return data && launchChecklistSummary(data).firstWinComplete ? false : 15_000
     },
   })
   const queryClient = useQueryClient()
@@ -65,14 +67,6 @@ function GettingStartedPage() {
   const [goalDraft, setGoalDraft] = useState<OnboardingOutcome>(outcome)
   const changeGoalButtonRef = useRef<HTMLButtonElement>(null)
   const canManage = status.permissions.settingsManage
-  const nextAction = selectActivationAction({ surface: 'launch_plan', status })
-  const nextTask = nextAction
-    ? summary.tasks.find((task) =>
-        nextAction.id === 'copy-board-link'
-          ? task.id === 'distribute-feedback'
-          : task.id === nextAction.id
-      )
-    : undefined
 
   useEffect(() => setGoalDraft(outcome), [outcome])
 
@@ -111,11 +105,32 @@ function GettingStartedPage() {
 
   const goalMutation = useMutation({
     mutationFn: (next: OnboardingOutcome) => setActivationGoalFn({ data: { outcome: next } }),
-    onSuccess: async () => {
+    onSuccess: async (result) => {
       await queryClient.invalidateQueries({ queryKey: ['admin', 'onboarding'] })
       await router.invalidate()
       setEditingGoal(false)
       requestAnimationFrame(() => changeGoalButtonRef.current?.focus())
+      if (result.enabledModules.length === 1) {
+        toast.success(
+          intl.formatMessage(
+            {
+              id: 'activation.goal.enabledOne',
+              defaultMessage: '{product} turned on',
+            },
+            { product: result.enabledModules[0] }
+          )
+        )
+      } else if (result.enabledModules.length > 1) {
+        toast.success(
+          intl.formatMessage(
+            {
+              id: 'activation.goal.enabledMany',
+              defaultMessage: 'Turned on {products}',
+            },
+            { products: result.enabledModules.join(', ') }
+          )
+        )
+      }
     },
     onError: (error) =>
       toast.error(
@@ -128,31 +143,45 @@ function GettingStartedPage() {
       ),
   })
 
-  const prerequisiteTasks = summary.tasks.filter((task) => task.classification === 'prerequisite')
-  const polishTasks = summary.tasks.filter((task) => task.classification === 'polish')
+  const prerequisiteTasks = summary.tasks.filter(
+    (task) => task.classification === 'prerequisite' && !task.isSkipped
+  )
+  const polishTasks = summary.tasks.filter(
+    (task) => task.classification === 'polish' && !task.isSkipped
+  )
   const firstWinTask = summary.tasks.find((task) => task.classification === 'first_win')
+  const currentTask = prerequisiteTasks.find(
+    (task) => task.availability === 'available' && !task.isCompleted
+  )
+  const allPrereqsSkipped =
+    summary.denominator === 0 &&
+    summary.skippedTasks.some((task) => task.classification === 'prerequisite')
+  const winNoun = FIRST_WIN_NOUN[outcome]
   const pageDescription = summary.firstWinComplete
     ? intl.formatMessage({
         id: 'activation.summary.firstWin',
         defaultMessage: 'You’re up and running',
       })
-    : summary.blockedCount > 0 && summary.remaining === 0
+    : summary.blockedCount > 0 && !currentTask
       ? intl.formatMessage({
           id: 'activation.summary.attention',
-          defaultMessage: 'Your workspace needs attention before you can launch',
+          defaultMessage: 'One thing needs attention before you can launch',
         })
-      : summary.allComplete
-        ? intl.formatMessage({
-            id: 'activation.summary.ready',
-            defaultMessage: 'Everything is ready for your first result',
-          })
+      : summary.remaining === 0
+        ? intl.formatMessage(
+            {
+              id: 'activation.summary.ready',
+              defaultMessage: 'You’re ready for your first {win}',
+            },
+            { win: winNoun }
+          )
         : intl.formatMessage(
             {
               id: 'activation.summary.remaining',
               defaultMessage:
-                '{count, plural, one {# setup step to go} other {# setup steps to go}}',
+                '{count, plural, one {# step to your first {win}} other {# steps to your first {win}}}',
             },
-            { count: summary.remaining }
+            { count: summary.remaining, win: winNoun }
           )
 
   return (
@@ -187,18 +216,29 @@ function GettingStartedPage() {
                 />
               </h2>
             </div>
-            <Button
-              ref={changeGoalButtonRef}
-              type="button"
-              variant="outline"
-              size="sm"
-              className="h-11 sm:h-9"
-              disabled={!canManage || status.goalManaged}
-              onClick={() => setEditingGoal((value) => !value)}
-            >
-              <PencilSquareIcon className="h-4 w-4" />
-              <FormattedMessage id="activation.goal.change" defaultMessage="Change goal" />
-            </Button>
+            <div className="flex flex-wrap items-center gap-2">
+              <Button asChild variant="ghost" size="sm" className="h-11 sm:h-9">
+                <Link to={OUTCOME_HOME[outcome].href}>
+                  <FormattedMessage
+                    id={`activation.home.${outcome}`}
+                    defaultMessage={OUTCOME_HOME[outcome].label}
+                  />
+                  <ArrowRightIcon className="h-4 w-4" />
+                </Link>
+              </Button>
+              <Button
+                ref={changeGoalButtonRef}
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-11 sm:h-9"
+                disabled={!canManage || status.goalManaged}
+                onClick={() => setEditingGoal((value) => !value)}
+              >
+                <PencilSquareIcon className="h-4 w-4" />
+                <FormattedMessage id="activation.goal.change" defaultMessage="Change goal" />
+              </Button>
+            </div>
           </div>
           {status.goalManaged && (
             <p className="text-xs text-muted-foreground">
@@ -246,34 +286,6 @@ function GettingStartedPage() {
           )}
         </section>
 
-        {nextAction && nextTask && (
-          <section
-            aria-labelledby="next-step-heading"
-            className="rounded-2xl border border-primary/25 bg-primary/5 p-6"
-          >
-            <p className="text-xs font-medium uppercase tracking-wide text-primary">
-              <FormattedMessage id="activation.nextStep.eyebrow" defaultMessage="Next step" />
-            </p>
-            <h2 id="next-step-heading" className="mt-2 text-lg font-semibold">
-              <FormattedMessage
-                id={`activation.task.${outcome}.${nextTask.id}.title`}
-                defaultMessage={nextTask.title}
-              />
-            </h2>
-            <p className="mt-1 max-w-xl text-sm text-muted-foreground">
-              <FormattedMessage
-                id={`activation.task.${outcome}.${nextTask.id}.description`}
-                defaultMessage={nextTask.description}
-              />
-            </p>
-            <ActivationActionButton
-              action={nextAction}
-              surface="launch_plan"
-              className="mt-5 h-11"
-            />
-          </section>
-        )}
-
         <section aria-labelledby="readiness-heading" className="space-y-4">
           <div className="flex items-end justify-between gap-4">
             <div>
@@ -290,39 +302,90 @@ function GettingStartedPage() {
                 />
               </p>
             </div>
-            <span className="text-sm font-medium tabular-nums" aria-live="polite">
-              {summary.doneCount} / {summary.denominator}
-            </span>
+            {!allPrereqsSkipped && (
+              <span className="text-sm font-medium tabular-nums" aria-live="polite">
+                {summary.doneCount} / {summary.denominator}
+              </span>
+            )}
           </div>
-          <div
-            className="h-2 overflow-hidden rounded-full bg-muted"
-            role="progressbar"
-            aria-label={intl.formatMessage({
-              id: 'activation.progress.label',
-              defaultMessage: 'Setup progress',
-            })}
-            aria-valuemin={0}
-            aria-valuemax={summary.denominator}
-            aria-valuenow={summary.doneCount}
-          >
-            <div
-              className="h-full rounded-full bg-primary transition-transform duration-300 motion-reduce:transition-none"
-              style={{
-                transform: `scaleX(${summary.denominator ? summary.doneCount / summary.denominator : 0})`,
-                transformOrigin: 'left',
-              }}
-            />
-          </div>
-          <TaskList
-            tasks={prerequisiteTasks}
-            outcome={outcome}
-            canManage={canManage}
-            pending={resolutionMutation.isPending || enableProductMutation.isPending}
-            showLinks={false}
-            onResolution={(taskId, resolution) => resolutionMutation.mutate({ taskId, resolution })}
-            onEnableProduct={(productId) => enableProductMutation.mutate(productId)}
-          />
+          {allPrereqsSkipped ? (
+            <p className="rounded-xl border bg-card px-5 py-4 text-sm text-muted-foreground">
+              <FormattedMessage
+                id="activation.readiness.allSkipped"
+                defaultMessage="All setup steps are skipped — add one back anytime, or head to your {home}."
+                values={{ home: OUTCOME_HOME[outcome].label }}
+              />
+            </p>
+          ) : (
+            <>
+              <div
+                className="h-2 overflow-hidden rounded-full bg-muted"
+                role="progressbar"
+                aria-label={intl.formatMessage({
+                  id: 'activation.progress.label',
+                  defaultMessage: 'Setup progress',
+                })}
+                aria-valuemin={0}
+                aria-valuemax={summary.denominator}
+                aria-valuenow={summary.doneCount}
+              >
+                <div
+                  className="h-full rounded-full bg-primary transition-transform duration-300 motion-reduce:transition-none"
+                  style={{
+                    transform: `scaleX(${summary.denominator ? summary.doneCount / summary.denominator : 0})`,
+                    transformOrigin: 'left',
+                  }}
+                />
+              </div>
+              <TaskList
+                tasks={prerequisiteTasks}
+                outcome={outcome}
+                status={status}
+                canManage={canManage}
+                pending={resolutionMutation.isPending || enableProductMutation.isPending}
+                currentTaskId={currentTask?.id}
+                onResolution={(taskId, resolution) =>
+                  resolutionMutation.mutate({ taskId, resolution })
+                }
+                onEnableProduct={(productId) => enableProductMutation.mutate(productId)}
+              />
+            </>
+          )}
         </section>
+
+        {summary.skippedTasks.length > 0 && (
+          <details className="group rounded-xl border bg-card">
+            <summary className="cursor-pointer list-none px-5 py-4 marker:hidden">
+              <div className="flex items-baseline justify-between gap-3">
+                <h2 id="skipped-heading" className="text-base font-semibold">
+                  <FormattedMessage id="activation.skipped.title" defaultMessage="Skipped steps" />
+                </h2>
+                <span className="text-xs tabular-nums text-muted-foreground">
+                  {summary.skippedTasks.length}
+                </span>
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">
+                <FormattedMessage
+                  id="activation.skipped.description"
+                  defaultMessage="Add a step back anytime to put it on your launch plan."
+                />
+              </p>
+            </summary>
+            <div className="border-t p-3">
+              <TaskList
+                tasks={summary.skippedTasks}
+                outcome={outcome}
+                status={status}
+                canManage={canManage}
+                pending={resolutionMutation.isPending || enableProductMutation.isPending}
+                onResolution={(taskId, resolution) =>
+                  resolutionMutation.mutate({ taskId, resolution })
+                }
+                onEnableProduct={(productId) => enableProductMutation.mutate(productId)}
+              />
+            </div>
+          </details>
+        )}
 
         {polishTasks.length > 0 && (
           <details className="group rounded-xl border bg-card">
@@ -341,9 +404,9 @@ function GettingStartedPage() {
               <TaskList
                 tasks={polishTasks}
                 outcome={outcome}
+                status={status}
                 canManage={canManage}
                 pending={resolutionMutation.isPending || enableProductMutation.isPending}
-                showLinks
                 onResolution={(taskId, resolution) =>
                   resolutionMutation.mutate({ taskId, resolution })
                 }
@@ -438,50 +501,65 @@ function productLabel(productId: ProductId): string {
 function TaskList({
   tasks,
   outcome,
+  status,
   canManage,
   pending,
-  showLinks,
+  currentTaskId,
   onResolution,
   onEnableProduct,
 }: {
   tasks: LaunchTask[]
   outcome: OnboardingOutcome
+  status: LaunchStatus
   canManage: boolean
   pending: boolean
-  showLinks: boolean
-  onResolution: (taskId: string, resolution: 'deferred' | 'dismissed' | null) => void
+  currentTaskId?: string
+  onResolution: (taskId: string, resolution: 'dismissed' | null) => void
   onEnableProduct: (productId: ProductId) => void
 }) {
   return (
-    <ul className="divide-y rounded-xl border bg-card">
+    <ul className="divide-y overflow-hidden rounded-xl border bg-card">
       {tasks.map((task) => {
         const moduleOffProduct =
           task.blocked?.kind === 'module-off' ? task.blocked.productId : undefined
         const canEnableModule = Boolean(moduleOffProduct && canManage)
         const waitingOnAdmin = Boolean(moduleOffProduct && !canManage)
+        const isCurrent = currentTaskId === task.id
+        const copyAction =
+          task.id === 'distribute-feedback' && !task.isCompleted && !task.isSkipped
+            ? copyBoardLinkAction(outcome, status)
+            : null
+        const description =
+          canEnableModule && moduleOffProduct
+            ? `${productLabel(moduleOffProduct)} was turned off in Settings. Turn it back on to continue — it’s your workspace goal.`
+            : (task.blockedReason ?? task.description)
         return (
-          <li key={task.id} className={cn('p-5', task.isDismissed && 'bg-muted/20')}>
+          <li
+            key={task.id}
+            className={cn(
+              'p-5',
+              isCurrent && 'border-l-[3px] border-l-primary bg-primary/5',
+              task.isSkipped && 'bg-muted/20'
+            )}
+          >
             <div className="flex items-start gap-4">
               <TaskStateIcon task={task} />
               <div className="min-w-0 flex-1">
                 <div className="flex flex-wrap items-center gap-2">
                   <h3
-                    className={cn(
-                      'text-sm font-medium',
-                      task.isDismissed && 'text-muted-foreground'
-                    )}
+                    className={cn('text-sm font-medium', task.isSkipped && 'text-muted-foreground')}
                   >
                     <FormattedMessage
                       id={`activation.task.${outcome}.${task.id}.title`}
                       defaultMessage={task.title}
                     />
                   </h3>
-                  {task.isDeferred && (
-                    <Badge variant="secondary">
-                      <FormattedMessage id="activation.state.later" defaultMessage="For later" />
+                  {isCurrent && (
+                    <Badge size="sm" shape="pill" variant="secondary">
+                      <FormattedMessage id="activation.state.upNext" defaultMessage="Up next" />
                     </Badge>
                   )}
-                  {task.isDismissed && (
+                  {task.isSkipped && (
                     <Badge variant="secondary">
                       <FormattedMessage id="activation.state.skipped" defaultMessage="Skipped" />
                     </Badge>
@@ -494,7 +572,8 @@ function TaskList({
                       />
                     </Badge>
                   ) : (
-                    task.availability === 'blocked' && (
+                    task.availability === 'blocked' &&
+                    !task.isSkipped && (
                       <Badge variant="outline">
                         <FormattedMessage
                           id="activation.state.attention"
@@ -506,8 +585,8 @@ function TaskList({
                 </div>
                 <p className="mt-1 text-xs text-muted-foreground">
                   <FormattedMessage
-                    id={`activation.task.${outcome}.${task.id}.${task.blockedReason ? 'blocked' : 'description'}`}
-                    defaultMessage={task.blockedReason ?? task.description}
+                    id={`activation.task.${outcome}.${task.id}.${task.blockedReason && !canEnableModule ? 'blocked' : 'description'}`}
+                    defaultMessage={description}
                   />
                 </p>
                 <div className="mt-3 flex flex-wrap gap-2">
@@ -526,63 +605,52 @@ function TaskList({
                       />
                     </Button>
                   )}
-                  {showLinks && !task.isDismissed && task.href && (
-                    <Button asChild size="sm" variant="outline" className="h-11 sm:h-9">
-                      <Link to={task.href}>
-                        <FormattedMessage
-                          id={`activation.task.${outcome}.${task.id}.${task.isCompleted ? 'completedAction' : 'action'}`}
-                          defaultMessage={task.isCompleted ? task.completedLabel : task.actionLabel}
-                        />
-                        <ArrowRightIcon className="h-3.5 w-3.5" />
-                      </Link>
-                    </Button>
+                  {copyAction && (
+                    <ActivationActionButton
+                      action={copyAction}
+                      surface="launch_plan"
+                      className="h-11 sm:h-9"
+                    />
                   )}
-                  {!waitingOnAdmin &&
-                    !task.isCompleted &&
-                    canManage &&
-                    task.classification === 'prerequisite' && (
+                  {!copyAction &&
+                    !canEnableModule &&
+                    !waitingOnAdmin &&
+                    !task.isSkipped &&
+                    task.href && (
                       <Button
-                        type="button"
+                        asChild
                         size="sm"
-                        variant="ghost"
+                        variant={isCurrent ? 'default' : 'outline'}
                         className="h-11 sm:h-9"
-                        disabled={pending}
-                        onClick={() => onResolution(task.id, task.isDeferred ? null : 'deferred')}
                       >
-                        {task.isDeferred ? (
-                          <ArrowUturnLeftIcon className="h-4 w-4" />
-                        ) : (
-                          <ClockIcon className="h-4 w-4" />
-                        )}
-                        <FormattedMessage
-                          id={
-                            task.isDeferred
-                              ? 'activation.action.moveUp'
-                              : 'activation.action.doLater'
-                          }
-                          defaultMessage={task.isDeferred ? 'Move up' : 'Do later'}
-                        />
+                        <Link to={task.href}>
+                          <FormattedMessage
+                            id={`activation.task.${outcome}.${task.id}.${task.isCompleted ? 'completedAction' : 'action'}`}
+                            defaultMessage={
+                              task.isCompleted ? task.completedLabel : task.actionLabel
+                            }
+                          />
+                          <ArrowRightIcon className="h-3.5 w-3.5" />
+                        </Link>
                       </Button>
                     )}
-                  {!task.isCompleted && canManage && task.classification === 'polish' && (
+                  {!waitingOnAdmin && !task.isCompleted && canManage && (
                     <Button
                       type="button"
                       size="sm"
                       variant="ghost"
                       className="h-11 sm:h-9"
                       disabled={pending}
-                      onClick={() => onResolution(task.id, task.isDismissed ? null : 'dismissed')}
+                      onClick={() => onResolution(task.id, task.isSkipped ? null : 'dismissed')}
                     >
-                      {task.isDismissed ? (
+                      {task.isSkipped ? (
                         <ArrowUturnLeftIcon className="h-4 w-4" />
                       ) : (
                         <MinusIcon className="h-4 w-4" />
                       )}
                       <FormattedMessage
-                        id={
-                          task.isDismissed ? 'activation.action.addBack' : 'activation.action.skip'
-                        }
-                        defaultMessage={task.isDismissed ? 'Add back' : 'Skip'}
+                        id={task.isSkipped ? 'activation.action.addBack' : 'activation.action.skip'}
+                        defaultMessage={task.isSkipped ? 'Add back' : 'Skip'}
                       />
                     </Button>
                   )}
@@ -601,9 +669,7 @@ function TaskStateIcon({ task }: { task: LaunchTask }) {
     <CheckIcon className="h-4 w-4" />
   ) : task.availability === 'blocked' ? (
     <LockClosedIcon className="h-4 w-4" />
-  ) : task.isDeferred ? (
-    <ClockIcon className="h-4 w-4" />
-  ) : task.isDismissed ? (
+  ) : task.isSkipped ? (
     <MinusIcon className="h-4 w-4" />
   ) : (
     <span className="h-2 w-2 rounded-full bg-current" />

--- a/apps/web/src/routes/admin/getting-started.tsx
+++ b/apps/web/src/routes/admin/getting-started.tsx
@@ -28,6 +28,7 @@ import { setActivationGoalFn } from '@/lib/server/functions/activation'
 import { updateFeatureFlagsFn } from '@/lib/server/functions/feature-flags'
 import {
   FIRST_WIN_NOUN,
+  isLaunchPlanActive,
   launchChecklistSummary,
   OUTCOME_HOME,
   OUTCOME_TAB_LABEL,
@@ -56,7 +57,8 @@ function GettingStartedPage() {
     ...adminQueries.onboardingStatus(),
     refetchInterval: (query) => {
       const data = query.state.data
-      return data && launchChecklistSummary(data).firstWinComplete ? false : 15_000
+      if (!data) return 15_000
+      return isLaunchPlanActive(launchChecklistSummary(data)) ? 15_000 : false
     },
   })
   const queryClient = useQueryClient()

--- a/apps/web/src/routes/admin/getting-started.tsx
+++ b/apps/web/src/routes/admin/getting-started.tsx
@@ -21,6 +21,7 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { PageHeader } from '@/components/shared/page-header'
 import { UseCaseSelector } from '@/components/onboarding/use-case-selector'
 import { ActivationActionButton } from '@/components/admin/activation-action-button'
+import { toastEnabledModules } from '@/lib/client/enabled-modules-toast'
 import { adminQueries } from '@/lib/client/queries/admin'
 import { setLaunchTaskResolutionFn } from '@/lib/server/functions/admin'
 import { setActivationGoalFn } from '@/lib/server/functions/activation'
@@ -110,27 +111,7 @@ function GettingStartedPage() {
       await router.invalidate()
       setEditingGoal(false)
       requestAnimationFrame(() => changeGoalButtonRef.current?.focus())
-      if (result.enabledModules.length === 1) {
-        toast.success(
-          intl.formatMessage(
-            {
-              id: 'activation.goal.enabledOne',
-              defaultMessage: '{product} turned on',
-            },
-            { product: result.enabledModules[0] }
-          )
-        )
-      } else if (result.enabledModules.length > 1) {
-        toast.success(
-          intl.formatMessage(
-            {
-              id: 'activation.goal.enabledMany',
-              defaultMessage: 'Turned on {products}',
-            },
-            { products: result.enabledModules.join(', ') }
-          )
-        )
-      }
+      toastEnabledModules(result.enabledModules)
     },
     onError: (error) =>
       toast.error(

--- a/apps/web/src/routes/admin/getting-started.tsx
+++ b/apps/web/src/routes/admin/getting-started.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { createFileRoute, Link } from '@tanstack/react-router'
+import { createFileRoute, Link, useRouter } from '@tanstack/react-router'
 import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
 import {
   ArrowPathIcon,
@@ -24,6 +24,7 @@ import { ActivationActionButton } from '@/components/admin/activation-action-but
 import { adminQueries } from '@/lib/client/queries/admin'
 import { setLaunchTaskResolutionFn } from '@/lib/server/functions/admin'
 import { setActivationGoalFn } from '@/lib/server/functions/activation'
+import { updateFeatureFlagsFn } from '@/lib/server/functions/feature-flags'
 import {
   launchChecklistSummary,
   OUTCOME_HOME,
@@ -33,6 +34,11 @@ import {
 import { normalizeOnboardingOutcome, type OnboardingOutcome } from '@/lib/shared/db-types'
 import { cn } from '@/lib/shared/utils'
 import { selectActivationAction } from '@/lib/shared/activation-action'
+import {
+  getProductFlagUpdate,
+  PRODUCT_DEFINITIONS,
+  type ProductId,
+} from '@/lib/shared/types/settings'
 
 export const Route = createFileRoute('/admin/getting-started')({
   loader: async ({ context }) => {
@@ -51,6 +57,7 @@ function GettingStartedPage() {
     },
   })
   const queryClient = useQueryClient()
+  const router = useRouter()
   const status = statusQuery.data
   const outcome = normalizeOnboardingOutcome(status.useCase) ?? 'product_feedback'
   const summary = launchChecklistSummary(status, outcome)
@@ -84,10 +91,29 @@ function GettingStartedPage() {
       ),
   })
 
+  const enableProductMutation = useMutation({
+    mutationFn: (productId: ProductId) =>
+      updateFeatureFlagsFn({ data: getProductFlagUpdate(productId, true) }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['admin', 'onboarding'] })
+      await router.invalidate()
+    },
+    onError: (error) =>
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : intl.formatMessage({
+              id: 'activation.error.enableProduct',
+              defaultMessage: 'We couldn’t turn that product on. Try again.',
+            })
+      ),
+  })
+
   const goalMutation = useMutation({
     mutationFn: (next: OnboardingOutcome) => setActivationGoalFn({ data: { outcome: next } }),
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ['admin', 'onboarding'] })
+      await router.invalidate()
       setEditingGoal(false)
       requestAnimationFrame(() => changeGoalButtonRef.current?.focus())
     },
@@ -282,7 +308,7 @@ function GettingStartedPage() {
             <div
               className="h-full rounded-full bg-primary transition-transform duration-300 motion-reduce:transition-none"
               style={{
-                transform: `scaleX(${summary.denominator ? summary.doneCount / summary.denominator : 1})`,
+                transform: `scaleX(${summary.denominator ? summary.doneCount / summary.denominator : 0})`,
                 transformOrigin: 'left',
               }}
             />
@@ -291,9 +317,10 @@ function GettingStartedPage() {
             tasks={prerequisiteTasks}
             outcome={outcome}
             canManage={canManage}
-            pending={resolutionMutation.isPending}
+            pending={resolutionMutation.isPending || enableProductMutation.isPending}
             showLinks={false}
             onResolution={(taskId, resolution) => resolutionMutation.mutate({ taskId, resolution })}
+            onEnableProduct={(productId) => enableProductMutation.mutate(productId)}
           />
         </section>
 
@@ -315,11 +342,12 @@ function GettingStartedPage() {
                 tasks={polishTasks}
                 outcome={outcome}
                 canManage={canManage}
-                pending={resolutionMutation.isPending}
+                pending={resolutionMutation.isPending || enableProductMutation.isPending}
                 showLinks
                 onResolution={(taskId, resolution) =>
                   resolutionMutation.mutate({ taskId, resolution })
                 }
+                onEnableProduct={(productId) => enableProductMutation.mutate(productId)}
               />
             </div>
           </details>
@@ -403,6 +431,10 @@ function GettingStartedPage() {
   )
 }
 
+function productLabel(productId: ProductId): string {
+  return PRODUCT_DEFINITIONS.find((product) => product.id === productId)?.label ?? 'product'
+}
+
 function TaskList({
   tasks,
   outcome,
@@ -410,6 +442,7 @@ function TaskList({
   pending,
   showLinks,
   onResolution,
+  onEnableProduct,
 }: {
   tasks: LaunchTask[]
   outcome: OnboardingOutcome
@@ -417,107 +450,148 @@ function TaskList({
   pending: boolean
   showLinks: boolean
   onResolution: (taskId: string, resolution: 'deferred' | 'dismissed' | null) => void
+  onEnableProduct: (productId: ProductId) => void
 }) {
   return (
     <ul className="divide-y rounded-xl border bg-card">
-      {tasks.map((task) => (
-        <li key={task.id} className={cn('p-5', task.isDismissed && 'bg-muted/20')}>
-          <div className="flex items-start gap-4">
-            <TaskStateIcon task={task} />
-            <div className="min-w-0 flex-1">
-              <div className="flex flex-wrap items-center gap-2">
-                <h3
-                  className={cn('text-sm font-medium', task.isDismissed && 'text-muted-foreground')}
-                >
-                  <FormattedMessage
-                    id={`activation.task.${outcome}.${task.id}.title`}
-                    defaultMessage={task.title}
-                  />
-                </h3>
-                {task.isDeferred && (
-                  <Badge variant="secondary">
-                    <FormattedMessage id="activation.state.later" defaultMessage="For later" />
-                  </Badge>
-                )}
-                {task.isDismissed && (
-                  <Badge variant="secondary">
-                    <FormattedMessage id="activation.state.skipped" defaultMessage="Skipped" />
-                  </Badge>
-                )}
-                {task.availability === 'blocked' && (
-                  <Badge variant="outline">
+      {tasks.map((task) => {
+        const moduleOffProduct =
+          task.blocked?.kind === 'module-off' ? task.blocked.productId : undefined
+        const canEnableModule = Boolean(moduleOffProduct && canManage)
+        const waitingOnAdmin = Boolean(moduleOffProduct && !canManage)
+        return (
+          <li key={task.id} className={cn('p-5', task.isDismissed && 'bg-muted/20')}>
+            <div className="flex items-start gap-4">
+              <TaskStateIcon task={task} />
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <h3
+                    className={cn(
+                      'text-sm font-medium',
+                      task.isDismissed && 'text-muted-foreground'
+                    )}
+                  >
                     <FormattedMessage
-                      id="activation.state.attention"
-                      defaultMessage="Needs attention"
+                      id={`activation.task.${outcome}.${task.id}.title`}
+                      defaultMessage={task.title}
                     />
-                  </Badge>
-                )}
-              </div>
-              <p className="mt-1 text-xs text-muted-foreground">
-                <FormattedMessage
-                  id={`activation.task.${outcome}.${task.id}.${task.blockedReason ? 'blocked' : 'description'}`}
-                  defaultMessage={task.blockedReason ?? task.description}
-                />
-              </p>
-              <div className="mt-3 flex flex-wrap gap-2">
-                {showLinks && !task.isDismissed && task.href && (
-                  <Button asChild size="sm" variant="outline" className="h-11 sm:h-9">
-                    <Link to={task.href}>
+                  </h3>
+                  {task.isDeferred && (
+                    <Badge variant="secondary">
+                      <FormattedMessage id="activation.state.later" defaultMessage="For later" />
+                    </Badge>
+                  )}
+                  {task.isDismissed && (
+                    <Badge variant="secondary">
+                      <FormattedMessage id="activation.state.skipped" defaultMessage="Skipped" />
+                    </Badge>
+                  )}
+                  {waitingOnAdmin ? (
+                    <Badge variant="outline">
                       <FormattedMessage
-                        id={`activation.task.${outcome}.${task.id}.${task.isCompleted ? 'completedAction' : 'action'}`}
-                        defaultMessage={task.isCompleted ? task.completedLabel : task.actionLabel}
+                        id="activation.state.waiting"
+                        defaultMessage="Waiting on an admin"
                       />
-                      <ArrowRightIcon className="h-3.5 w-3.5" />
-                    </Link>
-                  </Button>
-                )}
-                {!task.isCompleted && canManage && task.classification === 'prerequisite' && (
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="ghost"
-                    className="h-11 sm:h-9"
-                    disabled={pending}
-                    onClick={() => onResolution(task.id, task.isDeferred ? null : 'deferred')}
-                  >
-                    {task.isDeferred ? (
-                      <ArrowUturnLeftIcon className="h-4 w-4" />
-                    ) : (
-                      <ClockIcon className="h-4 w-4" />
+                    </Badge>
+                  ) : (
+                    task.availability === 'blocked' && (
+                      <Badge variant="outline">
+                        <FormattedMessage
+                          id="activation.state.attention"
+                          defaultMessage="Needs attention"
+                        />
+                      </Badge>
+                    )
+                  )}
+                </div>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  <FormattedMessage
+                    id={`activation.task.${outcome}.${task.id}.${task.blockedReason ? 'blocked' : 'description'}`}
+                    defaultMessage={task.blockedReason ?? task.description}
+                  />
+                </p>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {canEnableModule && moduleOffProduct && (
+                    <Button
+                      type="button"
+                      size="sm"
+                      className="h-11 sm:h-9"
+                      disabled={pending}
+                      onClick={() => onEnableProduct(moduleOffProduct)}
+                    >
+                      <FormattedMessage
+                        id={`activation.task.${outcome}.${task.id}.enable`}
+                        defaultMessage="Turn on {product}"
+                        values={{ product: productLabel(moduleOffProduct) }}
+                      />
+                    </Button>
+                  )}
+                  {showLinks && !task.isDismissed && task.href && (
+                    <Button asChild size="sm" variant="outline" className="h-11 sm:h-9">
+                      <Link to={task.href}>
+                        <FormattedMessage
+                          id={`activation.task.${outcome}.${task.id}.${task.isCompleted ? 'completedAction' : 'action'}`}
+                          defaultMessage={task.isCompleted ? task.completedLabel : task.actionLabel}
+                        />
+                        <ArrowRightIcon className="h-3.5 w-3.5" />
+                      </Link>
+                    </Button>
+                  )}
+                  {!waitingOnAdmin &&
+                    !task.isCompleted &&
+                    canManage &&
+                    task.classification === 'prerequisite' && (
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        className="h-11 sm:h-9"
+                        disabled={pending}
+                        onClick={() => onResolution(task.id, task.isDeferred ? null : 'deferred')}
+                      >
+                        {task.isDeferred ? (
+                          <ArrowUturnLeftIcon className="h-4 w-4" />
+                        ) : (
+                          <ClockIcon className="h-4 w-4" />
+                        )}
+                        <FormattedMessage
+                          id={
+                            task.isDeferred
+                              ? 'activation.action.moveUp'
+                              : 'activation.action.doLater'
+                          }
+                          defaultMessage={task.isDeferred ? 'Move up' : 'Do later'}
+                        />
+                      </Button>
                     )}
-                    <FormattedMessage
-                      id={
-                        task.isDeferred ? 'activation.action.moveUp' : 'activation.action.doLater'
-                      }
-                      defaultMessage={task.isDeferred ? 'Move up' : 'Do later'}
-                    />
-                  </Button>
-                )}
-                {!task.isCompleted && canManage && task.classification === 'polish' && (
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="ghost"
-                    className="h-11 sm:h-9"
-                    disabled={pending}
-                    onClick={() => onResolution(task.id, task.isDismissed ? null : 'dismissed')}
-                  >
-                    {task.isDismissed ? (
-                      <ArrowUturnLeftIcon className="h-4 w-4" />
-                    ) : (
-                      <MinusIcon className="h-4 w-4" />
-                    )}
-                    <FormattedMessage
-                      id={task.isDismissed ? 'activation.action.addBack' : 'activation.action.skip'}
-                      defaultMessage={task.isDismissed ? 'Add back' : 'Skip'}
-                    />
-                  </Button>
-                )}
+                  {!task.isCompleted && canManage && task.classification === 'polish' && (
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      className="h-11 sm:h-9"
+                      disabled={pending}
+                      onClick={() => onResolution(task.id, task.isDismissed ? null : 'dismissed')}
+                    >
+                      {task.isDismissed ? (
+                        <ArrowUturnLeftIcon className="h-4 w-4" />
+                      ) : (
+                        <MinusIcon className="h-4 w-4" />
+                      )}
+                      <FormattedMessage
+                        id={
+                          task.isDismissed ? 'activation.action.addBack' : 'activation.action.skip'
+                        }
+                        defaultMessage={task.isDismissed ? 'Add back' : 'Skip'}
+                      />
+                    </Button>
+                  )}
+                </div>
               </div>
             </div>
-          </div>
-        </li>
-      ))}
+          </li>
+        )
+      })}
     </ul>
   )
 }

--- a/apps/web/src/routes/onboarding/_layout.complete.tsx
+++ b/apps/web/src/routes/onboarding/_layout.complete.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, redirect } from '@tanstack/react-router'
 import { ArrowPathIcon, ArrowRightIcon, CheckIcon } from '@heroicons/react/24/solid'
 import { FormattedMessage, useIntl } from 'react-intl'
 import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
 import { checkOnboardingState, fetchOnboardingStatus } from '@/lib/server/functions/admin'
 import {
   acknowledgeActivationHandoffFn,
@@ -134,6 +135,11 @@ function LaunchPreview({ tasks }: { tasks: LaunchTask[] }) {
             >
               {task.title}
             </span>
+            {task.availability === 'blocked' && (
+              <Badge size="sm" shape="pill" variant="outline" className="ml-auto">
+                Needs attention
+              </Badge>
+            )}
           </li>
         )
       })}

--- a/apps/web/src/routes/onboarding/_layout.usecase.tsx
+++ b/apps/web/src/routes/onboarding/_layout.usecase.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react'
 import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router'
 import { ArrowPathIcon } from '@heroicons/react/24/solid'
-import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { UseCaseSelector } from '@/components/onboarding/use-case-selector'
+import { toastEnabledModules } from '@/lib/client/enabled-modules-toast'
 import { checkOnboardingState } from '@/lib/server/functions/admin'
 import { getCloudIdentityFn } from '@/lib/server/functions/cloud-identity'
 import { saveCloudOnboardingGoalFn } from '@/lib/server/functions/onboarding'
@@ -39,11 +39,7 @@ export function CloudUseCaseStep() {
       existingUseCase={existingUseCase}
       onSave={async (useCase) => {
         const result = await saveCloudOnboardingGoalFn({ data: { useCase } })
-        if (result.enabledModules.length === 1) {
-          toast.success(`${result.enabledModules[0]} turned on`)
-        } else if (result.enabledModules.length > 1) {
-          toast.success(`Turned on ${result.enabledModules.join(', ')}`)
-        }
+        toastEnabledModules(result.enabledModules)
         await navigate({ to: '/onboarding/complete' })
       }}
     />

--- a/apps/web/src/routes/onboarding/_layout.usecase.tsx
+++ b/apps/web/src/routes/onboarding/_layout.usecase.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router'
 import { ArrowPathIcon } from '@heroicons/react/24/solid'
+import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { UseCaseSelector } from '@/components/onboarding/use-case-selector'
 import { checkOnboardingState } from '@/lib/server/functions/admin'
@@ -37,7 +38,12 @@ export function CloudUseCaseStep() {
     <CloudUseCaseForm
       existingUseCase={existingUseCase}
       onSave={async (useCase) => {
-        await saveCloudOnboardingGoalFn({ data: { useCase } })
+        const result = await saveCloudOnboardingGoalFn({ data: { useCase } })
+        if (result.enabledModules.length === 1) {
+          toast.success(`${result.enabledModules[0]} turned on`)
+        } else if (result.enabledModules.length > 1) {
+          toast.success(`Turned on ${result.enabledModules.join(', ')}`)
+        }
         await navigate({ to: '/onboarding/complete' })
       }}
     />

--- a/apps/web/src/routes/onboarding/_layout.workspace.tsx
+++ b/apps/web/src/routes/onboarding/_layout.workspace.tsx
@@ -13,6 +13,7 @@ import {
 import { friendlyPlatformLabel, platformUrlSuffix } from '@/lib/shared/platform-label'
 import { checkOnboardingState } from '@/lib/server/functions/admin'
 import { UseCaseSelector } from '@/components/onboarding/use-case-selector'
+import { toastEnabledModules } from '@/lib/client/enabled-modules-toast'
 import { pickOnboardingStep } from './-onboarding-step'
 import { isPathManagedFromBootstrap, MANAGED_PATHS } from '@/lib/client/config-file'
 import { normalizeOnboardingOutcome, type OnboardingOutcome } from '@/lib/shared/db-types'
@@ -281,9 +282,10 @@ function WorkspaceAndGoalStep() {
     setIsLoading(true)
     setError('')
     try {
-      await saveWorkspaceAndGoalFn({
+      const result = await saveWorkspaceAndGoalFn({
         data: { workspaceName: workspaceName.trim(), useCase },
       })
+      toastEnabledModules(result.enabledModules)
       localStorage.removeItem(DRAFT_KEY)
       await navigate({ to: '/onboarding/complete' })
     } catch (err) {


### PR DESCRIPTION
## Summary

Cloud customers who pick Help Center or Customer support were landing on a dead-end launch plan: the goal's module stayed off, progress read `0 / 0` under a full bar, and the only CTA bounced off a feature-flag redirect.

Two commits, each shippable:

1. **Enable the goal's modules** (`saveCloudOnboardingGoalFn` and `setActivationGoalFn` call `enableFlagsForUseCase()`). Blocked essentials stay in the denominator (`0 / 1`, never `0 / 0`), the bar is empty at zero, and an admin can turn the module back on from the plan.
2. **Redesign the page.** Skip is one reversible verb, every row has a door, the current step is emphasized in place (no Next-step hero), and admin home moves on once every essential is done or skipped.

Control plane is untouched. No migrations. Phase 3 (orphaned starting-point fns, PLG events, Settings note) is out of scope.

## What changed

- Goal pick/change turns on the needed feature flags (additive; Settings → General remains the off-switch). Newly enabled modules are returned for a toast.
- `LaunchTask.blocked` is structured (`module-off` | `plan-limit` | `permission`). Module-off + `settings.manage` renders **Turn on ‹Product›**; otherwise **Waiting on an admin**.
- Skip writes `dismissed`; legacy `deferred` still reads as skipped. `resolved` = every prerequisite done-or-skipped. First win stays as `firstWinComplete` (quiet sidebar dot).
- Copy: Help Center essential is "Write your first article" / "Write article". Goal options include a "what you get" line.

## Deviations from the spec

- Headline when remaining is 0 and the milestone isn't reached: **"You're ready for your first ‹outcome›"** rather than "0 steps to…". The all-skipped empty state still replaces the bar.
- `distribute-feedback` without a board is `blocked.kind: 'permission'` with the existing "create a board first" reason — the spec's three kinds don't include a dependency, and only `module-off` gets special UI.
- Onboarding-handoff still says "Continue the article" for the orphaned starter path; the spec said to leave those other surfaces alone.

## Test plan

- [x] Typecheck
- [x] Unit tests: launch-checklist (blocked 0/1, skipped, all-skipped, new `resolved`, legacy `deferred`); cloud goal save + change-goal flag enabling
- [ ] e2e `getting-started.spec.ts` (Playwright setup failed here: no live magic-link row for `demo@example.com`)
- [ ] Manual: cloud-identity workspace → Help Center → sidebar shows Help Center, plan is 0/1 with Write article; Change goal to Customer support → toast names Support, inbox appears