### PR TITLE
fix(web): sample platform-credential ciphertext at pool checkout

### DIFF
--- a/apps/web/src/lib/server/encryption.ts
+++ b/apps/web/src/lib/server/encryption.ts
@@ -80,19 +80,18 @@ function hkdfInfo(namespace: string, purpose: string): string {
  * @param purpose - Identifies what the key is used for (e.g., 'integration-tokens')
  * @returns 256-bit derived key
  */
+/** HKDF-SHA256 for a purpose, from explicit IKM and workspace namespace. */
+export function derivePurposeKey(secretKey: string, namespace: string, purpose: string): Buffer {
+  return Buffer.from(
+    hkdfSync('sha256', secretKey, HKDF_SALT, hkdfInfo(namespace, purpose), KEY_LENGTH)
+  )
+}
+
 function deriveKey(purpose: string): Buffer {
   const cached = derivedKeys.get(purpose)
   if (cached) return cached
 
-  const derived = hkdfSync(
-    'sha256',
-    activeSecretKey(),
-    HKDF_SALT,
-    hkdfInfo(currentWorkspaceNamespace(), purpose),
-    KEY_LENGTH
-  )
-
-  const key = Buffer.from(derived)
+  const key = derivePurposeKey(activeSecretKey(), currentWorkspaceNamespace(), purpose)
   derivedKeys.set(purpose, key)
   return key
 }
@@ -151,7 +150,29 @@ export function decrypt(ciphertext: string, purpose: string): string {
   if (!purpose || typeof purpose !== 'string') {
     throw new Error('Encryption purpose is required')
   }
+  return openCiphertext(ciphertext, deriveKey(purpose))
+}
 
+/**
+ * Open ciphertext with an explicit master secret and namespace.
+ *
+ * Pool checkout samples stored rows before a workspace scope exists, so it
+ * cannot go through `decrypt()` (that reads ALS). Same wire format and HKDF
+ * info as `decrypt()`.
+ */
+export function decryptWithSecret(
+  ciphertext: string,
+  secretKey: string,
+  namespace: string,
+  purpose: string
+): string {
+  if (!purpose || typeof purpose !== 'string') {
+    throw new Error('Encryption purpose is required')
+  }
+  return openCiphertext(ciphertext, derivePurposeKey(secretKey, namespace, purpose))
+}
+
+function openCiphertext(ciphertext: string, key: Buffer): string {
   const parts = ciphertext.split('.')
   if (parts.length !== 3) {
     throw new Error('Invalid ciphertext format')
@@ -162,7 +183,6 @@ export function decrypt(ciphertext: string, purpose: string): string {
   const authTag = Buffer.from(authTagB64, 'base64url')
   const encrypted = Buffer.from(encryptedB64, 'base64url')
 
-  // Validate lengths to fail fast
   if (iv.length !== IV_LENGTH) {
     throw new Error('Invalid IV length')
   }
@@ -170,7 +190,6 @@ export function decrypt(ciphertext: string, purpose: string): string {
     throw new Error('Invalid auth tag length')
   }
 
-  const key = deriveKey(purpose)
   const decipher = createDecipheriv(ALGORITHM, key, iv, {
     authTagLength: AUTH_TAG_LENGTH,
   })

--- a/apps/web/src/lib/server/workspaces/__tests__/secret-key-custody.test.ts
+++ b/apps/web/src/lib/server/workspaces/__tests__/secret-key-custody.test.ts
@@ -457,10 +457,12 @@ describe('platform-credential corroboration at checkout', () => {
     const { sql } = fakeSql([
       [{ ...SETTINGS_ROW, stored_ciphertext: stored }],
       [{ catalog_name: null, catalog_oid: null }],
-      () =>
-        Object.assign(new Error('relation "integration_platform_credentials" does not exist'), {
-          code: '42P01',
-        }),
+      () => {
+        throw Object.assign(
+          new Error('relation "integration_platform_credentials" does not exist'),
+          { code: '42P01' }
+        )
+      },
     ])
     const observed = await observeWorkspaceIdentity(sql as never, KEY_AT_WRITE_TIME, WORKSPACE)
     expect(observed.storedCiphertext).toMatchObject({ kind: 'opened', source: 'jwks.private_key' })

--- a/apps/web/src/lib/server/workspaces/__tests__/secret-key-custody.test.ts
+++ b/apps/web/src/lib/server/workspaces/__tests__/secret-key-custody.test.ts
@@ -59,7 +59,12 @@ import {
   KEY_CUSTODY_FAILURE_CODES,
   observeWorkspaceIdentity,
 } from '../fingerprint'
-import { probeStoredCiphertext } from '../stored-ciphertext'
+import {
+  PLATFORM_CREDENTIALS_PURPOSE,
+  PLATFORM_CREDENTIALS_SOURCE,
+  probeHkdfCiphertext,
+  probeStoredCiphertext,
+} from '../stored-ciphertext'
 import { sealSecretKeyCanary } from '../vendor/fleet-secrets'
 
 const WORKSPACE = 'inst_cloud_ws_t2'
@@ -370,5 +375,119 @@ describe('the verdict, once it can see a real sample', () => {
     // And the derived list request-scope's own suite iterates carries it, so the
     // end-to-end assertion there covers this code rather than skipping it.
     expect(KEY_CUSTODY_FAILURE_CODES).toContain(verdict.code)
+  })
+})
+
+function sealPlatformCreds(masterSecret: string, workspaceKey: string, plaintext: string): string {
+  const info = `quackback:v1:t:${workspaceKey}:${PLATFORM_CREDENTIALS_PURPOSE}`
+  const key = Buffer.from(
+    hkdfSync('sha256', masterSecret, 'quackback-encryption-salt-v1', info, 32)
+  )
+  const iv = randomBytes(12)
+  const cipher = createCipheriv('aes-256-gcm', key, iv, { authTagLength: 16 })
+  const body = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()])
+  return [
+    iv.toString('base64url'),
+    cipher.getAuthTag().toString('base64url'),
+    body.toString('base64url'),
+  ].join('.')
+}
+
+describe('platform-credential corroboration at checkout', () => {
+  it('does not query platform credentials when no workspace key is passed', async () => {
+    const stored = await sealAuthSigningKey(KEY_AT_WRITE_TIME, JWK)
+    const { sql, statements } = fakeSql([
+      [{ ...SETTINGS_ROW, stored_ciphertext: stored }],
+      [{ catalog_name: null, catalog_oid: null }],
+    ])
+    await observeWorkspaceIdentity(sql as never, KEY_AT_WRITE_TIME)
+    expect(statements).toHaveLength(2)
+    expect(statements.join('\n')).not.toContain('integration_platform_credentials')
+  })
+
+  it('keeps a JWKS-opened sample when platform credentials open under the pooled info', async () => {
+    const stored = await sealAuthSigningKey(KEY_AT_WRITE_TIME, JWK)
+    const creds = sealPlatformCreds(KEY_AT_WRITE_TIME, WORKSPACE, '{"clientId":"x"}')
+    const { sql, statements } = fakeSql([
+      [{ ...SETTINGS_ROW, stored_ciphertext: stored }],
+      [{ catalog_name: null, catalog_oid: null }],
+      [{ secrets: creds }],
+    ])
+    const observed = await observeWorkspaceIdentity(sql as never, KEY_AT_WRITE_TIME, WORKSPACE)
+    expect(observed.storedCiphertext).toMatchObject({ kind: 'opened', source: 'jwks.private_key' })
+    expect(statements[2]).toContain('integration_platform_credentials')
+  })
+
+  it('refuses when JWKS opens but platform credentials were sealed under historical info', async () => {
+    const stored = await sealAuthSigningKey(KEY_AT_WRITE_TIME, JWK)
+    const historicalInfo = `quackback:v1:${PLATFORM_CREDENTIALS_PURPOSE}`
+    const key = Buffer.from(
+      hkdfSync('sha256', KEY_AT_WRITE_TIME, 'quackback-encryption-salt-v1', historicalInfo, 32)
+    )
+    const iv = randomBytes(12)
+    const cipher = createCipheriv('aes-256-gcm', key, iv, { authTagLength: 16 })
+    const body = Buffer.concat([cipher.update('{"clientId":"x"}', 'utf8'), cipher.final()])
+    const stale = [
+      iv.toString('base64url'),
+      cipher.getAuthTag().toString('base64url'),
+      body.toString('base64url'),
+    ].join('.')
+
+    const { sql } = fakeSql([
+      [{ ...SETTINGS_ROW, stored_ciphertext: stored }],
+      [{ catalog_name: null, catalog_oid: null }],
+      [{ secrets: stale }],
+    ])
+    const observed = await observeWorkspaceIdentity(sql as never, KEY_AT_WRITE_TIME, WORKSPACE)
+    expect(observed.storedCiphertext).toMatchObject({
+      kind: 'unopenable',
+      source: PLATFORM_CREDENTIALS_SOURCE,
+    })
+    const verdict = evaluateSecretKeyCanary(
+      WORKSPACE,
+      KEY_AT_WRITE_TIME,
+      sealSecretKeyCanary(KEY_AT_WRITE_TIME, WORKSPACE),
+      observed.storedCiphertext
+    )
+    expect(verdict).toMatchObject({ ok: false, code: 'secret_key_stored_ciphertext_mismatch' })
+  })
+
+  it('treats a missing platform-credentials table as no extra sample', async () => {
+    const stored = await sealAuthSigningKey(KEY_AT_WRITE_TIME, JWK)
+    const { sql } = fakeSql([
+      [{ ...SETTINGS_ROW, stored_ciphertext: stored }],
+      [{ catalog_name: null, catalog_oid: null }],
+      () =>
+        Object.assign(new Error('relation "integration_platform_credentials" does not exist'), {
+          code: '42P01',
+        }),
+    ])
+    const observed = await observeWorkspaceIdentity(sql as never, KEY_AT_WRITE_TIME, WORKSPACE)
+    expect(observed.storedCiphertext).toMatchObject({ kind: 'opened', source: 'jwks.private_key' })
+  })
+
+  it('opens pooled-info ciphertext and refuses historical-info ciphertext as a unit', () => {
+    const pooled = sealPlatformCreds(KEY_AT_WRITE_TIME, WORKSPACE, '{"clientId":"x"}')
+    expect(probeHkdfCiphertext(KEY_AT_WRITE_TIME, WORKSPACE, pooled).kind).toBe('opened')
+    const historical = (() => {
+      const key = Buffer.from(
+        hkdfSync(
+          'sha256',
+          KEY_AT_WRITE_TIME,
+          'quackback-encryption-salt-v1',
+          `quackback:v1:${PLATFORM_CREDENTIALS_PURPOSE}`,
+          32
+        )
+      )
+      const iv = randomBytes(12)
+      const cipher = createCipheriv('aes-256-gcm', key, iv, { authTagLength: 16 })
+      const body = Buffer.concat([cipher.update('{"clientId":"x"}', 'utf8'), cipher.final()])
+      return [
+        iv.toString('base64url'),
+        cipher.getAuthTag().toString('base64url'),
+        body.toString('base64url'),
+      ].join('.')
+    })()
+    expect(probeHkdfCiphertext(KEY_AT_WRITE_TIME, WORKSPACE, historical).kind).toBe('unopenable')
   })
 })

--- a/apps/web/src/lib/server/workspaces/fingerprint.ts
+++ b/apps/web/src/lib/server/workspaces/fingerprint.ts
@@ -57,7 +57,11 @@ import {
   type PhysicalFailure,
 } from './physical-identity'
 import { verifySecretKeyCanary } from './vendor/fleet-secrets'
-import { probeStoredCiphertext, type StoredCiphertextProbe } from './stored-ciphertext'
+import {
+  probeHkdfCiphertext,
+  probeStoredCiphertext,
+  type StoredCiphertextProbe,
+} from './stored-ciphertext'
 
 /** Where the workspace id was read from, for the refusal log. */
 export type StampSource = 'column' | 'metadata' | 'none'
@@ -289,7 +293,8 @@ async function readSettingsIdentity(sql: Sql): Promise<SettingsIdentityRow[]> {
  */
 export async function observeWorkspaceIdentity(
   sql: Sql,
-  secretKey: string
+  secretKey: string,
+  workspaceKey?: string
 ): Promise<WorkspaceIdentityObservation> {
   const rows = await readSettingsIdentity(sql)
 
@@ -340,8 +345,47 @@ export async function observeWorkspaceIdentity(
     stampSource,
     stampSourceConflict: conflict,
     secretCanary: normalise(row.cloud_secret_canary),
-    storedCiphertext: await probeStoredCiphertext(secretKey, row.stored_ciphertext),
+    storedCiphertext: await corroborateStoredCiphertext(
+      sql,
+      secretKey,
+      workspaceKey,
+      await probeStoredCiphertext(secretKey, row.stored_ciphertext)
+    ),
   }
+}
+
+/**
+ * JWKS is always sampled. When checkout also has the workspace key, try one
+ * platform-credential row sealed under the pooled HKDF info. Unopenable wins:
+ * that is the imported-tenant case (canary and JWKS pass, OAuth ciphertext does
+ * not). Missing table or no row leaves the JWKS result alone.
+ */
+async function corroborateStoredCiphertext(
+  sql: Sql,
+  secretKey: string,
+  workspaceKey: string | undefined,
+  jwks: StoredCiphertextProbe
+): Promise<StoredCiphertextProbe> {
+  if (!workspaceKey || jwks.kind === 'unopenable') return jwks
+  let sample: string | null = null
+  try {
+    const rows = (await sql`
+      SELECT secrets
+        FROM integration_platform_credentials
+       WHERE secrets IS NOT NULL AND secrets <> ''
+       ORDER BY created_at ASC, id ASC
+       LIMIT 1
+    `) as unknown as Array<{ secrets: string | null }>
+    sample = rows[0]?.secrets ?? null
+  } catch (err) {
+    if ((err as { code?: string } | null)?.code === '42P01') return jwks
+    throw err
+  }
+  const extra = probeHkdfCiphertext(secretKey, workspaceKey, sample)
+  if (extra.kind === 'unopenable') return extra
+  if (jwks.kind === 'opened') return jwks
+  if (extra.kind === 'opened') return extra
+  return jwks
 }
 
 /**

--- a/apps/web/src/lib/server/workspaces/pool-cache.ts
+++ b/apps/web/src/lib/server/workspaces/pool-cache.ts
@@ -283,7 +283,7 @@ async function verifyWorkspaceDatabase(
   // The resolved key goes in with the read: the identity question includes
   // whether this key opens ciphertext the database is already holding, and that
   // has to be answered from a sample rather than from the minted canary alone.
-  const observed = await observeWorkspaceIdentity(sql, secrets.secretKey)
+  const observed = await observeWorkspaceIdentity(sql, secrets.secretKey, workspace.workspaceKey)
   const verdict = evaluateWorkspaceIdentity(workspace.fingerprint, workspace.physical, observed)
   const keyVerdict = verdict.ok
     ? evaluateSecretKeyCanary(

--- a/apps/web/src/lib/server/workspaces/stored-ciphertext.ts
+++ b/apps/web/src/lib/server/workspaces/stored-ciphertext.ts
@@ -18,25 +18,22 @@
  * So the check gets a second, independent fact: a real sample of the workspace's
  * own ciphertext, opened with the key that is about to be put into service.
  *
- * ## Why `jwks.private_key` and nothing else
+ * ## Why `jwks.private_key` is the always-on sample
  *
- * Several things are encrypted at rest — integration OAuth bundles, webhook
- * signing secrets, connector secrets, app signing secrets — and
- * every one of them goes through `encryption.ts`, which derives its key with
- * HKDF over *the active workspace namespace and a purpose string*. Reproducing that
- * derivation here would mean this module reconstructing, before the workspace scope
- * exists, the exact namespace and purpose each row was written under. Get it
- * wrong and the sample fails to open under the correct key: a false refusal, an
- * outage, and a worse failure than the silent one being fixed.
+ * The `jwt()` plugin seals the auth signing key with the master secret
+ * **directly** (`secret: activeSecretKey()`), through the auth library's own
+ * `symmetricEncrypt`, with no HKDF in between. Opening it therefore requires no
+ * assumption about namespace or purpose. It is also the first ciphertext most
+ * workspaces ever write.
  *
- * The auth signing key is the exception. The `jwt()` plugin seals it with the
- * master secret **directly** (`secret: activeSecretKey()`), through the auth
- * library's own `symmetricEncrypt`, with no derivation in between. Opening it
- * therefore requires no assumption at all: the key either opens it or it does
- * not. It is also the value that actually broke, the only encrypted value the
- * broken workspace held, and the first ciphertext most workspaces ever write — a
- * workspace mints it on the first request that signs anything, long before it
- * connects an integration.
+ * Integration and platform-credential rows go through `encryption.ts` HKDF.
+ * Those cannot use `decrypt()` at checkout — that reads ALS, and the scope does
+ * not exist yet. When the observer has the workspace key, a second sample
+ * (`integration_platform_credentials.secrets`) is opened with `decryptWithSecret`
+ * using the same info string production uses. A wrong purpose string would
+ * refuse a healthy workspace, so the purpose is the production constant
+ * `integration-platform-credentials`. Absent rows stay `absent`; only an
+ * auth-tag failure is `unopenable`.
  *
  * The row is read with the library's own opener rather than a local
  * reimplementation, for the same reason `vendor/fleet-secrets.ts` is pinned
@@ -49,12 +46,17 @@
  * "refuse" — those are the verdict's to make, in one place, in `fingerprint.ts`.
  */
 import { symmetricDecrypt } from 'better-auth/crypto'
+import { decryptWithSecret } from '@/lib/server/encryption'
 
 /**
  * The one column sampled, named so the refusal can say where the evidence came
  * from. Not key material: a column name.
  */
 export const STORED_CIPHERTEXT_SOURCE = 'jwks.private_key'
+
+/** Second sample: HKDF-sealed platform OAuth app credentials. */
+export const PLATFORM_CREDENTIALS_SOURCE = 'integration_platform_credentials.secrets'
+export const PLATFORM_CREDENTIALS_PURPOSE = 'integration-platform-credentials'
 
 /**
  * Why a sample carried nothing to open.
@@ -127,6 +129,32 @@ export async function probeStoredCiphertext(
     await symmetricDecrypt({ key: secretKey, data: sealed })
     return { kind: 'opened', source }
   } catch {
+    return { kind: 'unopenable', source }
+  }
+}
+
+/**
+ * Open an `encryption.ts` ciphertext with an explicit master secret and
+ * workspace namespace — checkout has both, and no ALS scope yet.
+ */
+export function probeHkdfCiphertext(
+  secretKey: string,
+  workspaceKey: string,
+  sample: string | null,
+  source = PLATFORM_CREDENTIALS_SOURCE,
+  purpose = PLATFORM_CREDENTIALS_PURPOSE
+): StoredCiphertextProbe {
+  if (sample === null || sample === undefined) return { kind: 'absent', source, reason: 'no-row' }
+  if (sample.trim() === '') return { kind: 'absent', source, reason: 'empty' }
+  const parts = sample.split('.')
+  if (parts.length !== 3) return { kind: 'absent', source, reason: 'unrecognised' }
+  try {
+    decryptWithSecret(sample, secretKey, workspaceKey, purpose)
+    return { kind: 'opened', source }
+  } catch (err) {
+    if (err instanceof Error && err.message === 'Invalid ciphertext format') {
+      return { kind: 'absent', source, reason: 'unrecognised' }
+    }
     return { kind: 'unopenable', source }
   }
 }

--- a/apps/web/workspace-probe/probes/p09-assistant-principal.ts
+++ b/apps/web/workspace-probe/probes/p09-assistant-principal.ts
@@ -43,9 +43,10 @@ export const p09AssistantPrincipal: Probe = {
     'conversation or attribution table.',
   requires: ['db'],
   poolingCaveat:
-    'The memo this targets is process-scoped, so it can only be poisoned once one process serves both ' +
-    'workspaces. Today the probe proves the two ids are distinct and unreferenced, which is the baseline ' +
-    'the pooled check will be measured against.',
+    'The memos this originally targeted (assistant.orchestrator and assistant-principal) are ' +
+    'WorkspaceKeyedCache instances, so a process serving both workspaces no longer shares one ' +
+    'principal id. A pass here is evidence the two ids are distinct and unreferenced — the ' +
+    'restore/clone case — not a live shared-memo leak.',
 
   async run(ctx: ProbeContext) {
     const { alpha, bravo } = ctx


### PR DESCRIPTION
## Summary

Pool checkout already samples `jwks.private_key`. That is sealed with the master secret directly, so it can pass after a custody change while HKDF-sealed OAuth ciphertext stays unreadable — the imported-tenant outage.

When checkout has the workspace key, it now tries one `integration_platform_credentials.secrets` row using `decryptWithSecret` (explicit IKM + namespace, no ALS). `unopenable` refuses the workspace. A missing table (`42P01`) or no row leaves the JWKS result alone.

## Self-host

`observeWorkspaceIdentity` is pool-cache only. Single-tenancy never checks out a pool. Omitting `workspaceKey` (tests, any non-pool caller) skips the extra query.

## Test plan

- [x] no extra query without workspace key
- [x] pooled-info platform creds keep JWKS opened
- [x] historical-info platform creds → `secret_key_stored_ciphertext_mismatch`
- [x] missing table degrades like missing `jwks`
- [x] existing JWKS and encryption tests still pass