### PR TITLE
fix(web): refuse fleet SECRET_KEY under pooled tenancy with no scope

### DIFF
--- a/apps/web/src/lib/server/secret-key.ts
+++ b/apps/web/src/lib/server/secret-key.ts
@@ -7,9 +7,9 @@
  * is worse than no resolver at all: it reads as solved.
  *
  * Under a pooled workspace scope this is the workspace's own key, resolved from the
- * registry record's `appSecretsRef` on pool checkout. With no scope — every
- * self-hosted install, and every pooled code path that runs outside a request —
- * it is `config.secretKey`, unchanged byte for byte.
+ * registry record's `appSecretsRef` on pool checkout. With no scope on a
+ * self-hosted install it is `config.secretKey`, unchanged. Under pooled tenancy
+ * an unscoped read throws: the fleet-wide key must not encrypt workspace data.
  *
  * `getWorkspaceSecretKey()` returns exactly this one string and nothing else on
  * the scope, so the signing key and the storage credential no longer come out
@@ -31,8 +31,16 @@
  * instead of letting the fleet discover the problem one integration at a time.
  */
 import { config } from './config'
-import { getWorkspaceSecretKey } from './workspaces/workspace-context'
+import { isPooledTenancy } from './workspaces/mode'
+import { getWorkspaceSecretKey, WorkspaceScopeMissingError } from './workspaces/workspace-context'
 
 export function activeSecretKey(): string {
-  return getWorkspaceSecretKey() ?? config.secretKey
+  const scoped = getWorkspaceSecretKey()
+  if (scoped) return scoped
+  if (isPooledTenancy()) {
+    throw new WorkspaceScopeMissingError(
+      'encryption/signing was attempted with no workspace resolved.'
+    )
+  }
+  return config.secretKey
 }

--- a/apps/web/src/lib/server/workspaces/__tests__/scope-secret-custody.test.ts
+++ b/apps/web/src/lib/server/workspaces/__tests__/scope-secret-custody.test.ts
@@ -60,6 +60,7 @@ const {
   getWorkspaceSecretKey,
   getWorkspaceStorageCredential,
   runWithWorkspaceScope,
+  WorkspaceScopeMissingError,
   WorkspaceScopeSecretsMissingError,
 } = await import('../workspace-context')
 const { runWithLogContext } = await import('@/lib/server/log-context')
@@ -113,6 +114,13 @@ describe('the signing-key consumer still works', () => {
   it('falls back to the process key with no scope, which is the self-hosted path', () => {
     expect(getWorkspaceSecretKey()).toBeNull()
     expect(activeSecretKey()).toBe(FLEET_SECRET_KEY)
+  })
+
+  it('throws under pooled tenancy with no workspace scope', () => {
+    vi.stubEnv('QUACKBACK_TENANCY', 'pooled')
+    expect(getWorkspaceSecretKey()).toBeNull()
+    expect(() => activeSecretKey()).toThrow(WorkspaceScopeMissingError)
+    vi.unstubAllEnvs()
   })
 })
 


### PR DESCRIPTION
## Summary

`activeSecretKey()` fell back to `config.secretKey` whenever no workspace scope was active. That fallback **is** the self-host path. Under `QUACKBACK_TENANCY=pooled` it would let an unscoped encrypt/sign silently use the fleet key.

Pooled + unscoped now throws `WorkspaceScopeMissingError`. Self-host is unchanged.

Jobs already run inside `withWorkspaceScopeById`. Sweeps and telemetry fan out through `withSweepLock` → `runFleetPass`. Request auth is scoped by Host middleware.

## Self-host

`isPooledTenancy()` is false unless `QUACKBACK_TENANCY=pooled`. Existing test: falls back to the process key with no scope.

## Test plan

- [x] unscoped + single → fleet `SECRET_KEY`
- [x] unscoped + pooled → throws
- [x] scoped workspaces still get their own keys