### PR TITLE
fix(billing): stop promising seat changes on Stripe Checkout

### DIFF
--- a/apps/web/src/components/admin/settings/billing/__tests__/subscribe-dialog.test.tsx
+++ b/apps/web/src/components/admin/settings/billing/__tests__/subscribe-dialog.test.tsx
@@ -34,6 +34,7 @@ describe('SubscribeDialog', () => {
     expect(screen.getByText(/Due today/)).toBeInTheDocument()
     expect(screen.getByText('$864.00')).toBeInTheDocument()
     expect(screen.getByText(/Billing starts today and your trial ends/)).toBeInTheDocument()
+    expect(screen.queryByText(/checkout page/)).not.toBeInTheDocument()
     const form = document.querySelector('form')
     expect(form?.querySelector('input[name="quantity"]')).toHaveValue('3')
     expect(form?.querySelector('input[name="billingPeriod"]')).toHaveValue('annual')
@@ -53,6 +54,7 @@ describe('SubscribeDialog', () => {
     )
     expect(screen.queryByText(/your trial ends/)).not.toBeInTheDocument()
     expect(screen.getByText(/Payment is handled by Stripe/)).toBeInTheDocument()
+    expect(screen.queryByText(/checkout page/)).not.toBeInTheDocument()
   })
 
   it('switches due-today to monthly stickers', () => {

--- a/apps/web/src/components/admin/settings/billing/subscribe-dialog.tsx
+++ b/apps/web/src/components/admin/settings/billing/subscribe-dialog.tsx
@@ -116,8 +116,8 @@ export function SubscribeDialog(props: {
         </DialogFooter>
         <p className="text-[12px] text-muted-foreground">
           {props.endsTrial
-            ? 'Payment is handled by Stripe. Billing starts today and your trial ends when it goes through. You can still change the seat count on the checkout page.'
-            : 'Payment is handled by Stripe. You can still change the seat count on the checkout page.'}
+            ? 'Payment is handled by Stripe. Billing starts today and your trial ends when it goes through.'
+            : 'Payment is handled by Stripe.'}
         </p>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Summary
The subscribe dialog already picks seat count. Checkout no longer lets Stripe change that quantity, so drop the footnote that said you could still change seats on the checkout page.

Paired CP PR: https://github.com/QuackbackIO/quackback-cp/pull/178

## Test plan
- [ ] Open Subscribe on billing settings
- [ ] Confirm the dialog still has the in-app seat stepper
- [ ] Confirm the footnote no longer mentions changing seats on Stripe