### PR TITLE
fix(copy): say Workspace URL, not Friendly Quackback URL

### DIFF
--- a/apps/web/src/lib/server/functions/cloud-identity.ts
+++ b/apps/web/src/lib/server/functions/cloud-identity.ts
@@ -38,7 +38,7 @@ export const markCloudWorkspaceDetailsSeenFn = createServerFn({ method: 'POST' }
     const identity = await currentCloudIdentity()
     if (!identity) throw new Error('Cloud workspace identity is not enabled')
     if (!friendlyPlatformLabel(identity.platformHostname)) {
-      throw new Error('Choose a Quackback URL before continuing')
+      throw new Error('Choose a Workspace URL before continuing')
     }
     const { state } = await mutateSetupStateAtomic((current) => ({
       state: current.workspaceDetailsSeenAt

--- a/apps/web/src/lib/shared/platform-label.ts
+++ b/apps/web/src/lib/shared/platform-label.ts
@@ -23,7 +23,7 @@ export function hostnameRegistrableSuffix(hostname: string): string {
 }
 
 /**
- * Suffix shown next to the friendly Quackback URL field.
+ * Suffix shown next to the Workspace URL field.
  * Always taken from `platformHostname` when one exists — `canonicalOrigin`
  * becomes a custom domain after that domain is made primary.
  */

--- a/apps/web/src/routes/admin/__tests__/settings-general-identity.test.tsx
+++ b/apps/web/src/routes/admin/__tests__/settings-general-identity.test.tsx
@@ -13,7 +13,7 @@ vi.mock('@/components/admin/settings/logo-uploader', () => ({
 }))
 
 describe('General workspace identity', () => {
-  it('shows logo and name with no Quackback URL field', () => {
+  it('shows logo and name with no Workspace URL field', () => {
     render(
       <WorkspaceIdentityCard
         workspaceName="Acme"
@@ -28,7 +28,7 @@ describe('General workspace identity', () => {
     ).toBeInTheDocument()
     expect(screen.getByLabelText('Workspace Name')).toHaveValue('Acme')
     expect(screen.getByRole('button', { name: 'Change workspace logo' })).toBeInTheDocument()
-    expect(screen.queryByLabelText('Quackback URL')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Workspace URL')).not.toBeInTheDocument()
     expect(screen.queryByText(/Friendly Quackback URL/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/ws-/)).not.toBeInTheDocument()
   })

--- a/apps/web/src/routes/admin/__tests__/settings.domains.test.tsx
+++ b/apps/web/src/routes/admin/__tests__/settings.domains.test.tsx
@@ -63,7 +63,7 @@ describe('domains card', () => {
   })
 })
 
-describe('Quackback URL card', () => {
+describe('Workspace URL card', () => {
   it('does not prefill a generated host into the URL field', () => {
     render(
       <QuackbackUrlCard
@@ -75,7 +75,7 @@ describe('Quackback URL card', () => {
         onSubmit={vi.fn()}
       />
     )
-    expect(screen.getByLabelText('Quackback URL')).toHaveValue('')
+    expect(screen.getByLabelText('Workspace URL')).toHaveValue('')
     expect(screen.queryByDisplayValue(/ws-/)).not.toBeInTheDocument()
   })
 
@@ -92,7 +92,7 @@ describe('Quackback URL card', () => {
       />
     )
 
-    expect(screen.getByLabelText('Quackback URL')).toHaveValue('ws-generated')
+    expect(screen.getByLabelText('Workspace URL')).toHaveValue('ws-generated')
     expect(screen.getByText('.quackback.co.uk')).toBeInTheDocument()
     expect(screen.queryByText(/Preview:/)).not.toBeInTheDocument()
     expect(screen.queryByText(/Current:/)).not.toBeInTheDocument()

--- a/apps/web/src/routes/admin/__tests__/settings.general-cloud.test.tsx
+++ b/apps/web/src/routes/admin/__tests__/settings.general-cloud.test.tsx
@@ -25,7 +25,7 @@ describe('cloud workspace identity on General', () => {
     )
 
     expect(screen.getByLabelText('Workspace Name')).toBeInTheDocument()
-    expect(screen.queryByLabelText('Quackback URL')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Workspace URL')).not.toBeInTheDocument()
     expect(screen.queryByText(/Preview:/)).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /save/i })).not.toBeInTheDocument()
   })

--- a/apps/web/src/routes/admin/settings.domains.tsx
+++ b/apps/web/src/routes/admin/settings.domains.tsx
@@ -86,7 +86,7 @@ function DomainsSettingsPage() {
         window.location.assign(target)
         return
       }
-      toast.success('Quackback URL saved')
+      toast.success('Workspace URL saved')
       await router.invalidate()
     },
   })
@@ -168,7 +168,7 @@ export function QuackbackUrlCard(props: {
   onSubmit: () => void
 }) {
   return (
-    <SettingsCard title="Quackback URL" description="The address customers use for this workspace">
+    <SettingsCard title="Workspace URL" description="The address customers use for this workspace">
       <form
         className="max-w-xl space-y-5"
         onSubmit={(event) => {
@@ -178,7 +178,7 @@ export function QuackbackUrlCard(props: {
       >
         <div className="space-y-1.5">
           <Label htmlFor="platform-label" className="text-xs text-muted-foreground">
-            Quackback URL
+            Workspace URL
           </Label>
           <div className="flex h-9 items-center border border-input bg-transparent shadow-xs transition-[color,box-shadow] outline-none focus-within:border-ring focus-within:ring-ring/50 focus-within:ring-[3px] dark:bg-input/30 [border-radius:calc(var(--radius)*0.8)]">
             <Input
@@ -198,7 +198,7 @@ export function QuackbackUrlCard(props: {
         </div>
         {props.error && (
           <p role="alert" className="text-sm text-destructive">
-            {props.error.message || 'Could not save Quackback URL. Try again.'}
+            {props.error.message || 'Could not save Workspace URL. Try again.'}
           </p>
         )}
         <Button type="submit" disabled={props.pending || !props.platformLabel.trim()}>

--- a/apps/web/src/routes/onboarding/__tests__/cloud-details-goal.test.tsx
+++ b/apps/web/src/routes/onboarding/__tests__/cloud-details-goal.test.tsx
@@ -27,7 +27,7 @@ describe('cloud post-handoff onboarding', () => {
     render(<CloudWorkspaceDetailsForm identity={IDENTITY} onSave={save} />)
 
     expect(screen.getByLabelText('Workspace name')).toHaveValue('Untitled workspace')
-    expect(screen.getByLabelText('Friendly Quackback URL')).toHaveValue('')
+    expect(screen.getByLabelText('Workspace URL')).toHaveValue('')
     expect(screen.queryByText(/Current address:/)).not.toBeInTheDocument()
     expect(screen.queryByText(IDENTITY.canonicalOrigin)).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /Skip/ })).not.toBeInTheDocument()
@@ -38,7 +38,7 @@ describe('cloud post-handoff onboarding', () => {
     fireEvent.click(continueButton)
     expect(save).not.toHaveBeenCalled()
 
-    fireEvent.change(screen.getByLabelText('Friendly Quackback URL'), {
+    fireEvent.change(screen.getByLabelText('Workspace URL'), {
       target: { value: 'awesome' },
     })
     expect(continueButton).toBeEnabled()
@@ -62,7 +62,7 @@ describe('cloud post-handoff onboarding', () => {
       />
     )
 
-    expect(screen.getByLabelText('Friendly Quackback URL')).toHaveValue('')
+    expect(screen.getByLabelText('Workspace URL')).toHaveValue('')
     expect(screen.queryByText(/ws-4a048e07941c5e7840e986c0/)).not.toBeInTheDocument()
   })
 

--- a/apps/web/src/routes/onboarding/_layout.workspace.tsx
+++ b/apps/web/src/routes/onboarding/_layout.workspace.tsx
@@ -162,7 +162,7 @@ export function CloudWorkspaceDetailsForm(props: {
 
       <div className="space-y-2">
         <label htmlFor="cloud-platform-label" className="text-sm font-medium">
-          Friendly Quackback URL
+          Workspace URL
         </label>
         <div className="flex items-center rounded-md border bg-background focus-within:ring-2 focus-within:ring-ring">
           <Input


### PR DESCRIPTION
User-facing label change on onboarding and Admin → Domains. Tests updated.