### PR TITLE
feat(billing): convert trials with keep-your-work copy

### DIFF
--- a/apps/web/src/components/admin/__tests__/plan-notice-banner.test.tsx
+++ b/apps/web/src/components/admin/__tests__/plan-notice-banner.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment happy-dom
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { PlanNoticeBanner } from '../plan-notice-banner'
+
+const ENDED = {
+  label: 'Pro trial',
+  message: "You're on the Free plan. Nothing was deleted.",
+  expiresAt: '2026-08-18T00:00:00.000Z',
+  actionLabel: 'Continue with Pro',
+  actionUrl: '/admin/settings/billing',
+  dismissible: true,
+}
+
+const OPERATOR = {
+  label: 'Scheduled maintenance',
+  message: 'Back at 09:00 UTC',
+}
+
+describe('PlanNoticeBanner', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('still shows an operator notice after an ended-trial dismiss', async () => {
+    const { rerender } = render(<PlanNoticeBanner notice={ENDED} />)
+    expect(await screen.findByText('Pro trial')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }))
+    expect(screen.queryByText('Pro trial')).not.toBeInTheDocument()
+
+    rerender(<PlanNoticeBanner notice={OPERATOR} />)
+    expect(await screen.findByText('Scheduled maintenance')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/admin/plan-notice-banner.tsx
+++ b/apps/web/src/components/admin/plan-notice-banner.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { ArrowTopRightOnSquareIcon, XMarkIcon } from '@heroicons/react/24/solid'
 import type { PlanNotice } from '@/lib/server/domains/settings/tier-limits.types'
 import { presentPlanNotice } from '@/lib/shared/plan-notice'
@@ -24,10 +24,15 @@ function readDismissed(expiresAt: string | undefined): boolean {
  */
 export function PlanNoticeBanner({ notice }: PlanNoticeBannerProps) {
   const view = presentPlanNotice(notice)
-  const [dismissed, setDismissed] = useState(() =>
-    notice?.dismissible ? readDismissed(notice.expiresAt) : false
-  )
-  if (!view || dismissed) return null
+  const dismissible = Boolean(notice?.dismissible)
+  const [ready, setReady] = useState(!dismissible)
+  const [dismissed, setDismissed] = useState(false)
+  useEffect(() => {
+    if (!dismissible) return
+    setDismissed(readDismissed(notice?.expiresAt))
+    setReady(true)
+  }, [dismissible, notice?.expiresAt])
+  if (!view || !ready || dismissed) return null
 
   const tone = view.urgent
     ? 'bg-amber-500/10 border-amber-500/20'

--- a/apps/web/src/components/admin/plan-notice-banner.tsx
+++ b/apps/web/src/components/admin/plan-notice-banner.tsx
@@ -28,11 +28,15 @@ export function PlanNoticeBanner({ notice }: PlanNoticeBannerProps) {
   const [ready, setReady] = useState(!dismissible)
   const [dismissed, setDismissed] = useState(false)
   useEffect(() => {
-    if (!dismissible) return
+    if (!dismissible) {
+      setDismissed(false)
+      setReady(true)
+      return
+    }
     setDismissed(readDismissed(notice?.expiresAt))
     setReady(true)
   }, [dismissible, notice?.expiresAt])
-  if (!view || !ready || dismissed) return null
+  if (!view || !ready || (dismissible && dismissed)) return null
 
   const tone = view.urgent
     ? 'bg-amber-500/10 border-amber-500/20'

--- a/apps/web/src/components/admin/plan-notice-banner.tsx
+++ b/apps/web/src/components/admin/plan-notice-banner.tsx
@@ -1,24 +1,48 @@
-import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/solid'
+import { useState } from 'react'
+import { ArrowTopRightOnSquareIcon, XMarkIcon } from '@heroicons/react/24/solid'
 import type { PlanNotice } from '@/lib/server/domains/settings/tier-limits.types'
 import { presentPlanNotice } from '@/lib/shared/plan-notice'
+import { trialEndedStorageKey } from '@/lib/shared/billing/trial-state'
 
 interface PlanNoticeBannerProps {
   notice: PlanNotice | null
 }
 
+function readDismissed(expiresAt: string | undefined): boolean {
+  if (typeof window === 'undefined' || !expiresAt) return false
+  try {
+    return window.localStorage.getItem(trialEndedStorageKey(expiresAt)) === '1'
+  } catch {
+    return false
+  }
+}
+
 /**
- * Operator-set notice strip (e.g. "Free trial — 9 days left"). Driven
- * entirely by settings.tier_limits.notice; renders nothing when unset.
- * Not dismissible: it represents workspace state, and clearing the
- * notice (by whoever set it) is what removes it.
+ * Operator-set or trial notice strip. Driven by settings.tier_limits.notice
+ * or a derived trial countdown. Operator notices are not dismissible.
+ * The ended-trial banner is, via per-admin localStorage.
  */
 export function PlanNoticeBanner({ notice }: PlanNoticeBannerProps) {
   const view = presentPlanNotice(notice)
-  if (!view) return null
+  const [dismissed, setDismissed] = useState(() =>
+    notice?.dismissible ? readDismissed(notice.expiresAt) : false
+  )
+  if (!view || dismissed) return null
 
   const tone = view.urgent
     ? 'bg-amber-500/10 border-amber-500/20'
     : 'bg-primary/5 border-primary/10'
+
+  function dismiss() {
+    if (notice?.expiresAt) {
+      try {
+        window.localStorage.setItem(trialEndedStorageKey(notice.expiresAt), '1')
+      } catch {
+        /* private mode */
+      }
+    }
+    setDismissed(true)
+  }
 
   return (
     <div className={`flex items-center justify-between gap-3 px-4 py-2.5 text-sm border-b ${tone}`}>
@@ -26,7 +50,7 @@ export function PlanNoticeBanner({ notice }: PlanNoticeBannerProps) {
         <span className="font-medium text-foreground shrink-0">{view.label}</span>
         {view.daysLeft !== null && (
           <>
-            <span className="text-muted-foreground">—</span>
+            <span className="text-muted-foreground">·</span>
             <span
               className={
                 view.urgent
@@ -35,7 +59,9 @@ export function PlanNoticeBanner({ notice }: PlanNoticeBannerProps) {
               }
             >
               {view.daysLeft === 0
-                ? 'ends today'
+                ? view.dismissible
+                  ? 'ended'
+                  : 'ends today'
                 : `${view.daysLeft} day${view.daysLeft === 1 ? '' : 's'} left`}
             </span>
           </>
@@ -44,18 +70,30 @@ export function PlanNoticeBanner({ notice }: PlanNoticeBannerProps) {
           <span className="text-muted-foreground hidden sm:inline truncate">{view.message}</span>
         )}
       </div>
-      {view.actionUrl && (
-        <a
-          href={view.actionUrl}
-          {...(view.actionUrl.startsWith('/')
-            ? {}
-            : { target: '_blank', rel: 'noopener noreferrer' })}
-          className="shrink-0 inline-flex items-center gap-1 text-primary font-medium hover:underline"
-        >
-          {view.actionLabel ?? 'Manage'}
-          {!view.actionUrl.startsWith('/') && <ArrowTopRightOnSquareIcon className="h-3 w-3" />}
-        </a>
-      )}
+      <div className="flex items-center gap-2 shrink-0">
+        {view.actionUrl && (
+          <a
+            href={view.actionUrl}
+            {...(view.actionUrl.startsWith('/')
+              ? {}
+              : { target: '_blank', rel: 'noopener noreferrer' })}
+            className="inline-flex items-center gap-1 text-primary font-medium hover:underline"
+          >
+            {view.actionLabel ?? 'Manage'}
+            {!view.actionUrl.startsWith('/') && <ArrowTopRightOnSquareIcon className="h-3 w-3" />}
+          </a>
+        )}
+        {view.dismissible ? (
+          <button
+            type="button"
+            onClick={dismiss}
+            className="text-muted-foreground hover:text-foreground"
+            aria-label="Dismiss"
+          >
+            <XMarkIcon className="size-4" />
+          </button>
+        ) : null}
+      </div>
     </div>
   )
 }

--- a/apps/web/src/components/admin/settings/billing/__tests__/billing-settings.test.tsx
+++ b/apps/web/src/components/admin/settings/billing/__tests__/billing-settings.test.tsx
@@ -282,6 +282,26 @@ describe('BillingPlansView', () => {
     expect(screen.queryByRole('button', { name: /Continue with/ })).not.toBeInTheDocument()
   })
 
+  it('does not offer Continue when the catalogue did not load', () => {
+    renderView({
+      catalogue: null,
+      overview: {
+        ...paidOverview,
+        plan: 'growth',
+        planName: 'Growth',
+        status: null,
+        trialActive: true,
+        trialPlanId: 'growth',
+        trialPlanName: 'Growth',
+        trialExpiresAt: '2026-09-01T00:00:00.000Z',
+        canUpgrade: true,
+        canManageBilling: false,
+        seats: { used: 4, pending: 1, members: 3, purchased: null },
+      },
+    })
+    expect(screen.queryByRole('button', { name: /Continue with/ })).not.toBeInTheDocument()
+  })
+
   it('does not offer Continue with a historical trial on a paid plan', () => {
     renderView({
       overview: {

--- a/apps/web/src/components/admin/settings/billing/__tests__/billing-settings.test.tsx
+++ b/apps/web/src/components/admin/settings/billing/__tests__/billing-settings.test.tsx
@@ -282,6 +282,18 @@ describe('BillingPlansView', () => {
     expect(screen.queryByRole('button', { name: /Continue with/ })).not.toBeInTheDocument()
   })
 
+  it('does not offer Continue with a historical trial on a paid plan', () => {
+    renderView({
+      overview: {
+        ...paidOverview,
+        canUpgrade: true,
+        trialPlanId: null,
+        trialPlanName: null,
+      },
+    })
+    expect(screen.queryByRole('button', { name: /Continue with/ })).not.toBeInTheDocument()
+  })
+
   it('shows annual monthly equivalent from the catalogue', () => {
     renderView()
     expect(screen.getByText(/Moving up applies now/)).toBeInTheDocument()

--- a/apps/web/src/components/admin/settings/billing/__tests__/billing-settings.test.tsx
+++ b/apps/web/src/components/admin/settings/billing/__tests__/billing-settings.test.tsx
@@ -209,25 +209,60 @@ describe('BillingPlansView', () => {
     expect(screen.getAllByRole('button', { name: 'Start 7-day trial' })).toHaveLength(3)
     expect(screen.getByRole('button', { name: 'Current plan' })).toBeDisabled()
     expect(screen.queryByRole('button', { name: 'Downgrade' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Switch to Free' })).not.toBeInTheDocument()
   })
 
-  it('shows a trial badge and no seat meter while seats are uncapped', () => {
+  it('shows trial expiry, Continue with the plan, and uncapped seats', () => {
     renderView({
       overview: {
         ...paidOverview,
-        status: 'trialing',
+        plan: 'growth',
+        planName: 'Growth',
+        status: null,
         trialActive: true,
+        trialPlanId: 'growth',
+        trialPlanName: 'Growth',
         trialExpiresAt: '2026-09-01T00:00:00.000Z',
+        canUpgrade: true,
+        canManageBilling: false,
         seats: { used: 4, pending: 1, members: 3, purchased: null },
       },
     })
     expect(screen.getAllByText('Trial').length).toBeGreaterThan(0)
+    expect(screen.getByText(/Trial ends/)).toBeInTheDocument()
+    expect(screen.getByText(/Uncapped during your trial/)).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: 'Continue with Growth' }).length).toBeGreaterThan(
+      0
+    )
     expect(screen.queryByRole('button', { name: 'Add seats' })).not.toBeInTheDocument()
+  })
+
+  it('explains a trial that ended and that everyone keeps access', () => {
+    renderView({
+      overview: {
+        ...paidOverview,
+        plan: 'free',
+        planName: 'Free',
+        status: null,
+        trialActive: false,
+        trialEnded: true,
+        trialPlanId: 'pro',
+        trialPlanName: 'Pro',
+        trialExpiresAt: '2026-08-18T00:00:00.000Z',
+        canUpgrade: true,
+        canManageBilling: false,
+        seats: { used: 3, pending: 0, members: 3, purchased: null },
+      },
+    })
+    expect(screen.getByText('Trial ended')).toBeInTheDocument()
+    expect(screen.getByText(/Everything you built is still here/)).toBeInTheDocument()
+    expect(screen.getByText(/Everyone keeps access/)).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: 'Continue with Pro' }).length).toBeGreaterThan(0)
   })
 
   it('shows annual monthly equivalent from the catalogue', () => {
     renderView()
-    expect(screen.getByText(/Upgrades apply immediately/)).toBeInTheDocument()
+    expect(screen.getByText(/Moving up applies now/)).toBeInTheDocument()
     expect(screen.getByText('$24')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('radio', { name: 'Monthly' }))
     expect(screen.getByText('$30')).toBeInTheDocument()

--- a/apps/web/src/components/admin/settings/billing/__tests__/billing-settings.test.tsx
+++ b/apps/web/src/components/admin/settings/billing/__tests__/billing-settings.test.tsx
@@ -260,6 +260,28 @@ describe('BillingPlansView', () => {
     expect(screen.getAllByRole('button', { name: 'Continue with Pro' }).length).toBeGreaterThan(0)
   })
 
+  it('does not call a Free trial when the last plan name is missing', () => {
+    renderView({
+      overview: {
+        ...paidOverview,
+        plan: 'free',
+        planName: 'Free',
+        status: null,
+        trialActive: false,
+        trialEnded: true,
+        trialPlanId: null,
+        trialPlanName: null,
+        trialExpiresAt: '2026-08-18T00:00:00.000Z',
+        canUpgrade: true,
+        canManageBilling: false,
+        seats: { used: 3, pending: 0, members: 3, purchased: null },
+      },
+    })
+    expect(screen.getByText(/Your trial ended/)).toBeInTheDocument()
+    expect(screen.queryByText(/Your Free trial ended/)).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Continue with/ })).not.toBeInTheDocument()
+  })
+
   it('shows annual monthly equivalent from the catalogue', () => {
     renderView()
     expect(screen.getByText(/Moving up applies now/)).toBeInTheDocument()

--- a/apps/web/src/components/admin/settings/billing/__tests__/billing-settings.test.tsx
+++ b/apps/web/src/components/admin/settings/billing/__tests__/billing-settings.test.tsx
@@ -290,6 +290,30 @@ describe('BillingPlansView', () => {
     expect(screen.getByText('$30')).toBeInTheDocument()
   })
 
+  it('opens the subscribe dialog on the selected billing period', () => {
+    renderView({
+      overview: {
+        ...paidOverview,
+        plan: 'free',
+        planName: 'Free',
+        status: null,
+        trialActive: false,
+        trialEnded: true,
+        trialPlanId: 'pro',
+        trialPlanName: 'Pro',
+        trialExpiresAt: '2026-08-18T00:00:00.000Z',
+        canUpgrade: true,
+        canManageBilling: false,
+        renewalAt: null,
+        seats: { used: 3, pending: 0, members: 3, purchased: null },
+      },
+    })
+    fireEvent.click(screen.getByRole('radio', { name: 'Monthly' }))
+    fireEvent.click(screen.getAllByRole('button', { name: 'Continue with Pro' })[0])
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(document.querySelector('form input[name="billingPeriod"]')).toHaveValue('monthly')
+  })
+
   it('hides Top up when pack prices are missing', () => {
     const { aiTopUpPackCents: _ai, emailTopUpPackCents: _email, ...rest } = catalogue
     renderView({

--- a/apps/web/src/components/admin/settings/billing/__tests__/subscribe-dialog.test.tsx
+++ b/apps/web/src/components/admin/settings/billing/__tests__/subscribe-dialog.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment happy-dom
+import '@testing-library/jest-dom/vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { SubscribeDialog } from '../subscribe-dialog'
+
+const plan = {
+  id: 'pro' as const,
+  name: 'Pro',
+  rank: 2,
+  priceMonthlyCents: 3000,
+  priceYearlyCents: 28800,
+  billedPer: 'seat' as const,
+  bestFor: 'Teams',
+  highlights: [],
+  recommended: true,
+}
+
+describe('SubscribeDialog', () => {
+  it('floors seats at current usage and shows catalogue due-today', () => {
+    render(
+      <SubscribeDialog
+        open
+        onOpenChange={() => {}}
+        plan={plan}
+        endsTrial
+        minSeats={3}
+        discountMonths={2}
+      />
+    )
+    expect(screen.getByText('3')).toBeInTheDocument()
+    expect(screen.getByLabelText('Fewer seats')).toBeDisabled()
+    expect(screen.getByText(/Due today/)).toBeInTheDocument()
+    expect(screen.getByText('$864.00')).toBeInTheDocument()
+    expect(screen.getByText(/Billing starts today and your trial ends/)).toBeInTheDocument()
+    const form = document.querySelector('form')
+    expect(form?.querySelector('input[name="quantity"]')).toHaveValue('3')
+    expect(form?.querySelector('input[name="billingPeriod"]')).toHaveValue('annual')
+  })
+
+  it('drops the trial sentence for Free-to-paid', () => {
+    render(
+      <SubscribeDialog
+        open
+        onOpenChange={() => {}}
+        plan={plan}
+        endsTrial={false}
+        minSeats={1}
+        discountMonths={2}
+      />
+    )
+    expect(screen.queryByText(/your trial ends/)).not.toBeInTheDocument()
+    expect(screen.getByText(/Payment is handled by Stripe/)).toBeInTheDocument()
+  })
+
+  it('switches due-today to monthly stickers', () => {
+    render(
+      <SubscribeDialog
+        open
+        onOpenChange={() => {}}
+        plan={plan}
+        endsTrial
+        minSeats={2}
+        discountMonths={2}
+      />
+    )
+    fireEvent.click(screen.getByRole('radio', { name: 'Monthly' }))
+    expect(screen.getByText('$60.00')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/admin/settings/billing/__tests__/subscribe-dialog.test.tsx
+++ b/apps/web/src/components/admin/settings/billing/__tests__/subscribe-dialog.test.tsx
@@ -26,6 +26,7 @@ describe('SubscribeDialog', () => {
         endsTrial
         minSeats={3}
         discountMonths={2}
+        period="annual"
       />
     )
     expect(screen.getByText('3')).toBeInTheDocument()
@@ -47,6 +48,7 @@ describe('SubscribeDialog', () => {
         endsTrial={false}
         minSeats={1}
         discountMonths={2}
+        period="annual"
       />
     )
     expect(screen.queryByText(/your trial ends/)).not.toBeInTheDocument()
@@ -62,9 +64,44 @@ describe('SubscribeDialog', () => {
         endsTrial
         minSeats={2}
         discountMonths={2}
+        period="annual"
       />
     )
     fireEvent.click(screen.getByRole('radio', { name: 'Monthly' }))
     expect(screen.getByText('$60.00')).toBeInTheDocument()
+  })
+
+  it('opens on the period selected on the plans page', () => {
+    render(
+      <SubscribeDialog
+        open
+        onOpenChange={() => {}}
+        plan={plan}
+        endsTrial
+        minSeats={2}
+        discountMonths={2}
+        period="monthly"
+      />
+    )
+    expect(screen.getByRole('radio', { name: 'Monthly' })).toHaveAttribute('aria-checked', 'true')
+    expect(document.querySelector('input[name="billingPeriod"]')).toHaveValue('monthly')
+    expect(screen.getByText('$60.00')).toBeInTheDocument()
+  })
+
+  it('does not multiply a workspace price by seat usage', () => {
+    render(
+      <SubscribeDialog
+        open
+        onOpenChange={() => {}}
+        plan={{ ...plan, billedPer: 'workspace' }}
+        endsTrial
+        minSeats={4}
+        discountMonths={2}
+        period="annual"
+      />
+    )
+    expect(screen.queryByText('Seats')).not.toBeInTheDocument()
+    expect(screen.getByText('$288.00')).toBeInTheDocument()
+    expect(document.querySelector('input[name="quantity"]')).toHaveValue('1')
   })
 })

--- a/apps/web/src/components/admin/settings/billing/billing-settings.tsx
+++ b/apps/web/src/components/admin/settings/billing/billing-settings.tsx
@@ -19,8 +19,10 @@ import {
   type BillingPlanAction,
   type PaidPlanId,
 } from '@/lib/shared/billing/plan-action'
+import { daysUntil } from '@/lib/shared/billing/trial-state'
 import { AddSeatsDialog } from './add-seats-dialog'
 import { RemoveSeatsDialog } from './remove-seats-dialog'
+import { SubscribeDialog } from './subscribe-dialog'
 import { TopUpDialog } from './topup-dialog'
 import { UsageMeter } from './usage-meter'
 
@@ -63,7 +65,9 @@ export function BillingPlansView(props: {
   const [addSeatsOpen, setAddSeatsOpen] = useState(false)
   const [removeSeatsOpen, setRemoveSeatsOpen] = useState(false)
   const [topupMeter, setTopupMeter] = useState<'ai' | 'email' | null>(null)
+  const [subscribePlanId, setSubscribePlanId] = useState<PaidPlanId | null>(null)
   const { overview, catalogue } = props
+  const subscribePlan = catalogue?.plans.find((plan) => plan.id === subscribePlanId)
   const trialDays = catalogueTrialDays(catalogue)
   const trialedPlanIds = catalogueTrialedPlanIds(catalogue)
   const checkoutQuantity = Math.max(overview.seats?.used ?? 1, 1)
@@ -78,6 +82,7 @@ export function BillingPlansView(props: {
         catalogue={catalogue}
         onAddSeats={() => setAddSeatsOpen(true)}
         onRemoveSeats={() => setRemoveSeatsOpen(true)}
+        onSubscribe={setSubscribePlanId}
       />
 
       <UsageCard
@@ -92,8 +97,8 @@ export function BillingPlansView(props: {
           <div>
             <h2 className="text-base font-semibold">Plans</h2>
             <p className="mt-1 text-xs text-muted-foreground">
-              Upgrades apply immediately (pro-rata). Downgrades take effect at the end of the
-              current billing period. A {trialDays}-day trial is available once per paid plan.
+              Moving up applies now, billed pro-rata. Moving to a lower plan waits until the end of
+              the current period. You can try each paid plan once for {trialDays} days.
               {grandfatheredFlat ? ' Switching plans moves you onto per-seat pricing.' : null}
             </p>
           </div>
@@ -122,6 +127,8 @@ export function BillingPlansView(props: {
                 trialActive={overview.trialActive && overview.plan === plan.id}
                 index={index}
                 checkoutQuantity={checkoutQuantity}
+                subscribeIsContinuation={Boolean(overview.trialActive || overview.trialEnded)}
+                onSubscribe={setSubscribePlanId}
               />
             ))}
           </div>
@@ -148,6 +155,18 @@ export function BillingPlansView(props: {
 
       {addSeatsOpen ? <AddSeatsDialog open onOpenChange={setAddSeatsOpen} /> : null}
       {removeSeatsOpen ? <RemoveSeatsDialog open onOpenChange={setRemoveSeatsOpen} /> : null}
+      {subscribePlan && subscribePlan.id !== 'free' ? (
+        <SubscribeDialog
+          open
+          plan={subscribePlan}
+          endsTrial={Boolean(overview.trialActive || overview.trialEnded)}
+          minSeats={checkoutQuantity}
+          discountMonths={catalogue?.annualDiscountMonths ?? 2}
+          onOpenChange={(open) => {
+            if (!open) setSubscribePlanId(null)
+          }}
+        />
+      ) : null}
       {topupMeter ? (
         <TopUpDialog
           open
@@ -166,21 +185,43 @@ function CurrentPlanCard(props: {
   catalogue: BillingCatalogue | null
   onAddSeats: () => void
   onRemoveSeats: () => void
+  onSubscribe: (planId: PaidPlanId) => void
 }) {
   const { overview, catalogue } = props
   const plan = catalogue?.plans.find((entry) => entry.id === overview.plan)
   const purchased = overview.seats?.purchased ?? null
   const showSeats = purchased != null
+  const trialPlanName = overview.trialPlanName ?? overview.planName
+  const subscribePlanId = overview.trialPlanId ?? (overview.plan !== 'free' ? overview.plan : null)
+  const canSubscribe = Boolean(overview.canUpgrade && subscribePlanId)
+  const daysLeft =
+    overview.trialActive && overview.trialExpiresAt ? daysUntil(overview.trialExpiresAt) : null
   const statusLabel = overview.trialActive
     ? 'Trial'
-    : overview.status
-      ? (STATUS_LABELS[overview.status] ?? overview.status)
-      : null
+    : overview.trialEnded
+      ? 'Trial ended'
+      : overview.status
+        ? (STATUS_LABELS[overview.status] ?? overview.status)
+        : null
   const perSeat = plan ? seatUnitCents(plan, null) : 0
   const renewalBits: string[] = []
-  if (overview.cancellationAt)
-    renewalBits.push(`Access ends ${formatDate(overview.cancellationAt)}`)
-  else if (overview.renewalAt) renewalBits.push(`Renews ${formatDate(overview.renewalAt)}`)
+  if (overview.trialActive && overview.trialExpiresAt) {
+    const left =
+      daysLeft === null
+        ? ''
+        : daysLeft === 0
+          ? ' (ends today)'
+          : ` (${daysLeft} ${daysLeft === 1 ? 'day' : 'days'} left)`
+    renewalBits.push(`Trial ends ${formatDate(overview.trialExpiresAt)}${left}`)
+  } else if (overview.trialEnded && overview.trialExpiresAt) {
+    renewalBits.push(
+      `Your ${trialPlanName} trial ended ${formatDate(overview.trialExpiresAt)}. Everything you built is still here.`
+    )
+  } else if (overview.cancellationAt) {
+    renewalBits.push(`Paid through ${formatDate(overview.cancellationAt)}`)
+  } else if (overview.renewalAt) {
+    renewalBits.push(`Renews ${formatDate(overview.renewalAt)}`)
+  }
   if (showSeats && plan && plan.billedPer === 'seat') {
     renewalBits.push(`${purchased} seats × ${formatUsd(perSeat, 0)}/seat`)
   }
@@ -201,9 +242,20 @@ function CurrentPlanCard(props: {
             <p className="text-[13px] text-muted-foreground">{renewalBits.join(' · ')}</p>
           ) : null}
         </div>
-        {overview.canManageBilling ? <PortalButton label="Manage billing" /> : null}
+        <div className="flex shrink-0 items-center gap-2">
+          {canSubscribe && subscribePlanId ? (
+            <Button size="sm" type="button" onClick={() => props.onSubscribe(subscribePlanId)}>
+              Continue with {trialPlanName}
+            </Button>
+          ) : null}
+          {overview.canManageBilling ? <PortalButton label="Manage billing" /> : null}
+        </div>
       </div>
-      {showSeats ? (
+      {overview.trialActive ? (
+        <TrialSeatsRow overview={overview} />
+      ) : overview.trialEnded ? (
+        <EndedSeatsRow overview={overview} />
+      ) : showSeats ? (
         <SeatsBlock
           overview={overview}
           purchased={purchased}
@@ -212,6 +264,42 @@ function CurrentPlanCard(props: {
         />
       ) : null}
     </section>
+  )
+}
+
+function TrialSeatsRow(props: { overview: BillingProjectionOverview }) {
+  const seats = props.overview.seats
+  const used = seats?.used ?? 0
+  const members = seats?.members ?? used
+  const pending = seats?.pending ?? 0
+  return (
+    <div className="border-t border-border/50 px-6 py-5">
+      <p className="text-[13px] text-muted-foreground">
+        Uncapped during your trial · {members} {members === 1 ? 'member' : 'members'} · {pending}{' '}
+        pending {pending === 1 ? 'invite' : 'invites'} · checkout starts at your current {used}{' '}
+        {used === 1 ? 'seat' : 'seats'}
+      </p>
+    </div>
+  )
+}
+
+function EndedSeatsRow(props: { overview: BillingProjectionOverview }) {
+  const seats = props.overview.seats
+  const used = seats?.used ?? 0
+  const cap = 1
+  return (
+    <div className="flex flex-col gap-2.5 border-t border-border/50 px-6 py-5">
+      <div className="flex items-baseline justify-between gap-3">
+        <div className="text-[13px] font-medium">Seats</div>
+        <div className="font-mono text-[12px] text-muted-foreground tabular-nums">
+          {used} of {cap} used
+        </div>
+      </div>
+      <Progress value={used} max={cap} />
+      <p className="text-[12px] text-muted-foreground">
+        Everyone keeps access. New invites pause until you continue with a paid plan.
+      </p>
+    </div>
   )
 }
 
@@ -390,6 +478,8 @@ function PlanCard(props: {
   trialActive: boolean
   index: number
   checkoutQuantity: number
+  subscribeIsContinuation: boolean
+  onSubscribe: (planId: PaidPlanId) => void
 }) {
   const { plan, period, action } = props
   const isAnnual = period === 'annual'
@@ -447,6 +537,8 @@ function PlanCard(props: {
           trialDays={props.trialDays}
           period={period}
           checkoutQuantity={props.checkoutQuantity}
+          subscribeIsContinuation={props.subscribeIsContinuation}
+          onSubscribe={props.onSubscribe}
         />
       </div>
     </article>
@@ -459,6 +551,8 @@ function PlanActionButton(props: {
   trialDays: number
   period: 'monthly' | 'annual'
   checkoutQuantity: number
+  subscribeIsContinuation: boolean
+  onSubscribe: (planId: PaidPlanId) => void
 }) {
   const { action } = props
   if (action.kind === 'current') {
@@ -471,7 +565,7 @@ function PlanActionButton(props: {
   if (action.kind === 'unavailable') {
     return (
       <Button size="sm" variant="outline" className="w-full" disabled>
-        {props.planName === 'Free' ? 'Downgrade' : `Choose ${props.planName}`}
+        {props.planName === 'Free' ? 'Switch to Free' : `Choose ${props.planName}`}
       </Button>
     )
   }
@@ -483,7 +577,21 @@ function PlanActionButton(props: {
   if (action.kind === 'downgrade') {
     return <DowngradeButton />
   }
-  const label = action.kind === 'switch' ? `Switch to this plan` : `Subscribe to ${props.planName}`
+  if (action.kind === 'subscribe') {
+    return (
+      <Button
+        size="sm"
+        type="button"
+        className="w-full"
+        variant="outline"
+        onClick={() => props.onSubscribe(action.planId)}
+      >
+        {props.subscribeIsContinuation
+          ? `Continue with ${props.planName}`
+          : `Subscribe to ${props.planName}`}
+      </Button>
+    )
+  }
   return (
     <form method="post" action="/api/billing/session">
       <input type="hidden" name="action" value="checkout" />
@@ -491,7 +599,7 @@ function PlanActionButton(props: {
       <input type="hidden" name="billingPeriod" value={props.period} />
       <input type="hidden" name="quantity" value={String(props.checkoutQuantity)} />
       <Button size="sm" type="submit" className="w-full" variant="outline">
-        {label}
+        Switch to this plan
       </Button>
     </form>
   )
@@ -513,8 +621,8 @@ function TrialButton(props: { planId: PaidPlanId; planName: string; trialDays: n
       <ConfirmDialog
         open={open}
         onOpenChange={setOpen}
-        title={`Start a ${props.trialDays}-day ${props.planName} trial?`}
-        description={`You’ll have ${props.planName} for ${props.trialDays} days. When it ends you return to Free. Nothing is deleted. You can’t trial ${props.planName} again.`}
+        title={`Try ${props.planName} for ${props.trialDays} days?`}
+        description={`You’ll have ${props.planName} for ${props.trialDays} days. When it ends you continue on Free with everything you have built. Each paid plan can be tried once.`}
         confirmLabel={`Start ${props.planName} trial`}
         onConfirm={() => {
           const form = document.getElementById(`trial-${props.planId}`) as HTMLFormElement | null
@@ -544,14 +652,14 @@ function DowngradeButton() {
         className="w-full"
         onClick={() => setOpen(true)}
       >
-        Downgrade
+        Switch to Free
       </Button>
       <ConfirmDialog
         open={open}
         onOpenChange={setOpen}
-        title="Downgrade to Free?"
-        description="Your workspace stays online. New work that exceeds Free limits will be refused; existing data is kept. A paid plan stays in force until the end of the current period. An active trial ends now."
-        confirmLabel="Downgrade to Free"
+        title="Switch to Free?"
+        description="You’ll keep all existing data and stay online. New work that goes past Free limits will pause until you pick a paid plan again. If you are on a paid period, Free starts when it ends. An active trial ends now."
+        confirmLabel="Switch to Free"
         variant="destructive"
         onConfirm={() => {
           const form = document.getElementById('downgrade-free') as HTMLFormElement | null

--- a/apps/web/src/components/admin/settings/billing/billing-settings.tsx
+++ b/apps/web/src/components/admin/settings/billing/billing-settings.tsx
@@ -195,7 +195,9 @@ function CurrentPlanCard(props: {
   const trialPlanName =
     overview.trialPlanName && overview.trialPlanName !== 'Free' ? overview.trialPlanName : null
   const subscribePlanId = overview.trialPlanId ?? (overview.plan !== 'free' ? overview.plan : null)
-  const canSubscribe = Boolean(overview.canUpgrade && subscribePlanId)
+  const canSubscribe = Boolean(
+    overview.canUpgrade && subscribePlanId && (overview.trialActive || overview.trialEnded)
+  )
   const daysLeft =
     overview.trialActive && overview.trialExpiresAt ? daysUntil(overview.trialExpiresAt) : null
   const statusLabel = overview.trialActive

--- a/apps/web/src/components/admin/settings/billing/billing-settings.tsx
+++ b/apps/web/src/components/admin/settings/billing/billing-settings.tsx
@@ -196,7 +196,10 @@ function CurrentPlanCard(props: {
     overview.trialPlanName && overview.trialPlanName !== 'Free' ? overview.trialPlanName : null
   const subscribePlanId = overview.trialPlanId ?? (overview.plan !== 'free' ? overview.plan : null)
   const canSubscribe = Boolean(
-    overview.canUpgrade && subscribePlanId && (overview.trialActive || overview.trialEnded)
+    overview.canUpgrade &&
+    subscribePlanId &&
+    (overview.trialActive || overview.trialEnded) &&
+    catalogue?.plans.some((entry) => entry.id === subscribePlanId)
   )
   const daysLeft =
     overview.trialActive && overview.trialExpiresAt ? daysUntil(overview.trialExpiresAt) : null

--- a/apps/web/src/components/admin/settings/billing/billing-settings.tsx
+++ b/apps/web/src/components/admin/settings/billing/billing-settings.tsx
@@ -191,7 +191,8 @@ function CurrentPlanCard(props: {
   const plan = catalogue?.plans.find((entry) => entry.id === overview.plan)
   const purchased = overview.seats?.purchased ?? null
   const showSeats = purchased != null
-  const trialPlanName = overview.trialPlanName ?? overview.planName
+  const trialPlanName =
+    overview.trialPlanName && overview.trialPlanName !== 'Free' ? overview.trialPlanName : null
   const subscribePlanId = overview.trialPlanId ?? (overview.plan !== 'free' ? overview.plan : null)
   const canSubscribe = Boolean(overview.canUpgrade && subscribePlanId)
   const daysLeft =
@@ -215,7 +216,9 @@ function CurrentPlanCard(props: {
     renewalBits.push(`Trial ends ${formatDate(overview.trialExpiresAt)}${left}`)
   } else if (overview.trialEnded && overview.trialExpiresAt) {
     renewalBits.push(
-      `Your ${trialPlanName} trial ended ${formatDate(overview.trialExpiresAt)}. Everything you built is still here.`
+      trialPlanName
+        ? `Your ${trialPlanName} trial ended ${formatDate(overview.trialExpiresAt)}. Everything you built is still here.`
+        : `Your trial ended ${formatDate(overview.trialExpiresAt)}. Everything you built is still here.`
     )
   } else if (overview.cancellationAt) {
     renewalBits.push(`Paid through ${formatDate(overview.cancellationAt)}`)
@@ -245,7 +248,7 @@ function CurrentPlanCard(props: {
         <div className="flex shrink-0 items-center gap-2">
           {canSubscribe && subscribePlanId ? (
             <Button size="sm" type="button" onClick={() => props.onSubscribe(subscribePlanId)}>
-              Continue with {trialPlanName}
+              Continue with {trialPlanName ?? 'a paid plan'}
             </Button>
           ) : null}
           {overview.canManageBilling ? <PortalButton label="Manage billing" /> : null}

--- a/apps/web/src/components/admin/settings/billing/billing-settings.tsx
+++ b/apps/web/src/components/admin/settings/billing/billing-settings.tsx
@@ -162,6 +162,7 @@ export function BillingPlansView(props: {
           endsTrial={Boolean(overview.trialActive || overview.trialEnded)}
           minSeats={checkoutQuantity}
           discountMonths={catalogue?.annualDiscountMonths ?? 2}
+          period={period}
           onOpenChange={(open) => {
             if (!open) setSubscribePlanId(null)
           }}

--- a/apps/web/src/components/admin/settings/billing/subscribe-dialog.tsx
+++ b/apps/web/src/components/admin/settings/billing/subscribe-dialog.tsx
@@ -20,13 +20,15 @@ export function SubscribeDialog(props: {
   endsTrial: boolean
   minSeats: number
   discountMonths: number
+  period: 'monthly' | 'annual'
 }) {
-  const [period, setPeriod] = useState<'monthly' | 'annual'>('annual')
+  const billedPerSeat = props.plan.billedPer === 'seat'
+  const [period, setPeriod] = useState<'monthly' | 'annual'>(props.period)
   const [seats, setSeats] = useState(() => Math.max(props.minSeats, 1))
-  const quantity = Math.max(seats, props.minSeats, 1)
+  const quantity = billedPerSeat ? Math.max(seats, props.minSeats, 1) : 1
   const isAnnual = period === 'annual'
   const unitCents = isAnnual ? props.plan.priceYearlyCents : props.plan.priceMonthlyCents
-  const dueCents = quantity * unitCents
+  const dueCents = billedPerSeat ? quantity * unitCents : unitCents
   const monthlyCents = isAnnual
     ? Math.round(props.plan.priceYearlyCents / 12)
     : props.plan.priceMonthlyCents
@@ -37,7 +39,7 @@ export function SubscribeDialog(props: {
         <DialogHeader>
           <DialogTitle>Subscribe to {props.plan.name}</DialogTitle>
           <DialogDescription>
-            {props.plan.billedPer === 'seat'
+            {billedPerSeat
               ? `${formatUsd(monthlyCents, 0)}/seat/${isAnnual ? 'mo billed yearly' : 'mo'}.`
               : `${formatUsd(monthlyCents, 0)}/${isAnnual ? 'mo billed yearly' : 'mo'}.`}
           </DialogDescription>
@@ -72,7 +74,7 @@ export function SubscribeDialog(props: {
           ))}
         </div>
 
-        {props.plan.billedPer === 'seat' ? (
+        {billedPerSeat ? (
           <div className="flex items-center justify-between gap-3">
             <div className="text-sm font-medium">Seats</div>
             <QuantityStepper
@@ -86,7 +88,7 @@ export function SubscribeDialog(props: {
         ) : null}
 
         <div className="flex flex-col gap-2 rounded-[10px] border border-border/50 bg-muted/30 px-4 py-3">
-          {props.plan.billedPer === 'seat' ? (
+          {billedPerSeat ? (
             <div className="flex items-baseline justify-between gap-3 text-[13px]">
               <span className="text-muted-foreground">
                 {quantity} {quantity === 1 ? 'seat' : 'seats'} × {formatUsd(unitCents, 0)}

--- a/apps/web/src/components/admin/settings/billing/subscribe-dialog.tsx
+++ b/apps/web/src/components/admin/settings/billing/subscribe-dialog.tsx
@@ -1,0 +1,123 @@
+import { useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { formatUsd } from '@/lib/shared/format-usd'
+import { cn } from '@/lib/shared/utils'
+import type { BillingCatalogue } from '@/lib/server/control-plane/client'
+import { QuantityStepper } from './quantity-stepper'
+
+export function SubscribeDialog(props: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  plan: BillingCatalogue['plans'][number]
+  endsTrial: boolean
+  minSeats: number
+  discountMonths: number
+}) {
+  const [period, setPeriod] = useState<'monthly' | 'annual'>('annual')
+  const [seats, setSeats] = useState(() => Math.max(props.minSeats, 1))
+  const quantity = Math.max(seats, props.minSeats, 1)
+  const isAnnual = period === 'annual'
+  const unitCents = isAnnual ? props.plan.priceYearlyCents : props.plan.priceMonthlyCents
+  const dueCents = quantity * unitCents
+  const monthlyCents = isAnnual
+    ? Math.round(props.plan.priceYearlyCents / 12)
+    : props.plan.priceMonthlyCents
+
+  return (
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Subscribe to {props.plan.name}</DialogTitle>
+          <DialogDescription>
+            {props.plan.billedPer === 'seat'
+              ? `${formatUsd(monthlyCents, 0)}/seat/${isAnnual ? 'mo billed yearly' : 'mo'}.`
+              : `${formatUsd(monthlyCents, 0)}/${isAnnual ? 'mo billed yearly' : 'mo'}.`}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div
+          role="radiogroup"
+          aria-label="Billing period"
+          className="inline-flex items-center rounded-full border border-border/50 bg-muted/30 p-0.5"
+        >
+          {(['annual', 'monthly'] as const).map((option) => (
+            <button
+              key={option}
+              type="button"
+              role="radio"
+              aria-checked={period === option}
+              onClick={() => setPeriod(option)}
+              className={cn(
+                'inline-flex h-8 items-center rounded-full px-3 text-[13px] font-medium',
+                period === option
+                  ? 'bg-background text-foreground shadow-xs'
+                  : 'text-muted-foreground hover:text-foreground'
+              )}
+            >
+              {option === 'annual' ? 'Annual' : 'Monthly'}
+              {option === 'annual' && (
+                <span className="ms-1.5 text-[11px] font-semibold text-primary">
+                  {props.discountMonths} mo free
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+
+        {props.plan.billedPer === 'seat' ? (
+          <div className="flex items-center justify-between gap-3">
+            <div className="text-sm font-medium">Seats</div>
+            <QuantityStepper
+              value={quantity}
+              min={Math.max(props.minSeats, 1)}
+              onChange={setSeats}
+              decreaseLabel="Fewer seats"
+              increaseLabel="More seats"
+            />
+          </div>
+        ) : null}
+
+        <div className="flex flex-col gap-2 rounded-[10px] border border-border/50 bg-muted/30 px-4 py-3">
+          {props.plan.billedPer === 'seat' ? (
+            <div className="flex items-baseline justify-between gap-3 text-[13px]">
+              <span className="text-muted-foreground">
+                {quantity} {quantity === 1 ? 'seat' : 'seats'} × {formatUsd(unitCents, 0)}
+                {isAnnual ? '/seat/yr' : '/seat/mo'}
+              </span>
+            </div>
+          ) : null}
+          <div className="flex items-baseline justify-between gap-3 text-[13px] font-medium">
+            <span>Due today</span>
+            <span className="tabular-nums">{formatUsd(dueCents, 2)}</span>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="ghost" onClick={() => props.onOpenChange(false)}>
+            Cancel
+          </Button>
+          <form method="post" action="/api/billing/session">
+            <input type="hidden" name="action" value="checkout" />
+            <input type="hidden" name="planId" value={props.plan.id} />
+            <input type="hidden" name="billingPeriod" value={period} />
+            <input type="hidden" name="quantity" value={String(quantity)} />
+            <Button type="submit">Continue to checkout</Button>
+          </form>
+        </DialogFooter>
+        <p className="text-[12px] text-muted-foreground">
+          {props.endsTrial
+            ? 'Payment is handled by Stripe. Billing starts today and your trial ends when it goes through. You can still change the seat count on the checkout page.'
+            : 'Payment is handled by Stripe. You can still change the seat count on the checkout page.'}
+        </p>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/components/admin/settings/team/seat-gate-panel.tsx
+++ b/apps/web/src/components/admin/settings/team/seat-gate-panel.tsx
@@ -30,7 +30,12 @@ export function SeatGatePanel({ usage, onAddSeat }: { usage: SeatUsage; onAddSea
           </Button>
         ) : (
           <Button type="button" size="sm" className="shrink-0" asChild>
-            <Link to="/admin/settings/billing">See plans</Link>
+            <Link
+              to="/admin/settings/billing"
+              search={{ checkout: undefined, billing_error: undefined }}
+            >
+              See plans
+            </Link>
           </Button>
         )}
       </div>

--- a/apps/web/src/lib/server/control-plane/client.ts
+++ b/apps/web/src/lib/server/control-plane/client.ts
@@ -173,6 +173,7 @@ export type BillingCatalogue = {
   }>
   trialDays?: number
   trialedPlanIds?: Array<'growth' | 'pro' | 'scale'>
+  lastTrialPlanId?: 'growth' | 'pro' | 'scale' | null
 }
 
 export type CustomerInvoice = {

--- a/apps/web/src/lib/server/domains/billing/__tests__/projection-overview.test.ts
+++ b/apps/web/src/lib/server/domains/billing/__tests__/projection-overview.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { composeAiUsage, purchasedSeatsFromProjection } from '../projection-overview'
+import {
+  composeAiUsage,
+  purchasedSeatsFromProjection,
+  trialPlanIdForOverview,
+} from '../projection-overview'
 
 describe('composeAiUsage', () => {
   it('converts tokens at the catalogue blended rate and derives extra from the cap', () => {
@@ -49,5 +53,40 @@ describe('purchasedSeatsFromProjection', () => {
     expect(purchasedSeatsFromProjection({ ...billed, trialActive: true })).toBeNull()
     expect(purchasedSeatsFromProjection({ ...billed, billedPer: 'workspace' })).toBeNull()
     expect(purchasedSeatsFromProjection({ ...billed, billedPer: undefined })).toBeNull()
+  })
+})
+
+describe('trialPlanIdForOverview', () => {
+  it('uses the live plan while the product trial is running', () => {
+    expect(
+      trialPlanIdForOverview({
+        trialActive: true,
+        trialEnded: false,
+        plan: 'growth',
+        lastTrialPlanId: 'pro',
+      })
+    ).toBe('growth')
+  })
+
+  it('uses lastTrialPlanId only in the ended window', () => {
+    expect(
+      trialPlanIdForOverview({
+        trialActive: false,
+        trialEnded: true,
+        plan: 'free',
+        lastTrialPlanId: 'pro',
+      })
+    ).toBe('pro')
+  })
+
+  it('ignores historical trial plans on a paid workspace', () => {
+    expect(
+      trialPlanIdForOverview({
+        trialActive: false,
+        trialEnded: false,
+        plan: 'scale',
+        lastTrialPlanId: 'growth',
+      })
+    ).toBeNull()
   })
 })

--- a/apps/web/src/lib/server/domains/billing/projection-overview.ts
+++ b/apps/web/src/lib/server/domains/billing/projection-overview.ts
@@ -1,6 +1,7 @@
 import { getCloudConfig } from '@/lib/server/domains/settings/cloud/cloud.service'
 import { PLAN_CATALOGUE, type PlanId } from '@/lib/server/domains/settings/cloud/cloud.types'
 import type { BillingCatalogue, CataloguePlanId } from '@/lib/server/control-plane/client'
+import { isTrialEnded } from '@/lib/shared/billing/trial-state'
 
 export type BillingSeatsOverview = {
   used: number
@@ -20,7 +21,10 @@ export interface BillingProjectionOverview {
   planName: string
   status: string | null
   trialActive: boolean
+  trialEnded?: boolean
   trialExpiresAt: string | null
+  trialPlanId?: Exclude<PlanId, 'free'> | null
+  trialPlanName?: string | null
   renewalAt: string | null
   cancellationAt: string | null
   canUpgrade: boolean
@@ -113,12 +117,25 @@ export async function getBillingProjectionOverview(): Promise<BillingProjectionO
         })
       : null
 
+  const lastTrialPlanId = catalogue?.lastTrialPlanId ?? null
+  const trialPlanId =
+    cloud.trialActive && cloud.plan && cloud.plan !== 'free' ? cloud.plan : lastTrialPlanId
+  const trialEnded = isTrialEnded({
+    plan: cloud.plan,
+    trialActive: cloud.trialActive,
+    trialExpiresAt: cloud.trialExpiresAt,
+    status: cloud.subscriptionStatus,
+  })
+
   return {
     plan: cloud.plan,
     planName: PLAN_CATALOGUE[cloud.plan].name,
     status: cloud.subscriptionStatus,
     trialActive: cloud.trialActive,
+    trialEnded,
     trialExpiresAt: cloud.trialExpiresAt,
+    trialPlanId,
+    trialPlanName: trialPlanId ? PLAN_CATALOGUE[trialPlanId].name : null,
     renewalAt: cloud.renewalAt,
     cancellationAt: cloud.cancellationAt,
     canUpgrade: cloud.canUpgrade,

--- a/apps/web/src/lib/server/domains/billing/projection-overview.ts
+++ b/apps/web/src/lib/server/domains/billing/projection-overview.ts
@@ -62,6 +62,20 @@ export function catalogueAiIncludedCents(
  * Free, trial, workspace-billed, and missing billedPer (grandfathered /
  * catalogue unavailable) stay null so Add seats cannot target an overlay.
  */
+/** lastTrialPlanId is catalogue history. Only surface it while a product
+ *  trial is running or in the 7-day ended window; a paid workspace must
+ *  not keep a Continue-with CTA for a plan it already left. */
+export function trialPlanIdForOverview(input: {
+  trialActive: boolean
+  trialEnded: boolean
+  plan: PlanId
+  lastTrialPlanId: Exclude<PlanId, 'free'> | null
+}): Exclude<PlanId, 'free'> | null {
+  if (input.trialActive && input.plan !== 'free') return input.plan
+  if (input.trialEnded) return input.lastTrialPlanId
+  return null
+}
+
 export function purchasedSeatsFromProjection(input: {
   billedPer: 'seat' | 'workspace' | undefined
   plan: PlanId
@@ -117,14 +131,18 @@ export async function getBillingProjectionOverview(): Promise<BillingProjectionO
         })
       : null
 
-  const lastTrialPlanId = catalogue?.lastTrialPlanId ?? null
-  const trialPlanId =
-    cloud.trialActive && cloud.plan && cloud.plan !== 'free' ? cloud.plan : lastTrialPlanId
   const trialEnded = isTrialEnded({
     plan: cloud.plan,
     trialActive: cloud.trialActive,
     trialExpiresAt: cloud.trialExpiresAt,
     status: cloud.subscriptionStatus,
+  })
+  const lastTrialPlanId = catalogue?.lastTrialPlanId ?? null
+  const trialPlanId = trialPlanIdForOverview({
+    trialActive: cloud.trialActive,
+    trialEnded,
+    plan: cloud.plan,
+    lastTrialPlanId,
   })
 
   return {

--- a/apps/web/src/lib/server/domains/settings/cloud/__tests__/billing-projection.test.ts
+++ b/apps/web/src/lib/server/domains/settings/cloud/__tests__/billing-projection.test.ts
@@ -146,4 +146,16 @@ describe('projected commercial state', () => {
     expect(atExpiry.trialActive).toBe(false)
     expect(atExpiry.trialExpiresAt).toBe(PROJECTION.trialExpiresAt)
   })
+
+  it('does not keep a Trial badge after a mid-trial purchase', () => {
+    const cloud = resolveCloudConfig(
+      {
+        enabled: true,
+        projection: { ...PROJECTION, subscriptionStatus: 'active', planLimitsExpireAt: null },
+      },
+      new Date('2026-08-14T12:00:00.000Z')
+    )
+    expect(cloud.trialActive).toBe(false)
+    expect(cloud.plan).toBe('pro')
+  })
 })

--- a/apps/web/src/lib/server/domains/settings/cloud/__tests__/billing-projection.test.ts
+++ b/apps/web/src/lib/server/domains/settings/cloud/__tests__/billing-projection.test.ts
@@ -158,4 +158,17 @@ describe('projected commercial state', () => {
     expect(cloud.trialActive).toBe(false)
     expect(cloud.plan).toBe('pro')
   })
+
+  it('does not treat a live Stripe subscription as a product trial', () => {
+    const cloud = resolveCloudConfig(
+      {
+        enabled: true,
+        projection: { ...PROJECTION, subscriptionStatus: 'trialing', planLimitsExpireAt: null },
+      },
+      new Date('2026-08-14T12:00:00.000Z')
+    )
+    expect(cloud.trialActive).toBe(false)
+    expect(cloud.subscriptionStatus).toBe('trialing')
+    expect(cloud.plan).toBe('pro')
+  })
 })

--- a/apps/web/src/lib/server/domains/settings/cloud/__tests__/commercial-notice.test.ts
+++ b/apps/web/src/lib/server/domains/settings/cloud/__tests__/commercial-notice.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { trialEndedNotice, trialNotice } from '../commercial-notice'
+import type { CloudConfig } from '../cloud.types'
+
+const NOW = new Date('2026-08-20T12:00:00.000Z')
+
+function config(overrides: Partial<CloudConfig> = {}): CloudConfig {
+  return {
+    enabled: true,
+    plan: 'growth',
+    entitlements: {},
+    subscriptionStatus: null,
+    trialStartedAt: '2026-08-06T00:00:00.000Z',
+    trialExpiresAt: '2026-08-22T00:00:00.000Z',
+    trialActive: true,
+    canUpgrade: true,
+    canManageBilling: false,
+    renewalAt: null,
+    cancellationAt: null,
+    ...overrides,
+  }
+}
+
+describe('trialNotice', () => {
+  it('keeps See plans until the last three days', () => {
+    const notice = trialNotice(config({ trialExpiresAt: '2026-08-30T00:00:00.000Z' }), NOW)
+    expect(notice).toMatchObject({
+      label: 'Growth trial',
+      actionLabel: 'See plans',
+      message: expect.stringContaining('continue on Free'),
+    })
+  })
+
+  it('switches the action to Continue with the plan in the last three days', () => {
+    const notice = trialNotice(config({ trialExpiresAt: '2026-08-21T12:00:00.000Z' }), NOW)
+    expect(notice?.actionLabel).toBe('Continue with Growth')
+  })
+})
+
+describe('trialEndedNotice', () => {
+  it('leads with keep-your-work copy and a Continue action', () => {
+    const notice = trialEndedNotice(
+      config({
+        plan: 'free',
+        trialActive: false,
+        trialExpiresAt: '2026-08-18T00:00:00.000Z',
+      }),
+      { trialPlanName: 'Growth', now: NOW }
+    )
+    expect(notice).toMatchObject({
+      label: 'Growth trial',
+      dismissible: true,
+      actionLabel: 'Continue with Growth',
+    })
+    expect(notice?.message).toMatch(/everything you built is still here/)
+  })
+})

--- a/apps/web/src/lib/server/domains/settings/cloud/cloud.service.ts
+++ b/apps/web/src/lib/server/domains/settings/cloud/cloud.service.ts
@@ -21,7 +21,9 @@ export function resolveCloudConfig(
     projection.planLimitsExpireAt !== null &&
     now.getTime() >= Date.parse(projection.planLimitsExpireAt)
   const trialActive =
-    projection.trialExpiresAt !== null && now.getTime() < Date.parse(projection.trialExpiresAt)
+    projection.subscriptionStatus == null &&
+    projection.trialExpiresAt !== null &&
+    now.getTime() < Date.parse(projection.trialExpiresAt)
 
   return {
     enabled: true,

--- a/apps/web/src/lib/server/domains/settings/cloud/commercial-notice.ts
+++ b/apps/web/src/lib/server/domains/settings/cloud/commercial-notice.ts
@@ -1,5 +1,6 @@
 import type { PlanNotice } from '../tier-limits.types'
 import { PLAN_CATALOGUE, type CloudConfig } from './cloud.types'
+import { daysUntil, isTrialEnded } from '@/lib/shared/billing/trial-state'
 
 export const IN_APP_PLANS_PATH = '/admin/settings/billing'
 
@@ -7,14 +8,64 @@ export function plansActionUrl(config: Pick<CloudConfig, 'enabled' | 'canUpgrade
   return config.enabled && config.canUpgrade ? IN_APP_PLANS_PATH : null
 }
 
+function planLabel(config: CloudConfig, trialPlanName?: string | null): string {
+  if (trialPlanName) return trialPlanName
+  return config.plan ? PLAN_CATALOGUE[config.plan].name : PLAN_CATALOGUE.pro.name
+}
+
 /** Trial countdown derived from the control-plane-owned expiry timestamp. */
-export function trialNotice(config: CloudConfig): PlanNotice | null {
+export function trialNotice(config: CloudConfig, now: Date = new Date()): PlanNotice | null {
   if (!config.enabled || !config.trialActive || !config.trialExpiresAt) return null
   const actionUrl = plansActionUrl(config)
+  const daysLeft = daysUntil(config.trialExpiresAt, now)
+  const urgent = daysLeft !== null && daysLeft <= 3
   return {
-    label: `${config.plan ? PLAN_CATALOGUE[config.plan].name : PLAN_CATALOGUE.pro.name} trial`,
-    message: 'Your workspace moves to the Free plan when this ends. Nothing is deleted.',
+    label: `${planLabel(config)} trial`,
+    message: 'When this ends you will continue on Free. Everything you have built stays.',
     expiresAt: config.trialExpiresAt,
-    ...(actionUrl ? { actionUrl, actionLabel: 'See plans' } : {}),
+    ...(actionUrl
+      ? {
+          actionUrl,
+          actionLabel: urgent ? `Continue with ${planLabel(config)}` : 'See plans',
+        }
+      : {}),
   }
+}
+
+export function trialEndedNotice(
+  config: CloudConfig,
+  options: { trialPlanName?: string | null; now?: Date } = {}
+): PlanNotice | null {
+  if (!config.enabled || !config.plan) return null
+  const now = options.now ?? new Date()
+  if (
+    !isTrialEnded({
+      plan: config.plan,
+      trialActive: config.trialActive,
+      trialExpiresAt: config.trialExpiresAt,
+      status: config.subscriptionStatus,
+      now,
+    })
+  ) {
+    return null
+  }
+  const actionUrl = plansActionUrl(config)
+  const name = options.trialPlanName
+  const ended = formatNoticeDate(config.trialExpiresAt!)
+  return {
+    label: name ? `${name} trial` : 'Trial',
+    message: name
+      ? `Your ${name} trial ended ${ended}. You are on Free now, and everything you built is still here.`
+      : `Your trial ended ${ended}. You are on Free now, and everything you built is still here.`,
+    expiresAt: config.trialExpiresAt!,
+    dismissible: true,
+    ...(actionUrl ? { actionUrl, actionLabel: name ? `Continue with ${name}` : 'See plans' } : {}),
+  }
+}
+
+function formatNoticeDate(iso: string): string {
+  const date = new Date(iso)
+  return Number.isNaN(date.getTime())
+    ? iso
+    : date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
 }

--- a/apps/web/src/lib/server/domains/settings/tier-limits.types.ts
+++ b/apps/web/src/lib/server/domains/settings/tier-limits.types.ts
@@ -43,6 +43,8 @@ export interface PlanNotice {
   /** When set the banner renders an action button linking here. */
   actionUrl?: string
   actionLabel?: string
+  /** Ended-trial banner only: per-admin localStorage dismiss. */
+  dismissible?: boolean
 }
 
 export interface TierLimits {

--- a/apps/web/src/lib/server/functions/__tests__/plan-notice-auth.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/plan-notice-auth.test.ts
@@ -17,6 +17,7 @@ const hoisted = vi.hoisted(() => ({
   mockRequireAuth: vi.fn(),
   mockGetTierLimits: vi.fn(),
   mockGetWorkspaceSettings: vi.fn(),
+  mockFetchCatalogue: vi.fn(),
 }))
 
 vi.mock('@/lib/server/domains/settings/settings.service', () => ({
@@ -29,6 +30,14 @@ vi.mock('@/lib/server/functions/auth-helpers', () => ({
 
 vi.mock('@/lib/server/domains/settings/tier-limits.service', () => ({
   getTierLimits: hoisted.mockGetTierLimits,
+}))
+
+vi.mock('@/lib/server/control-plane/client', () => ({
+  fetchBillingCatalogue: (...args: unknown[]) => hoisted.mockFetchCatalogue(...args),
+}))
+
+vi.mock('@/lib/server/control-plane/starter-trial', () => ({
+  reportStarterTrialIfDue: vi.fn().mockResolvedValue(undefined),
 }))
 
 type AnyHandler = () => Promise<unknown>
@@ -165,8 +174,21 @@ describe('getPlanNotice — the trial countdown', () => {
     )
   })
 
-  it('says nothing once the trial has ended, with the row unchanged', async () => {
+  it('keeps a calm ended banner for seven days after expiry', async () => {
     vi.setSystemTime(AFTER)
+    hoisted.mockFetchCatalogue.mockResolvedValue({ lastTrialPlanId: 'pro' })
+    hoisted.mockGetWorkspaceSettings.mockResolvedValue({ settings: { cloud: trialing } })
+    await expect(getPlanNoticeHandler()).resolves.toEqual(
+      expect.objectContaining({
+        label: 'Pro trial',
+        dismissible: true,
+        actionLabel: 'Continue with Pro',
+      })
+    )
+  })
+
+  it('drops the ended banner after seven days, with the row unchanged', async () => {
+    vi.setSystemTime(new Date('2026-03-23T00:00:00.000Z'))
     hoisted.mockGetWorkspaceSettings.mockResolvedValue({ settings: { cloud: trialing } })
     await expect(getPlanNoticeHandler()).resolves.toBeNull()
   })

--- a/apps/web/src/lib/server/functions/plan-notice.ts
+++ b/apps/web/src/lib/server/functions/plan-notice.ts
@@ -27,7 +27,22 @@ export const getPlanNotice = createServerFn({ method: 'GET' }).handler(
     await reportStarterTrialIfDue({ principalId: auth.principal.id })
 
     const { getCloudConfig } = await import('@/lib/server/domains/settings/cloud/cloud.service')
-    const { trialNotice } = await import('@/lib/server/domains/settings/cloud/commercial-notice')
-    return trialNotice(await getCloudConfig())
+    const { trialNotice, trialEndedNotice } =
+      await import('@/lib/server/domains/settings/cloud/commercial-notice')
+    const cloud = await getCloudConfig()
+    const running = trialNotice(cloud)
+    if (running) return running
+
+    let trialPlanName: string | null = null
+    try {
+      const { fetchBillingCatalogue } = await import('@/lib/server/control-plane/client')
+      const { PLAN_CATALOGUE } = await import('@/lib/server/domains/settings/cloud/cloud.types')
+      const catalogue = await fetchBillingCatalogue()
+      const last = catalogue.lastTrialPlanId
+      if (last && last in PLAN_CATALOGUE) trialPlanName = PLAN_CATALOGUE[last].name
+    } catch {
+      /* catalogue is optional; ended copy falls back to "Your trial ended" */
+    }
+    return trialEndedNotice(cloud, { trialPlanName })
   }
 )

--- a/apps/web/src/lib/server/functions/plan-notice.ts
+++ b/apps/web/src/lib/server/functions/plan-notice.ts
@@ -33,16 +33,20 @@ export const getPlanNotice = createServerFn({ method: 'GET' }).handler(
     const running = trialNotice(cloud)
     if (running) return running
 
-    let trialPlanName: string | null = null
+    const ended = trialEndedNotice(cloud)
+    if (!ended) return null
+
     try {
       const { fetchBillingCatalogue } = await import('@/lib/server/control-plane/client')
       const { PLAN_CATALOGUE } = await import('@/lib/server/domains/settings/cloud/cloud.types')
       const catalogue = await fetchBillingCatalogue()
       const last = catalogue.lastTrialPlanId
-      if (last && last in PLAN_CATALOGUE) trialPlanName = PLAN_CATALOGUE[last].name
+      if (last && last in PLAN_CATALOGUE) {
+        return trialEndedNotice(cloud, { trialPlanName: PLAN_CATALOGUE[last].name })
+      }
     } catch {
-      /* catalogue is optional; ended copy falls back to "Your trial ended" */
+      /* catalogue is optional; ended copy falls back without the plan name */
     }
-    return trialEndedNotice(cloud, { trialPlanName })
+    return ended
   }
 )

--- a/apps/web/src/lib/shared/billing/__tests__/checkout-flash.test.ts
+++ b/apps/web/src/lib/shared/billing/__tests__/checkout-flash.test.ts
@@ -31,7 +31,7 @@ describe('checkoutSuccessCopy', () => {
   it('names the plan, seats, and per-seat price after conversion', () => {
     expect(checkoutSuccessCopy(overview, catalogue)).toEqual({
       title: "You're subscribed",
-      body: "You're on Pro · 3 seats · $30/seat. You can change this any time.",
+      body: "You're on Pro · 3 seats. You can change this any time.",
     })
   })
 

--- a/apps/web/src/lib/shared/billing/__tests__/checkout-flash.test.ts
+++ b/apps/web/src/lib/shared/billing/__tests__/checkout-flash.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { checkoutSuccessCopy } from '../checkout-flash'
+import type { BillingProjectionOverview } from '@/lib/server/domains/billing/projection-overview'
+import type { BillingCatalogue } from '@/lib/server/control-plane/client'
+
+const catalogue = {
+  plans: [
+    {
+      id: 'pro',
+      name: 'Pro',
+      rank: 2,
+      priceMonthlyCents: 3000,
+      priceYearlyCents: 28800,
+      billedPer: 'seat',
+      bestFor: '',
+      highlights: [],
+      recommended: true,
+    },
+  ],
+} as BillingCatalogue
+
+const overview = {
+  plan: 'pro',
+  planName: 'Pro',
+  status: 'active',
+  trialActive: false,
+  seats: { used: 3, pending: 0, members: 3, purchased: 3 },
+} as BillingProjectionOverview
+
+describe('checkoutSuccessCopy', () => {
+  it('names the plan, seats, and per-seat price after conversion', () => {
+    expect(checkoutSuccessCopy(overview, catalogue)).toEqual({
+      title: "You're subscribed",
+      body: "You're on Pro · 3 seats · $30/seat. You can change this any time.",
+    })
+  })
+
+  it('falls back while the projection still looks like a trial', () => {
+    expect(checkoutSuccessCopy({ ...overview, trialActive: true }, catalogue).body).toMatch(
+      /plan, seats, and invoices/
+    )
+  })
+})

--- a/apps/web/src/lib/shared/billing/__tests__/checkout-flash.test.ts
+++ b/apps/web/src/lib/shared/billing/__tests__/checkout-flash.test.ts
@@ -17,7 +17,7 @@ const catalogue = {
       recommended: true,
     },
   ],
-} as BillingCatalogue
+} as unknown as BillingCatalogue
 
 const overview = {
   plan: 'pro',

--- a/apps/web/src/lib/shared/billing/__tests__/trial-state.test.ts
+++ b/apps/web/src/lib/shared/billing/__tests__/trial-state.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { daysUntil, isTrialEnded } from '../trial-state'
+
+const NOW = new Date('2026-08-20T12:00:00.000Z')
+
+describe('isTrialEnded', () => {
+  it('is true on Free after a trial window, for seven days', () => {
+    expect(
+      isTrialEnded({
+        plan: 'free',
+        trialActive: false,
+        trialExpiresAt: '2026-08-18T00:00:00.000Z',
+        status: null,
+        now: NOW,
+      })
+    ).toBe(true)
+  })
+
+  it('is false while the trial is still running', () => {
+    expect(
+      isTrialEnded({
+        plan: 'growth',
+        trialActive: true,
+        trialExpiresAt: '2026-08-22T00:00:00.000Z',
+        status: null,
+        now: NOW,
+      })
+    ).toBe(false)
+  })
+
+  it('is false after a paid conversion', () => {
+    expect(
+      isTrialEnded({
+        plan: 'free',
+        trialActive: false,
+        trialExpiresAt: '2026-08-18T00:00:00.000Z',
+        status: 'active',
+        now: NOW,
+      })
+    ).toBe(false)
+  })
+
+  it('is false more than seven days after expiry', () => {
+    expect(
+      isTrialEnded({
+        plan: 'free',
+        trialActive: false,
+        trialExpiresAt: '2026-08-01T00:00:00.000Z',
+        status: null,
+        now: NOW,
+      })
+    ).toBe(false)
+  })
+})
+
+describe('daysUntil', () => {
+  it('ceils remaining whole days', () => {
+    expect(daysUntil('2026-08-22T00:00:00.000Z', NOW)).toBe(2)
+  })
+})

--- a/apps/web/src/lib/shared/billing/checkout-flash.ts
+++ b/apps/web/src/lib/shared/billing/checkout-flash.ts
@@ -1,4 +1,3 @@
-import { formatUsd } from '@/lib/shared/format-usd'
 import type { BillingCatalogue } from '@/lib/server/control-plane/client'
 import type { BillingProjectionOverview } from '@/lib/server/domains/billing/projection-overview'
 
@@ -14,12 +13,9 @@ export function checkoutSuccessCopy(
   }
   const plan = catalogue?.plans.find((entry) => entry.id === overview.plan)
   const seats = overview.seats?.purchased ?? overview.seats?.used ?? 0
-  const unit =
-    plan && plan.billedPer === 'seat' ? plan.priceMonthlyCents : (plan?.priceMonthlyCents ?? 0)
   const bits = [`You're on ${overview.planName}`]
   if (plan?.billedPer === 'seat' && seats > 0) {
     bits.push(`${seats} ${seats === 1 ? 'seat' : 'seats'}`)
-    bits.push(`${formatUsd(unit, 0)}/seat`)
   }
   return {
     title: "You're subscribed",

--- a/apps/web/src/lib/shared/billing/checkout-flash.ts
+++ b/apps/web/src/lib/shared/billing/checkout-flash.ts
@@ -1,0 +1,28 @@
+import { formatUsd } from '@/lib/shared/format-usd'
+import type { BillingCatalogue } from '@/lib/server/control-plane/client'
+import type { BillingProjectionOverview } from '@/lib/server/domains/billing/projection-overview'
+
+export function checkoutSuccessCopy(
+  overview: BillingProjectionOverview | null | undefined,
+  catalogue: BillingCatalogue | null | undefined
+): { title: string; body: string } {
+  if (!overview || overview.plan === 'free' || overview.trialActive) {
+    return {
+      title: "You're subscribed",
+      body: 'Your plan, seats, and invoices are on this page. You can change them any time.',
+    }
+  }
+  const plan = catalogue?.plans.find((entry) => entry.id === overview.plan)
+  const seats = overview.seats?.purchased ?? overview.seats?.used ?? 0
+  const unit =
+    plan && plan.billedPer === 'seat' ? plan.priceMonthlyCents : (plan?.priceMonthlyCents ?? 0)
+  const bits = [`You're on ${overview.planName}`]
+  if (plan?.billedPer === 'seat' && seats > 0) {
+    bits.push(`${seats} ${seats === 1 ? 'seat' : 'seats'}`)
+    bits.push(`${formatUsd(unit, 0)}/seat`)
+  }
+  return {
+    title: "You're subscribed",
+    body: `${bits.join(' · ')}. You can change this any time.`,
+  }
+}

--- a/apps/web/src/lib/shared/billing/trial-state.ts
+++ b/apps/web/src/lib/shared/billing/trial-state.ts
@@ -1,0 +1,35 @@
+const DAY_MS = 24 * 60 * 60 * 1000
+const ENDED_BANNER_MS = 7 * DAY_MS
+
+export function daysUntil(iso: string, now: Date = new Date()): number | null {
+  const expires = Date.parse(iso)
+  if (Number.isNaN(expires)) return null
+  return Math.max(0, Math.ceil((expires - now.getTime()) / DAY_MS))
+}
+
+export function hasLivePaidSub(status: string | null | undefined): boolean {
+  return Boolean(status && status !== 'canceled')
+}
+
+/** Free + past trial window + no live sub, still inside the 7-day ended notice. */
+export function isTrialEnded(input: {
+  plan: string
+  trialActive: boolean
+  trialExpiresAt: string | null
+  status: string | null
+  now?: Date
+}): boolean {
+  if (input.trialActive) return false
+  if (input.plan !== 'free') return false
+  if (hasLivePaidSub(input.status)) return false
+  if (!input.trialExpiresAt) return false
+  const expires = Date.parse(input.trialExpiresAt)
+  if (Number.isNaN(expires)) return false
+  const now = (input.now ?? new Date()).getTime()
+  if (now < expires) return false
+  return now - expires <= ENDED_BANNER_MS
+}
+
+export function trialEndedStorageKey(expiresAt: string): string {
+  return `qb.trial-ended:${expiresAt}`
+}

--- a/apps/web/src/lib/shared/plan-notice.ts
+++ b/apps/web/src/lib/shared/plan-notice.ts
@@ -13,6 +13,7 @@ export interface PlanNoticeView {
   urgent: boolean
   actionUrl?: string
   actionLabel?: string
+  dismissible: boolean
 }
 
 const DAY_MS = 24 * 60 * 60 * 1000
@@ -36,5 +37,6 @@ export function presentPlanNotice(
     urgent: daysLeft !== null && daysLeft <= 3,
     actionUrl: notice.actionUrl,
     actionLabel: notice.actionLabel,
+    dismissible: Boolean(notice.dismissible),
   }
 }

--- a/apps/web/src/routes/admin/settings.billing.tsx
+++ b/apps/web/src/routes/admin/settings.billing.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import { createFileRoute, useRouteContext } from '@tanstack/react-router'
 import { CreditCardIcon, XMarkIcon } from '@heroicons/react/24/solid'
 import { PERMISSIONS } from '@/lib/shared/permissions'
@@ -8,6 +9,7 @@ import { PageHeader } from '@/components/shared/page-header'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { BillingSettings } from '@/components/admin/settings/billing/billing-settings'
 import { billingQueries } from '@/lib/client/queries/billing'
+import { checkoutSuccessCopy } from '@/lib/shared/billing/checkout-flash'
 import { cn } from '@/lib/shared/utils'
 
 const BILLING_ERROR_COPY: Record<string, string> = {
@@ -74,12 +76,7 @@ function BillingPage() {
         description="Manage your plan, seats, and billing history here."
       />
       {search.checkout === 'success' ? (
-        <BillingFlash
-          tone="success"
-          title="You're subscribed"
-          body="Your plan, seats, and invoices are on this page. You can change them any time."
-          onDismiss={() => navigate({ search: {}, replace: true })}
-        />
+        <CheckoutSuccessFlash onDismiss={() => navigate({ search: {}, replace: true })} />
       ) : null}
       {search.billing_error ? (
         <BillingFlash
@@ -100,6 +97,15 @@ function BillingPage() {
         </p>
       )}
     </div>
+  )
+}
+
+function CheckoutSuccessFlash(props: { onDismiss: () => void }) {
+  const overview = useQuery(billingQueries.overview())
+  const catalogue = useQuery(billingQueries.catalogue())
+  const copy = checkoutSuccessCopy(overview.data, catalogue.data ?? null)
+  return (
+    <BillingFlash tone="success" title={copy.title} body={copy.body} onDismiss={props.onDismiss} />
   )
 }
 

--- a/apps/web/src/routes/admin/settings.billing.tsx
+++ b/apps/web/src/routes/admin/settings.billing.tsx
@@ -1,23 +1,47 @@
+import { useEffect, useState } from 'react'
 import { createFileRoute, useRouteContext } from '@tanstack/react-router'
-import { CreditCardIcon } from '@heroicons/react/24/solid'
+import { CreditCardIcon, XMarkIcon } from '@heroicons/react/24/solid'
 import { PERMISSIONS } from '@/lib/shared/permissions'
 import { assertRoutePermission } from '@/lib/shared/route-permission'
 import { BackLink } from '@/components/ui/back-link'
 import { PageHeader } from '@/components/shared/page-header'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { BillingSettings } from '@/components/admin/settings/billing/billing-settings'
 import { billingQueries } from '@/lib/client/queries/billing'
+import { cn } from '@/lib/shared/utils'
+
+const BILLING_ERROR_COPY: Record<string, string> = {
+  seats_below_usage: 'Pick at least as many seats as people you already have.',
+  already_on_plan: 'You are already on this plan.',
+  unavailable: 'That billing action is not available right now.',
+  invalid: 'That billing request was not valid. Try again from this page.',
+  unauthorized: 'Sign in again to manage billing.',
+  forbidden: 'You do not have permission to change billing.',
+  not_teammate: 'You do not have permission to change billing.',
+}
 
 /**
  * Plan & billing.
  *
  * Gated on `billing.manage`, the permission the RBAC catalogue has carried
- * for this purpose since custom roles shipped — Owner holds it, Admin does
+ * for this purpose since custom roles shipped. Owner holds it, Admin does
  * not. A valid control-plane projection is also required; self-hosted
  * workspaces therefore have no navigation item or commercial dependency.
  */
 export const Route = createFileRoute('/admin/settings/billing')({
-  loader: async ({ context }) => {
+  validateSearch: (search: Record<string, unknown>) => ({
+    checkout:
+      search.checkout === 'success' || search.checkout === 'cancelled'
+        ? search.checkout
+        : undefined,
+    billing_error: typeof search.billing_error === 'string' ? search.billing_error : undefined,
+  }),
+  loaderDeps: ({ search }) => ({ checkout: search.checkout }),
+  loader: async ({ context, deps }) => {
     assertRoutePermission(context.permissions, PERMISSIONS.BILLING_MANAGE)
+    if (deps.checkout === 'success') {
+      await context.queryClient.invalidateQueries({ queryKey: billingQueries.all })
+    }
     await Promise.all([
       context.queryClient.ensureQueryData(billingQueries.overview()),
       context.queryClient.ensureQueryData(billingQueries.catalogue()).catch(() => null),
@@ -30,6 +54,14 @@ export const Route = createFileRoute('/admin/settings/billing')({
 
 function BillingPage() {
   const { billingEnabled } = useRouteContext({ from: '__root__' })
+  const search = Route.useSearch()
+  const navigate = Route.useNavigate()
+
+  useEffect(() => {
+    if (search.checkout === 'cancelled') {
+      void navigate({ search: {}, replace: true })
+    }
+  }, [search.checkout, navigate])
 
   return (
     <div className="space-y-6 max-w-5xl">
@@ -41,6 +73,25 @@ function BillingPage() {
         title="Plans & billing"
         description="Manage your plan, seats, and billing history here."
       />
+      {search.checkout === 'success' ? (
+        <BillingFlash
+          tone="success"
+          title="You're subscribed"
+          body="Your plan, seats, and invoices are on this page. You can change them any time."
+          onDismiss={() => navigate({ search: {}, replace: true })}
+        />
+      ) : null}
+      {search.billing_error ? (
+        <BillingFlash
+          tone="error"
+          title="Couldn’t update billing"
+          body={
+            BILLING_ERROR_COPY[search.billing_error] ??
+            'Billing is temporarily unavailable. Try again in a moment.'
+          }
+          onDismiss={() => navigate({ search: {}, replace: true })}
+        />
+      ) : null}
       {billingEnabled ? (
         <BillingSettings />
       ) : (
@@ -49,5 +100,37 @@ function BillingPage() {
         </p>
       )}
     </div>
+  )
+}
+
+function BillingFlash(props: {
+  tone: 'success' | 'error'
+  title: string
+  body: string
+  onDismiss: () => void
+}) {
+  const [open, setOpen] = useState(true)
+  if (!open) return null
+  return (
+    <Alert
+      variant={props.tone === 'error' ? 'destructive' : 'default'}
+      className={cn(
+        props.tone === 'success' && 'border-emerald-500/30 bg-emerald-500/10 text-foreground'
+      )}
+    >
+      <AlertTitle>{props.title}</AlertTitle>
+      <AlertDescription>{props.body}</AlertDescription>
+      <button
+        type="button"
+        className="absolute top-3 right-3 text-muted-foreground hover:text-foreground"
+        aria-label="Dismiss"
+        onClick={() => {
+          setOpen(false)
+          props.onDismiss()
+        }}
+      >
+        <XMarkIcon className="size-4" />
+      </button>
+    </Alert>
   )
 }

--- a/apps/web/src/routes/admin/settings.billing.tsx
+++ b/apps/web/src/routes/admin/settings.billing.tsx
@@ -54,6 +54,10 @@ export const Route = createFileRoute('/admin/settings/billing')({
   component: BillingPage,
 })
 
+function clearBillingFlash() {
+  return { checkout: undefined, billing_error: undefined }
+}
+
 function BillingPage() {
   const { billingEnabled } = useRouteContext({ from: '__root__' })
   const search = Route.useSearch()
@@ -61,7 +65,7 @@ function BillingPage() {
 
   useEffect(() => {
     if (search.checkout === 'cancelled') {
-      void navigate({ search: {}, replace: true })
+      void navigate({ search: clearBillingFlash, replace: true })
     }
   }, [search.checkout, navigate])
 
@@ -76,7 +80,9 @@ function BillingPage() {
         description="Manage your plan, seats, and billing history here."
       />
       {search.checkout === 'success' ? (
-        <CheckoutSuccessFlash onDismiss={() => navigate({ search: {}, replace: true })} />
+        <CheckoutSuccessFlash
+          onDismiss={() => navigate({ search: clearBillingFlash, replace: true })}
+        />
       ) : null}
       {search.billing_error ? (
         <BillingFlash
@@ -86,7 +92,7 @@ function BillingPage() {
             BILLING_ERROR_COPY[search.billing_error] ??
             'Billing is temporarily unavailable. Try again in a moment.'
           }
-          onDismiss={() => navigate({ search: {}, replace: true })}
+          onDismiss={() => navigate({ search: clearBillingFlash, replace: true })}
         />
       ) : null}
       {billingEnabled ? (

--- a/apps/web/src/routes/api/billing/__tests__/session-error.test.ts
+++ b/apps/web/src/routes/api/billing/__tests__/session-error.test.ts
@@ -1,42 +1,46 @@
 import { describe, expect, it } from 'vitest'
 import { billingSessionErrorResponse } from '../session'
 
+function location(res: Response): string {
+  return res.headers.get('location') ?? ''
+}
+
 describe('billingSessionErrorResponse', () => {
-  it('names an already-on-plan refusal instead of a 503', async () => {
+  it('sends form posts back to billing with a named error', () => {
     const res = billingSessionErrorResponse(new Error('already_on_plan'))
-    expect(res.status).toBe(409)
-    await expect(res.json()).resolves.toEqual({ error: 'already_on_plan' })
+    expect(res.status).toBe(303)
+    expect(location(res)).toBe('/admin/settings/billing?billing_error=already_on_plan')
   })
 
-  it('names a missing session as 401 instead of a 503', async () => {
+  it('names a missing session as unauthorized', () => {
     const res = billingSessionErrorResponse(new Error('Authentication required'))
-    expect(res.status).toBe(401)
-    await expect(res.json()).resolves.toEqual({ error: 'unauthorized' })
+    expect(res.status).toBe(303)
+    expect(location(res)).toBe('/admin/settings/billing?billing_error=unauthorized')
   })
 
-  it('names a foreign-workspace session as 403 not_teammate', async () => {
+  it('names a foreign-workspace session as not_teammate', () => {
     const res = billingSessionErrorResponse(new Error('Access denied: Not a team member'))
-    expect(res.status).toBe(403)
-    await expect(res.json()).resolves.toEqual({ error: 'not_teammate' })
+    expect(res.status).toBe(303)
+    expect(location(res)).toBe('/admin/settings/billing?billing_error=not_teammate')
   })
 
-  it('names a missing billing permission as 403 forbidden', async () => {
+  it('names a missing billing permission as forbidden', () => {
     const res = billingSessionErrorResponse(
       new Error("Access denied: Requires permission 'billing.manage', role member lacks it")
     )
-    expect(res.status).toBe(403)
-    await expect(res.json()).resolves.toEqual({ error: 'forbidden' })
+    expect(res.status).toBe(303)
+    expect(location(res)).toBe('/admin/settings/billing?billing_error=forbidden')
   })
 
-  it('names a seat cut below live usage as 400', async () => {
+  it('names a seat cut below live usage', () => {
     const res = billingSessionErrorResponse(new Error('seats_below_usage'))
-    expect(res.status).toBe(400)
-    await expect(res.json()).resolves.toEqual({ error: 'seats_below_usage' })
+    expect(res.status).toBe(303)
+    expect(location(res)).toBe('/admin/settings/billing?billing_error=seats_below_usage')
   })
 
-  it('keeps unknown failures as 503', async () => {
+  it('does not leak unknown failure text into the URL', () => {
     const res = billingSessionErrorResponse(new Error('stripe down'))
-    expect(res.status).toBe(503)
-    await expect(res.json()).resolves.toEqual({ error: 'stripe down' })
+    expect(res.status).toBe(303)
+    expect(location(res)).toBe('/admin/settings/billing?billing_error=unavailable')
   })
 })

--- a/apps/web/src/routes/api/billing/__tests__/session.test.ts
+++ b/apps/web/src/routes/api/billing/__tests__/session.test.ts
@@ -109,8 +109,10 @@ describe('POST /api/billing/session seats', () => {
 
   it('refuses a quantity below live seat usage before the hosted call', async () => {
     const res = await POST({ request: seatsRequest(6) })
-    expect(res.status).toBe(400)
-    await expect(res.json()).resolves.toEqual({ error: 'seats_below_usage' })
+    expect(res.status).toBe(303)
+    expect(res.headers.get('location')).toBe(
+      '/admin/settings/billing?billing_error=seats_below_usage'
+    )
     expect(hoisted.createHostedBillingSession).not.toHaveBeenCalled()
     expect(hoisted.forUpdate).toHaveBeenCalledWith('update')
   })

--- a/apps/web/src/routes/api/billing/__tests__/session.test.ts
+++ b/apps/web/src/routes/api/billing/__tests__/session.test.ts
@@ -6,6 +6,7 @@ const hoisted = vi.hoisted(() => ({
   getCloudConfig: vi.fn(),
   countSeatUsage: vi.fn(),
   createHostedBillingSession: vi.fn(),
+  fetchBillingCatalogue: vi.fn(),
   transaction: vi.fn(),
   forUpdate: vi.fn(),
   transactionActive: false,
@@ -39,6 +40,7 @@ vi.mock('@/lib/server/db', async (importOriginal) => {
 
 vi.mock('@/lib/server/control-plane/client', () => ({
   createHostedBillingSession: (...args: unknown[]) => hoisted.createHostedBillingSession(...args),
+  fetchBillingCatalogue: (...args: unknown[]) => hoisted.fetchBillingCatalogue(...args),
 }))
 
 import { Route } from '../session'
@@ -167,6 +169,9 @@ describe('POST /api/billing/session checkout', () => {
     hoisted.createHostedBillingSession.mockResolvedValue({
       url: 'https://billing.example.com/checkout',
     })
+    hoisted.fetchBillingCatalogue.mockResolvedValue({
+      plans: [{ id: 'growth', billedPer: 'seat' }],
+    })
   })
 
   it('raises a stale quantity to live seat usage before the hosted call', async () => {
@@ -196,6 +201,20 @@ describe('POST /api/billing/session checkout', () => {
     expect(hoisted.createHostedBillingSession).toHaveBeenCalledWith(
       expect.objectContaining({ quantity: 1 })
     )
+  })
+
+  it('keeps quantity 1 for a workspace-priced plan', async () => {
+    hoisted.fetchBillingCatalogue.mockResolvedValue({
+      plans: [{ id: 'growth', billedPer: 'workspace' }],
+    })
+    const res = await POST({ request: checkoutRequest(1) })
+    expect(res.status).toBe(303)
+    expect(hoisted.createHostedBillingSession).toHaveBeenCalledWith({
+      action: 'checkout',
+      planId: 'growth',
+      billingPeriod: 'monthly',
+      quantity: 1,
+    })
   })
 
   it('forwards a quantity at or above live usage', async () => {

--- a/apps/web/src/routes/api/billing/session.ts
+++ b/apps/web/src/routes/api/billing/session.ts
@@ -118,21 +118,29 @@ async function createSeatChangeSession(quantity: number) {
   })
 }
 
-/** Floor checkout seats at live usage so a stale form cannot under-seat. */
+/** Floor seat-billed checkout at live usage so a stale form cannot under-seat.
+ *  Workspace-priced plans stay quantity 1. */
 async function createCheckoutSession(input: {
   planId: 'growth' | 'pro' | 'scale'
   billingPeriod: 'monthly' | 'annual'
   quantity?: number
 }) {
   const { countSeatUsage } = await import('@/lib/server/domains/principals/seat-usage')
-  const { createHostedBillingSession } = await import('@/lib/server/control-plane/client')
+  const { createHostedBillingSession, fetchBillingCatalogue } =
+    await import('@/lib/server/control-plane/client')
   return withSettingsLock(async (tx) => {
-    const seats = await countSeatUsage(tx)
+    const [seats, catalogue] = await Promise.all([
+      countSeatUsage(tx),
+      fetchBillingCatalogue().catch(() => null),
+    ])
+    const billedPer = catalogue?.plans.find((plan) => plan.id === input.planId)?.billedPer
+    const quantity =
+      billedPer === 'workspace' ? 1 : Math.max(input.quantity ?? seats.used, seats.used, 1)
     return createHostedBillingSession({
       action: 'checkout',
       planId: input.planId,
       billingPeriod: input.billingPeriod,
-      quantity: Math.max(input.quantity ?? seats.used, seats.used, 1),
+      quantity,
     })
   })
 }

--- a/apps/web/src/routes/api/billing/session.ts
+++ b/apps/web/src/routes/api/billing/session.ts
@@ -3,24 +3,26 @@ import { z } from 'zod'
 import { isSameOriginFormPost } from '@/lib/server/http/same-origin-form'
 import { PERMISSIONS } from '@/lib/shared/permissions'
 
+export function billingErrorCode(error: unknown): string {
+  const message = error instanceof Error ? error.message : ''
+  if (message === 'already_on_plan') return 'already_on_plan'
+  if (message === 'seats_below_usage') return 'seats_below_usage'
+  if (message === 'Authentication required') return 'unauthorized'
+  if (message === 'Access denied: Not a team member') return 'not_teammate'
+  if (message.startsWith('Access denied:')) return 'forbidden'
+  return 'unavailable'
+}
+
+/** Browser form POSTs must 303 back to billing. Raw JSON is a dead end. */
+export function billingFormErrorResponse(error: unknown, code = billingErrorCode(error)): Response {
+  return new Response(null, {
+    status: 303,
+    headers: { location: `/admin/settings/billing?billing_error=${encodeURIComponent(code)}` },
+  })
+}
+
 export function billingSessionErrorResponse(error: unknown): Response {
-  const message = error instanceof Error ? error.message : 'Billing is temporarily unavailable.'
-  if (message === 'already_on_plan') {
-    return Response.json({ error: 'already_on_plan' }, { status: 409 })
-  }
-  if (message === 'seats_below_usage') {
-    return Response.json({ error: 'seats_below_usage' }, { status: 400 })
-  }
-  if (message === 'Authentication required') {
-    return Response.json({ error: 'unauthorized' }, { status: 401 })
-  }
-  if (message === 'Access denied: Not a team member') {
-    return Response.json({ error: 'not_teammate' }, { status: 403 })
-  }
-  if (message.startsWith('Access denied:')) {
-    return Response.json({ error: 'forbidden' }, { status: 403 })
-  }
-  return Response.json({ error: message }, { status: 503 })
+  return billingFormErrorResponse(error)
 }
 
 const actionSchema = z.discriminatedUnion('action', [
@@ -58,8 +60,7 @@ export const Route = createFileRoute('/api/billing/session')({
           await requireAuth({ permission: PERMISSIONS.BILLING_MANAGE })
           const form = await request.formData()
           const parsed = actionSchema.safeParse(Object.fromEntries(form.entries()))
-          if (!parsed.success)
-            return Response.json({ error: 'invalid_billing_action' }, { status: 400 })
+          if (!parsed.success) return billingFormErrorResponse(null, 'invalid')
           const { getCloudConfig } =
             await import('@/lib/server/domains/settings/cloud/cloud.service')
           const cloud = await getCloudConfig()
@@ -68,7 +69,7 @@ export const Route = createFileRoute('/api/billing/session')({
               ? cloud.canManageBilling
               : cloud.canUpgrade || cloud.canManageBilling
           if (!cloud.enabled || !actionAllowed) {
-            return Response.json({ error: 'billing_action_unavailable' }, { status: 403 })
+            return billingFormErrorResponse(null, 'unavailable')
           }
           const { createHostedBillingSession } = await import('@/lib/server/control-plane/client')
           const session =

--- a/apps/web/src/routes/api/billing/trial.ts
+++ b/apps/web/src/routes/api/billing/trial.ts
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { z } from 'zod'
 import { isSameOriginFormPost } from '@/lib/server/http/same-origin-form'
 import { PERMISSIONS } from '@/lib/shared/permissions'
-import { billingSessionErrorResponse } from './session'
+import { billingFormErrorResponse, billingSessionErrorResponse } from './session'
 
 const trialSchema = z.object({
   planId: z.enum(['growth', 'pro', 'scale']),
@@ -21,13 +21,13 @@ export const Route = createFileRoute('/api/billing/trial')({
           const form = await request.formData()
           const parsed = trialSchema.safeParse(Object.fromEntries(form.entries()))
           if (!parsed.success) {
-            return Response.json({ error: 'invalid_billing_action' }, { status: 400 })
+            return billingFormErrorResponse(null, 'invalid')
           }
           const { getCloudConfig } =
             await import('@/lib/server/domains/settings/cloud/cloud.service')
           const cloud = await getCloudConfig()
           if (!cloud.enabled || !cloud.canUpgrade) {
-            return Response.json({ error: 'billing_action_unavailable' }, { status: 403 })
+            return billingFormErrorResponse(null, 'unavailable')
           }
           const { startWorkspaceTrial } = await import('@/lib/server/control-plane/client')
           await startWorkspaceTrial(parsed.data.planId)


### PR DESCRIPTION
## Summary
Implements SEAT-BILLING-SPEC §4b on the OSS billing page: trial and trial-ended plan cards, a subscribe dialog in front of Checkout, checkout return flashes, and form-POST errors that 303 back to Plans & billing instead of raw JSON.

Copy follows PLG keep-your-work language: switch to Free instead of downgrade, Continue with {plan} after a trial, and lead with data staying put.

## Test plan
- [x] Unit tests for trial states, subscribe dialog, checkout flash, form-error 303s, trialActive guard after a paid conversion
- [ ] On a Cloud workspace: trialing card shows expiry + Continue with {plan}; dialog floors seats and names due today
- [ ] Free-to-paid dialog drops the trial sentence
- [ ] `?checkout=success` flash names plan, seats, price; `?checkout=cancelled` is silent
- [ ] Form error `seats_below_usage` lands on the billing page, not a JSON body
- [ ] Ended trial: keep-your-work card, over-cap seat meter, dismissible amber banner for 7 days

Pairs with QuackbackIO/quackback-cp `feat/trial-to-paid-conversion`.