### PR TITLE
feat(billing): send expired trials to a checkout page

### DIFF
--- a/apps/web/src/components/admin/plan-notice-banner.tsx
+++ b/apps/web/src/components/admin/plan-notice-banner.tsx
@@ -20,7 +20,7 @@ function readDismissed(expiresAt: string | undefined): boolean {
 /**
  * Operator-set or trial notice strip. Driven by settings.tier_limits.notice
  * or a derived trial countdown. Operator notices are not dismissible.
- * The ended-trial banner is, via per-admin localStorage.
+ * An expired product trial is a persistent red strip, not dismissible.
  */
 export function PlanNoticeBanner({ notice }: PlanNoticeBannerProps) {
   const view = presentPlanNotice(notice)
@@ -38,9 +38,16 @@ export function PlanNoticeBanner({ notice }: PlanNoticeBannerProps) {
   }, [dismissible, notice?.expiresAt])
   if (!view || !ready || (dismissible && dismissed)) return null
 
-  const tone = view.urgent
-    ? 'bg-amber-500/10 border-amber-500/20'
-    : 'bg-primary/5 border-primary/10'
+  const ended = view.ended
+  const tone = ended
+    ? 'bg-red-600 text-white border-red-700'
+    : view.urgent
+      ? 'bg-amber-500/10 border-amber-500/20'
+      : 'bg-primary/5 border-primary/10'
+  const muted = ended ? 'text-white/80' : 'text-muted-foreground'
+  const actionClass = ended
+    ? 'inline-flex items-center gap-1 font-medium text-white underline underline-offset-2 hover:text-white'
+    : 'inline-flex items-center gap-1 text-primary font-medium hover:underline'
 
   function dismiss() {
     if (notice?.expiresAt) {
@@ -56,8 +63,10 @@ export function PlanNoticeBanner({ notice }: PlanNoticeBannerProps) {
   return (
     <div className={`flex items-center justify-between gap-3 px-4 py-2.5 text-sm border-b ${tone}`}>
       <div className="flex items-center gap-2 min-w-0">
-        <span className="font-medium text-foreground shrink-0">{view.label}</span>
-        {view.daysLeft !== null && (
+        <span className={`font-medium shrink-0 ${ended ? 'text-white' : 'text-foreground'}`}>
+          {view.label}
+        </span>
+        {!ended && view.daysLeft !== null && (
           <>
             <span className="text-muted-foreground">·</span>
             <span
@@ -68,15 +77,13 @@ export function PlanNoticeBanner({ notice }: PlanNoticeBannerProps) {
               }
             >
               {view.daysLeft === 0
-                ? view.dismissible
-                  ? 'ended'
-                  : 'ends today'
+                ? 'ends today'
                 : `${view.daysLeft} day${view.daysLeft === 1 ? '' : 's'} left`}
             </span>
           </>
         )}
         {view.message && (
-          <span className="text-muted-foreground hidden sm:inline truncate">{view.message}</span>
+          <span className={`${muted} hidden sm:inline truncate`}>{view.message}</span>
         )}
       </div>
       <div className="flex items-center gap-2 shrink-0">
@@ -86,7 +93,7 @@ export function PlanNoticeBanner({ notice }: PlanNoticeBannerProps) {
             {...(view.actionUrl.startsWith('/')
               ? {}
               : { target: '_blank', rel: 'noopener noreferrer' })}
-            className="inline-flex items-center gap-1 text-primary font-medium hover:underline"
+            className={actionClass}
           >
             {view.actionLabel ?? 'Manage'}
             {!view.actionUrl.startsWith('/') && <ArrowTopRightOnSquareIcon className="h-3 w-3" />}

--- a/apps/web/src/components/admin/settings/billing/__tests__/billing-settings.test.tsx
+++ b/apps/web/src/components/admin/settings/billing/__tests__/billing-settings.test.tsx
@@ -254,7 +254,7 @@ describe('BillingPlansView', () => {
     expect(screen.queryByRole('button', { name: 'Add seats' })).not.toBeInTheDocument()
   })
 
-  it('explains a trial that ended and that everyone keeps access', () => {
+  it('sends an ended trial to the choose-a-plan page with payment', () => {
     renderView({
       overview: {
         ...paidOverview,
@@ -271,10 +271,10 @@ describe('BillingPlansView', () => {
         seats: { used: 3, pending: 0, members: 3, purchased: null },
       },
     })
-    expect(screen.getByText('Trial ended')).toBeInTheDocument()
-    expect(screen.getByText(/Everything you built is still here/)).toBeInTheDocument()
-    expect(screen.getByText(/Everyone keeps access/)).toBeInTheDocument()
-    expect(screen.getAllByRole('button', { name: 'Continue with Pro' }).length).toBeGreaterThan(0)
+    expect(screen.getByText('Order summary')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Continue to payment' })).toBeInTheDocument()
+    expect(screen.getByText('Current')).toBeInTheDocument()
+    expect(screen.getByText(/Downgrade to Free plan/)).toBeInTheDocument()
   })
 
   it('does not call a Free trial when the last plan name is missing', () => {
@@ -294,9 +294,9 @@ describe('BillingPlansView', () => {
         seats: { used: 3, pending: 0, members: 3, purchased: null },
       },
     })
-    expect(screen.getByText(/Your trial ended/)).toBeInTheDocument()
+    expect(screen.getByText('Order summary')).toBeInTheDocument()
     expect(screen.queryByText(/Your Free trial ended/)).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /Continue with/ })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Continue to payment' })).toBeInTheDocument()
   })
 
   it('does not offer Continue when the catalogue did not load', () => {
@@ -358,7 +358,7 @@ describe('BillingPlansView', () => {
       },
     })
     fireEvent.click(screen.getByRole('radio', { name: 'Monthly' }))
-    fireEvent.click(screen.getAllByRole('button', { name: 'Continue with Pro' })[0])
+    fireEvent.click(screen.getByRole('button', { name: 'Continue to payment' }))
     expect(screen.getByRole('dialog')).toBeInTheDocument()
     expect(document.querySelector('form input[name="billingPeriod"]')).toHaveValue('monthly')
   })

--- a/apps/web/src/components/admin/settings/billing/billing-settings.tsx
+++ b/apps/web/src/components/admin/settings/billing/billing-settings.tsx
@@ -25,6 +25,8 @@ import { RemoveSeatsDialog } from './remove-seats-dialog'
 import { SubscribeDialog } from './subscribe-dialog'
 import { TopUpDialog } from './topup-dialog'
 import { UsageMeter } from './usage-meter'
+import { TrialExpiredBilling } from './trial-expired-billing'
+import { FreeDowngradeDialog } from './free-downgrade-dialog'
 
 /** Workspace-local presentation of the control-plane billing projection. */
 export function BillingSettings() {
@@ -74,6 +76,16 @@ export function BillingPlansView(props: {
   const currentCataloguePlan = catalogue?.plans.find((plan) => plan.id === overview.plan)
   const grandfatheredFlat =
     currentCataloguePlan?.billedPer === 'workspace' && overview.plan !== 'free'
+
+  if (overview.trialEnded) {
+    return (
+      <TrialExpiredBilling
+        overview={overview}
+        catalogue={catalogue}
+        catalogueError={props.catalogueError}
+      />
+    )
+  }
 
   return (
     <div className="space-y-6">
@@ -693,22 +705,7 @@ function DowngradeButton() {
       >
         Switch to Free
       </Button>
-      <ConfirmDialog
-        open={open}
-        onOpenChange={setOpen}
-        title="Switch to Free?"
-        description="You’ll keep all existing data and stay online. New work that goes past Free limits will pause until you pick a paid plan again. If you are on a paid period, Free starts when it ends. An active trial ends now."
-        confirmLabel="Switch to Free"
-        variant="destructive"
-        onConfirm={() => {
-          const form = document.getElementById('downgrade-free') as HTMLFormElement | null
-          form?.requestSubmit()
-        }}
-      />
-      <form id="downgrade-free" method="post" action="/api/billing/session" className="hidden">
-        <input type="hidden" name="action" value="downgrade" />
-        <input type="hidden" name="planId" value="free" />
-      </form>
+      {open ? <FreeDowngradeDialog open onOpenChange={setOpen} /> : null}
     </>
   )
 }

--- a/apps/web/src/components/admin/settings/billing/free-downgrade-dialog.tsx
+++ b/apps/web/src/components/admin/settings/billing/free-downgrade-dialog.tsx
@@ -1,0 +1,97 @@
+import { useQuery } from '@tanstack/react-query'
+import { billingQueries } from '@/lib/client/queries/billing'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+
+export function FreeDowngradeDialog(props: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const preview = useQuery({
+    ...billingQueries.freeDowngradePreview(),
+    enabled: props.open,
+  })
+  const issues = preview.data?.issues ?? []
+  const features = preview.data?.featuresDisabled ?? []
+  const blocked = issues.length > 0
+
+  return (
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Action required before downgrading</DialogTitle>
+          <DialogDescription>
+            Please resolve the following issues before downgrading to the Free plan.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Alert>
+          <AlertDescription>
+            Downgrading to the Free plan will remove access to paid features.
+          </AlertDescription>
+        </Alert>
+
+        {preview.isLoading ? (
+          <p className="text-sm text-muted-foreground">Checking this workspace against Free…</p>
+        ) : blocked ? (
+          <div className="space-y-2">
+            <p className="text-sm font-medium">Issues to resolve ({issues.length}):</p>
+            <ul className="divide-y divide-border overflow-hidden rounded-xl border border-border">
+              {issues.map((issue) => (
+                <li key={issue.key} className="flex items-center justify-between gap-3 px-4 py-3">
+                  <span className="text-sm">{issue.message}</span>
+                  <Button size="sm" variant="outline" asChild>
+                    <a href={issue.href}>{issue.actionLabel}</a>
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">This workspace fits the Free plan.</p>
+        )}
+
+        {features.length > 0 ? (
+          <div className="space-y-2">
+            <p className="text-sm font-medium">Features that will be disabled:</p>
+            <ul className="space-y-2 rounded-xl border border-border px-4 py-3">
+              {features.map((line) => (
+                <li key={line} className="flex gap-2 text-sm text-muted-foreground">
+                  <span className="mt-1 size-1.5 shrink-0 rounded-full bg-amber-400" />
+                  {line}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => props.onOpenChange(false)}>
+            Keep features
+          </Button>
+          {blocked ? (
+            <Button type="button" disabled>
+              Resolve issues first
+            </Button>
+          ) : (
+            <form method="post" action="/api/billing/session">
+              <input type="hidden" name="action" value="downgrade" />
+              <input type="hidden" name="planId" value="free" />
+              <Button type="submit" variant="destructive">
+                Switch to Free
+              </Button>
+            </form>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/components/admin/settings/billing/trial-expired-billing.tsx
+++ b/apps/web/src/components/admin/settings/billing/trial-expired-billing.tsx
@@ -1,0 +1,256 @@
+import { useState } from 'react'
+import type { BillingProjectionOverview } from '@/lib/server/domains/billing/projection-overview'
+import type { BillingCatalogue } from '@/lib/server/control-plane/client'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/shared/utils'
+import { formatUsd } from '@/lib/shared/format-usd'
+import {
+  billingPlanAction,
+  catalogueTrialedPlanIds,
+  type PaidPlanId,
+} from '@/lib/shared/billing/plan-action'
+import { FreeDowngradeDialog } from './free-downgrade-dialog'
+import { SubscribeDialog } from './subscribe-dialog'
+
+export function TrialExpiredBilling(props: {
+  overview: BillingProjectionOverview
+  catalogue: BillingCatalogue | null
+  catalogueError: string | null
+}) {
+  const [period, setPeriod] = useState<'monthly' | 'annual'>('annual')
+  const [selectedId, setSelectedId] = useState<PaidPlanId | 'free'>(
+    (props.overview.trialPlanId as PaidPlanId | undefined) ?? 'pro'
+  )
+  const [subscribeOpen, setSubscribeOpen] = useState(false)
+  const [freeOpen, setFreeOpen] = useState(false)
+  const { overview, catalogue } = props
+  const trialedPlanIds = catalogueTrialedPlanIds(catalogue)
+  const plans = catalogue?.plans ?? []
+  const selected = plans.find((plan) => plan.id === selectedId)
+  const paidSelected = selected && selected.id !== 'free' ? selected : null
+  const checkoutQuantity = Math.max(overview.seats?.used ?? 1, 1)
+  const trialName = overview.trialPlanName ?? 'your plan'
+
+  return (
+    <div className="space-y-6">
+      <p className="text-sm text-muted-foreground">
+        Need more time to test everything? Pick a plan below, including Free after you remove
+        anything that exceeds it.
+      </p>
+
+      <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_20rem]">
+        <div className="space-y-5">
+          <div className="flex flex-wrap items-end justify-between gap-3">
+            <div>
+              <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                1 Configure plan
+              </p>
+              <h2 className="mt-1 text-base font-semibold">Billing cycle</h2>
+            </div>
+            <PeriodToggle
+              value={period}
+              discountMonths={catalogue?.annualDiscountMonths ?? 2}
+              onChange={setPeriod}
+            />
+          </div>
+
+          {props.catalogueError ? (
+            <p role="alert" className="text-[13px] text-destructive">
+              Couldn’t load plans. {props.catalogueError}
+            </p>
+          ) : null}
+
+          <div className="overflow-hidden rounded-xl border border-border/50 bg-card">
+            {plans.map((plan) => {
+              const action = billingPlanAction(plan.id, overview, trialedPlanIds)
+              const isCurrent = overview.trialPlanId
+                ? plan.id === overview.trialPlanId
+                : plan.id === 'free'
+              const isSelected = plan.id === selectedId
+              const monthly =
+                period === 'annual'
+                  ? Math.round(plan.priceYearlyCents / 12)
+                  : plan.priceMonthlyCents
+              return (
+                <button
+                  key={plan.id}
+                  type="button"
+                  onClick={() => setSelectedId(plan.id as PaidPlanId | 'free')}
+                  className={cn(
+                    'flex w-full items-start justify-between gap-3 border-b border-border/50 px-5 py-4 text-left last:border-b-0',
+                    isSelected && 'bg-primary/5'
+                  )}
+                >
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-1.5">
+                      <span className="text-sm font-semibold">{plan.name}</span>
+                      {isCurrent ? (
+                        <Badge size="sm" shape="pill" variant="secondary">
+                          Current
+                        </Badge>
+                      ) : null}
+                    </div>
+                    <p className="mt-1 text-[13px] text-muted-foreground">{plan.bestFor}</p>
+                    {plan.id === 'free' ? (
+                      <span
+                        className="mt-2 inline-flex text-[13px] font-medium text-primary"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          setFreeOpen(true)
+                        }}
+                      >
+                        Downgrade to Free plan
+                      </span>
+                    ) : null}
+                  </div>
+                  <p className="shrink-0 text-right">
+                    <span className="text-lg font-semibold tabular-nums">
+                      {formatUsd(monthly, 0)}
+                    </span>
+                    <span className="block text-[12px] text-muted-foreground">
+                      {plan.id === 'free'
+                        ? 'forever'
+                        : plan.billedPer === 'seat'
+                          ? '/seat/mo'
+                          : '/mo'}
+                    </span>
+                  </p>
+                  {action.kind === 'subscribe' || action.kind === 'current' ? (
+                    <span className="sr-only">{plan.name}</span>
+                  ) : null}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+
+        <aside className="space-y-3 lg:pt-8">
+          <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            2 Payment
+          </p>
+          <div className="rounded-xl border border-border/50 bg-card p-5">
+            <h3 className="text-sm font-semibold">Order summary</h3>
+            {paidSelected ? (
+              <OrderSummary plan={paidSelected} period={period} seats={checkoutQuantity} />
+            ) : (
+              <p className="mt-3 text-[13px] text-muted-foreground">
+                Free has no charge. Resolve anything over the Free caps, then switch.
+              </p>
+            )}
+            {paidSelected ? (
+              <Button className="mt-4 w-full" type="button" onClick={() => setSubscribeOpen(true)}>
+                Continue to payment
+              </Button>
+            ) : (
+              <Button className="mt-4 w-full" type="button" onClick={() => setFreeOpen(true)}>
+                Switch to Free
+              </Button>
+            )}
+          </div>
+        </aside>
+      </div>
+
+      {paidSelected && subscribeOpen ? (
+        <SubscribeDialog
+          open
+          plan={paidSelected}
+          endsTrial
+          minSeats={checkoutQuantity}
+          discountMonths={catalogue?.annualDiscountMonths ?? 2}
+          period={period}
+          onOpenChange={setSubscribeOpen}
+        />
+      ) : null}
+      {freeOpen ? <FreeDowngradeDialog open onOpenChange={setFreeOpen} /> : null}
+      <p className="sr-only">Your {trialName} trial has ended.</p>
+    </div>
+  )
+}
+
+function OrderSummary(props: {
+  plan: BillingCatalogue['plans'][number]
+  period: 'monthly' | 'annual'
+  seats: number
+}) {
+  const yearly = props.period === 'annual'
+  const billedPerSeat = props.plan.billedPer === 'seat'
+  const unit = yearly ? props.plan.priceYearlyCents : props.plan.priceMonthlyCents
+  const quantity = billedPerSeat ? props.seats : 1
+  const total = unit * quantity
+  const monthly = yearly ? Math.round(total / 12) : total
+  return (
+    <dl className="mt-4 space-y-2 text-[13px]">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <dt className="font-medium">{props.plan.name} plan</dt>
+          <dd className="text-muted-foreground">
+            {billedPerSeat
+              ? `${quantity} seat${quantity === 1 ? '' : 's'} × ${formatUsd(unit, 0)}/${yearly ? 'year' : 'mo'}`
+              : yearly
+                ? 'Billed yearly'
+                : 'Billed monthly'}
+          </dd>
+        </div>
+        <dd className="font-medium tabular-nums">
+          {formatUsd(total, 0)}
+          {yearly ? '/year' : '/mo'}
+        </dd>
+      </div>
+      <div className="flex items-center justify-between border-t border-border/50 pt-2">
+        <dt className="font-medium">Total</dt>
+        <dd className="font-medium tabular-nums">
+          {formatUsd(total, 0)}
+          {yearly ? '/year' : '/mo'}
+        </dd>
+      </div>
+      {yearly ? (
+        <div className="flex items-center justify-between text-muted-foreground">
+          <dt>Monthly equivalent</dt>
+          <dd className="tabular-nums">{formatUsd(monthly, 0)}/mo</dd>
+        </div>
+      ) : null}
+    </dl>
+  )
+}
+
+function PeriodToggle(props: {
+  value: 'monthly' | 'annual'
+  discountMonths: number
+  onChange: (next: 'monthly' | 'annual') => void
+}) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Billing period"
+      className="inline-flex items-center rounded-full border border-border/50 bg-muted/30 p-0.5"
+    >
+      {(['monthly', 'annual'] as const).map((option) => (
+        <button
+          key={option}
+          type="button"
+          role="radio"
+          aria-checked={props.value === option}
+          onClick={() => props.onChange(option)}
+          className={cn(
+            'inline-flex h-8 items-center rounded-full px-3 text-[13px] font-medium',
+            props.value === option
+              ? 'bg-background text-foreground shadow-xs'
+              : 'text-muted-foreground hover:text-foreground'
+          )}
+        >
+          {option === 'annual' ? (
+            <>
+              Yearly
+              <span className="ms-1.5 text-[11px] font-semibold text-primary">
+                {props.discountMonths} mo free
+              </span>
+            </>
+          ) : (
+            'Monthly'
+          )}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/apps/web/src/lib/client/queries/__tests__/ensure-billing-catalogue.test.ts
+++ b/apps/web/src/lib/client/queries/__tests__/ensure-billing-catalogue.test.ts
@@ -7,6 +7,7 @@ vi.mock('@/lib/server/functions/billing', () => ({
   fetchBillingInvoicesFn: vi.fn(),
   fetchBillingOverviewFn: vi.fn(),
   fetchPlanUsageFn: vi.fn(),
+  fetchFreeDowngradePreviewFn: vi.fn(),
 }))
 
 const { billingQueries, ensureBillingCatalogue } = await import('../billing')

--- a/apps/web/src/lib/client/queries/billing.ts
+++ b/apps/web/src/lib/client/queries/billing.ts
@@ -4,6 +4,7 @@ import {
   fetchBillingInvoicesFn,
   fetchBillingOverviewFn,
   fetchPlanUsageFn,
+  fetchFreeDowngradePreviewFn,
   fetchSeatsPreviewFn,
 } from '@/lib/server/functions/billing'
 
@@ -33,6 +34,12 @@ export const billingQueries = {
       queryKey: ['billing', 'usage'] as const,
       queryFn: () => fetchPlanUsageFn(),
       staleTime: 30_000,
+    }),
+  freeDowngradePreview: () =>
+    queryOptions({
+      queryKey: ['billing', 'free-downgrade'] as const,
+      queryFn: () => fetchFreeDowngradePreviewFn(),
+      staleTime: 10_000,
     }),
   seatsPreview: (quantity: number) =>
     queryOptions({

--- a/apps/web/src/lib/server/domains/settings/cloud/__tests__/commercial-notice.test.ts
+++ b/apps/web/src/lib/server/domains/settings/cloud/__tests__/commercial-notice.test.ts
@@ -27,7 +27,7 @@ describe('trialNotice', () => {
     expect(notice).toMatchObject({
       label: 'Growth trial',
       actionLabel: 'See plans',
-      message: expect.stringContaining('continue on Free'),
+      message: expect.stringContaining('pick a paid plan'),
     })
   })
 
@@ -48,10 +48,10 @@ describe('trialEndedNotice', () => {
       { trialPlanName: 'Growth', now: NOW }
     )
     expect(notice).toMatchObject({
-      label: 'Growth trial',
-      dismissible: true,
-      actionLabel: 'Continue with Growth',
+      label: 'Growth trial ended',
+      actionLabel: 'Update billing',
     })
-    expect(notice?.message).toMatch(/everything you built is still here/)
+    expect(notice?.dismissible).toBeUndefined()
+    expect(notice?.message).toMatch(/trial has come to an end/)
   })
 })

--- a/apps/web/src/lib/server/domains/settings/cloud/commercial-notice.ts
+++ b/apps/web/src/lib/server/domains/settings/cloud/commercial-notice.ts
@@ -21,7 +21,7 @@ export function trialNotice(config: CloudConfig, now: Date = new Date()): PlanNo
   const urgent = daysLeft !== null && daysLeft <= 3
   return {
     label: `${planLabel(config)} trial`,
-    message: 'When this ends you will continue on Free. Everything you have built stays.',
+    message: 'When this ends, pick a paid plan or switch to Free from billing.',
     expiresAt: config.trialExpiresAt,
     ...(actionUrl
       ? {
@@ -51,21 +51,12 @@ export function trialEndedNotice(
   }
   const actionUrl = plansActionUrl(config)
   const name = options.trialPlanName
-  const ended = formatNoticeDate(config.trialExpiresAt!)
+  const product = name ?? 'Quackback'
   return {
-    label: name ? `${name} trial` : 'Trial',
-    message: name
-      ? `Your ${name} trial ended ${ended}. You are on Free now, and everything you built is still here.`
-      : `Your trial ended ${ended}. You are on Free now, and everything you built is still here.`,
+    label: name ? `${name} trial ended` : 'Trial ended',
+    message: `Your trial has come to an end. Please update your billing information to continue using ${product}.`,
     expiresAt: config.trialExpiresAt!,
-    dismissible: true,
-    ...(actionUrl ? { actionUrl, actionLabel: name ? `Continue with ${name}` : 'See plans' } : {}),
+    ended: true,
+    ...(actionUrl ? { actionUrl, actionLabel: 'Update billing' } : {}),
   }
-}
-
-function formatNoticeDate(iso: string): string {
-  const date = new Date(iso)
-  return Number.isNaN(date.getTime())
-    ? iso
-    : date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
 }

--- a/apps/web/src/lib/server/domains/settings/tier-limits.types.ts
+++ b/apps/web/src/lib/server/domains/settings/tier-limits.types.ts
@@ -45,6 +45,8 @@ export interface PlanNotice {
   actionLabel?: string
   /** Ended-trial banner only: per-admin localStorage dismiss. */
   dismissible?: boolean
+  /** Expired-trial strip: persistent red, no countdown. */
+  ended?: boolean
 }
 
 export interface TierLimits {

--- a/apps/web/src/lib/server/functions/__tests__/plan-notice-auth.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/plan-notice-auth.test.ts
@@ -174,23 +174,30 @@ describe('getPlanNotice — the trial countdown', () => {
     )
   })
 
-  it('keeps a calm ended banner for seven days after expiry', async () => {
+  it('keeps a persistent ended banner after expiry', async () => {
     vi.setSystemTime(AFTER)
     hoisted.mockFetchCatalogue.mockResolvedValue({ lastTrialPlanId: 'pro' })
     hoisted.mockGetWorkspaceSettings.mockResolvedValue({ settings: { cloud: trialing } })
     await expect(getPlanNoticeHandler()).resolves.toEqual(
       expect.objectContaining({
-        label: 'Pro trial',
-        dismissible: true,
-        actionLabel: 'Continue with Pro',
+        label: 'Pro trial ended',
+        ended: true,
+        actionLabel: 'Update billing',
       })
     )
   })
 
-  it('drops the ended banner after seven days, with the row unchanged', async () => {
+  it('still shows the ended banner more than seven days later', async () => {
     vi.setSystemTime(new Date('2026-03-23T00:00:00.000Z'))
+    hoisted.mockFetchCatalogue.mockResolvedValue({ lastTrialPlanId: 'pro' })
     hoisted.mockGetWorkspaceSettings.mockResolvedValue({ settings: { cloud: trialing } })
-    await expect(getPlanNoticeHandler()).resolves.toBeNull()
+    await expect(getPlanNoticeHandler()).resolves.toEqual(
+      expect.objectContaining({
+        label: 'Pro trial ended',
+        ended: true,
+        actionLabel: 'Update billing',
+      })
+    )
   })
 
   it('never talks over a notice the operator set', async () => {

--- a/apps/web/src/lib/server/functions/billing.ts
+++ b/apps/web/src/lib/server/functions/billing.ts
@@ -45,15 +45,10 @@ export const fetchSeatsPreviewFn = createServerFn({ method: 'GET' })
     }
   })
 
-export const fetchPlanUsageFn = createServerFn({ method: 'GET' }).handler(async () => {
-  await requireAuth({ permission: PERMISSIONS.BILLING_MANAGE })
-  const { getTierLimits } = await import('@/lib/server/domains/settings/tier-limits.service')
+async function loadUsageCounts(): Promise<Record<string, number>> {
   const { aiTokensThisMonth } = await import('@/lib/server/domains/ai/usage-counter')
-  const { finiteUsageLines } = await import('@/lib/server/domains/billing/plan-usage')
   const { db, eq, isNull, sql, posts, boards, roles, statusComponents, emailSendingDomains } =
     await import('@/lib/server/db')
-
-  const limits = await getTierLimits()
   const { countSeatUsage } = await import('@/lib/server/domains/principals/seat-usage')
   const { emailsSentThisMonth } = await import('@/lib/server/email/email-budget')
   const [boardRow, postRow, seats, statusRow, roleRow, domainRow, aiTokens, emailsSent] =
@@ -79,45 +74,80 @@ export const fetchPlanUsageFn = createServerFn({ method: 'GET' }).handler(async 
       aiTokensThisMonth(),
       emailsSentThisMonth(),
     ])
+  return {
+    maxBoards: boardRow[0]?.count ?? 0,
+    maxPosts: postRow[0]?.count ?? 0,
+    maxTeamSeats: seats.used,
+    maxStatusComponents: statusRow[0]?.count ?? 0,
+    maxCustomRoles: roleRow[0]?.count ?? 0,
+    maxSendingDomains: domainRow[0]?.count ?? 0,
+    aiTokensPerMonth: aiTokens,
+    emailsPerMonth: emailsSent,
+  }
+}
 
+export const fetchPlanUsageFn = createServerFn({ method: 'GET' }).handler(async () => {
+  await requireAuth({ permission: PERMISSIONS.BILLING_MANAGE })
+  const { getTierLimits } = await import('@/lib/server/domains/settings/tier-limits.service')
+  const { finiteUsageLines } = await import('@/lib/server/domains/billing/plan-usage')
+  const [limits, used] = await Promise.all([getTierLimits(), loadUsageCounts()])
   return finiteUsageLines([
-    { key: 'maxBoards', label: 'boards', used: boardRow[0]?.count ?? 0, limit: limits.maxBoards },
-    { key: 'maxPosts', label: 'posts', used: postRow[0]?.count ?? 0, limit: limits.maxPosts },
+    { key: 'maxBoards', label: 'boards', used: used.maxBoards ?? 0, limit: limits.maxBoards },
+    { key: 'maxPosts', label: 'posts', used: used.maxPosts ?? 0, limit: limits.maxPosts },
     {
       key: 'maxTeamSeats',
       label: 'seats',
-      used: seats.used,
+      used: used.maxTeamSeats ?? 0,
       limit: limits.maxTeamSeats,
     },
     {
       key: 'maxStatusComponents',
       label: 'status components',
-      used: statusRow[0]?.count ?? 0,
+      used: used.maxStatusComponents ?? 0,
       limit: limits.maxStatusComponents,
     },
     {
       key: 'maxCustomRoles',
       label: 'custom roles',
-      used: roleRow[0]?.count ?? 0,
+      used: used.maxCustomRoles ?? 0,
       limit: limits.maxCustomRoles,
     },
     {
       key: 'maxSendingDomains',
       label: 'sending domains',
-      used: domainRow[0]?.count ?? 0,
+      used: used.maxSendingDomains ?? 0,
       limit: limits.maxSendingDomains,
     },
     {
       key: 'aiTokensPerMonth',
       label: 'AI tokens this month',
-      used: aiTokens,
+      used: used.aiTokensPerMonth ?? 0,
       limit: limits.aiTokensPerMonth,
     },
     {
       key: 'emailsPerMonth',
       label: 'emails',
-      used: emailsSent,
+      used: used.emailsPerMonth ?? 0,
       limit: limits.emailsPerMonth,
     },
   ])
 })
+
+export const fetchFreeDowngradePreviewFn = createServerFn({ method: 'GET' }).handler(async () => {
+  await requireAuth({ permission: PERMISSIONS.BILLING_MANAGE })
+  const { getBillingProjectionOverview } =
+    await import('@/lib/server/domains/billing/projection-overview')
+  const [overview, used] = await Promise.all([getBillingProjectionOverview(), loadUsageCounts()])
+  const { freeDowngradeIssues, featuresDisabledOnFree } =
+    await import('@/lib/shared/billing/free-downgrade')
+  return {
+    issues: freeDowngradeIssues(used),
+    featuresDisabled: featuresDisabledOnFree(overview?.trialPlanId ?? overview?.plan),
+  }
+})
+
+export async function assertFitsFreePlan(): Promise<void> {
+  const used = await loadUsageCounts()
+  const { freeDowngradeIssues } = await import('@/lib/shared/billing/free-downgrade')
+  if (freeDowngradeIssues(used).length > 0) throw new Error('over_free_limits')
+}

--- a/apps/web/src/lib/server/policy/authz-matrix/MATRIX.md
+++ b/apps/web/src/lib/server/policy/authz-matrix/MATRIX.md
@@ -100,7 +100,7 @@ Profiles: **Owner** = admin class + an admin-owned full API key (scoped keys hol
 
 ## 2. Surfaces and their enforced authorization
 
-### Server functions (`requireAuth`) — 667 surfaces
+### Server functions (`requireAuth`) — 668 surfaces
 
 | Surface | Enforces |
 | --- | --- |
@@ -261,6 +261,7 @@ Profiles: **Owner** = admin class + an admin-owned full API key (scoped keys hol
 | `lib/server/functions/billing.ts`::fetchBillingInvoicesFn | billing.manage |
 | `lib/server/functions/billing.ts`::fetchSeatsPreviewFn | billing.manage |
 | `lib/server/functions/billing.ts`::fetchPlanUsageFn | billing.manage |
+| `lib/server/functions/billing.ts`::fetchFreeDowngradePreviewFn | billing.manage |
 | `lib/server/functions/blocking.ts`::getPersonBlockStatusFn | people.view |
 | `lib/server/functions/blocking.ts`::blockPersonFn | people.manage |
 | `lib/server/functions/blocking.ts`::unblockPersonFn | people.manage |
@@ -978,7 +979,7 @@ Key scopes are enforced: an API key holds exactly its stored scopes (owner permi
 
 ## 4. Entry points without a requireAuth/key gate
 
-189 of 968 entry points hold no `requireAuth` / `withApiKeyAuth` / `requireTeamAuth` gate.
+189 of 969 entry points hold no `requireAuth` / `withApiKeyAuth` / `requireTeamAuth` gate.
 Each is expected to be intentionally public, a pre-auth flow, a signature-verified webhook, or a handler that delegates auth (e.g. the MCP route).
 **Adding a row here is an access-control change** — confirm the new entry point is meant to be reachable without a gate.
 

--- a/apps/web/src/lib/shared/billing/__tests__/free-downgrade.test.ts
+++ b/apps/web/src/lib/shared/billing/__tests__/free-downgrade.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { featuresDisabledOnFree, freeDowngradeIssues } from '../free-downgrade'
+
+describe('freeDowngradeIssues', () => {
+  it('is empty when usage fits Free', () => {
+    expect(
+      freeDowngradeIssues({
+        maxBoards: 2,
+        maxPosts: 10,
+        maxTeamSeats: 1,
+        maxStatusComponents: 1,
+        maxCustomRoles: 0,
+        maxSendingDomains: 0,
+      })
+    ).toEqual([])
+  })
+
+  it('asks to remove the extra boards, matching the Free cap of 2', () => {
+    const issues = freeDowngradeIssues({ maxBoards: 3 })
+    expect(issues).toEqual([
+      {
+        key: 'maxBoards',
+        message: 'You have 3 boards',
+        actionLabel: 'Remove 1 board',
+        href: '/admin/settings/boards',
+      },
+    ])
+  })
+
+  it('pluralizes seats to remove', () => {
+    const issues = freeDowngradeIssues({ maxTeamSeats: 4 })
+    expect(issues[0]).toMatchObject({
+      message: 'You have 4 seats',
+      actionLabel: 'Remove 3 seats',
+    })
+  })
+})
+
+describe('featuresDisabledOnFree', () => {
+  it('names Pro features when the trial plan is Pro', () => {
+    expect(featuresDisabledOnFree('pro')).toContain('Workflows and automations will be disabled')
+    expect(featuresDisabledOnFree('pro')).toContain('MCP access will be revoked')
+  })
+})

--- a/apps/web/src/lib/shared/billing/__tests__/plan-action.test.ts
+++ b/apps/web/src/lib/shared/billing/__tests__/plan-action.test.ts
@@ -82,6 +82,19 @@ describe('billingPlanAction', () => {
     expect(billingPlanAction('pro', grant)).toEqual({ kind: 'subscribe', planId: 'pro' })
   })
 
+  it('treats an ended trial as choosing a plan, with Free as a gated downgrade', () => {
+    const ended: BillingProjectionOverview = {
+      ...unpaidFree,
+      trialEnded: true,
+      trialPlanId: 'pro',
+      trialPlanName: 'Pro',
+      trialExpiresAt: '2026-08-18T00:00:00.000Z',
+    }
+    expect(billingPlanAction('pro', ended)).toEqual({ kind: 'subscribe', planId: 'pro' })
+    expect(billingPlanAction('growth', ended)).toEqual({ kind: 'subscribe', planId: 'growth' })
+    expect(billingPlanAction('free', ended).kind).toBe('downgrade')
+  })
+
   it('covers every catalogue id', () => {
     const ids: CataloguePlanId[] = ['free', 'growth', 'pro', 'scale']
     for (const id of ids) {

--- a/apps/web/src/lib/shared/billing/__tests__/trial-state.test.ts
+++ b/apps/web/src/lib/shared/billing/__tests__/trial-state.test.ts
@@ -4,7 +4,7 @@ import { daysUntil, isTrialEnded } from '../trial-state'
 const NOW = new Date('2026-08-20T12:00:00.000Z')
 
 describe('isTrialEnded', () => {
-  it('is true on Free after a trial window, for seven days', () => {
+  it('is true on Free after a trial window until they subscribe', () => {
     expect(
       isTrialEnded({
         plan: 'free',
@@ -40,7 +40,7 @@ describe('isTrialEnded', () => {
     ).toBe(false)
   })
 
-  it('is false more than seven days after expiry', () => {
+  it('stays true more than seven days after expiry until they subscribe', () => {
     expect(
       isTrialEnded({
         plan: 'free',
@@ -49,7 +49,7 @@ describe('isTrialEnded', () => {
         status: null,
         now: NOW,
       })
-    ).toBe(false)
+    ).toBe(true)
   })
 })
 

--- a/apps/web/src/lib/shared/billing/free-downgrade.ts
+++ b/apps/web/src/lib/shared/billing/free-downgrade.ts
@@ -1,0 +1,97 @@
+import type { PlanUsageLine } from './plan-usage'
+
+/** Numeric Free caps. Must match CP `FREE_TIER_LIMITS`. */
+export const FREE_PLAN_CAPS = {
+  maxBoards: 2,
+  maxPosts: 50,
+  maxTeamSeats: 1,
+  maxStatusComponents: 3,
+  maxCustomRoles: 0,
+  maxSendingDomains: 0,
+} as const
+
+export type FreeCapKey = keyof typeof FREE_PLAN_CAPS
+
+export type FreeDowngradeIssue = {
+  key: FreeCapKey
+  message: string
+  actionLabel: string
+  href: string
+}
+
+const RESOURCE: Record<FreeCapKey, { singular: string; plural: string; href: string }> = {
+  maxBoards: { singular: 'board', plural: 'boards', href: '/admin/settings/boards' },
+  maxPosts: { singular: 'post', plural: 'posts', href: '/admin' },
+  maxTeamSeats: { singular: 'seat', plural: 'seats', href: '/admin/settings/members' },
+  maxStatusComponents: {
+    singular: 'status component',
+    plural: 'status components',
+    href: '/admin/settings/status',
+  },
+  maxCustomRoles: {
+    singular: 'custom role',
+    plural: 'custom roles',
+    href: '/admin/settings/members',
+  },
+  maxSendingDomains: {
+    singular: 'sending domain',
+    plural: 'sending domains',
+    href: '/admin/settings/domains',
+  },
+}
+
+export const FREE_DISABLED_FEATURES: Record<string, string[]> = {
+  growth: [
+    'Custom domains will be disabled',
+    'AI assistant, drafts and insights will be disabled',
+    'API access will be revoked',
+    'Webhooks will be disabled',
+    'MCP access will be revoked',
+  ],
+  pro: [
+    'Custom domains will be disabled',
+    'Workflows and automations will be disabled',
+    'AI assistant, drafts and insights will be disabled',
+    'API access will be revoked',
+    'Webhooks will be disabled',
+    'MCP access will be revoked',
+  ],
+  scale: [
+    'Custom domains will be disabled',
+    'Workflows and automations will be disabled',
+    'Single sign-on will be disabled',
+    'AI assistant, drafts and insights will be disabled',
+    'API access will be revoked',
+    'Webhooks will be disabled',
+    'MCP access will be revoked',
+    'The audit log will be disabled',
+  ],
+}
+
+export function usedByKey(lines: readonly PlanUsageLine[]): Record<string, number> {
+  return Object.fromEntries(lines.map((line) => [line.key, line.used]))
+}
+
+export function freeDowngradeIssues(used: Record<string, number>): FreeDowngradeIssue[] {
+  const issues: FreeDowngradeIssue[] = []
+  for (const key of Object.keys(FREE_PLAN_CAPS) as FreeCapKey[]) {
+    const cap = FREE_PLAN_CAPS[key]
+    const count = used[key] ?? 0
+    if (count <= cap) continue
+    const remove = count - cap
+    const noun = RESOURCE[key]
+    const unit = remove === 1 ? noun.singular : noun.plural
+    issues.push({
+      key,
+      message: `You have ${count} ${count === 1 ? noun.singular : noun.plural}`,
+      actionLabel: `Remove ${remove} ${unit}`,
+      href: noun.href,
+    })
+  }
+  return issues
+}
+
+export function featuresDisabledOnFree(planId: string | null | undefined): string[] {
+  if (!planId) return FREE_DISABLED_FEATURES.pro
+  return FREE_DISABLED_FEATURES[planId] ?? FREE_DISABLED_FEATURES.pro
+}

--- a/apps/web/src/lib/shared/billing/plan-action.ts
+++ b/apps/web/src/lib/shared/billing/plan-action.ts
@@ -26,6 +26,12 @@ export function billingPlanAction(
   trialedPlanIds: readonly string[] = []
 ): BillingPlanAction {
   const canAct = overview.canUpgrade || overview.canManageBilling
+  if (overview.trialEnded && overview.trialPlanId) {
+    if (!canAct) return { kind: 'unavailable' }
+    if (planId === 'free') return { kind: 'downgrade' }
+    if (isPaidPlanId(planId)) return { kind: 'subscribe', planId }
+    return { kind: 'unavailable' }
+  }
   if (overview.plan === planId) return { kind: 'current' }
   if (!canAct) return { kind: 'unavailable' }
 

--- a/apps/web/src/lib/shared/billing/trial-state.ts
+++ b/apps/web/src/lib/shared/billing/trial-state.ts
@@ -1,5 +1,4 @@
 const DAY_MS = 24 * 60 * 60 * 1000
-const ENDED_BANNER_MS = 7 * DAY_MS
 
 export function daysUntil(iso: string, now: Date = new Date()): number | null {
   const expires = Date.parse(iso)
@@ -11,7 +10,7 @@ export function hasLivePaidSub(status: string | null | undefined): boolean {
   return Boolean(status && status !== 'canceled')
 }
 
-/** Free + past trial window + no live sub, still inside the 7-day ended notice. */
+/** Free + past trial window + no live sub. Stays true until they subscribe. */
 export function isTrialEnded(input: {
   plan: string
   trialActive: boolean
@@ -26,8 +25,7 @@ export function isTrialEnded(input: {
   const expires = Date.parse(input.trialExpiresAt)
   if (Number.isNaN(expires)) return false
   const now = (input.now ?? new Date()).getTime()
-  if (now < expires) return false
-  return now - expires <= ENDED_BANNER_MS
+  return now >= expires
 }
 
 export function trialEndedStorageKey(expiresAt: string): string {

--- a/apps/web/src/lib/shared/plan-notice.ts
+++ b/apps/web/src/lib/shared/plan-notice.ts
@@ -14,6 +14,7 @@ export interface PlanNoticeView {
   actionUrl?: string
   actionLabel?: string
   dismissible: boolean
+  ended: boolean
 }
 
 const DAY_MS = 24 * 60 * 60 * 1000
@@ -38,5 +39,6 @@ export function presentPlanNotice(
     actionUrl: notice.actionUrl,
     actionLabel: notice.actionLabel,
     dismissible: Boolean(notice.dismissible),
+    ended: Boolean(notice.ended),
   }
 }

--- a/apps/web/src/routes/admin/settings.billing.tsx
+++ b/apps/web/src/routes/admin/settings.billing.tsx
@@ -14,6 +14,7 @@ import { cn } from '@/lib/shared/utils'
 
 const BILLING_ERROR_COPY: Record<string, string> = {
   seats_below_usage: 'Pick at least as many seats as people you already have.',
+  over_free_limits: 'Remove anything that is over the Free plan before switching.',
   already_on_plan: 'You are already on this plan.',
   already_on_addon: 'Branding removal is already on this workspace.',
   not_on_addon: 'Branding removal is not on this workspace.',

--- a/apps/web/src/routes/api/billing/session.ts
+++ b/apps/web/src/routes/api/billing/session.ts
@@ -9,6 +9,7 @@ export function billingErrorCode(error: unknown): string {
   if (message === 'already_on_addon') return 'already_on_addon'
   if (message === 'not_on_addon') return 'not_on_addon'
   if (message === 'seats_below_usage') return 'seats_below_usage'
+  if (message === 'over_free_limits') return 'over_free_limits'
   if (message === 'Authentication required') return 'unauthorized'
   if (message === 'Access denied: Not a team member') return 'not_teammate'
   if (message.startsWith('Access denied:')) return 'forbidden'
@@ -79,6 +80,10 @@ export const Route = createFileRoute('/api/billing/session')({
               : cloud.canUpgrade || cloud.canManageBilling
           if (!cloud.enabled || !actionAllowed) {
             return billingFormErrorResponse(null, 'unavailable')
+          }
+          if (parsed.data.action === 'downgrade') {
+            const { assertFitsFreePlan } = await import('@/lib/server/functions/billing')
+            await assertFitsFreePlan()
           }
           const { createHostedBillingSession } = await import('@/lib/server/control-plane/client')
           const session =


### PR DESCRIPTION
## Summary

Keep the workspace online after the product trial ends. Billing at `/admin/settings/billing` shows a persistent trial-ended notice and a configure-plan / order-summary checkout. Paid plans subscribe; Free is a gated downgrade that only proceeds after over-limit boards, posts, seats, roles, sending domains, and status components are removed.

Subscribe is the trialled plan (or Pro). Free is never treated as Current just because the projection already fell back to Free at expiry.

CP companion: QuackbackIO/quackback-cp (workspace display / pin / stay-live trial).

## Test plan

- [x] trial-state, plan-action, commercial-notice, plan-notice unit tests
- [x] free-downgrade preview / over-limit tests
- [x] billing-settings page tests
- [ ] Expired trial workspace still loads
- [ ] Billing page shows trial-ended checkout, not a suspended workspace
- [ ] Subscribe opens checkout for the trialled plan
- [ ] Free downgrade blocked until over-limit resources are removed