### PR TITLE
feat(billing): allow custom colours on Free and Growth

### DIFF
--- a/.github/workflows/assistant-evals.yml
+++ b/.github/workflows/assistant-evals.yml
@@ -69,11 +69,11 @@ jobs:
 
       - name: Checkout
         if: steps.gate.outputs.run == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Bun
         if: steps.gate.outputs.run == 'true'
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.4.0
 
@@ -97,7 +97,7 @@ jobs:
 
       - name: Upload failure transcripts
         if: always() && steps.gate.outputs.run == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: assistant-eval-transcripts
           path: apps/web/evals/.results/

--- a/apps/web/src/components/admin/settings/branding/__tests__/use-branding-state.test.ts
+++ b/apps/web/src/components/admin/settings/branding/__tests__/use-branding-state.test.ts
@@ -3,7 +3,13 @@ import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { act, renderHook } from '@testing-library/react'
 
 const { saveBrandingTheme } = vi.hoisted(() => ({
-  saveBrandingTheme: vi.fn(async () => undefined),
+  saveBrandingTheme: vi.fn(
+    async (_input: {
+      brandingConfig: Record<string, unknown>
+      customCss: string
+      customCssWrite: 'persist' | 'clear' | 'rewrite'
+    }) => undefined
+  ),
 }))
 
 vi.mock('@/lib/client/mutations/settings', () => ({
@@ -55,7 +61,7 @@ describe('useBrandingState setThemeMode', () => {
     expect(result.current.cssText).toBe(custom)
   })
 
-  it('skips the customCss write when leftover Advanced CSS is unchanged', async () => {
+  it('rewrites leftover Advanced CSS as remainder-only when extras are unchanged', async () => {
     const leftover = ':root { --primary: oklch(0.5 0.2 250); }\n.brand { color: red; }\n'
     const { result } = renderHook(() =>
       useBrandingState({
@@ -73,11 +79,15 @@ describe('useBrandingState setThemeMode', () => {
     })
 
     expect(saveBrandingTheme).toHaveBeenCalledWith(
-      expect.objectContaining({ customCssWrite: 'skip' })
+      expect.objectContaining({
+        customCssWrite: 'rewrite',
+        customCss: expect.stringContaining('.brand { color: red; }'),
+      })
     )
+    expect(saveBrandingTheme.mock.calls[0]?.[0].customCss).not.toContain('--primary')
   })
 
-  it('skips the customCss write when leftover extra rules are unchanged after a var edit', async () => {
+  it('rewrites remainder-only CSS after a colour/var edit that leaves extras unchanged', async () => {
     const leftover = [
       ':root { --primary: oklch(0.5 0.2 250); --radius: 0.625rem; }',
       '.dark { --primary: oklch(0.7 0.2 250); --radius: 0.625rem; }',
@@ -102,8 +112,13 @@ describe('useBrandingState setThemeMode', () => {
     expect(result.current.cssText).toContain('1.25rem')
     expect(result.current.cssText).toContain('.brand { color: red; }')
     expect(saveBrandingTheme).toHaveBeenCalledWith(
-      expect.objectContaining({ customCssWrite: 'skip' })
+      expect.objectContaining({
+        customCssWrite: 'rewrite',
+        customCss: expect.stringContaining('.brand { color: red; }'),
+      })
     )
+    expect(saveBrandingTheme.mock.calls[0]?.[0].customCss).not.toContain('--primary')
+    expect(saveBrandingTheme.mock.calls[0]?.[0].customCss).not.toContain('--radius')
   })
 
   it('clears stored customCss when cssText is generated theme CSS', async () => {
@@ -142,8 +157,12 @@ describe('useBrandingState setThemeMode', () => {
     })
 
     expect(saveBrandingTheme).toHaveBeenCalledWith(
-      expect.objectContaining({ customCssWrite: 'persist' })
+      expect.objectContaining({
+        customCssWrite: 'persist',
+        customCss: expect.stringContaining('.hero { color: blue; }'),
+      })
     )
+    expect(saveBrandingTheme.mock.calls[0]?.[0].customCss).not.toContain('--primary')
   })
 })
 

--- a/apps/web/src/components/admin/settings/branding/__tests__/use-branding-state.test.ts
+++ b/apps/web/src/components/admin/settings/branding/__tests__/use-branding-state.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+
+vi.mock('@/lib/client/mutations/settings', () => ({
+  useSaveBrandingTheme: () => ({ mutateAsync: vi.fn() }),
+}))
+
+import { useBrandingState } from '../use-branding-state'
+
+describe('useBrandingState setThemeMode', () => {
+  it('regenerates cssText when it is still generated CSS for the previous mode', () => {
+    const { result } = renderHook(() =>
+      useBrandingState({
+        initialLogoUrl: null,
+        initialThemeConfig: { themeMode: 'user' },
+        initialCustomCss: '',
+      })
+    )
+
+    expect(result.current.cssText).toContain(':root')
+    expect(result.current.cssText).toContain('.dark')
+
+    act(() => {
+      result.current.setThemeMode('light')
+    })
+
+    expect(result.current.themeMode).toBe('light')
+    expect(result.current.cssText).toContain(':root')
+    expect(result.current.cssText).not.toMatch(/\.dark\s*\{/)
+  })
+
+  it('leaves Advanced CSS extra rules untouched', () => {
+    const custom = ':root { --primary: oklch(0.5 0.2 250); }\n.brand { color: red; }\n'
+    const { result } = renderHook(() =>
+      useBrandingState({
+        initialLogoUrl: null,
+        initialThemeConfig: { themeMode: 'user' },
+        initialCustomCss: custom,
+      })
+    )
+
+    act(() => {
+      result.current.setThemeMode('dark')
+    })
+
+    expect(result.current.cssText).toBe(custom)
+  })
+})

--- a/apps/web/src/components/admin/settings/branding/__tests__/use-branding-state.test.ts
+++ b/apps/web/src/components/admin/settings/branding/__tests__/use-branding-state.test.ts
@@ -208,4 +208,18 @@ describe('useBrandingState initial cssText', () => {
     expect(result.current.cssText).toContain('.brand { color: red; }')
     expect(result.current.cssText).not.toBe('.brand { color: red; }')
   })
+
+  it('keeps a CSS-only palette when brandingConfig is empty', () => {
+    const cssPrimary = 'oklch(0.55 0.2 250)'
+    const { result } = renderHook(() =>
+      useBrandingState({
+        initialLogoUrl: null,
+        initialThemeConfig: { themeMode: 'user' },
+        initialCustomCss: `:root { --primary: ${cssPrimary}; }\n.brand { color: red; }\n`,
+      })
+    )
+
+    expect(result.current.parsedCssVariables.light['--primary']).toBe(cssPrimary)
+    expect(result.current.cssText).toContain('.brand { color: red; }')
+  })
 })

--- a/apps/web/src/components/admin/settings/branding/__tests__/use-branding-state.test.ts
+++ b/apps/web/src/components/admin/settings/branding/__tests__/use-branding-state.test.ts
@@ -209,6 +209,24 @@ describe('useBrandingState initial cssText', () => {
     expect(result.current.cssText).not.toBe('.brand { color: red; }')
   })
 
+  it('seeds both palettes when themeMode is light so the dark side survives', () => {
+    const darkPrimary = 'oklch(0.4 0.2 250)'
+    const { result } = renderHook(() =>
+      useBrandingState({
+        initialLogoUrl: null,
+        initialThemeConfig: {
+          themeMode: 'light',
+          dark: { primary: darkPrimary },
+        },
+        initialCustomCss: '',
+      })
+    )
+
+    expect(result.current.themeMode).toBe('light')
+    expect(result.current.cssText).toMatch(/\.dark\s*\{/)
+    expect(result.current.parsedCssVariables.dark['--primary']).toBe(darkPrimary)
+  })
+
   it('keeps a CSS-only palette when brandingConfig is empty', () => {
     const cssPrimary = 'oklch(0.55 0.2 250)'
     const { result } = renderHook(() =>

--- a/apps/web/src/components/admin/settings/branding/__tests__/use-branding-state.test.ts
+++ b/apps/web/src/components/admin/settings/branding/__tests__/use-branding-state.test.ts
@@ -9,7 +9,7 @@ vi.mock('@/lib/client/mutations/settings', () => ({
 import { useBrandingState } from '../use-branding-state'
 
 describe('useBrandingState setThemeMode', () => {
-  it('regenerates cssText when it is still generated CSS for the previous mode', () => {
+  it('keeps both palettes in cssText when switching from user to light', () => {
     const { result } = renderHook(() =>
       useBrandingState({
         initialLogoUrl: null,
@@ -19,7 +19,7 @@ describe('useBrandingState setThemeMode', () => {
     )
 
     expect(result.current.cssText).toContain(':root')
-    expect(result.current.cssText).toContain('.dark')
+    expect(result.current.cssText).toMatch(/\.dark\s*\{/)
 
     act(() => {
       result.current.setThemeMode('light')
@@ -27,7 +27,7 @@ describe('useBrandingState setThemeMode', () => {
 
     expect(result.current.themeMode).toBe('light')
     expect(result.current.cssText).toContain(':root')
-    expect(result.current.cssText).not.toMatch(/\.dark\s*\{/)
+    expect(result.current.cssText).toMatch(/\.dark\s*\{/)
   })
 
   it('leaves Advanced CSS extra rules untouched', () => {
@@ -45,5 +45,27 @@ describe('useBrandingState setThemeMode', () => {
     })
 
     expect(result.current.cssText).toBe(custom)
+  })
+})
+
+describe('useBrandingState typography', () => {
+  it('reads font and radius from the dark block in dark-only CSS', () => {
+    const custom = [
+      '.dark {',
+      '  --font-sans: "Lora", ui-serif, Georgia, serif;',
+      '  --radius: 1.25rem;',
+      '}',
+      '',
+    ].join('\n')
+    const { result } = renderHook(() =>
+      useBrandingState({
+        initialLogoUrl: null,
+        initialThemeConfig: { themeMode: 'dark' },
+        initialCustomCss: custom,
+      })
+    )
+
+    expect(result.current.font).toBe('"Lora", ui-serif, Georgia, serif')
+    expect(result.current.radius).toBe(1.25)
   })
 })

--- a/apps/web/src/components/admin/settings/branding/__tests__/use-branding-state.test.ts
+++ b/apps/web/src/components/admin/settings/branding/__tests__/use-branding-state.test.ts
@@ -1,12 +1,20 @@
 // @vitest-environment happy-dom
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { act, renderHook } from '@testing-library/react'
 
+const { saveBrandingTheme } = vi.hoisted(() => ({
+  saveBrandingTheme: vi.fn(async () => undefined),
+}))
+
 vi.mock('@/lib/client/mutations/settings', () => ({
-  useSaveBrandingTheme: () => ({ mutateAsync: vi.fn() }),
+  useSaveBrandingTheme: () => ({ mutateAsync: saveBrandingTheme }),
 }))
 
 import { useBrandingState } from '../use-branding-state'
+
+beforeEach(() => {
+  saveBrandingTheme.mockClear()
+})
 
 describe('useBrandingState setThemeMode', () => {
   it('keeps both palettes in cssText when switching from user to light', () => {
@@ -45,6 +53,28 @@ describe('useBrandingState setThemeMode', () => {
     })
 
     expect(result.current.cssText).toBe(custom)
+  })
+
+  it('skips the customCss write when leftover Advanced CSS is unchanged', async () => {
+    const leftover = ':root { --primary: oklch(0.5 0.2 250); }\n.brand { color: red; }\n'
+    const { result } = renderHook(() =>
+      useBrandingState({
+        initialLogoUrl: null,
+        initialThemeConfig: { themeMode: 'user' },
+        initialCustomCss: leftover,
+      })
+    )
+
+    act(() => {
+      result.current.setThemeMode('light')
+    })
+    await act(async () => {
+      await result.current.saveTheme()
+    })
+
+    expect(saveBrandingTheme).toHaveBeenCalledWith(
+      expect.objectContaining({ customCssWrite: 'skip' })
+    )
   })
 })
 

--- a/apps/web/src/components/admin/settings/branding/__tests__/use-branding-state.test.ts
+++ b/apps/web/src/components/admin/settings/branding/__tests__/use-branding-state.test.ts
@@ -76,6 +76,75 @@ describe('useBrandingState setThemeMode', () => {
       expect.objectContaining({ customCssWrite: 'skip' })
     )
   })
+
+  it('skips the customCss write when leftover extra rules are unchanged after a var edit', async () => {
+    const leftover = [
+      ':root { --primary: oklch(0.5 0.2 250); --radius: 0.625rem; }',
+      '.dark { --primary: oklch(0.7 0.2 250); --radius: 0.625rem; }',
+      '.brand { color: red; }',
+      '',
+    ].join('\n')
+    const { result } = renderHook(() =>
+      useBrandingState({
+        initialLogoUrl: null,
+        initialThemeConfig: { themeMode: 'user' },
+        initialCustomCss: leftover,
+      })
+    )
+
+    act(() => {
+      result.current.setRadius(1.25)
+    })
+    await act(async () => {
+      await result.current.saveTheme()
+    })
+
+    expect(result.current.cssText).toContain('1.25rem')
+    expect(result.current.cssText).toContain('.brand { color: red; }')
+    expect(saveBrandingTheme).toHaveBeenCalledWith(
+      expect.objectContaining({ customCssWrite: 'skip' })
+    )
+  })
+
+  it('clears stored customCss when cssText is generated theme CSS', async () => {
+    const { result } = renderHook(() =>
+      useBrandingState({
+        initialLogoUrl: null,
+        initialThemeConfig: { themeMode: 'user' },
+        initialCustomCss: '',
+      })
+    )
+
+    await act(async () => {
+      await result.current.saveTheme()
+    })
+
+    expect(saveBrandingTheme).toHaveBeenCalledWith(
+      expect.objectContaining({ customCssWrite: 'clear' })
+    )
+  })
+
+  it('persists when leftover extra rules themselves change', async () => {
+    const leftover = ':root { --primary: oklch(0.5 0.2 250); }\n.brand { color: red; }\n'
+    const { result } = renderHook(() =>
+      useBrandingState({
+        initialLogoUrl: null,
+        initialThemeConfig: { themeMode: 'user' },
+        initialCustomCss: leftover,
+      })
+    )
+
+    act(() => {
+      result.current.setCssText(`${leftover}.hero { color: blue; }\n`)
+    })
+    await act(async () => {
+      await result.current.saveTheme()
+    })
+
+    expect(saveBrandingTheme).toHaveBeenCalledWith(
+      expect.objectContaining({ customCssWrite: 'persist' })
+    )
+  })
 })
 
 describe('useBrandingState typography', () => {

--- a/apps/web/src/components/admin/settings/branding/__tests__/use-branding-state.test.ts
+++ b/apps/web/src/components/admin/settings/branding/__tests__/use-branding-state.test.ts
@@ -54,11 +54,13 @@ describe('useBrandingState setThemeMode', () => {
       })
     )
 
+    const before = result.current.cssText
     act(() => {
       result.current.setThemeMode('dark')
     })
 
-    expect(result.current.cssText).toBe(custom)
+    expect(result.current.cssText).toBe(before)
+    expect(result.current.cssText).toContain('.brand { color: red; }')
   })
 
   it('rewrites leftover Advanced CSS as remainder-only when extras are unchanged', async () => {
@@ -168,22 +170,42 @@ describe('useBrandingState setThemeMode', () => {
 
 describe('useBrandingState typography', () => {
   it('reads font and radius from the dark block in dark-only CSS', () => {
-    const custom = [
-      '.dark {',
-      '  --font-sans: "Lora", ui-serif, Georgia, serif;',
-      '  --radius: 1.25rem;',
-      '}',
-      '',
-    ].join('\n')
     const { result } = renderHook(() =>
       useBrandingState({
         initialLogoUrl: null,
-        initialThemeConfig: { themeMode: 'dark' },
-        initialCustomCss: custom,
+        initialThemeConfig: {
+          themeMode: 'dark',
+          dark: {
+            fontSans: '"Lora", ui-serif, Georgia, serif',
+            radius: '1.25rem',
+          },
+        },
+        initialCustomCss: '',
       })
     )
 
     expect(result.current.font).toBe('"Lora", ui-serif, Georgia, serif')
     expect(result.current.radius).toBe(1.25)
+  })
+})
+
+describe('useBrandingState initial cssText', () => {
+  it('seeds generated theme CSS from brandingConfig and appends remainder-only custom CSS', () => {
+    const customPrimary = 'oklch(0.55 0.2 250)'
+    const { result } = renderHook(() =>
+      useBrandingState({
+        initialLogoUrl: null,
+        initialThemeConfig: {
+          themeMode: 'user',
+          light: { primary: customPrimary },
+          dark: { primary: customPrimary },
+        },
+        initialCustomCss: '.brand { color: red; }',
+      })
+    )
+
+    expect(result.current.cssText).toContain(`--primary: ${customPrimary}`)
+    expect(result.current.cssText).toContain('.brand { color: red; }')
+    expect(result.current.cssText).not.toBe('.brand { color: red; }')
   })
 })

--- a/apps/web/src/components/admin/settings/branding/use-branding-state.ts
+++ b/apps/web/src/components/admin/settings/branding/use-branding-state.ts
@@ -6,6 +6,7 @@ import {
   extractCssVariables,
   generateReadableCSS,
   isGeneratedThemeCss,
+  advancedCssRemainder,
   parseCssToMinimal,
   replaceCssVar,
   normalizeFontSans,
@@ -305,12 +306,12 @@ export function useBrandingState(options: UseBrandingStateOptions): BrandingStat
       }
 
       // Generated theme CSS is reconstructed from brandingConfig, so posting
-      // it as customCss would hit the Pro-only gate. Leftover Advanced CSS
-      // that the user did not edit must not be rewritten either — a theme-mode
-      // switch keeps cssText as-is, and that save is still a structured write.
+      // it as customCss would hit the Pro-only gate. Leftover extra rules
+      // that the user did not edit must not be rewritten either — colour,
+      // font, and radius edits live in :root/.dark and still skip the write.
       const customCssWrite = isGeneratedThemeCss(cssText, lightMinimal, darkMinimal)
         ? 'clear'
-        : cssText.trim() === initialCustomCss.trim()
+        : advancedCssRemainder(cssText) === advancedCssRemainder(initialCustomCss)
           ? 'skip'
           : 'persist'
 

--- a/apps/web/src/components/admin/settings/branding/use-branding-state.ts
+++ b/apps/web/src/components/admin/settings/branding/use-branding-state.ts
@@ -195,44 +195,20 @@ export function useBrandingState(options: UseBrandingStateOptions): BrandingStat
     initialMode === 'dark' ? 'dark' : 'light'
   )
   const [themeMode, setThemeModeRaw] = useState<ThemeMode>(() => initialMode)
+
+  // Forced light/dark also locks the preview toggle. cssText is left intact so
+  // the inactive palette is still present when saveTheme parses brandingConfig.
+  const setThemeMode = useCallback((mode: ThemeMode) => {
+    setThemeModeRaw(mode)
+    if (mode === 'dark') setPreviewMode('dark')
+    else if (mode === 'light') setPreviewMode('light')
+  }, [])
   const [cssText, setCssText] = useState(() =>
     buildInitialCss(initialCustomCss, initialThemeConfig)
   )
 
   const [isSaving, setIsSaving] = useState(false)
   const [saveSuccess, setSaveSuccess] = useState(false)
-
-  const defaultPreset = themePresets.default
-  const defaultLightMinimal = useMemo(() => extractMinimal(defaultPreset.light), [defaultPreset])
-  const defaultDarkMinimal = useMemo(() => extractMinimal(defaultPreset.dark), [defaultPreset])
-
-  // When theme mode changes, auto-switch preview to match and regenerate CSS
-  // if the editor is still showing generated theme CSS (not Advanced CSS).
-  const setThemeMode = useCallback(
-    (mode: ThemeMode) => {
-      const previousMode = themeMode
-      setThemeModeRaw(mode)
-      if (mode === 'dark') setPreviewMode('dark')
-      else if (mode === 'light') setPreviewMode('light')
-
-      setCssText((prev) => {
-        if (previousMode === mode) return prev
-        const parsed = extractCssVariables(prev)
-        const lightMinimal: Partial<MinimalThemeVariables> = {
-          ...defaultLightMinimal,
-          ...parseCssToMinimal(parsed.light),
-        }
-        const darkMinimal: Partial<MinimalThemeVariables> = {
-          ...defaultDarkMinimal,
-          ...parseCssToMinimal(parsed.dark),
-        }
-        const previousGenerated = generateReadableCSS(lightMinimal, darkMinimal, previousMode)
-        if (prev.trim() !== previousGenerated.trim()) return prev
-        return generateReadableCSS(lightMinimal, darkMinimal, mode)
-      })
-    },
-    [themeMode, defaultLightMinimal, defaultDarkMinimal]
-  )
 
   // ============================================
   // Parsed CSS variables (derived synchronously — regex is <1ms)
@@ -245,8 +221,15 @@ export function useBrandingState(options: UseBrandingStateOptions): BrandingStat
   const previewModeDisabled: 'light' | 'dark' | null =
     themeMode === 'dark' ? 'light' : themeMode === 'light' ? 'dark' : null
 
+  const defaultPreset = themePresets.default
+  const defaultLightMinimal = useMemo(() => extractMinimal(defaultPreset.light), [defaultPreset])
+  const defaultDarkMinimal = useMemo(() => extractMinimal(defaultPreset.dark), [defaultPreset])
+
   const font = useMemo(
-    () => parsedCssVariables.light['--font-sans'] || DEFAULT_FONT,
+    () =>
+      parsedCssVariables.light['--font-sans'] ||
+      parsedCssVariables.dark['--font-sans'] ||
+      DEFAULT_FONT,
     [parsedCssVariables]
   )
 
@@ -256,7 +239,7 @@ export function useBrandingState(options: UseBrandingStateOptions): BrandingStat
   )
 
   const radius = useMemo(() => {
-    const raw = parsedCssVariables.light['--radius']
+    const raw = parsedCssVariables.light['--radius'] || parsedCssVariables.dark['--radius']
     if (!raw) return DEFAULT_RADIUS
     const match = raw.match(/^([\d.]+)rem$/)
     return match ? parseFloat(match[1]) : DEFAULT_RADIUS

--- a/apps/web/src/components/admin/settings/branding/use-branding-state.ts
+++ b/apps/web/src/components/admin/settings/branding/use-branding-state.ts
@@ -185,7 +185,7 @@ function buildInitialCss(initialCustomCss: string, initialThemeConfig: ThemeConf
   // has the inactive side in cssText for saveTheme to parse. Preview
   // locking uses initialThemeConfig.themeMode separately.
   const generated = generateReadableCSS(lightMinimal, darkMinimal, 'user')
-  const remainder = advancedCssRemainder(initialCustomCss)
+  const remainder = advancedCssRemainder(initialCustomCss, generated)
   if (!remainder) return generated
   return `${generated.trimEnd()}\n\n${remainder}`
 }
@@ -317,11 +317,12 @@ export function useBrandingState(options: UseBrandingStateOptions): BrandingStat
       // customCss is remainder-only so leftover :root/.dark theme vars cannot
       // override the saved colours. Extra rules that changed still persist
       // through the Pro gate; unchanged extras are rewritten without it.
-      const remainder = advancedCssRemainder(cssText)
+      const generated = generateReadableCSS(lightMinimal, darkMinimal, 'user')
+      const remainder = advancedCssRemainder(cssText, generated)
       const customCssWrite =
         isGeneratedThemeCss(cssText, lightMinimal, darkMinimal) || !remainder
           ? 'clear'
-          : remainder === advancedCssRemainder(initialCustomCss)
+          : remainder === advancedCssRemainder(initialCustomCss, generated)
             ? 'rewrite'
             : 'persist'
 

--- a/apps/web/src/components/admin/settings/branding/use-branding-state.ts
+++ b/apps/web/src/components/admin/settings/branding/use-branding-state.ts
@@ -166,10 +166,6 @@ export interface BrandingState {
 }
 
 function buildInitialCss(initialCustomCss: string, initialThemeConfig: ThemeConfig): string {
-  // If user already has custom CSS, use it as-is
-  if (initialCustomCss.trim()) return initialCustomCss
-
-  // Otherwise generate readable CSS from the structured config
   const defaultPreset = themePresets.default
   const lightMinimal = extractMinimal({
     ...defaultPreset.light,
@@ -180,7 +176,10 @@ function buildInitialCss(initialCustomCss: string, initialThemeConfig: ThemeConf
     ...(initialThemeConfig.dark ?? {}),
   })
 
-  return generateReadableCSS(lightMinimal, darkMinimal, initialThemeConfig.themeMode)
+  const generated = generateReadableCSS(lightMinimal, darkMinimal, initialThemeConfig.themeMode)
+  const remainder = advancedCssRemainder(initialCustomCss)
+  if (!remainder) return generated
+  return `${generated.trimEnd()}\n\n${remainder}`
 }
 
 export function useBrandingState(options: UseBrandingStateOptions): BrandingState {

--- a/apps/web/src/components/admin/settings/branding/use-branding-state.ts
+++ b/apps/web/src/components/admin/settings/branding/use-branding-state.ts
@@ -5,6 +5,7 @@ import {
   extractMinimal,
   extractCssVariables,
   generateReadableCSS,
+  isGeneratedThemeCss,
   parseCssToMinimal,
   replaceCssVar,
   normalizeFontSans,
@@ -194,19 +195,44 @@ export function useBrandingState(options: UseBrandingStateOptions): BrandingStat
     initialMode === 'dark' ? 'dark' : 'light'
   )
   const [themeMode, setThemeModeRaw] = useState<ThemeMode>(() => initialMode)
-
-  // When theme mode changes, auto-switch preview to match and regenerate CSS
-  const setThemeMode = useCallback((mode: ThemeMode) => {
-    setThemeModeRaw(mode)
-    if (mode === 'dark') setPreviewMode('dark')
-    else if (mode === 'light') setPreviewMode('light')
-  }, [])
   const [cssText, setCssText] = useState(() =>
     buildInitialCss(initialCustomCss, initialThemeConfig)
   )
 
   const [isSaving, setIsSaving] = useState(false)
   const [saveSuccess, setSaveSuccess] = useState(false)
+
+  const defaultPreset = themePresets.default
+  const defaultLightMinimal = useMemo(() => extractMinimal(defaultPreset.light), [defaultPreset])
+  const defaultDarkMinimal = useMemo(() => extractMinimal(defaultPreset.dark), [defaultPreset])
+
+  // When theme mode changes, auto-switch preview to match and regenerate CSS
+  // if the editor is still showing generated theme CSS (not Advanced CSS).
+  const setThemeMode = useCallback(
+    (mode: ThemeMode) => {
+      const previousMode = themeMode
+      setThemeModeRaw(mode)
+      if (mode === 'dark') setPreviewMode('dark')
+      else if (mode === 'light') setPreviewMode('light')
+
+      setCssText((prev) => {
+        if (previousMode === mode) return prev
+        const parsed = extractCssVariables(prev)
+        const lightMinimal: Partial<MinimalThemeVariables> = {
+          ...defaultLightMinimal,
+          ...parseCssToMinimal(parsed.light),
+        }
+        const darkMinimal: Partial<MinimalThemeVariables> = {
+          ...defaultDarkMinimal,
+          ...parseCssToMinimal(parsed.dark),
+        }
+        const previousGenerated = generateReadableCSS(lightMinimal, darkMinimal, previousMode)
+        if (prev.trim() !== previousGenerated.trim()) return prev
+        return generateReadableCSS(lightMinimal, darkMinimal, mode)
+      })
+    },
+    [themeMode, defaultLightMinimal, defaultDarkMinimal]
+  )
 
   // ============================================
   // Parsed CSS variables (derived synchronously — regex is <1ms)
@@ -218,10 +244,6 @@ export function useBrandingState(options: UseBrandingStateOptions): BrandingStat
   // ============================================
   const previewModeDisabled: 'light' | 'dark' | null =
     themeMode === 'dark' ? 'light' : themeMode === 'light' ? 'dark' : null
-
-  const defaultPreset = themePresets.default
-  const defaultLightMinimal = useMemo(() => extractMinimal(defaultPreset.light), [defaultPreset])
-  const defaultDarkMinimal = useMemo(() => extractMinimal(defaultPreset.dark), [defaultPreset])
 
   const font = useMemo(
     () => parsedCssVariables.light['--font-sans'] || DEFAULT_FONT,
@@ -299,11 +321,12 @@ export function useBrandingState(options: UseBrandingStateOptions): BrandingStat
         dark: { ...darkMinimal, fontSans: font, radius: `${radius}rem` },
       }
 
-      const generatedCss = generateReadableCSS(lightMinimal, darkMinimal, themeMode)
       // The Advanced CSS panel writes extra rules into cssText. Generated
       // theme CSS is reconstructed from brandingConfig on the portal, so
       // posting it as customCss would hit the Pro-only customCss gate.
-      const persistCustomCss = cssText.trim() !== generatedCss.trim()
+      // Classify against every theme mode: a mode switch that left cssText
+      // as the previous mode's generated blocks is not Advanced CSS.
+      const persistCustomCss = !isGeneratedThemeCss(cssText, lightMinimal, darkMinimal)
 
       // The mutation hook invalidates the branding + customCss queries on success,
       // so the next visit reflects the save instead of re-seeding the editor from

--- a/apps/web/src/components/admin/settings/branding/use-branding-state.ts
+++ b/apps/web/src/components/admin/settings/branding/use-branding-state.ts
@@ -299,12 +299,19 @@ export function useBrandingState(options: UseBrandingStateOptions): BrandingStat
         dark: { ...darkMinimal, fontSans: font, radius: `${radius}rem` },
       }
 
+      const generatedCss = generateReadableCSS(lightMinimal, darkMinimal, themeMode)
+      // The Advanced CSS panel writes extra rules into cssText. Generated
+      // theme CSS is reconstructed from brandingConfig on the portal, so
+      // posting it as customCss would hit the Pro-only customCss gate.
+      const persistCustomCss = cssText.trim() !== generatedCss.trim()
+
       // The mutation hook invalidates the branding + customCss queries on success,
       // so the next visit reflects the save instead of re-seeding the editor from
       // the stale pre-save cache.
       await saveBrandingTheme({
         brandingConfig: themeConfig as unknown as Record<string, unknown>,
         customCss: cssText,
+        persistCustomCss,
       })
 
       setSaveSuccess(true)

--- a/apps/web/src/components/admin/settings/branding/use-branding-state.ts
+++ b/apps/web/src/components/admin/settings/branding/use-branding-state.ts
@@ -181,7 +181,10 @@ function buildInitialCss(initialCustomCss: string, initialThemeConfig: ThemeConf
     ...(initialThemeConfig.dark ?? {}),
   }
 
-  const generated = generateReadableCSS(lightMinimal, darkMinimal, initialThemeConfig.themeMode)
+  // Always emit both palettes so a later switch back to user mode still
+  // has the inactive side in cssText for saveTheme to parse. Preview
+  // locking uses initialThemeConfig.themeMode separately.
+  const generated = generateReadableCSS(lightMinimal, darkMinimal, 'user')
   const remainder = advancedCssRemainder(initialCustomCss)
   if (!remainder) return generated
   return `${generated.trimEnd()}\n\n${remainder}`
@@ -230,13 +233,12 @@ export function useBrandingState(options: UseBrandingStateOptions): BrandingStat
   const defaultLightMinimal = useMemo(() => extractMinimal(defaultPreset.light), [defaultPreset])
   const defaultDarkMinimal = useMemo(() => extractMinimal(defaultPreset.dark), [defaultPreset])
 
-  const font = useMemo(
-    () =>
-      parsedCssVariables.light['--font-sans'] ||
-      parsedCssVariables.dark['--font-sans'] ||
-      DEFAULT_FONT,
-    [parsedCssVariables]
-  )
+  const font = useMemo(() => {
+    const light = parsedCssVariables.light['--font-sans']
+    const dark = parsedCssVariables.dark['--font-sans']
+    if (themeMode === 'dark') return dark || light || DEFAULT_FONT
+    return light || dark || DEFAULT_FONT
+  }, [parsedCssVariables, themeMode])
 
   const currentFontId = useMemo(
     () => FONT_OPTIONS.find((f) => f.value === normalizeFontSans(font))?.id || 'inter',
@@ -244,11 +246,13 @@ export function useBrandingState(options: UseBrandingStateOptions): BrandingStat
   )
 
   const radius = useMemo(() => {
-    const raw = parsedCssVariables.light['--radius'] || parsedCssVariables.dark['--radius']
+    const light = parsedCssVariables.light['--radius']
+    const dark = parsedCssVariables.dark['--radius']
+    const raw = themeMode === 'dark' ? dark || light : light || dark
     if (!raw) return DEFAULT_RADIUS
     const match = raw.match(/^([\d.]+)rem$/)
     return match ? parseFloat(match[1]) : DEFAULT_RADIUS
-  }, [parsedCssVariables])
+  }, [parsedCssVariables, themeMode])
 
   const activePresetId = useMemo(() => {
     const parsedLight = parseCssToMinimal(parsedCssVariables.light)

--- a/apps/web/src/components/admin/settings/branding/use-branding-state.ts
+++ b/apps/web/src/components/admin/settings/branding/use-branding-state.ts
@@ -304,12 +304,15 @@ export function useBrandingState(options: UseBrandingStateOptions): BrandingStat
         dark: { ...darkMinimal, fontSans: font, radius: `${radius}rem` },
       }
 
-      // The Advanced CSS panel writes extra rules into cssText. Generated
-      // theme CSS is reconstructed from brandingConfig on the portal, so
-      // posting it as customCss would hit the Pro-only customCss gate.
-      // Classify against every theme mode: a mode switch that left cssText
-      // as the previous mode's generated blocks is not Advanced CSS.
-      const persistCustomCss = !isGeneratedThemeCss(cssText, lightMinimal, darkMinimal)
+      // Generated theme CSS is reconstructed from brandingConfig, so posting
+      // it as customCss would hit the Pro-only gate. Leftover Advanced CSS
+      // that the user did not edit must not be rewritten either — a theme-mode
+      // switch keeps cssText as-is, and that save is still a structured write.
+      const customCssWrite = isGeneratedThemeCss(cssText, lightMinimal, darkMinimal)
+        ? 'clear'
+        : cssText.trim() === initialCustomCss.trim()
+          ? 'skip'
+          : 'persist'
 
       // The mutation hook invalidates the branding + customCss queries on success,
       // so the next visit reflects the save instead of re-seeding the editor from
@@ -317,7 +320,7 @@ export function useBrandingState(options: UseBrandingStateOptions): BrandingStat
       await saveBrandingTheme({
         brandingConfig: themeConfig as unknown as Record<string, unknown>,
         customCss: cssText,
-        persistCustomCss,
+        customCssWrite,
       })
 
       setSaveSuccess(true)
@@ -325,7 +328,16 @@ export function useBrandingState(options: UseBrandingStateOptions): BrandingStat
     } finally {
       setIsSaving(false)
     }
-  }, [cssText, themeMode, font, radius, defaultLightMinimal, defaultDarkMinimal, saveBrandingTheme])
+  }, [
+    cssText,
+    themeMode,
+    font,
+    radius,
+    defaultLightMinimal,
+    defaultDarkMinimal,
+    saveBrandingTheme,
+    initialCustomCss,
+  ])
 
   return {
     logoUrl,

--- a/apps/web/src/components/admin/settings/branding/use-branding-state.ts
+++ b/apps/web/src/components/admin/settings/branding/use-branding-state.ts
@@ -167,14 +167,19 @@ export interface BrandingState {
 
 function buildInitialCss(initialCustomCss: string, initialThemeConfig: ThemeConfig): string {
   const defaultPreset = themePresets.default
-  const lightMinimal = extractMinimal({
-    ...defaultPreset.light,
+  const parsed = extractCssVariables(initialCustomCss)
+  // Structured brandingConfig wins; CSS-parsed values fill gaps so a
+  // CSS-only palette (empty/partial config) is not replaced by defaults.
+  const lightMinimal: Partial<MinimalThemeVariables> = {
+    ...extractMinimal(defaultPreset.light),
+    ...parseCssToMinimal(parsed.light),
     ...(initialThemeConfig.light ?? {}),
-  })
-  const darkMinimal = extractMinimal({
-    ...defaultPreset.dark,
+  }
+  const darkMinimal: Partial<MinimalThemeVariables> = {
+    ...extractMinimal(defaultPreset.dark),
+    ...parseCssToMinimal(parsed.dark),
     ...(initialThemeConfig.dark ?? {}),
-  })
+  }
 
   const generated = generateReadableCSS(lightMinimal, darkMinimal, initialThemeConfig.themeMode)
   const remainder = advancedCssRemainder(initialCustomCss)

--- a/apps/web/src/components/admin/settings/branding/use-branding-state.ts
+++ b/apps/web/src/components/admin/settings/branding/use-branding-state.ts
@@ -305,22 +305,24 @@ export function useBrandingState(options: UseBrandingStateOptions): BrandingStat
         dark: { ...darkMinimal, fontSans: font, radius: `${radius}rem` },
       }
 
-      // Generated theme CSS is reconstructed from brandingConfig, so posting
-      // it as customCss would hit the Pro-only gate. Leftover extra rules
-      // that the user did not edit must not be rewritten either — colour,
-      // font, and radius edits live in :root/.dark and still skip the write.
-      const customCssWrite = isGeneratedThemeCss(cssText, lightMinimal, darkMinimal)
-        ? 'clear'
-        : advancedCssRemainder(cssText) === advancedCssRemainder(initialCustomCss)
-          ? 'skip'
-          : 'persist'
+      // Generated theme CSS is reconstructed from brandingConfig. Stored
+      // customCss is remainder-only so leftover :root/.dark theme vars cannot
+      // override the saved colours. Extra rules that changed still persist
+      // through the Pro gate; unchanged extras are rewritten without it.
+      const remainder = advancedCssRemainder(cssText)
+      const customCssWrite =
+        isGeneratedThemeCss(cssText, lightMinimal, darkMinimal) || !remainder
+          ? 'clear'
+          : remainder === advancedCssRemainder(initialCustomCss)
+            ? 'rewrite'
+            : 'persist'
 
       // The mutation hook invalidates the branding + customCss queries on success,
       // so the next visit reflects the save instead of re-seeding the editor from
       // the stale pre-save cache.
       await saveBrandingTheme({
         brandingConfig: themeConfig as unknown as Record<string, unknown>,
-        customCss: cssText,
+        customCss: remainder,
         customCssWrite,
       })
 

--- a/apps/web/src/lib/client/mutations/__tests__/settings.test.ts
+++ b/apps/web/src/lib/client/mutations/__tests__/settings.test.ts
@@ -79,9 +79,9 @@ describe('settings config mutations cache invalidation', () => {
     expect(result).toBeInstanceOf(Promise)
   })
 
-  it('useSaveBrandingTheme skips the customCss write unless persistCustomCss is set', async () => {
+  it('useSaveBrandingTheme clears stored customCss unless persistCustomCss is set', async () => {
     const { useSaveBrandingTheme } = await import('../settings')
-    const mutation = useSaveBrandingTheme() as {
+    const mutation = useSaveBrandingTheme() as unknown as {
       mutationFn: (input: {
         brandingConfig: Record<string, unknown>
         customCss: string
@@ -95,14 +95,16 @@ describe('settings config mutations cache invalidation', () => {
       persistCustomCss: false,
     })
     expect(updateThemeFn).toHaveBeenCalledOnce()
-    expect(updateCustomCssFn).not.toHaveBeenCalled()
+    expect(updateCustomCssFn).toHaveBeenCalledWith({ data: { customCss: '' } })
 
     await mutation.mutationFn({
       brandingConfig: { preset: 'default' },
       customCss: '.brand { color: red; }',
       persistCustomCss: true,
     })
-    expect(updateCustomCssFn).toHaveBeenCalledOnce()
+    expect(updateCustomCssFn).toHaveBeenCalledWith({
+      data: { customCss: '.brand { color: red; }' },
+    })
   })
 
   it('useSaveBrandingTheme.onSuccess awaits invalidation of branding and customCss queries', async () => {

--- a/apps/web/src/lib/client/mutations/__tests__/settings.test.ts
+++ b/apps/web/src/lib/client/mutations/__tests__/settings.test.ts
@@ -79,23 +79,25 @@ describe('settings config mutations cache invalidation', () => {
     expect(result).toBeInstanceOf(Promise)
   })
 
-  it('useSaveBrandingTheme persist/clear/skip customCss writes', async () => {
+  it('useSaveBrandingTheme persist/clear/rewrite customCss writes', async () => {
     const { useSaveBrandingTheme } = await import('../settings')
     const mutation = useSaveBrandingTheme() as unknown as {
       mutationFn: (input: {
         brandingConfig: Record<string, unknown>
         customCss: string
-        customCssWrite: 'persist' | 'clear' | 'skip'
+        customCssWrite: 'persist' | 'clear' | 'rewrite'
       }) => Promise<unknown>
     }
 
     await mutation.mutationFn({
       brandingConfig: { preset: 'default' },
-      customCss: ':root { --primary: red; }',
-      customCssWrite: 'skip',
+      customCss: '.brand { color: red; }',
+      customCssWrite: 'rewrite',
     })
     expect(updateThemeFn).toHaveBeenCalledOnce()
-    expect(updateCustomCssFn).not.toHaveBeenCalled()
+    expect(updateCustomCssFn).toHaveBeenCalledWith({
+      data: { customCss: '.brand { color: red; }' },
+    })
 
     await mutation.mutationFn({
       brandingConfig: { preset: 'default' },

--- a/apps/web/src/lib/client/mutations/__tests__/settings.test.ts
+++ b/apps/web/src/lib/client/mutations/__tests__/settings.test.ts
@@ -79,28 +79,35 @@ describe('settings config mutations cache invalidation', () => {
     expect(result).toBeInstanceOf(Promise)
   })
 
-  it('useSaveBrandingTheme clears stored customCss unless persistCustomCss is set', async () => {
+  it('useSaveBrandingTheme persist/clear/skip customCss writes', async () => {
     const { useSaveBrandingTheme } = await import('../settings')
     const mutation = useSaveBrandingTheme() as unknown as {
       mutationFn: (input: {
         brandingConfig: Record<string, unknown>
         customCss: string
-        persistCustomCss: boolean
+        customCssWrite: 'persist' | 'clear' | 'skip'
       }) => Promise<unknown>
     }
 
     await mutation.mutationFn({
       brandingConfig: { preset: 'default' },
       customCss: ':root { --primary: red; }',
-      persistCustomCss: false,
+      customCssWrite: 'skip',
     })
     expect(updateThemeFn).toHaveBeenCalledOnce()
+    expect(updateCustomCssFn).not.toHaveBeenCalled()
+
+    await mutation.mutationFn({
+      brandingConfig: { preset: 'default' },
+      customCss: ':root { --primary: red; }',
+      customCssWrite: 'clear',
+    })
     expect(updateCustomCssFn).toHaveBeenCalledWith({ data: { customCss: '' } })
 
     await mutation.mutationFn({
       brandingConfig: { preset: 'default' },
       customCss: '.brand { color: red; }',
-      persistCustomCss: true,
+      customCssWrite: 'persist',
     })
     expect(updateCustomCssFn).toHaveBeenCalledWith({
       data: { customCss: '.brand { color: red; }' },

--- a/apps/web/src/lib/client/mutations/__tests__/settings.test.ts
+++ b/apps/web/src/lib/client/mutations/__tests__/settings.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const invalidateQueries = vi.fn()
+const updateThemeFn = vi.fn(async () => ({ ok: true }))
+const updateCustomCssFn = vi.fn(async () => ({ ok: true }))
 
 vi.mock('@tanstack/react-query', async () => {
   const actual =
@@ -11,6 +13,12 @@ vi.mock('@tanstack/react-query', async () => {
     useQueryClient: vi.fn(() => ({ invalidateQueries })),
   }
 })
+
+vi.mock('@/lib/server/functions/settings', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/server/functions/settings')>()),
+  updateThemeFn,
+  updateCustomCssFn,
+}))
 
 describe('settings config mutations cache invalidation', () => {
   beforeEach(() => {
@@ -69,6 +77,32 @@ describe('settings config mutations cache invalidation', () => {
 
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['settings', 'helpCenterConfig'] })
     expect(result).toBeInstanceOf(Promise)
+  })
+
+  it('useSaveBrandingTheme skips the customCss write unless persistCustomCss is set', async () => {
+    const { useSaveBrandingTheme } = await import('../settings')
+    const mutation = useSaveBrandingTheme() as {
+      mutationFn: (input: {
+        brandingConfig: Record<string, unknown>
+        customCss: string
+        persistCustomCss: boolean
+      }) => Promise<unknown>
+    }
+
+    await mutation.mutationFn({
+      brandingConfig: { preset: 'default' },
+      customCss: ':root { --primary: red; }',
+      persistCustomCss: false,
+    })
+    expect(updateThemeFn).toHaveBeenCalledOnce()
+    expect(updateCustomCssFn).not.toHaveBeenCalled()
+
+    await mutation.mutationFn({
+      brandingConfig: { preset: 'default' },
+      customCss: '.brand { color: red; }',
+      persistCustomCss: true,
+    })
+    expect(updateCustomCssFn).toHaveBeenCalledOnce()
   })
 
   it('useSaveBrandingTheme.onSuccess awaits invalidation of branding and customCss queries', async () => {

--- a/apps/web/src/lib/client/mutations/settings.ts
+++ b/apps/web/src/lib/client/mutations/settings.ts
@@ -475,8 +475,11 @@ export function useSaveBrandingTheme() {
       const { throwIfServerFnFailed } = await import('@/lib/shared/describe-upgrade')
       const theme = await updateThemeFn({ data: { brandingConfig: input.brandingConfig } })
       throwIfServerFnFailed(theme)
-      if (!input.persistCustomCss) return [theme, null] as const
-      const css = await updateCustomCssFn({ data: { customCss: input.customCss } })
+      // Empty customCss is ungated and clears a leftover Advanced CSS row so
+      // it cannot override the generated theme on the portal.
+      const css = await updateCustomCssFn({
+        data: { customCss: input.persistCustomCss ? input.customCss : '' },
+      })
       throwIfServerFnFailed(css)
       return [theme, css] as const
     },

--- a/apps/web/src/lib/client/mutations/settings.ts
+++ b/apps/web/src/lib/client/mutations/settings.ts
@@ -466,13 +466,17 @@ export function useSaveBrandingTheme() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async (input: { brandingConfig: Record<string, unknown>; customCss: string }) => {
+    mutationFn: async (input: {
+      brandingConfig: Record<string, unknown>
+      customCss: string
+      /** Advanced CSS only. Generated theme CSS is reconstructed from brandingConfig. */
+      persistCustomCss: boolean
+    }) => {
       const { throwIfServerFnFailed } = await import('@/lib/shared/describe-upgrade')
-      const [theme, css] = await Promise.all([
-        updateThemeFn({ data: { brandingConfig: input.brandingConfig } }),
-        updateCustomCssFn({ data: { customCss: input.customCss } }),
-      ])
+      const theme = await updateThemeFn({ data: { brandingConfig: input.brandingConfig } })
       throwIfServerFnFailed(theme)
+      if (!input.persistCustomCss) return [theme, null] as const
+      const css = await updateCustomCssFn({ data: { customCss: input.customCss } })
       throwIfServerFnFailed(css)
       return [theme, css] as const
     },

--- a/apps/web/src/lib/client/mutations/settings.ts
+++ b/apps/web/src/lib/client/mutations/settings.ts
@@ -470,18 +470,18 @@ export function useSaveBrandingTheme() {
       brandingConfig: Record<string, unknown>
       customCss: string
       /**
-       * persist: Advanced CSS changed — write cssText (Pro-gated).
-       * clear: generated theme CSS — write empty so leftover CSS cannot override.
-       * skip: leftover Advanced CSS unchanged — do not touch the stored row.
+       * persist: Advanced CSS changed — write remainder (Pro-gated).
+       * clear: generated-only theme CSS — write empty so leftover CSS cannot override.
+       * rewrite: extra rules unchanged — write remainder-only so stale :root/.dark
+       *   theme vars cannot override the saved structured colours.
        */
-      customCssWrite: 'persist' | 'clear' | 'skip'
+      customCssWrite: 'persist' | 'clear' | 'rewrite'
     }) => {
       const { throwIfServerFnFailed } = await import('@/lib/shared/describe-upgrade')
       const theme = await updateThemeFn({ data: { brandingConfig: input.brandingConfig } })
       throwIfServerFnFailed(theme)
-      if (input.customCssWrite === 'skip') return [theme, null] as const
       const css = await updateCustomCssFn({
-        data: { customCss: input.customCssWrite === 'persist' ? input.customCss : '' },
+        data: { customCss: input.customCssWrite === 'clear' ? '' : input.customCss },
       })
       throwIfServerFnFailed(css)
       return [theme, css] as const

--- a/apps/web/src/lib/client/mutations/settings.ts
+++ b/apps/web/src/lib/client/mutations/settings.ts
@@ -469,16 +469,19 @@ export function useSaveBrandingTheme() {
     mutationFn: async (input: {
       brandingConfig: Record<string, unknown>
       customCss: string
-      /** Advanced CSS only. Generated theme CSS is reconstructed from brandingConfig. */
-      persistCustomCss: boolean
+      /**
+       * persist: Advanced CSS changed — write cssText (Pro-gated).
+       * clear: generated theme CSS — write empty so leftover CSS cannot override.
+       * skip: leftover Advanced CSS unchanged — do not touch the stored row.
+       */
+      customCssWrite: 'persist' | 'clear' | 'skip'
     }) => {
       const { throwIfServerFnFailed } = await import('@/lib/shared/describe-upgrade')
       const theme = await updateThemeFn({ data: { brandingConfig: input.brandingConfig } })
       throwIfServerFnFailed(theme)
-      // Empty customCss is ungated and clears a leftover Advanced CSS row so
-      // it cannot override the generated theme on the portal.
+      if (input.customCssWrite === 'skip') return [theme, null] as const
       const css = await updateCustomCssFn({
-        data: { customCss: input.persistCustomCss ? input.customCss : '' },
+        data: { customCss: input.customCssWrite === 'persist' ? input.customCss : '' },
       })
       throwIfServerFnFailed(css)
       return [theme, css] as const

--- a/apps/web/src/lib/server/domains/settings/__tests__/branding-tier-gate.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/branding-tier-gate.test.ts
@@ -93,4 +93,28 @@ describe('updateCustomCss — customCss gate', () => {
     })
     await expect(updateCustomCss('')).resolves.toBe('')
   })
+
+  it('allows stripping generated theme declarations from stored CSS when the feature is off', async () => {
+    vi.mocked(getTierLimits).mockResolvedValue({
+      ...OSS_TIER_LIMITS,
+      features: { ...OSS_TIER_LIMITS.features, customCss: false },
+    })
+    const stored = ':root { --primary: oklch(0.5 0.2 250); }\n.brand { color: red; }\n'
+    hoisted.mockRequireSettings.mockResolvedValue({ id: 'org_x', customCss: stored })
+    await expect(updateCustomCss('.brand { color: red; }')).resolves.toBe('.brand { color: red; }')
+  })
+
+  it('rejects adding extra rules when the feature is off', async () => {
+    vi.mocked(getTierLimits).mockResolvedValue({
+      ...OSS_TIER_LIMITS,
+      features: { ...OSS_TIER_LIMITS.features, customCss: false },
+    })
+    hoisted.mockRequireSettings.mockResolvedValue({
+      id: 'org_x',
+      customCss: ':root { --primary: oklch(0.5 0.2 250); }\n.brand { color: red; }\n',
+    })
+    await expect(
+      updateCustomCss('.brand { color: red; }\n.hero { color: blue; }')
+    ).rejects.toBeInstanceOf(TierLimitError)
+  })
 })

--- a/apps/web/src/lib/server/domains/settings/__tests__/tier-limits.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/tier-limits.test.ts
@@ -232,7 +232,14 @@ describe('resolveEffectiveTierLimits (cloud, no operator row)', () => {
     const effective = resolveEffectiveTierLimits(null, growth, beforeExpiry)
     expect(effective.features.analyticsExports).toBe(false)
     expect(effective.features.integrations).toBe(false)
-    expect(effective.features.customColors).toBe(false)
+    expect(effective.features.customColors).toBe(true)
+    expect(effective.features.customCss).toBe(false)
+  })
+
+  it('allows custom colours on Free', () => {
+    const free: BillingProjection = { ...PROJECTION, effectivePlan: 'free' }
+    const effective = resolveEffectiveTierLimits(null, free, beforeExpiry)
+    expect(effective.features.customColors).toBe(true)
     expect(effective.features.customCss).toBe(false)
   })
 
@@ -243,6 +250,7 @@ describe('resolveEffectiveTierLimits (cloud, no operator row)', () => {
     expect(effective.features.webhooks).toBe(false)
     expect(effective.features.analyticsExports).toBe(false)
     expect(effective.features.integrations).toBe(false)
+    expect(effective.features.customColors).toBe(true)
   })
 
   it('still raises a stored operator floor in the least-restrictive direction', () => {

--- a/apps/web/src/lib/server/domains/settings/settings.media.ts
+++ b/apps/web/src/lib/server/domains/settings/settings.media.ts
@@ -1,6 +1,7 @@
 import { db, eq, settings } from '@/lib/server/db'
 import { deleteObject } from '@/lib/server/storage/s3'
 import { ValidationError } from '@/lib/shared/errors'
+import { advancedCssRemainder } from '@/lib/shared/theme/generator'
 import { assertNotManaged } from '@/lib/server/config-file/managed-guard'
 import { logger } from '@/lib/server/logger'
 import type { BrandingConfig } from './settings.types'
@@ -75,15 +76,17 @@ export async function updateCustomCss(css: string): Promise<string> {
     if (css.includes('<')) {
       throw new ValidationError('INVALID_CUSTOM_CSS', 'Custom CSS cannot contain the "<" character')
     }
-    // Clearing CSS (empty string) is always allowed so a workspace whose
-    // tier just stopped including custom CSS can wipe it without being
-    // blocked. Anything non-empty hits the feature gate.
-    if (css.trim().length > 0) {
+    const org = await requireSettings()
+    const trimmed = css.trim()
+    // Empty is always allowed so a workspace whose tier just stopped including
+    // custom CSS can wipe it. Stripping generated theme declarations from CSS
+    // already stored is also ungated — that rewrite cannot introduce extra
+    // rules. Any other non-empty write hits the feature gate.
+    if (trimmed.length > 0 && trimmed !== advancedCssRemainder(org.customCss ?? '')) {
       const { assertTierFeature } = await import('./tier-enforce')
       await assertTierFeature('customCss', 'Custom CSS')
     }
 
-    const org = await requireSettings()
     await db.update(settings).set({ customCss: css }).where(eq(settings.id, org.id))
     await invalidateSettingsCache()
     return css

--- a/apps/web/src/lib/server/domains/settings/tier-limits.service.ts
+++ b/apps/web/src/lib/server/domains/settings/tier-limits.service.ts
@@ -48,13 +48,13 @@ const PLAN_ONLY_FEATURES: Record<
 > = {
   free: {
     analyticsExports: false,
-    customColors: false,
+    customColors: true,
     customCss: false,
     integrations: false,
   },
   growth: {
     analyticsExports: false,
-    customColors: false,
+    customColors: true,
     customCss: false,
     integrations: false,
   },

--- a/apps/web/src/lib/shared/theme/__tests__/generated-theme-css.test.ts
+++ b/apps/web/src/lib/shared/theme/__tests__/generated-theme-css.test.ts
@@ -63,4 +63,17 @@ describe('advancedCssRemainder', () => {
     expect(remainder).toContain('--token: "}"')
     expect(remainder).toMatch(/color-scheme:\s*dark/)
   })
+
+  it('strips generated theme declarations nested inside at-rules', () => {
+    const css = '@layer base { :root { --primary: oklch(0.5 0.2 250); color-scheme: dark; } }\n'
+    const remainder = advancedCssRemainder(css)
+    expect(remainder).toContain('@layer')
+    expect(remainder).toMatch(/color-scheme:\s*dark/)
+    expect(remainder).not.toContain('--primary')
+  })
+
+  it('treats a generated var with a leading comment as generated', () => {
+    const css = ':root { /* primary */ --primary: oklch(0.5 0.2 250); }\n'
+    expect(advancedCssRemainder(css)).toBe('')
+  })
 })

--- a/apps/web/src/lib/shared/theme/__tests__/generated-theme-css.test.ts
+++ b/apps/web/src/lib/shared/theme/__tests__/generated-theme-css.test.ts
@@ -42,4 +42,11 @@ describe('advancedCssRemainder', () => {
     const css = generateReadableCSS(lightMinimal, darkMinimal, 'user')
     expect(advancedCssRemainder(`${css}\n.brand { color: red; }\n`)).toBe('.brand { color: red; }')
   })
+
+  it('keeps unknown declarations inside :root after stripping generated vars', () => {
+    const css = ':root { --primary: oklch(0.5 0.2 250); color-scheme: dark; }\n'
+    const remainder = advancedCssRemainder(css)
+    expect(remainder).toMatch(/:root\s*\{[^}]*color-scheme:\s*dark/)
+    expect(remainder).not.toContain('--primary')
+  })
 })

--- a/apps/web/src/lib/shared/theme/__tests__/generated-theme-css.test.ts
+++ b/apps/web/src/lib/shared/theme/__tests__/generated-theme-css.test.ts
@@ -56,4 +56,11 @@ describe('advancedCssRemainder', () => {
     expect(remainder).toContain('--logo: url(data:image/png;base64,abc)')
     expect(remainder).not.toContain('--primary')
   })
+
+  it('does not end a :root block on a quoted brace', () => {
+    const css = ':root { --token: "}"; color-scheme: dark; }\n'
+    const remainder = advancedCssRemainder(css)
+    expect(remainder).toContain('--token: "}"')
+    expect(remainder).toMatch(/color-scheme:\s*dark/)
+  })
 })

--- a/apps/web/src/lib/shared/theme/__tests__/generated-theme-css.test.ts
+++ b/apps/web/src/lib/shared/theme/__tests__/generated-theme-css.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { extractMinimal } from '../expand'
+import { generateReadableCSS, isGeneratedThemeCss } from '../generator'
+import { themePresets } from '../presets'
+import type { ThemeMode } from '../types'
+
+const lightMinimal = extractMinimal(themePresets.default.light)
+const darkMinimal = extractMinimal(themePresets.default.dark)
+const THEME_MODES: ThemeMode[] = ['user', 'light', 'dark']
+
+describe('isGeneratedThemeCss', () => {
+  it('returns true for generated CSS in every theme mode', () => {
+    for (const mode of THEME_MODES) {
+      const css = generateReadableCSS(lightMinimal, darkMinimal, mode)
+      expect(isGeneratedThemeCss(css, lightMinimal, darkMinimal)).toBe(true)
+    }
+  })
+
+  it('returns false when generated CSS has an extra rule', () => {
+    const css = generateReadableCSS(lightMinimal, darkMinimal, 'user')
+    expect(isGeneratedThemeCss(`${css}\n.brand { color: red; }\n`, lightMinimal, darkMinimal)).toBe(
+      false
+    )
+  })
+
+  it('treats CSS generated for a different mode as generated, not Advanced CSS', () => {
+    const userCss = generateReadableCSS(lightMinimal, darkMinimal, 'user')
+    const lightCss = generateReadableCSS(lightMinimal, darkMinimal, 'light')
+    expect(userCss).not.toBe(lightCss)
+    expect(isGeneratedThemeCss(userCss, lightMinimal, darkMinimal)).toBe(true)
+    expect(isGeneratedThemeCss(lightCss, lightMinimal, darkMinimal)).toBe(true)
+  })
+})

--- a/apps/web/src/lib/shared/theme/__tests__/generated-theme-css.test.ts
+++ b/apps/web/src/lib/shared/theme/__tests__/generated-theme-css.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { extractCssVariables } from '../css-parser'
 import { extractMinimal } from '../expand'
 import { advancedCssRemainder, generateReadableCSS, isGeneratedThemeCss } from '../generator'
 import { themePresets } from '../presets'
@@ -75,5 +76,36 @@ describe('advancedCssRemainder', () => {
   it('treats a generated var with a leading comment as generated', () => {
     const css = ':root { /* primary */ --primary: oklch(0.5 0.2 250); }\n'
     expect(advancedCssRemainder(css)).toBe('')
+  })
+
+  it('keeps a derived var whose value differs from expandTheme output', () => {
+    const light = { primary: 'oklch(0.5 0.2 250)' }
+    const generated = generateReadableCSS(light, {}, 'user')
+    const customFg = 'oklch(0.1 0 0)'
+    const css = `:root { --primary: oklch(0.5 0.2 250); --primary-foreground: ${customFg}; }\n`
+    const remainder = advancedCssRemainder(css, generated)
+    expect(remainder).toContain(`--primary-foreground: ${customFg}`)
+    expect(remainder).not.toMatch(/--primary:/)
+  })
+
+  it('keeps a font-family that differs from the generated stack', () => {
+    const generated = generateReadableCSS(lightMinimal, darkMinimal, 'user')
+    const css = ':root { --primary: oklch(0.5 0.2 250); font-family: "My Brand"; }\n'
+    const remainder = advancedCssRemainder(css, generated)
+    expect(remainder).toContain('font-family: "My Brand"')
+  })
+
+  it('imports a last declaration without a trailing semicolon', () => {
+    const css = ':root { --primary: oklch(0.5 0.2 250); color-scheme: dark }\n'
+    const remainder = advancedCssRemainder(css)
+    expect(remainder).toMatch(/color-scheme:\s*dark/)
+    expect(remainder).not.toContain('--primary')
+  })
+})
+
+describe('extractCssVariables', () => {
+  it('reads a last custom property without a trailing semicolon', () => {
+    const vars = extractCssVariables(':root { --primary: oklch(0.5 0.2 250) }')
+    expect(vars.light['--primary']).toBe('oklch(0.5 0.2 250)')
   })
 })

--- a/apps/web/src/lib/shared/theme/__tests__/generated-theme-css.test.ts
+++ b/apps/web/src/lib/shared/theme/__tests__/generated-theme-css.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { extractMinimal } from '../expand'
-import { generateReadableCSS, isGeneratedThemeCss } from '../generator'
+import { advancedCssRemainder, generateReadableCSS, isGeneratedThemeCss } from '../generator'
 import { themePresets } from '../presets'
 import type { ThemeMode } from '../types'
 
@@ -29,5 +29,17 @@ describe('isGeneratedThemeCss', () => {
     expect(userCss).not.toBe(lightCss)
     expect(isGeneratedThemeCss(userCss, lightMinimal, darkMinimal)).toBe(true)
     expect(isGeneratedThemeCss(lightCss, lightMinimal, darkMinimal)).toBe(true)
+  })
+})
+
+describe('advancedCssRemainder', () => {
+  it('returns empty for generated CSS', () => {
+    const css = generateReadableCSS(lightMinimal, darkMinimal, 'user')
+    expect(advancedCssRemainder(css)).toBe('')
+  })
+
+  it('returns extra rules after stripping theme blocks', () => {
+    const css = generateReadableCSS(lightMinimal, darkMinimal, 'user')
+    expect(advancedCssRemainder(`${css}\n.brand { color: red; }\n`)).toBe('.brand { color: red; }')
   })
 })

--- a/apps/web/src/lib/shared/theme/__tests__/generated-theme-css.test.ts
+++ b/apps/web/src/lib/shared/theme/__tests__/generated-theme-css.test.ts
@@ -49,4 +49,11 @@ describe('advancedCssRemainder', () => {
     expect(remainder).toMatch(/:root\s*\{[^}]*color-scheme:\s*dark/)
     expect(remainder).not.toContain('--primary')
   })
+
+  it('does not split on a semicolon inside a declaration value', () => {
+    const css = ':root { --primary: oklch(0.5 0.2 250); --logo: url(data:image/png;base64,abc); }\n'
+    const remainder = advancedCssRemainder(css)
+    expect(remainder).toContain('--logo: url(data:image/png;base64,abc)')
+    expect(remainder).not.toContain('--primary')
+  })
 })

--- a/apps/web/src/lib/shared/theme/css-parser.ts
+++ b/apps/web/src/lib/shared/theme/css-parser.ts
@@ -58,7 +58,7 @@ export function extractCssVariables(css: string): ParsedCssVariables {
 function parseVariables(block: string, target: Record<string, string>) {
   // Match --variable-name: value; with support for multi-line values
   // Uses a more robust regex that handles values containing parentheses, spaces, etc.
-  const varMatches = block.matchAll(/--([\w-]+)\s*:\s*([^;]+);/g)
+  const varMatches = block.matchAll(/--([\w-]+)\s*:\s*([^;]+);?/g)
   for (const match of varMatches) {
     const name = `--${match[1].trim()}`
     const value = match[2].trim()

--- a/apps/web/src/lib/shared/theme/generator.ts
+++ b/apps/web/src/lib/shared/theme/generator.ts
@@ -110,11 +110,66 @@ function isGeneratedThemeDeclaration(decl: string): boolean {
   return name != null && GENERATED_THEME_VAR_NAMES.has(name)
 }
 
+/** Split a declaration block on `;` while ignoring those inside quotes, comments, or parentheses (including `url(...)`). */
+function splitCssDeclarations(body: string): string[] {
+  const decls: string[] = []
+  let start = 0
+  let quote: '"' | "'" | null = null
+  let comment = false
+  let paren = 0
+
+  for (let i = 0; i < body.length; i++) {
+    const c = body[i]
+    const next = body[i + 1]
+
+    if (comment) {
+      if (c === '*' && next === '/') {
+        comment = false
+        i++
+      }
+      continue
+    }
+    if (quote) {
+      if (c === '\\') {
+        i++
+        continue
+      }
+      if (c === quote) quote = null
+      continue
+    }
+    if (c === '/' && next === '*') {
+      comment = true
+      i++
+      continue
+    }
+    if (c === '"' || c === "'") {
+      quote = c
+      continue
+    }
+    if (c === '(') {
+      paren++
+      continue
+    }
+    if (c === ')' && paren > 0) {
+      paren--
+      continue
+    }
+    if (c === ';' && paren === 0) {
+      const decl = body.slice(start, i).trim()
+      if (decl) decls.push(decl)
+      start = i + 1
+    }
+  }
+
+  const tail = body.slice(start).trim()
+  if (tail) decls.push(tail)
+  return decls
+}
+
 function keepNonGeneratedDeclarations(body: string): string {
   const kept: string[] = []
-  for (const raw of body.split(';')) {
-    const decl = raw.trim()
-    if (!decl || isGeneratedThemeDeclaration(decl)) continue
+  for (const decl of splitCssDeclarations(body)) {
+    if (isGeneratedThemeDeclaration(decl)) continue
     kept.push(`  ${decl};`)
   }
   return kept.join('\n')

--- a/apps/web/src/lib/shared/theme/generator.ts
+++ b/apps/web/src/lib/shared/theme/generator.ts
@@ -104,9 +104,20 @@ const GENERATED_THEME_VAR_NAMES = new Set(
     .map(([, cssVar]) => cssVar)
 )
 
+function stripLeadingCssComments(decl: string): string {
+  let s = decl.trim()
+  while (s.startsWith('/*')) {
+    const end = s.indexOf('*/')
+    if (end === -1) break
+    s = s.slice(end + 2).trim()
+  }
+  return s
+}
+
 function isGeneratedThemeDeclaration(decl: string): boolean {
-  if (/^font-family\s*:/i.test(decl)) return true
-  const name = /^(--[\w-]+)\s*:/.exec(decl)?.[1]
+  const stripped = stripLeadingCssComments(decl)
+  if (/^font-family\s*:/i.test(stripped)) return true
+  const name = /^(--[\w-]+)\s*:/.exec(stripped)?.[1]
   return name != null && GENERATED_THEME_VAR_NAMES.has(name)
 }
 
@@ -236,10 +247,9 @@ export function advancedCssRemainder(cssText: string): string {
   let out = ''
   let i = 0
   const scan: CssScan = { quote: null, comment: false, paren: 0 }
-  let braceDepth = 0
 
   while (i < cssText.length) {
-    if (braceDepth === 0 && isCssCode(scan) && scan.paren === 0) {
+    if (isCssCode(scan) && scan.paren === 0) {
       const theme = matchThemeSelector(cssText, i)
       if (theme) {
         const close = findMatchingBrace(cssText, theme.openBrace)
@@ -254,11 +264,6 @@ export function advancedCssRemainder(cssText: string): string {
       }
     }
 
-    const c = cssText[i]
-    if (isCssCode(scan) && scan.paren === 0) {
-      if (c === '{') braceDepth++
-      else if (c === '}' && braceDepth > 0) braceDepth--
-    }
     const n = advanceCssScan(scan, cssText, i)
     out += cssText.slice(i, i + n)
     i += n

--- a/apps/web/src/lib/shared/theme/generator.ts
+++ b/apps/web/src/lib/shared/theme/generator.ts
@@ -110,57 +110,68 @@ function isGeneratedThemeDeclaration(decl: string): boolean {
   return name != null && GENERATED_THEME_VAR_NAMES.has(name)
 }
 
+interface CssScan {
+  quote: '"' | "'" | null
+  comment: boolean
+  paren: number
+}
+
+function isCssCode(scan: CssScan): boolean {
+  return !scan.comment && scan.quote === null
+}
+
+/** Consume one token of CSS context (quotes, comments, `url()` / paren depth). Returns chars consumed. */
+function advanceCssScan(scan: CssScan, source: string, i: number): number {
+  const c = source[i]
+  const next = source[i + 1]
+  if (scan.comment) {
+    if (c === '*' && next === '/') {
+      scan.comment = false
+      return 2
+    }
+    return 1
+  }
+  if (scan.quote) {
+    if (c === '\\' && next !== undefined) return 2
+    if (c === scan.quote) scan.quote = null
+    return 1
+  }
+  if (c === '/' && next === '*') {
+    scan.comment = true
+    return 2
+  }
+  if (c === '"' || c === "'") {
+    scan.quote = c
+    return 1
+  }
+  if (c === '(') {
+    scan.paren++
+    return 1
+  }
+  if (c === ')' && scan.paren > 0) {
+    scan.paren--
+    return 1
+  }
+  return 1
+}
+
 /** Split a declaration block on `;` while ignoring those inside quotes, comments, or parentheses (including `url(...)`). */
 function splitCssDeclarations(body: string): string[] {
   const decls: string[] = []
+  const scan: CssScan = { quote: null, comment: false, paren: 0 }
   let start = 0
-  let quote: '"' | "'" | null = null
-  let comment = false
-  let paren = 0
-
-  for (let i = 0; i < body.length; i++) {
+  let i = 0
+  while (i < body.length) {
     const c = body[i]
-    const next = body[i + 1]
-
-    if (comment) {
-      if (c === '*' && next === '/') {
-        comment = false
-        i++
-      }
-      continue
-    }
-    if (quote) {
-      if (c === '\\') {
-        i++
-        continue
-      }
-      if (c === quote) quote = null
-      continue
-    }
-    if (c === '/' && next === '*') {
-      comment = true
-      i++
-      continue
-    }
-    if (c === '"' || c === "'") {
-      quote = c
-      continue
-    }
-    if (c === '(') {
-      paren++
-      continue
-    }
-    if (c === ')' && paren > 0) {
-      paren--
-      continue
-    }
-    if (c === ';' && paren === 0) {
+    if (c === ';' && isCssCode(scan) && scan.paren === 0) {
       const decl = body.slice(start, i).trim()
       if (decl) decls.push(decl)
       start = i + 1
+      i++
+      continue
     }
+    i += advanceCssScan(scan, body, i)
   }
-
   const tail = body.slice(start).trim()
   if (tail) decls.push(tail)
   return decls
@@ -175,6 +186,46 @@ function keepNonGeneratedDeclarations(body: string): string {
   return kept.join('\n')
 }
 
+function matchThemeSelector(
+  source: string,
+  i: number
+): { selector: ':root' | '.dark'; openBrace: number } | null {
+  if (i > 0 && /[\w-]/.test(source[i - 1] ?? '')) return null
+  let selector: ':root' | '.dark' | null = null
+  if (source.startsWith(':root', i)) selector = ':root'
+  else if (source.startsWith('.dark', i)) selector = '.dark'
+  if (!selector) return null
+  let j = i + selector.length
+  while (j < source.length && /\s/.test(source[j] ?? '')) j++
+  if (source[j] !== '{') return null
+  return { selector, openBrace: j }
+}
+
+/** Index of the `}` that closes the `{` at `openIndex`, ignoring braces inside quotes, comments, or parentheses. */
+function findMatchingBrace(source: string, openIndex: number): number {
+  const scan: CssScan = { quote: null, comment: false, paren: 0 }
+  let depth = 0
+  let i = openIndex
+  while (i < source.length) {
+    const c = source[i]
+    if (isCssCode(scan) && scan.paren === 0) {
+      if (c === '{') {
+        depth++
+        i++
+        continue
+      }
+      if (c === '}') {
+        depth--
+        if (depth === 0) return i
+        i++
+        continue
+      }
+    }
+    i += advanceCssScan(scan, source, i)
+  }
+  return source.length
+}
+
 /**
  * CSS left after removing generated theme declarations.
  * Drops `:root` / `.dark` variables (and the generated `font-family` rule)
@@ -182,15 +233,38 @@ function keepNonGeneratedDeclarations(body: string): string {
  * leaves every other rule as-is. Generated-only CSS yields ''.
  */
 export function advancedCssRemainder(cssText: string): string {
-  const result = cssText.replace(
-    /(?<![\w-])(:root|\.dark)\s*\{([\s\S]*?)\}/g,
-    (_match, selector: string, body: string) => {
-      const kept = keepNonGeneratedDeclarations(body)
-      if (!kept) return ''
-      return `${selector} {\n${kept}\n}`
+  let out = ''
+  let i = 0
+  const scan: CssScan = { quote: null, comment: false, paren: 0 }
+  let braceDepth = 0
+
+  while (i < cssText.length) {
+    if (braceDepth === 0 && isCssCode(scan) && scan.paren === 0) {
+      const theme = matchThemeSelector(cssText, i)
+      if (theme) {
+        const close = findMatchingBrace(cssText, theme.openBrace)
+        const body = cssText.slice(theme.openBrace + 1, close)
+        const kept = keepNonGeneratedDeclarations(body)
+        if (kept) out += `${theme.selector} {\n${kept}\n}`
+        i = close < cssText.length ? close + 1 : cssText.length
+        scan.quote = null
+        scan.comment = false
+        scan.paren = 0
+        continue
+      }
     }
-  )
-  return result.replace(/(?:\n[ \t]*){3,}/g, '\n\n').trim()
+
+    const c = cssText[i]
+    if (isCssCode(scan) && scan.paren === 0) {
+      if (c === '{') braceDepth++
+      else if (c === '}' && braceDepth > 0) braceDepth--
+    }
+    const n = advanceCssScan(scan, cssText, i)
+    out += cssText.slice(i, i + n)
+    i += n
+  }
+
+  return out.replace(/(?:\n[ \t]*){3,}/g, '\n\n').trim()
 }
 
 function formatCssBlock(selector: string, vars: ThemeVariables): string {

--- a/apps/web/src/lib/shared/theme/generator.ts
+++ b/apps/web/src/lib/shared/theme/generator.ts
@@ -98,15 +98,44 @@ export function isGeneratedThemeCss(
   )
 }
 
+const GENERATED_THEME_VAR_NAMES = new Set(
+  Object.entries(variableMap)
+    .filter(([key]) => !SHADOW_KEYS.has(key))
+    .map(([, cssVar]) => cssVar)
+)
+
+function isGeneratedThemeDeclaration(decl: string): boolean {
+  if (/^font-family\s*:/i.test(decl)) return true
+  const name = /^(--[\w-]+)\s*:/.exec(decl)?.[1]
+  return name != null && GENERATED_THEME_VAR_NAMES.has(name)
+}
+
+function keepNonGeneratedDeclarations(body: string): string {
+  const kept: string[] = []
+  for (const raw of body.split(';')) {
+    const decl = raw.trim()
+    if (!decl || isGeneratedThemeDeclaration(decl)) continue
+    kept.push(`  ${decl};`)
+  }
+  return kept.join('\n')
+}
+
 /**
- * CSS left after removing generated `:root` / `.dark` theme blocks.
- * Extra rules (Advanced CSS) remain; generated-only CSS yields ''.
+ * CSS left after removing generated theme declarations.
+ * Drops `:root` / `.dark` variables (and the generated `font-family` rule)
+ * that `generateReadableCSS` emits, keeps unknown inner declarations, and
+ * leaves every other rule as-is. Generated-only CSS yields ''.
  */
 export function advancedCssRemainder(cssText: string): string {
-  return cssText
-    .replace(/:root\s*\{[\s\S]*?\}/g, '')
-    .replace(/\.dark\s*\{[\s\S]*?\}/g, '')
-    .trim()
+  const result = cssText.replace(
+    /(?<![\w-])(:root|\.dark)\s*\{([\s\S]*?)\}/g,
+    (_match, selector: string, body: string) => {
+      const kept = keepNonGeneratedDeclarations(body)
+      if (!kept) return ''
+      return `${selector} {\n${kept}\n}`
+    }
+  )
+  return result.replace(/(?:\n[ \t]*){3,}/g, '\n\n').trim()
 }
 
 function formatCssBlock(selector: string, vars: ThemeVariables): string {

--- a/apps/web/src/lib/shared/theme/generator.ts
+++ b/apps/web/src/lib/shared/theme/generator.ts
@@ -98,6 +98,17 @@ export function isGeneratedThemeCss(
   )
 }
 
+/**
+ * CSS left after removing generated `:root` / `.dark` theme blocks.
+ * Extra rules (Advanced CSS) remain; generated-only CSS yields ''.
+ */
+export function advancedCssRemainder(cssText: string): string {
+  return cssText
+    .replace(/:root\s*\{[\s\S]*?\}/g, '')
+    .replace(/\.dark\s*\{[\s\S]*?\}/g, '')
+    .trim()
+}
+
 function formatCssBlock(selector: string, vars: ThemeVariables): string {
   const lines: string[] = [`${selector} {`]
 

--- a/apps/web/src/lib/shared/theme/generator.ts
+++ b/apps/web/src/lib/shared/theme/generator.ts
@@ -98,10 +98,25 @@ export function isGeneratedThemeCss(
   )
 }
 
-const GENERATED_THEME_VAR_NAMES = new Set(
-  Object.entries(variableMap)
-    .filter(([key]) => !SHADOW_KEYS.has(key))
-    .map(([, cssVar]) => cssVar)
+const MINIMAL_THEME_CSS_VARS = new Set(
+  (
+    [
+      'primary',
+      'background',
+      'foreground',
+      'card',
+      'muted',
+      'mutedForeground',
+      'border',
+      'destructive',
+      'success',
+      'ring',
+      'secondary',
+      'accent',
+      'fontSans',
+      'radius',
+    ] as const
+  ).map((key) => variableMap[key])
 )
 
 function stripLeadingCssComments(decl: string): string {
@@ -114,11 +129,26 @@ function stripLeadingCssComments(decl: string): string {
   return s
 }
 
-function isGeneratedThemeDeclaration(decl: string): boolean {
+function normalizeCssValue(value: string): string {
+  return value.trim().replace(/\s+/g, ' ')
+}
+
+function parsePropertyValue(decl: string): { property: string; value: string } | null {
   const stripped = stripLeadingCssComments(decl)
-  if (/^font-family\s*:/i.test(stripped)) return true
-  const name = /^(--[\w-]+)\s*:/.exec(stripped)?.[1]
-  return name != null && GENERATED_THEME_VAR_NAMES.has(name)
+  const match = /^((?:--[\w-]+)|font-family)\s*:\s*(.*)$/i.exec(stripped)
+  if (!match) return null
+  const property = match[1].toLowerCase() === 'font-family' ? 'font-family' : match[1]
+  return { property, value: match[2].replace(/;?\s*$/, '').trim() }
+}
+
+function isGeneratedThemeDeclaration(decl: string, generated: Map<string, string>): boolean {
+  const parsed = parsePropertyValue(decl)
+  if (!parsed) return false
+  const emitted = generated.get(parsed.property)
+  if (emitted === undefined) return false
+  // Minimal keys live in brandingConfig; stale copies must not override.
+  if (parsed.property !== 'font-family' && MINIMAL_THEME_CSS_VARS.has(parsed.property)) return true
+  return normalizeCssValue(parsed.value) === normalizeCssValue(emitted)
 }
 
 interface CssScan {
@@ -188,13 +218,22 @@ function splitCssDeclarations(body: string): string[] {
   return decls
 }
 
-function keepNonGeneratedDeclarations(body: string): string {
+function keepNonGeneratedDeclarations(body: string, generated: Map<string, string>): string {
   const kept: string[] = []
   for (const decl of splitCssDeclarations(body)) {
-    if (isGeneratedThemeDeclaration(decl)) continue
+    if (isGeneratedThemeDeclaration(decl, generated)) continue
     kept.push(`  ${decl};`)
   }
   return kept.join('\n')
+}
+
+function declMapFromBlock(body: string): Map<string, string> {
+  const map = new Map<string, string>()
+  for (const decl of splitCssDeclarations(body)) {
+    const parsed = parsePropertyValue(decl)
+    if (parsed) map.set(parsed.property, parsed.value)
+  }
+  return map
 }
 
 function matchThemeSelector(
@@ -237,13 +276,11 @@ function findMatchingBrace(source: string, openIndex: number): number {
   return source.length
 }
 
-/**
- * CSS left after removing generated theme declarations.
- * Drops `:root` / `.dark` variables (and the generated `font-family` rule)
- * that `generateReadableCSS` emits, keeps unknown inner declarations, and
- * leaves every other rule as-is. Generated-only CSS yields ''.
- */
-export function advancedCssRemainder(cssText: string): string {
+function walkThemeBlocks(
+  cssText: string,
+  onThemeBlock: (selector: ':root' | '.dark', body: string) => string | void,
+  copyOther = false
+): string {
   let out = ''
   let i = 0
   const scan: CssScan = { quote: null, comment: false, paren: 0 }
@@ -254,8 +291,8 @@ export function advancedCssRemainder(cssText: string): string {
       if (theme) {
         const close = findMatchingBrace(cssText, theme.openBrace)
         const body = cssText.slice(theme.openBrace + 1, close)
-        const kept = keepNonGeneratedDeclarations(body)
-        if (kept) out += `${theme.selector} {\n${kept}\n}`
+        const replacement = onThemeBlock(theme.selector, body)
+        if (copyOther && replacement) out += replacement
         i = close < cssText.length ? close + 1 : cssText.length
         scan.quote = null
         scan.comment = false
@@ -265,11 +302,54 @@ export function advancedCssRemainder(cssText: string): string {
     }
 
     const n = advanceCssScan(scan, cssText, i)
-    out += cssText.slice(i, i + n)
+    if (copyOther) out += cssText.slice(i, i + n)
     i += n
   }
 
-  return out.replace(/(?:\n[ \t]*){3,}/g, '\n\n').trim()
+  return out
+}
+
+function generatedDeclMaps(generatedCss: string): Record<':root' | '.dark', Map<string, string>> {
+  const maps: Record<':root' | '.dark', Map<string, string>> = {
+    ':root': new Map(),
+    '.dark': new Map(),
+  }
+  walkThemeBlocks(generatedCss, (selector, body) => {
+    maps[selector] = declMapFromBlock(body)
+  })
+  return maps
+}
+
+function inferGeneratedCss(cssText: string): string {
+  const light: Record<string, string> = {}
+  const dark: Record<string, string> = {}
+  walkThemeBlocks(cssText, (selector, body) => {
+    const target = selector === ':root' ? light : dark
+    for (const [property, value] of declMapFromBlock(body)) {
+      if (property.startsWith('--')) target[property] = value
+    }
+  })
+  return generateReadableCSS(parseCssToMinimal(light), parseCssToMinimal(dark), 'user')
+}
+
+/**
+ * CSS left after removing generated theme declarations.
+ * Drops `:root` / `.dark` declarations that `generateReadableCSS` emits
+ * (minimal keys always; derived keys and `font-family` only when the value
+ * matches). Unknown inner declarations stay. Generated-only CSS yields ''.
+ */
+export function advancedCssRemainder(cssText: string, generatedCss?: string): string {
+  const maps = generatedDeclMaps(generatedCss ?? inferGeneratedCss(cssText))
+  const result = walkThemeBlocks(
+    cssText,
+    (selector, body) => {
+      const kept = keepNonGeneratedDeclarations(body, maps[selector])
+      if (!kept) return ''
+      return `${selector} {\n${kept}\n}`
+    },
+    true
+  )
+  return result.replace(/(?:\n[ \t]*){3,}/g, '\n\n').trim()
 }
 
 function formatCssBlock(selector: string, vars: ThemeVariables): string {

--- a/apps/web/src/lib/shared/theme/generator.ts
+++ b/apps/web/src/lib/shared/theme/generator.ts
@@ -80,6 +80,24 @@ export function generateReadableCSS(
   return parts.join('\n\n') + '\n'
 }
 
+const THEME_MODES = ['user', 'light', 'dark'] as const satisfies readonly ThemeMode[]
+
+/**
+ * True when `cssText` is the output of `generateReadableCSS` for any theme
+ * mode. Extra rules (Advanced CSS) fail this check.
+ */
+export function isGeneratedThemeCss(
+  cssText: string,
+  lightMinimal: Partial<MinimalThemeVariables>,
+  darkMinimal: Partial<MinimalThemeVariables>
+): boolean {
+  const trimmed = cssText.trim()
+  if (!trimmed) return false
+  return THEME_MODES.some(
+    (mode) => generateReadableCSS(lightMinimal, darkMinimal, mode).trim() === trimmed
+  )
+}
+
 function formatCssBlock(selector: string, vars: ThemeVariables): string {
   const lines: string[] = [`${selector} {`]
 

--- a/apps/web/src/lib/shared/theme/index.ts
+++ b/apps/web/src/lib/shared/theme/index.ts
@@ -95,6 +95,7 @@ export { hexToOklch, oklchToHex, isValidHex, isValidOklch } from './colors'
 export {
   generateThemeCSS,
   generateReadableCSS,
+  isGeneratedThemeCss,
   parseCssToMinimal,
   replaceCssVar,
   parseThemeConfig,

--- a/apps/web/src/lib/shared/theme/index.ts
+++ b/apps/web/src/lib/shared/theme/index.ts
@@ -96,6 +96,7 @@ export {
   generateThemeCSS,
   generateReadableCSS,
   isGeneratedThemeCss,
+  advancedCssRemainder,
   parseCssToMinimal,
   replaceCssVar,
   parseThemeConfig,


### PR DESCRIPTION
## Why

Free and Growth workspaces could not save portal theme colours. The signed projection only carries entitlements; `customColors` is a plan-only flag copied from the catalogue, and it was Pro/Scale only.

## What

- Set `customColors: true` on Free and Growth (custom CSS stays Pro).
- Cover Free in the effective-limits tests.

Tenants pick this up when this image is on the workspace.