### PR TITLE
fix(web): skip workspace resolution for /api/health/live

### DIFF
--- a/apps/web/src/lib/server/workspaces/__tests__/request-scope.test.ts
+++ b/apps/web/src/lib/server/workspaces/__tests__/request-scope.test.ts
@@ -414,7 +414,7 @@ describe('resolveWorkspaceAndContinue', () => {
     }
   })
 
-  it.each(['/api/health', '/api/health/ready'])(
+  it.each(['/api/health', '/api/health/live', '/api/health/ready'])(
     'serves %s without resolving a workspace at all',
     async (path) => {
       // The platform hits these every couple of seconds, and on a wildcard

--- a/apps/web/src/lib/server/workspaces/request-scope.ts
+++ b/apps/web/src/lib/server/workspaces/request-scope.ts
@@ -62,10 +62,11 @@ function refusal(status: number, body: string, extra?: Record<string, string>): 
  * they arrive on a workspace hostname like everything else. Resolving a workspace for
  * them would open a pool — and therefore **wake a suspended workspace
  * database** — once per probe, forever, which silently destroys the idle-cost
- * model the pooling exists for. Readiness under pooled tenancy asserts only that
- * the process can reach the control store, so it needs no workspace either.
+ * model the pooling exists for. Liveness is process-up only. Readiness under
+ * pooled tenancy asserts only that the process can reach the control store, so
+ * it needs no workspace either.
  */
-const FLEET_PATHS = ['/api/health', '/api/health/ready']
+const FLEET_PATHS = ['/api/health', '/api/health/live', '/api/health/ready']
 
 export { requestWorkspaceHost } from './saas-edge-host'
 


### PR DESCRIPTION
## Summary

`/api/health/live` is the canonical liveness probe but was missing from `FLEET_PATHS`. On a tenant hostname it resolved a workspace (waking a suspended database). On the Railway origin it 404'd as `unknown_host` instead of returning `{status: ok}`.

## Self-host

No change. Workspace middleware is a pass-through when `QUACKBACK_TENANCY` is not `pooled`.

## Test plan

- [x] `request-scope.test.ts` now includes `/api/health/live` in the fleet-path cases
- [x] prefix non-match (`/api/health-report`) still resolves a workspace