### PR TITLE
fix(web): show the live sender on the email channel status

### DIFF
--- a/apps/web/src/lib/server/domains/channel-accounts/channel-account.service.ts
+++ b/apps/web/src/lib/server/domains/channel-accounts/channel-account.service.ts
@@ -547,7 +547,8 @@ export async function getSendingAddress(
  * The sending address an outbound message for a conversation should come from
  * (§4.8): the conversation's assigned team's sending address for the module, else
  * the default team's, else null so the caller falls back to the workspace default
- * (EMAIL_FROM). The one place the outbound From is resolved.
+ * (`getEmailFrom()`, registry `email.from` when pooled). The one place the outbound
+ * From is resolved.
  *
  * Every answer passes the sending-identity guard on the way out. A row's mere
  * existence in this database is not authority to send as the address it holds:

--- a/apps/web/src/lib/server/functions/settings.ts
+++ b/apps/web/src/lib/server/functions/settings.ts
@@ -1107,12 +1107,18 @@ const moderationDefaultSchema = z.object({
 export const getEmailChannelStatusFn = createServerFn({ method: 'GET' }).handler(async () => {
   log.debug('get email channel status')
   await requireAuth({ permission: PERMISSIONS.SETTINGS_MANAGE })
-  const { getEmailProvider } = await import('@quackback/email')
+  const { getEmailProvider, getEmailFrom } = await import('@quackback/email')
   const { isEmailInboundConfigured, inboundMintDomain } =
     await import('@/lib/server/domains/conversation/conversation.email-channel')
+  let fromAddress: string | null = null
+  try {
+    fromAddress = getEmailFrom()
+  } catch {
+    fromAddress = null
+  }
   return {
     provider: getEmailProvider(),
-    fromAddress: process.env.EMAIL_FROM ?? null,
+    fromAddress,
     inboundConfigured: isEmailInboundConfigured(),
     // The domain as every reader of it resolves it, not as it was typed. A value
     // naming no single domain resolves to none, so this surface reports the


### PR DESCRIPTION
## Summary

`getEmailChannelStatusFn` still read `process.env.EMAIL_FROM`. Pooled sends now use registry `email.from`, so Settings → Channels could show the fleet noreply while mail went out as the workspace From.

The status handler now uses `getEmailFrom()` (same resolver as send). Missing config still reports null.

## Self-host

No workspace scope → resolver returns null → `EMAIL_FROM`, same as today.

## Test plan

- [x] existing `getEmailFrom` pooled vs self-host tests
- [ ] Channels page on a cloud workspace shows registry From after deploy