### PR TITLE
fix(billing): treat Free after a lapsed trial as already on Free

### DIFF
--- a/apps/web/src/routes/api/billing/__tests__/session-error.test.ts
+++ b/apps/web/src/routes/api/billing/__tests__/session-error.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { billingSessionErrorResponse } from '../session'
+import { billingDowngradeAlreadyOnPlanResponse, billingSessionErrorResponse } from '../session'
 
 function location(res: Response): string {
   return res.headers.get('location') ?? ''
@@ -16,6 +16,13 @@ describe('billingSessionErrorResponse', () => {
     const res = billingSessionErrorResponse(new Error('already_on_plan'))
     expect(res.status).toBe(303)
     expect(location(res)).toBe('/admin/settings/billing?billing_error=already_on_plan')
+  })
+
+  it('treats Switch to Free after a lapsed trial as already on Free', () => {
+    const res = billingDowngradeAlreadyOnPlanResponse(new Error('already_on_plan'))
+    expect(res?.status).toBe(303)
+    expect(res && location(res)).toBe('/admin/settings/billing')
+    expect(billingDowngradeAlreadyOnPlanResponse(new Error('unavailable'))).toBeNull()
   })
 
   it('names a missing session as unauthorized', () => {

--- a/apps/web/src/routes/api/billing/session.ts
+++ b/apps/web/src/routes/api/billing/session.ts
@@ -28,6 +28,16 @@ export function billingSessionErrorResponse(error: unknown): Response {
   return billingFormErrorResponse(error)
 }
 
+/** Switch to Free after the trial window lapsed is already commercially Free.
+ *  Treat that conflict as success so the expired page can confirm Free. */
+export function billingDowngradeAlreadyOnPlanResponse(error: unknown): Response | null {
+  if (billingErrorCode(error) !== 'already_on_plan') return null
+  return new Response(null, {
+    status: 303,
+    headers: { location: '/admin/settings/billing' },
+  })
+}
+
 const actionSchema = z.discriminatedUnion('action', [
   z.object({ action: z.literal('portal') }),
   z.object({
@@ -65,12 +75,14 @@ export const Route = createFileRoute('/api/billing/session')({
         if (!isSameOriginFormPost(request)) {
           return Response.json({ error: 'invalid_origin' }, { status: 403 })
         }
+        let action: string | undefined
         try {
           const { requireAuth } = await import('@/lib/server/functions/auth-helpers')
           await requireAuth({ permission: PERMISSIONS.BILLING_MANAGE })
           const form = await request.formData()
           const parsed = actionSchema.safeParse(Object.fromEntries(form.entries()))
           if (!parsed.success) return billingFormErrorResponse(null, 'invalid')
+          action = parsed.data.action
           const { getCloudConfig } =
             await import('@/lib/server/domains/settings/cloud/cloud.service')
           const cloud = await getCloudConfig()
@@ -102,6 +114,10 @@ export const Route = createFileRoute('/api/billing/session')({
                 : '/admin/settings/billing'
           return new Response(null, { status: 303, headers: { location } })
         } catch (error) {
+          if (action === 'downgrade') {
+            const already = billingDowngradeAlreadyOnPlanResponse(error)
+            if (already) return already
+          }
           return billingSessionErrorResponse(error)
         }
       },


### PR DESCRIPTION
## Why
Switch to Free after expiry is commercially already Free. The form treated that conflict as an error and showed "You are already on this plan."

## What
If the downgrade action gets `already_on_plan`, redirect back to billing without an error flash.

Companion: quackback-cp `fix/free-downgrade-after-trial` (closes the trial and drops the expired interstitial).