### PR TITLE
feat(billing): quieter plans page with per-plan trials and Free downgrade

### DIFF
--- a/apps/web/src/components/admin/settings/billing/__tests__/billing-settings.test.tsx
+++ b/apps/web/src/components/admin/settings/billing/__tests__/billing-settings.test.tsx
@@ -66,6 +66,7 @@ const overview = {
   plan: 'pro' as const,
   planName: 'Pro',
   status: 'active',
+  trialActive: false,
   trialExpiresAt: null,
   renewalAt: '2026-09-14T00:00:00.000Z',
   cancellationAt: null,
@@ -100,20 +101,19 @@ describe('BillingPlansView', () => {
       />
     )
 
-    expect(screen.getByRole('heading', { name: 'Current plan' })).toBeInTheDocument()
-    expect(screen.getByText(/Renews on/)).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Plans' })).toBeInTheDocument()
+    expect(screen.getByText(/Renews/)).toBeInTheDocument()
     expect(screen.getAllByRole('radio')).toHaveLength(2)
-    expect(screen.getByText('Current')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Current plan' })).toBeDisabled()
-    const change = screen.getByRole('button', { name: 'Change to Scale' })
-    expect(change).toBeInTheDocument()
-    const form = change.closest('form')
+    const scaleField = document.querySelector('input[name="planId"][value="scale"]')
+    const form = scaleField?.closest('form')
     expect(form).toHaveAttribute('action', '/api/billing/session')
     expect(form?.querySelector('input[name="action"]')).toHaveValue('checkout')
-    expect(form?.querySelector('input[name="planId"]')).toHaveValue('scale')
     expect(form?.querySelector('input[name="billingPeriod"]')).toHaveValue('annual')
+    expect(screen.getAllByRole('button', { name: 'Switch to this plan' }).length).toBeGreaterThan(0)
+    expect(screen.getByRole('button', { name: 'Downgrade' })).toBeEnabled()
     expect(screen.getByText('INV-1001')).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /View/ })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'View invoice' })).toHaveAttribute(
       'href',
       'https://billing.example.com/invoice/in_1'
     )
@@ -133,9 +133,31 @@ describe('BillingPlansView', () => {
         ]}
       />
     )
-    expect(screen.getByRole('heading', { name: 'Usage' })).toBeInTheDocument()
-    expect(screen.getByText('1 of 3 boards')).toBeInTheDocument()
-    expect(screen.getByText('1 of 1 seats')).toBeInTheDocument()
+    expect(screen.getByText(/1 of 3 boards/)).toBeInTheDocument()
+    expect(screen.getByText(/1 of 1 seats/)).toBeInTheDocument()
+  })
+
+  it('offers a 7-day trial on untried paid plans from Free', () => {
+    render(
+      <BillingPlansView
+        overview={{
+          ...overview,
+          plan: 'free',
+          planName: 'Free',
+          status: null,
+          canUpgrade: true,
+          canManageBilling: false,
+          renewalAt: null,
+        }}
+        catalogue={catalogue}
+        catalogueError={null}
+        invoices={[]}
+        invoicesError={null}
+      />
+    )
+    expect(screen.getAllByRole('button', { name: 'Start 7-day trial' })).toHaveLength(3)
+    expect(screen.getByRole('button', { name: 'Current plan' })).toBeDisabled()
+    expect(screen.queryByRole('button', { name: 'Downgrade' })).not.toBeInTheDocument()
   })
 
   it('shows annual monthly equivalent from the catalogue', () => {
@@ -149,6 +171,7 @@ describe('BillingPlansView', () => {
       />
     )
     expect(screen.getByText(/Upgrades apply immediately/)).toBeInTheDocument()
+    expect(screen.getByText(/7-day trial is available once per paid plan/)).toBeInTheDocument()
     expect(screen.getByText('$49')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('radio', { name: 'Monthly' }))
     expect(screen.getByText('$62')).toBeInTheDocument()

--- a/apps/web/src/components/admin/settings/billing/billing-settings.tsx
+++ b/apps/web/src/components/admin/settings/billing/billing-settings.tsx
@@ -4,13 +4,19 @@ import { ArrowTopRightOnSquareIcon, CheckIcon } from '@heroicons/react/24/solid'
 import type { BillingProjectionOverview } from '@/lib/server/domains/billing/projection-overview'
 import type { BillingCatalogue, CustomerInvoice } from '@/lib/server/control-plane/client'
 import { billingQueries } from '@/lib/client/queries/billing'
-import { SettingsCard } from '@/components/admin/settings/settings-card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { ConfirmDialog } from '@/components/shared/confirm-dialog'
 import { cn } from '@/lib/shared/utils'
 import { formatUsd } from '@/lib/shared/format-usd'
 import { formatUsageLine } from '@/lib/shared/billing/plan-usage'
-import { MENU_LABEL } from '@/components/ui/menu'
+import {
+  billingPlanAction,
+  catalogueTrialDays,
+  catalogueTrialedPlanIds,
+  type BillingPlanAction,
+  type PaidPlanId,
+} from '@/lib/shared/billing/plan-action'
 
 /** Workspace-local presentation of the control-plane billing projection. */
 export function BillingSettings() {
@@ -49,59 +55,31 @@ export function BillingPlansView(props: {
 }) {
   const [period, setPeriod] = useState<'monthly' | 'annual'>('annual')
   const { overview, catalogue } = props
+  const trialDays = catalogueTrialDays(catalogue)
+  const trialedPlanIds = catalogueTrialedPlanIds(catalogue)
+  const usageLines = (props.usage ?? []).map(formatUsageLine)
 
   return (
     <div className="space-y-8">
-      <SettingsCard
-        title="Current plan"
-        description="Commercial access is kept up to date by Quackback Cloud."
-        contentClassName="px-4 py-4 sm:px-6"
-        action={overview.canManageBilling ? <PortalButton label="Manage billing" /> : undefined}
-      >
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="text-sm font-medium">{overview.planName}</span>
-          {overview.status && (
-            <Badge size="sm" shape="pill" variant={statusVariant(overview.status)}>
-              {STATUS_LABELS[overview.status] ?? overview.status}
-            </Badge>
-          )}
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0 space-y-1">
+          <StatusLine overview={overview} />
+          {usageLines.length > 0 ? (
+            <p className="font-mono text-[12px] text-muted-foreground tabular-nums">
+              {usageLines.join(' · ')}
+            </p>
+          ) : null}
         </div>
-        {overview.trialExpiresAt && (
-          <p className="mt-2 text-[13px] text-muted-foreground">
-            Pro trial ends on {formatDate(overview.trialExpiresAt)}.
-          </p>
-        )}
-        {overview.renewalAt && (
-          <p className="mt-2 text-[13px] text-muted-foreground">
-            Renews on {formatDate(overview.renewalAt)}.
-          </p>
-        )}
-        {overview.cancellationAt && (
-          <p className="mt-2 text-[13px] text-muted-foreground">
-            Access ends on {formatDate(overview.cancellationAt)}.
-          </p>
-        )}
-      </SettingsCard>
-
-      {props.usage && props.usage.length > 0 ? (
-        <SettingsCard title="Usage" description="How much of this plan you are using.">
-          <ul className="space-y-1.5 text-[13px]">
-            {props.usage.map((line) => (
-              <li key={line.key} className="font-mono tabular-nums">
-                {formatUsageLine(line)}
-              </li>
-            ))}
-          </ul>
-        </SettingsCard>
-      ) : null}
+        {overview.canManageBilling ? <PortalButton label="Manage billing" /> : null}
+      </div>
 
       <section className="space-y-4">
         <div className="flex flex-wrap items-end justify-between gap-3">
           <div>
             <h2 className="text-base font-semibold">Plans</h2>
             <p className="mt-1 text-xs text-muted-foreground">
-              Prices come from Quackback Cloud. Upgrades apply immediately (pro-rata). Downgrades
-              take effect at the end of the current billing period.
+              Upgrades apply immediately (pro-rata). Downgrades take effect at the end of the
+              current billing period. A {trialDays}-day trial is available once per paid plan.
             </p>
           </div>
           <PeriodToggle
@@ -124,13 +102,9 @@ export function BillingPlansView(props: {
                 key={plan.id}
                 plan={plan}
                 period={period}
-                current={overview.plan === plan.id}
-                canCheckout={
-                  (overview.canUpgrade || overview.canManageBilling) &&
-                  plan.id !== 'free' &&
-                  overview.plan !== plan.id
-                }
-                paidChange={overview.canManageBilling && !overview.canUpgrade}
+                trialDays={trialDays}
+                action={billingPlanAction(plan.id, overview, trialedPlanIds)}
+                trialActive={overview.trialActive && overview.plan === plan.id}
                 index={index}
               />
             ))}
@@ -138,40 +112,51 @@ export function BillingPlansView(props: {
         )}
       </section>
 
-      <SettingsCard
-        title="Invoices"
-        description="Issued by Quackback Cloud. Open an invoice for the hosted copy."
-        contentClassName="p-0"
-      >
+      <section className="space-y-3">
+        <h2 className="text-base font-semibold">Previous invoices</h2>
         {props.invoicesError ? (
-          <p role="alert" className="px-4 py-4 text-[13px] text-destructive sm:px-6">
+          <p role="alert" className="text-[13px] text-destructive">
             Couldn’t load invoices. {props.invoicesError}
           </p>
         ) : props.invoices.length === 0 ? (
-          <p className="px-4 py-4 text-[13px] text-muted-foreground sm:px-6">
+          <p className="text-[13px] text-muted-foreground">
             No invoices yet.
             {overview.canManageBilling ? ' Past invoices also appear in Manage billing.' : null}
           </p>
         ) : (
-          <InvoiceTable invoices={props.invoices} />
+          <InvoiceList invoices={props.invoices} />
         )}
-      </SettingsCard>
+      </section>
     </div>
   )
+}
+
+function StatusLine({ overview }: { overview: BillingProjectionOverview }) {
+  const bits: string[] = []
+  if (overview.trialActive && overview.trialExpiresAt) {
+    bits.push(`${overview.planName} trial · ends ${formatDate(overview.trialExpiresAt)}`)
+  } else if (overview.status) {
+    bits.push(STATUS_LABELS[overview.status] ?? overview.status)
+  }
+  if (overview.cancellationAt) bits.push(`Access ends ${formatDate(overview.cancellationAt)}`)
+  else if (overview.renewalAt) bits.push(`Renews ${formatDate(overview.renewalAt)}`)
+  if (bits.length === 0) return null
+  return <p className="text-[13px] text-muted-foreground">{bits.join(' · ')}</p>
 }
 
 function PlanCard(props: {
   plan: BillingCatalogue['plans'][number]
   period: 'monthly' | 'annual'
-  current: boolean
-  canCheckout: boolean
-  paidChange: boolean
+  trialDays: number
+  action: BillingPlanAction
+  trialActive: boolean
   index: number
 }) {
-  const { plan, period } = props
+  const { plan, period, action } = props
   const isAnnual = period === 'annual'
   const monthlyCents = isAnnual ? Math.round(plan.priceYearlyCents / 12) : plan.priceMonthlyCents
   const unit = plan.billedPer === 'seat' ? '/seat/mo' : '/mo'
+  const current = action.kind === 'current'
 
   return (
     <article
@@ -180,28 +165,29 @@ function PlanCard(props: {
         props.index > 0 && 'border-t border-border/50 sm:border-t-0',
         props.index % 2 === 1 && 'sm:border-l sm:border-border/50',
         props.index > 0 && 'xl:border-l xl:border-border/50',
-        plan.recommended && 'bg-primary/5'
+        current && 'bg-muted/30 ring-1 ring-inset ring-foreground/15',
+        plan.recommended && !current && 'bg-primary/5'
       )}
     >
-      <div className="min-h-5">
-        {props.current ? (
-          <span className="inline-flex rounded-full border border-border/60 px-2 py-0.5 text-[11px] font-semibold tracking-wider text-muted-foreground uppercase">
-            Current
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <h3 className="text-sm font-semibold">{plan.name}</h3>
+            {props.trialActive ? (
+              <Badge size="sm" shape="pill" variant="secondary">
+                Trial
+              </Badge>
+            ) : null}
+          </div>
+          <p className="mt-1 text-[13px] leading-snug text-muted-foreground">{plan.bestFor}</p>
+        </div>
+        <p className="shrink-0 text-right">
+          <span className="text-lg font-semibold tracking-tight tabular-nums">
+            {formatUsd(monthlyCents, 0)}
           </span>
-        ) : plan.recommended ? (
-          <span className="inline-flex rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-[11px] font-semibold tracking-wider text-primary uppercase">
-            Best for most teams
-          </span>
-        ) : null}
+          <span className="block text-[12px] text-muted-foreground">{unit}</span>
+        </p>
       </div>
-      <h3 className="mt-3 text-sm font-semibold">{plan.name}</h3>
-      <p className="mt-1 text-[13px] leading-snug text-muted-foreground">{plan.bestFor}</p>
-      <p className="mt-5 flex items-baseline gap-1">
-        <span className="text-[28px] font-semibold tracking-tight tabular-nums">
-          {formatUsd(monthlyCents, 0)}
-        </span>
-        <span className="text-[13px] text-muted-foreground">{unit}</span>
-      </p>
       {plan.id !== 'free' && (
         <p className="mt-1 text-[12px] text-muted-foreground">
           {isAnnual ? `${formatUsd(plan.priceYearlyCents, 0)} billed yearly` : 'billed monthly'}
@@ -210,37 +196,131 @@ function PlanCard(props: {
       <ul className="mt-4 flex-1 space-y-2">
         {plan.highlights.map((line) => (
           <li key={line} className="flex items-start gap-2 text-[13px] leading-snug">
-            <CheckIcon className="mt-0.5 size-3.5 shrink-0 text-primary" />
+            <CheckIcon className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
             <span>{line}</span>
           </li>
         ))}
       </ul>
       <div className="mt-5">
-        {props.current ? (
-          <Button size="sm" variant="outline" className="w-full" disabled>
-            Current plan
-          </Button>
-        ) : props.canCheckout ? (
-          <form method="post" action="/api/billing/session">
-            <input type="hidden" name="action" value="checkout" />
-            <input type="hidden" name="planId" value={plan.id} />
-            <input type="hidden" name="billingPeriod" value={period} />
-            <Button
-              size="sm"
-              type="submit"
-              className="w-full"
-              variant={plan.recommended ? 'default' : 'outline'}
-            >
-              {props.paidChange ? `Change to ${plan.name}` : `Choose ${plan.name}`}
-            </Button>
-          </form>
-        ) : (
-          <Button size="sm" variant="outline" className="w-full" disabled>
-            Choose {plan.name}
-          </Button>
-        )}
+        <PlanActionButton
+          action={action}
+          planName={plan.name}
+          trialDays={props.trialDays}
+          period={period}
+        />
       </div>
     </article>
+  )
+}
+
+function PlanActionButton(props: {
+  action: BillingPlanAction
+  planName: string
+  trialDays: number
+  period: 'monthly' | 'annual'
+}) {
+  const { action } = props
+  if (action.kind === 'current') {
+    return (
+      <Button size="sm" variant="outline" className="w-full" disabled>
+        Current plan
+      </Button>
+    )
+  }
+  if (action.kind === 'unavailable') {
+    return (
+      <Button size="sm" variant="outline" className="w-full" disabled>
+        {props.planName === 'Free' ? 'Downgrade' : `Choose ${props.planName}`}
+      </Button>
+    )
+  }
+  if (action.kind === 'trial') {
+    return (
+      <TrialButton planId={action.planId} planName={props.planName} trialDays={props.trialDays} />
+    )
+  }
+  if (action.kind === 'downgrade') {
+    return <DowngradeButton />
+  }
+  const label = action.kind === 'switch' ? `Switch to this plan` : `Subscribe to ${props.planName}`
+  return (
+    <form method="post" action="/api/billing/session">
+      <input type="hidden" name="action" value="checkout" />
+      <input type="hidden" name="planId" value={action.planId} />
+      <input type="hidden" name="billingPeriod" value={props.period} />
+      <Button size="sm" type="submit" className="w-full" variant="outline">
+        {label}
+      </Button>
+    </form>
+  )
+}
+
+function TrialButton(props: { planId: PaidPlanId; planName: string; trialDays: number }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      <Button
+        size="sm"
+        type="button"
+        variant="outline"
+        className="w-full"
+        onClick={() => setOpen(true)}
+      >
+        Start {props.trialDays}-day trial
+      </Button>
+      <ConfirmDialog
+        open={open}
+        onOpenChange={setOpen}
+        title={`Start a ${props.trialDays}-day ${props.planName} trial?`}
+        description={`You’ll have ${props.planName} for ${props.trialDays} days. When it ends you return to Free. Nothing is deleted. You can’t trial ${props.planName} again.`}
+        confirmLabel={`Start ${props.planName} trial`}
+        onConfirm={() => {
+          const form = document.getElementById(`trial-${props.planId}`) as HTMLFormElement | null
+          form?.requestSubmit()
+        }}
+      />
+      <form
+        id={`trial-${props.planId}`}
+        method="post"
+        action="/api/billing/trial"
+        className="hidden"
+      >
+        <input type="hidden" name="planId" value={props.planId} />
+      </form>
+    </>
+  )
+}
+
+function DowngradeButton() {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      <Button
+        size="sm"
+        type="button"
+        variant="outline"
+        className="w-full"
+        onClick={() => setOpen(true)}
+      >
+        Downgrade
+      </Button>
+      <ConfirmDialog
+        open={open}
+        onOpenChange={setOpen}
+        title="Downgrade to Free?"
+        description="Your workspace stays online. New work that exceeds Free limits will be refused; existing data is kept. A paid plan stays in force until the end of the current period. An active trial ends now."
+        confirmLabel="Downgrade to Free"
+        variant="destructive"
+        onConfirm={() => {
+          const form = document.getElementById('downgrade-free') as HTMLFormElement | null
+          form?.requestSubmit()
+        }}
+      />
+      <form id="downgrade-free" method="post" action="/api/billing/session" className="hidden">
+        <input type="hidden" name="action" value="downgrade" />
+        <input type="hidden" name="planId" value="free" />
+      </form>
+    </>
   )
 }
 
@@ -281,68 +361,48 @@ function PeriodToggle(props: {
   )
 }
 
-function InvoiceTable({ invoices }: { invoices: CustomerInvoice[] }) {
+function InvoiceList({ invoices }: { invoices: CustomerInvoice[] }) {
   return (
-    <table className="w-full caption-bottom text-[13px]">
-      <thead>
-        <tr className="border-b border-border/50">
-          <th className={cn(MENU_LABEL, 'px-4 py-2 text-left font-medium sm:px-6')}>Date</th>
-          <th className={cn(MENU_LABEL, 'px-4 py-2 text-left font-medium')}>Number</th>
-          <th className={cn(MENU_LABEL, 'px-4 py-2 text-left font-medium')}>Amount</th>
-          <th className={cn(MENU_LABEL, 'px-4 py-2 text-left font-medium')}>Status</th>
-          <th className="px-4 py-2 sm:px-6" />
-        </tr>
-      </thead>
-      <tbody>
-        {invoices.map((invoice) => (
-          <tr key={invoice.id} className="border-b border-border/50 last:border-0">
-            <td className="px-4 py-2.5 sm:px-6">{formatDate(invoice.createdAt)}</td>
-            <td className="px-4 py-2.5 font-mono text-[12px] text-muted-foreground">
-              {invoice.number ?? '—'}
-            </td>
-            <td className="px-4 py-2.5 tabular-nums">{formatUsd(invoice.amountCents, 2)}</td>
-            <td className="px-4 py-2.5 capitalize">{invoice.status}</td>
-            <td className="px-4 py-2.5 text-right sm:px-6">
-              {invoice.hostedUrl ? (
-                <a
-                  href={invoice.hostedUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="inline-flex items-center gap-1 text-[13px] text-primary hover:underline"
-                >
-                  View
-                  <ArrowTopRightOnSquareIcon className="size-3.5" />
-                </a>
-              ) : null}
-            </td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
+    <ul className="divide-y divide-border/50 rounded-xl border border-border/50">
+      {invoices.map((invoice) => (
+        <li key={invoice.id} className="flex items-center gap-3 px-4 py-2.5 text-[13px]">
+          <span className="min-w-0 flex-1 truncate font-medium">{invoice.number ?? 'Invoice'}</span>
+          <span className="hidden text-muted-foreground sm:inline">
+            {formatDate(invoice.createdAt)}
+          </span>
+          <span className="tabular-nums">{formatUsd(invoice.amountCents, 2)}</span>
+          <span className="hidden capitalize text-muted-foreground md:inline">
+            {invoice.status}
+          </span>
+          {invoice.hostedUrl ? (
+            <a
+              href={invoice.hostedUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex text-muted-foreground hover:text-foreground"
+              aria-label="View invoice"
+            >
+              <ArrowTopRightOnSquareIcon className="size-3.5" />
+            </a>
+          ) : (
+            <span className="size-3.5" />
+          )}
+        </li>
+      ))}
+    </ul>
   )
 }
 
-function PortalButton(props: { label: string; variant?: 'default' | 'outline'; wide?: boolean }) {
+function PortalButton(props: { label: string }) {
   return (
     <form method="post" action="/api/billing/session">
       <input type="hidden" name="action" value="portal" />
-      <Button
-        size="sm"
-        type="submit"
-        variant={props.variant ?? 'default'}
-        className={props.wide ? 'w-full' : undefined}
-      >
+      <Button size="sm" type="submit" variant="outline">
         {props.label}
         <ArrowTopRightOnSquareIcon className="size-3.5" />
       </Button>
     </form>
   )
-}
-
-function statusVariant(status: string): 'secondary' | 'destructive' | 'outline' {
-  if (status === 'active' || status === 'trialing') return 'secondary'
-  if (status === 'past_due' || status === 'canceled') return 'destructive'
-  return 'outline'
 }
 
 function formatDate(iso: string): string {

--- a/apps/web/src/lib/server/control-plane/client.ts
+++ b/apps/web/src/lib/server/control-plane/client.ts
@@ -161,6 +161,8 @@ export type BillingCatalogue = {
     highlights: string[]
     recommended: boolean
   }>
+  trialDays?: number
+  trialedPlanIds?: Array<'growth' | 'pro' | 'scale'>
 }
 
 export type CustomerInvoice = {
@@ -181,15 +183,35 @@ export async function createHostedBillingSession(
         planId: 'growth' | 'pro' | 'scale'
         billingPeriod: 'monthly' | 'annual'
       }
-): Promise<string> {
-  const result = await callWorkspaceControlPlane<{ url?: unknown }>(
+    | { action: 'downgrade'; planId: 'free' }
+): Promise<{ url?: string; status?: 'downgraded' | 'scheduled' }> {
+  const result = await callWorkspaceControlPlane<{ url?: unknown; status?: unknown }>(
     '/api/v1/internal/billing/session',
     input
   )
+  if (input.action === 'downgrade') {
+    if (result.status === 'downgraded' || result.status === 'scheduled') {
+      return { status: result.status }
+    }
+    throw new ControlPlaneUnavailableError()
+  }
   if (typeof result.url !== 'string' || !result.url.startsWith('https://')) {
     throw new ControlPlaneUnavailableError()
   }
-  return result.url
+  return { url: result.url }
+}
+
+export async function startWorkspaceTrial(
+  planId: 'growth' | 'pro' | 'scale'
+): Promise<'started' | 'already_started'> {
+  const result = await callWorkspaceControlPlane<{ status?: unknown }>(
+    '/api/v1/internal/billing/start-trial',
+    { planId }
+  )
+  if (result.status !== 'started' && result.status !== 'already_started') {
+    throw new ControlPlaneUnavailableError()
+  }
+  return result.status
 }
 
 export async function reportTrialActivation(input: {

--- a/apps/web/src/lib/server/control-plane/starter-trial.ts
+++ b/apps/web/src/lib/server/control-plane/starter-trial.ts
@@ -31,7 +31,7 @@ export function starterTrialEvidence(state: SetupState): StarterTrialEvidence | 
 /**
  * Re-report stamped starter evidence when Cloud is on and no trial has landed
  * locally. A control-plane outage at wizard completion must not permanently
- * skip the one immutable Pro trial.
+ * skip the starter Pro trial.
  */
 export async function reportStarterTrialIfDue(identity?: {
   principalId: string

--- a/apps/web/src/lib/server/domains/billing/projection-overview.ts
+++ b/apps/web/src/lib/server/domains/billing/projection-overview.ts
@@ -5,6 +5,7 @@ export interface BillingProjectionOverview {
   plan: PlanId
   planName: string
   status: string | null
+  trialActive: boolean
   trialExpiresAt: string | null
   renewalAt: string | null
   cancellationAt: string | null
@@ -20,6 +21,7 @@ export async function getBillingProjectionOverview(): Promise<BillingProjectionO
     plan: cloud.plan,
     planName: PLAN_CATALOGUE[cloud.plan].name,
     status: cloud.subscriptionStatus,
+    trialActive: cloud.trialActive,
     trialExpiresAt: cloud.trialExpiresAt,
     renewalAt: cloud.renewalAt,
     cancellationAt: cloud.cancellationAt,

--- a/apps/web/src/lib/server/domains/settings/cloud/commercial-notice.ts
+++ b/apps/web/src/lib/server/domains/settings/cloud/commercial-notice.ts
@@ -12,7 +12,7 @@ export function trialNotice(config: CloudConfig): PlanNotice | null {
   if (!config.enabled || !config.trialActive || !config.trialExpiresAt) return null
   const actionUrl = plansActionUrl(config)
   return {
-    label: `${PLAN_CATALOGUE.pro.name} trial`,
+    label: `${config.plan ? PLAN_CATALOGUE[config.plan].name : PLAN_CATALOGUE.pro.name} trial`,
     message: 'Your workspace moves to the Free plan when this ends. Nothing is deleted.',
     expiresAt: config.trialExpiresAt,
     ...(actionUrl ? { actionUrl, actionLabel: 'See plans' } : {}),

--- a/apps/web/src/lib/server/policy/authz-matrix/MATRIX.md
+++ b/apps/web/src/lib/server/policy/authz-matrix/MATRIX.md
@@ -771,11 +771,12 @@ Profiles: **Owner** = admin class + an admin-owned full API key (scoped keys hol
 | `lib/server/functions/workflows.ts`::runWorkflowManuallyFn | conversation.reply |
 | `lib/server/functions/workspace-wipe.ts`::wipeCloudWorkspaceFn | END_USER (any authenticated) |
 
-### Public REST API (`withApiKeyAuth`) — 125 surfaces
+### Public REST API (`withApiKeyAuth`) — 126 surfaces
 
 | Surface | Enforces |
 | --- | --- |
 | `routes/api/billing/session.ts`::POST | billing.manage |
+| `routes/api/billing/trial.ts`::POST | billing.manage |
 | `routes/api/export.companies.ts`::GET | company.view |
 | `routes/api/export.users.ts`::handleExportUsers | people.view |
 | `routes/api/v1/apps/boards.ts`::GET | PUBLIC (any valid key) |
@@ -976,7 +977,7 @@ Key scopes are enforced: an API key holds exactly its stored scopes (owner permi
 
 ## 4. Entry points without a requireAuth/key gate
 
-188 of 965 entry points hold no `requireAuth` / `withApiKeyAuth` / `requireTeamAuth` gate.
+188 of 966 entry points hold no `requireAuth` / `withApiKeyAuth` / `requireTeamAuth` gate.
 Each is expected to be intentionally public, a pre-auth flow, a signature-verified webhook, or a handler that delegates auth (e.g. the MCP route).
 **Adding a row here is an access-control change** — confirm the new entry point is meant to be reachable without a gate.
 

--- a/apps/web/src/lib/shared/billing/__tests__/plan-action.test.ts
+++ b/apps/web/src/lib/shared/billing/__tests__/plan-action.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import { billingPlanAction, type CataloguePlanId } from '../plan-action'
+import type { BillingProjectionOverview } from '@/lib/server/domains/billing/projection-overview'
+
+const unpaidFree: BillingProjectionOverview = {
+  plan: 'free',
+  planName: 'Free',
+  status: null,
+  trialActive: false,
+  trialExpiresAt: null,
+  renewalAt: null,
+  cancellationAt: null,
+  canUpgrade: true,
+  canManageBilling: false,
+  purchasablePlans: [
+    { id: 'growth', name: 'Growth' },
+    { id: 'pro', name: 'Pro' },
+    { id: 'scale', name: 'Scale' },
+  ],
+}
+
+describe('billingPlanAction', () => {
+  it('offers a 7-day trial of untried paid plans on Free', () => {
+    expect(billingPlanAction('free', unpaidFree).kind).toBe('current')
+    expect(billingPlanAction('growth', unpaidFree)).toEqual({ kind: 'trial', planId: 'growth' })
+    expect(billingPlanAction('pro', unpaidFree)).toEqual({ kind: 'trial', planId: 'pro' })
+  })
+
+  it('does not re-trial a plan already in the ledger', () => {
+    expect(billingPlanAction('growth', unpaidFree, ['growth'])).toEqual({
+      kind: 'subscribe',
+      planId: 'growth',
+    })
+    expect(billingPlanAction('pro', unpaidFree, ['growth'])).toEqual({
+      kind: 'trial',
+      planId: 'pro',
+    })
+  })
+
+  it('ends an active trial via Free and converts other plans via checkout', () => {
+    const trialing: BillingProjectionOverview = {
+      ...unpaidFree,
+      plan: 'growth',
+      planName: 'Growth',
+      trialActive: true,
+      trialExpiresAt: '2026-09-01T00:00:00.000Z',
+    }
+    expect(billingPlanAction('growth', trialing).kind).toBe('current')
+    expect(billingPlanAction('free', trialing).kind).toBe('downgrade')
+    expect(billingPlanAction('pro', trialing)).toEqual({ kind: 'subscribe', planId: 'pro' })
+  })
+
+  it('switches paid plans and always allows a Free downgrade', () => {
+    const paid: BillingProjectionOverview = {
+      ...unpaidFree,
+      plan: 'growth',
+      planName: 'Growth',
+      status: 'active',
+      canUpgrade: false,
+      canManageBilling: true,
+      renewalAt: '2026-09-14T00:00:00.000Z',
+    }
+    expect(billingPlanAction('growth', paid).kind).toBe('current')
+    expect(billingPlanAction('pro', paid)).toEqual({ kind: 'switch', planId: 'pro' })
+    expect(billingPlanAction('free', paid).kind).toBe('downgrade')
+  })
+
+  it('does not let a complimentary grant self-downgrade', () => {
+    const grant: BillingProjectionOverview = {
+      ...unpaidFree,
+      plan: 'scale',
+      planName: 'Scale',
+      status: null,
+      canUpgrade: true,
+      canManageBilling: false,
+    }
+    expect(billingPlanAction('scale', grant).kind).toBe('current')
+    expect(billingPlanAction('free', grant).kind).toBe('unavailable')
+    expect(billingPlanAction('pro', grant)).toEqual({ kind: 'subscribe', planId: 'pro' })
+  })
+
+  it('covers every catalogue id', () => {
+    const ids: CataloguePlanId[] = ['free', 'growth', 'pro', 'scale']
+    for (const id of ids) {
+      expect(billingPlanAction(id, unpaidFree).kind).toBeTruthy()
+    }
+  })
+})

--- a/apps/web/src/lib/shared/billing/plan-action.ts
+++ b/apps/web/src/lib/shared/billing/plan-action.ts
@@ -1,0 +1,59 @@
+import type { BillingProjectionOverview } from '@/lib/server/domains/billing/projection-overview'
+import type { BillingCatalogue } from '@/lib/server/control-plane/client'
+
+export type PaidPlanId = 'growth' | 'pro' | 'scale'
+export type CataloguePlanId = 'free' | PaidPlanId
+
+export type BillingPlanAction =
+  | { kind: 'current' }
+  | { kind: 'trial'; planId: PaidPlanId }
+  | { kind: 'subscribe'; planId: PaidPlanId }
+  | { kind: 'switch'; planId: PaidPlanId }
+  | { kind: 'downgrade' }
+  | { kind: 'unavailable' }
+
+function isPaidPlanId(id: string): id is PaidPlanId {
+  return id === 'growth' || id === 'pro' || id === 'scale'
+}
+
+function hasLivePaidSub(overview: BillingProjectionOverview): boolean {
+  return Boolean(overview.status && overview.status !== 'canceled')
+}
+
+export function billingPlanAction(
+  planId: CataloguePlanId,
+  overview: BillingProjectionOverview,
+  trialedPlanIds: readonly string[] = []
+): BillingPlanAction {
+  const canAct = overview.canUpgrade || overview.canManageBilling
+  if (overview.plan === planId) return { kind: 'current' }
+  if (!canAct) return { kind: 'unavailable' }
+
+  if (planId === 'free') {
+    if (overview.trialActive || hasLivePaidSub(overview)) return { kind: 'downgrade' }
+    return { kind: 'unavailable' }
+  }
+
+  if (!isPaidPlanId(planId)) return { kind: 'unavailable' }
+
+  if (hasLivePaidSub(overview)) return { kind: 'switch', planId }
+
+  // Complimentary grant: convert via checkout, never a second product trial.
+  if (overview.plan !== 'free' && !overview.trialActive) {
+    return { kind: 'subscribe', planId }
+  }
+
+  const alreadyTrialed = trialedPlanIds.includes(planId)
+  if (!alreadyTrialed && !overview.trialActive && overview.canUpgrade) {
+    return { kind: 'trial', planId }
+  }
+  return { kind: 'subscribe', planId }
+}
+
+export function catalogueTrialDays(catalogue: BillingCatalogue | null): number {
+  return catalogue?.trialDays && catalogue.trialDays > 0 ? catalogue.trialDays : 7
+}
+
+export function catalogueTrialedPlanIds(catalogue: BillingCatalogue | null): PaidPlanId[] {
+  return (catalogue?.trialedPlanIds ?? []).filter(isPaidPlanId)
+}

--- a/apps/web/src/routes/admin/settings.billing.tsx
+++ b/apps/web/src/routes/admin/settings.billing.tsx
@@ -38,8 +38,8 @@ function BillingPage() {
       </div>
       <PageHeader
         icon={CreditCardIcon}
-        title="Plan & billing"
-        description="Your Quackback Cloud plan and billing access."
+        title="Plans & billing"
+        description="Manage your plan and billing history here."
       />
       {billingEnabled ? (
         <BillingSettings />

--- a/apps/web/src/routes/api/billing/session.ts
+++ b/apps/web/src/routes/api/billing/session.ts
@@ -27,6 +27,10 @@ const actionSchema = z.discriminatedUnion('action', [
     planId: z.enum(['growth', 'pro', 'scale']),
     billingPeriod: z.enum(['monthly', 'annual']),
   }),
+  z.object({
+    action: z.literal('downgrade'),
+    planId: z.literal('free'),
+  }),
 ])
 
 export const Route = createFileRoute('/api/billing/session')({
@@ -54,8 +58,12 @@ export const Route = createFileRoute('/api/billing/session')({
             return Response.json({ error: 'billing_action_unavailable' }, { status: 403 })
           }
           const { createHostedBillingSession } = await import('@/lib/server/control-plane/client')
-          const url = await createHostedBillingSession(parsed.data)
-          return new Response(null, { status: 303, headers: { location: url } })
+          const session = await createHostedBillingSession(parsed.data)
+          const location =
+            typeof session.url === 'string' && session.url.startsWith('https://')
+              ? session.url
+              : '/admin/settings/billing'
+          return new Response(null, { status: 303, headers: { location } })
         } catch (error) {
           return billingSessionErrorResponse(error)
         }

--- a/apps/web/src/routes/api/billing/trial.ts
+++ b/apps/web/src/routes/api/billing/trial.ts
@@ -1,0 +1,44 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { z } from 'zod'
+import { isSameOriginFormPost } from '@/lib/server/http/same-origin-form'
+import { PERMISSIONS } from '@/lib/shared/permissions'
+import { billingSessionErrorResponse } from './session'
+
+const trialSchema = z.object({
+  planId: z.enum(['growth', 'pro', 'scale']),
+})
+
+export const Route = createFileRoute('/api/billing/trial')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        if (!isSameOriginFormPost(request)) {
+          return Response.json({ error: 'invalid_origin' }, { status: 403 })
+        }
+        try {
+          const { requireAuth } = await import('@/lib/server/functions/auth-helpers')
+          await requireAuth({ permission: PERMISSIONS.BILLING_MANAGE })
+          const form = await request.formData()
+          const parsed = trialSchema.safeParse(Object.fromEntries(form.entries()))
+          if (!parsed.success) {
+            return Response.json({ error: 'invalid_billing_action' }, { status: 400 })
+          }
+          const { getCloudConfig } =
+            await import('@/lib/server/domains/settings/cloud/cloud.service')
+          const cloud = await getCloudConfig()
+          if (!cloud.enabled || !cloud.canUpgrade) {
+            return Response.json({ error: 'billing_action_unavailable' }, { status: 403 })
+          }
+          const { startWorkspaceTrial } = await import('@/lib/server/control-plane/client')
+          await startWorkspaceTrial(parsed.data.planId)
+          return new Response(null, {
+            status: 303,
+            headers: { location: '/admin/settings/billing' },
+          })
+        } catch (error) {
+          return billingSessionErrorResponse(error)
+        }
+      },
+    },
+  },
+})


### PR DESCRIPTION
## Summary

- Redesign Plans & billing: plan cards are the page (current card ringed), compact usage line, sparse invoice list.
- Start a 7-day trial of any paid plan the workspace has not already trialed. Free is always a downgrade target for trial and paid workspaces.
- Trial banner names the serving plan, not a hardcoded Pro trial.
- New `/api/billing/trial` and a session `downgrade` action. Catalogue extras (`trialDays`, `trialedPlanIds`) are optional so a brief CP skew does not blank the page.

## Test plan

- [ ] `bun test` for billing-settings, plan-action, session-error, plan-notice-auth
- [ ] Cloud workspace on Free: Growth/Pro/Scale show **Start 7-day trial**; Free is Current
- [ ] Starting a trial rings that card, shows the Trial pill, and the banner names that plan
- [ ] Downgrade during a trial ends it now; that plan’s CTA becomes Subscribe, not Trial
- [ ] Paid workspace: **Switch to this plan** still goes to checkout/portal; Free shows **Downgrade**
- [ ] Self-hosted: page still says billing is Cloud-only

Depends on: https://github.com/QuackbackIO/quackback-cp/pull/146 (ship CP first)