### PR TITLE
fix(billing): show the plan's other usage meters

### DIFF
--- a/apps/web/src/components/admin/settings/billing/__tests__/billing-settings.test.tsx
+++ b/apps/web/src/components/admin/settings/billing/__tests__/billing-settings.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import '@testing-library/jest-dom/vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import type { BillingCatalogue } from '@/lib/server/control-plane/client'
 import type { BillingProjectionOverview } from '@/lib/server/domains/billing/projection-overview'
@@ -378,5 +378,33 @@ describe('BillingPlansView', () => {
     })
     expect(screen.queryByText('Emails')).not.toBeInTheDocument()
     expect(screen.getAllByRole('button', { name: 'Top up' })).toHaveLength(1)
+  })
+
+  it('shows API requests and finite plan limits for the current subscription', () => {
+    renderView({
+      usage: [
+        { key: 'apiRequestsPerMonth', label: 'API requests', used: 1200, limit: 250_000 },
+        { key: 'maxStatusComponents', label: 'status components', used: 4, limit: 25 },
+        { key: 'maxCustomRoles', label: 'custom roles', used: 1, limit: 5 },
+        { key: 'maxSendingDomains', label: 'sending domains', used: 0, limit: 3 },
+        { key: 'maxTeamSeats', label: 'seats', used: 7, limit: 10 },
+        { key: 'aiTokensPerMonth', label: 'AI tokens this month', used: 100, limit: 6_000_000 },
+        { key: 'maxBoards', label: 'boards', used: 2, limit: null },
+      ],
+    })
+    expect(screen.getByText('AI usage')).toBeInTheDocument()
+    expect(screen.getByText('API requests')).toBeInTheDocument()
+    expect(screen.getByText('1,200 of 250,000')).toBeInTheDocument()
+    expect(screen.getByText('Status components')).toBeInTheDocument()
+    expect(screen.getByText('4 of 25')).toBeInTheDocument()
+    expect(screen.getByText('Custom roles')).toBeInTheDocument()
+    expect(screen.getByText('1 of 5')).toBeInTheDocument()
+    expect(screen.getByText('Sending domains')).toBeInTheDocument()
+    expect(screen.getByText('0 of 3')).toBeInTheDocument()
+    const usage = screen.getByRole('heading', { name: 'Usage' }).closest('section')
+    expect(usage).toBeTruthy()
+    expect(within(usage as HTMLElement).queryByText('Seats')).not.toBeInTheDocument()
+    expect(screen.queryByText('AI tokens this month')).not.toBeInTheDocument()
+    expect(screen.queryByText('Boards')).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/components/admin/settings/billing/billing-settings.tsx
+++ b/apps/web/src/components/admin/settings/billing/billing-settings.tsx
@@ -379,6 +379,15 @@ function SeatsBlock(props: {
   )
 }
 
+/** Seats live on the current-plan card; AI tokens are the dollar AI meter. */
+const USAGE_CARD_SKIP = new Set(['maxTeamSeats', 'aiTokensPerMonth'])
+
+function usageMeterLabel(line: { key: string; label: string }): string {
+  if (line.key === 'emailsPerMonth') return 'Emails'
+  if (line.key === 'apiRequestsPerMonth') return 'API requests'
+  return line.label.charAt(0).toUpperCase() + line.label.slice(1)
+}
+
 function UsageCard(props: {
   overview: BillingProjectionOverview
   catalogue: BillingCatalogue | null
@@ -387,21 +396,31 @@ function UsageCard(props: {
 }) {
   const emails = props.usage.find((line) => line.key === 'emailsPerMonth')
   const api = props.usage.find((line) => line.key === 'apiRequestsPerMonth')
+  const inventory = props.usage.filter(
+    (line) =>
+      line.limit != null &&
+      !USAGE_CARD_SKIP.has(line.key) &&
+      line.key !== 'emailsPerMonth' &&
+      line.key !== 'apiRequestsPerMonth'
+  )
   const ai = props.overview.ai
   const canTopUp = props.overview.canManageBilling
   const hasAi = ai != null && (ai.includedCents > 0 || ai.extraCents > 0)
   const hasEmails = emails != null && emails.limit != null
   const hasApi = api != null && api.limit != null
-  if (!hasAi && !hasEmails && !hasApi) return null
+  if (!hasAi && !hasEmails && !hasApi && inventory.length === 0) return null
 
   const reset = nextMonthResetLabel()
   const meterUsed = ai ? Math.min(ai.usedCents, ai.includedCents) : 0
+  const hasMonthly = hasAi || hasEmails || hasApi
 
   return (
     <section className="overflow-hidden rounded-xl border border-border/50 bg-card">
       <div className="flex items-center justify-between border-b border-border/50 px-6 py-4">
         <h2 className="text-base font-semibold">Usage</h2>
-        <div className="text-[12px] text-muted-foreground">Monthly meters reset {reset}</div>
+        {hasMonthly ? (
+          <div className="text-[12px] text-muted-foreground">Monthly meters reset {reset}</div>
+        ) : null}
       </div>
       <div className="grid grid-cols-1 gap-x-8 gap-y-5 p-6 sm:grid-cols-2">
         {hasAi && ai ? (
@@ -460,6 +479,17 @@ function UsageCard(props: {
             limit={api.limit}
           />
         ) : null}
+        {inventory.map((line) =>
+          line.limit != null ? (
+            <UsageMeter
+              key={line.key}
+              label={usageMeterLabel(line)}
+              valueText={`${line.used.toLocaleString()} of ${line.limit.toLocaleString()}`}
+              used={line.used}
+              limit={line.limit}
+            />
+          ) : null
+        )}
       </div>
     </section>
   )

--- a/apps/web/src/lib/server/domains/api/__tests__/monthly-usage.test.ts
+++ b/apps/web/src/lib/server/domains/api/__tests__/monthly-usage.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest'
+import { secondsUntilNextUtcMonth } from '../monthly-usage'
+
+describe('secondsUntilNextUtcMonth', () => {
+  it('is at least one second and lands on the next UTC month start', () => {
+    const at = new Date('2026-08-30T09:00:00.000Z')
+    const seconds = secondsUntilNextUtcMonth(at)
+    expect(seconds).toBe(Math.ceil((Date.UTC(2026, 8, 1) - at.getTime()) / 1000))
+  })
+})

--- a/apps/web/src/lib/server/domains/api/__tests__/rate-limit-tier.test.ts
+++ b/apps/web/src/lib/server/domains/api/__tests__/rate-limit-tier.test.ts
@@ -4,11 +4,11 @@ vi.mock('@/lib/server/domains/settings/tier-limits.service', () => ({
   getTierLimits: vi.fn(),
 }))
 
-const mockIncrementBucket = vi.fn()
+const mockIncrementBuckets = vi.fn()
 const mockBucketRetryAfter = vi.fn()
 
 vi.mock('@/lib/server/utils/rate-bucket', () => ({
-  incrementBucket: (...args: unknown[]) => mockIncrementBucket(...args),
+  incrementBuckets: (...args: unknown[]) => mockIncrementBuckets(...args),
   bucketRetryAfter: (...args: unknown[]) => mockBucketRetryAfter(...args),
 }))
 
@@ -23,11 +23,11 @@ describe('checkRateLimit — tier-aware', () => {
 
   it('uses apiRequestsPerMinute from tier when set', async () => {
     vi.mocked(getTierLimits).mockResolvedValue({ ...OSS_TIER_LIMITS, apiRequestsPerMinute: 5 })
-    mockIncrementBucket.mockResolvedValueOnce({ count: 5 })
+    mockIncrementBuckets.mockResolvedValueOnce([5, 1])
     const allowed = await checkRateLimit('1.1.1.1')
     expect(allowed).toEqual({ allowed: true, remaining: 0 })
 
-    mockIncrementBucket.mockResolvedValueOnce({ count: 6 })
+    mockIncrementBuckets.mockResolvedValueOnce([6, 1])
     mockBucketRetryAfter.mockResolvedValueOnce(60)
     const blocked = await checkRateLimit('1.1.1.1')
     expect(blocked).toEqual({ allowed: false, remaining: 0, retryAfter: 60 })
@@ -35,11 +35,11 @@ describe('checkRateLimit — tier-aware', () => {
 
   it('falls back to OSS default cap when tier limit is null', async () => {
     vi.mocked(getTierLimits).mockResolvedValue(OSS_TIER_LIMITS)
-    mockIncrementBucket.mockResolvedValueOnce({ count: 100 })
+    mockIncrementBuckets.mockResolvedValueOnce([100, 1])
     const allowed = await checkRateLimit('2.2.2.2')
     expect(allowed).toEqual({ allowed: true, remaining: 0 })
 
-    mockIncrementBucket.mockResolvedValueOnce({ count: 101 })
+    mockIncrementBuckets.mockResolvedValueOnce([101, 1])
     mockBucketRetryAfter.mockResolvedValueOnce(60)
     const blocked = await checkRateLimit('2.2.2.2')
     expect(blocked).toEqual({ allowed: false, remaining: 0, retryAfter: 60 })
@@ -47,24 +47,24 @@ describe('checkRateLimit — tier-aware', () => {
 
   it('uses a shared per-IP key regardless of import mode', async () => {
     vi.mocked(getTierLimits).mockResolvedValue(OSS_TIER_LIMITS)
-    mockIncrementBucket.mockResolvedValueOnce({ count: 1 })
+    mockIncrementBuckets.mockResolvedValueOnce([1, 1])
     await checkRateLimit('3.3.3.3', true)
-    expect(mockIncrementBucket).toHaveBeenCalledWith({
-      key: 'api:rl:3.3.3.3',
-      windowSeconds: 60,
-    })
+    expect(mockIncrementBuckets).toHaveBeenCalledWith([
+      { key: 'api:rl:3.3.3.3', windowSeconds: 60 },
+      expect.objectContaining({ key: 'api:month' }),
+    ])
   })
 
   it('applies the import-mode multiplier with a 2000 floor', async () => {
     vi.mocked(getTierLimits).mockResolvedValue({ ...OSS_TIER_LIMITS, apiRequestsPerMinute: 5 })
-    mockIncrementBucket.mockResolvedValueOnce({ count: 2000 })
+    mockIncrementBuckets.mockResolvedValueOnce([2000, 1])
     const result = await checkRateLimit('4.4.4.4', true)
     expect(result).toEqual({ allowed: true, remaining: 0 })
   })
 
   it('fails open when the primitive reports a Redis error (null count)', async () => {
     vi.mocked(getTierLimits).mockResolvedValue(OSS_TIER_LIMITS)
-    mockIncrementBucket.mockResolvedValueOnce({ count: null })
+    mockIncrementBuckets.mockResolvedValueOnce([null, 1])
     const result = await checkRateLimit('5.5.5.5')
     expect(result).toEqual({ allowed: true, remaining: 100 })
   })

--- a/apps/web/src/lib/server/domains/api/monthly-usage.ts
+++ b/apps/web/src/lib/server/domains/api/monthly-usage.ts
@@ -1,0 +1,12 @@
+/** Workspace-scoped monthly REST API request counter. */
+export const API_MONTH_BUCKET_KEY = 'api:month'
+
+export function secondsUntilNextUtcMonth(at = new Date()): number {
+  const next = new Date(Date.UTC(at.getUTCFullYear(), at.getUTCMonth() + 1, 1))
+  return Math.max(1, Math.ceil((next.getTime() - at.getTime()) / 1000))
+}
+
+export async function apiRequestsThisMonth(): Promise<number> {
+  const { getBucketCount } = await import('@/lib/server/utils/rate-bucket')
+  return getBucketCount(API_MONTH_BUCKET_KEY)
+}

--- a/apps/web/src/lib/server/domains/api/rate-limit.ts
+++ b/apps/web/src/lib/server/domains/api/rate-limit.ts
@@ -7,11 +7,8 @@
  * Forwarding headers are ignored unless TRUSTED_PROXY_HOPS is configured;
  * see getClientIp() below for the two resolution modes.
  */
-import {
-  bucketRetryAfter,
-  incrementBucket,
-  type RateBucketSpec,
-} from '@/lib/server/utils/rate-bucket'
+import { bucketRetryAfter, incrementBuckets } from '@/lib/server/utils/rate-bucket'
+import { API_MONTH_BUCKET_KEY, secondsUntilNextUtcMonth } from './monthly-usage'
 import { isIP } from 'node:net'
 import { config } from '@/lib/server/config'
 import { getRequestIP } from '@tanstack/react-start/server'
@@ -53,14 +50,17 @@ export async function checkRateLimit(
   const baseLimit = limits.apiRequestsPerMinute ?? MAX_REQUESTS
   const maxRequests = importMode ? Math.max(baseLimit * 20, IMPORT_MIN) : baseLimit
 
-  const spec: RateBucketSpec = { key: rateLimitKey(ip), windowSeconds: WINDOW_SECONDS }
-  const { count } = await incrementBucket(spec)
+  const minute = { key: rateLimitKey(ip), windowSeconds: WINDOW_SECONDS }
+  const [count] = await incrementBuckets([
+    minute,
+    { key: API_MONTH_BUCKET_KEY, windowSeconds: secondsUntilNextUtcMonth() },
+  ])
 
   // Redis error → fail open.
   if (count === null) return { allowed: true, remaining: maxRequests }
 
   if (count > maxRequests) {
-    return { allowed: false, remaining: 0, retryAfter: await bucketRetryAfter(spec) }
+    return { allowed: false, remaining: 0, retryAfter: await bucketRetryAfter(minute) }
   }
 
   return { allowed: true, remaining: Math.max(0, maxRequests - count) }

--- a/apps/web/src/lib/server/functions/billing.ts
+++ b/apps/web/src/lib/server/functions/billing.ts
@@ -51,29 +51,40 @@ async function loadUsageCounts(): Promise<Record<string, number>> {
     await import('@/lib/server/db')
   const { countSeatUsage } = await import('@/lib/server/domains/principals/seat-usage')
   const { emailsSentThisMonth } = await import('@/lib/server/email/email-budget')
-  const [boardRow, postRow, seats, statusRow, roleRow, domainRow, aiTokens, emailsSent] =
-    await Promise.all([
-      db
-        .select({ count: sql<number>`count(*)::int` })
-        .from(boards)
-        .where(isNull(boards.deletedAt)),
-      db
-        .select({ count: sql<number>`count(*)::int` })
-        .from(posts)
-        .where(isNull(posts.deletedAt)),
-      countSeatUsage(),
-      db
-        .select({ count: sql<number>`count(*)::int` })
-        .from(statusComponents)
-        .where(isNull(statusComponents.deletedAt)),
-      db
-        .select({ count: sql<number>`count(*)::int` })
-        .from(roles)
-        .where(eq(roles.isSystem, false)),
-      db.select({ count: sql<number>`count(*)::int` }).from(emailSendingDomains),
-      aiTokensThisMonth(),
-      emailsSentThisMonth(),
-    ])
+  const { apiRequestsThisMonth } = await import('@/lib/server/domains/api/monthly-usage')
+  const [
+    boardRow,
+    postRow,
+    seats,
+    statusRow,
+    roleRow,
+    domainRow,
+    aiTokens,
+    emailsSent,
+    apiRequests,
+  ] = await Promise.all([
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(boards)
+      .where(isNull(boards.deletedAt)),
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(posts)
+      .where(isNull(posts.deletedAt)),
+    countSeatUsage(),
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(statusComponents)
+      .where(isNull(statusComponents.deletedAt)),
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(roles)
+      .where(eq(roles.isSystem, false)),
+    db.select({ count: sql<number>`count(*)::int` }).from(emailSendingDomains),
+    aiTokensThisMonth(),
+    emailsSentThisMonth(),
+    apiRequestsThisMonth(),
+  ])
   return {
     maxBoards: boardRow[0]?.count ?? 0,
     maxPosts: postRow[0]?.count ?? 0,
@@ -83,6 +94,7 @@ async function loadUsageCounts(): Promise<Record<string, number>> {
     maxSendingDomains: domainRow[0]?.count ?? 0,
     aiTokensPerMonth: aiTokens,
     emailsPerMonth: emailsSent,
+    apiRequestsPerMonth: apiRequests,
   }
 }
 
@@ -129,6 +141,12 @@ export const fetchPlanUsageFn = createServerFn({ method: 'GET' }).handler(async 
       label: 'emails',
       used: used.emailsPerMonth ?? 0,
       limit: limits.emailsPerMonth,
+    },
+    {
+      key: 'apiRequestsPerMonth',
+      label: 'API requests',
+      used: used.apiRequestsPerMonth ?? 0,
+      limit: limits.apiRequestsPerMonth,
     },
   ])
 })

--- a/apps/web/src/lib/server/kv/pg-kv.ts
+++ b/apps/web/src/lib/server/kv/pg-kv.ts
@@ -297,6 +297,16 @@ export async function incrementRateBuckets(
   })
 }
 
+/** Live count for a window that has not expired. Missing or expired is 0. */
+export async function rateBucketCount(key: string): Promise<number> {
+  const result = await db.execute(sql`
+    SELECT count FROM rate_bucket
+    WHERE workspace_key = ${currentWorkspaceNamespace()} AND key = ${key} AND window_expires_at > now()
+  `)
+  const rows = getExecuteRows<{ count: number }>(result)
+  return Number(rows[0]?.count ?? 0)
+}
+
 /** TTL. Falls back to the window size when the bucket is absent or expired. */
 export async function rateBucketRetryAfter(spec: BucketIncrement): Promise<number> {
   const result = await db.execute(sql`

--- a/apps/web/src/lib/server/utils/__tests__/rate-bucket.test.ts
+++ b/apps/web/src/lib/server/utils/__tests__/rate-bucket.test.ts
@@ -15,15 +15,18 @@ const hoisted = vi.hoisted(() => ({
   one: vi.fn(),
   many: vi.fn(),
   retry: vi.fn(),
+  count: vi.fn(),
 }))
 
 vi.mock('@/lib/server/kv/pg-kv', () => ({
   incrementRateBucket: hoisted.one,
   incrementRateBuckets: hoisted.many,
   rateBucketRetryAfter: hoisted.retry,
+  rateBucketCount: hoisted.count,
 }))
 
-const { incrementBucket, incrementBuckets, bucketRetryAfter } = await import('../rate-bucket')
+const { incrementBucket, incrementBuckets, bucketRetryAfter, getBucketCount } =
+  await import('../rate-bucket')
 
 beforeEach(() => vi.clearAllMocks())
 
@@ -67,6 +70,19 @@ describe('incrementBuckets', () => {
         { key: 'b', windowSeconds: 60 },
       ])
     ).toEqual([null, null])
+  })
+})
+
+describe('getBucketCount', () => {
+  it('returns the live count', async () => {
+    hoisted.count.mockResolvedValueOnce(12)
+    expect(await getBucketCount('api:month')).toBe(12)
+    expect(hoisted.count).toHaveBeenCalledWith('api:month')
+  })
+
+  it('treats a store error as zero', async () => {
+    hoisted.count.mockRejectedValueOnce(new Error('database unreachable'))
+    expect(await getBucketCount('api:month')).toBe(0)
   })
 })
 

--- a/apps/web/src/lib/server/utils/rate-bucket.ts
+++ b/apps/web/src/lib/server/utils/rate-bucket.ts
@@ -25,6 +25,7 @@
 import {
   incrementRateBucket,
   incrementRateBuckets,
+  rateBucketCount,
   rateBucketRetryAfter,
 } from '@/lib/server/kv/pg-kv'
 import { logger } from '@/lib/server/logger'
@@ -83,5 +84,15 @@ export async function bucketRetryAfter(spec: RateBucketSpec): Promise<number> {
     return await rateBucketRetryAfter(spec)
   } catch {
     return spec.windowSeconds
+  }
+}
+
+/** Live count, or 0 when the bucket is missing, expired, or the store errors. */
+export async function getBucketCount(key: string): Promise<number> {
+  try {
+    return await rateBucketCount(key)
+  } catch (error) {
+    log.error({ err: error, key }, 'bucket count failed, treating as zero')
+    return 0
   }
 }

--- a/apps/web/src/routes/admin/settings.billing.tsx
+++ b/apps/web/src/routes/admin/settings.billing.tsx
@@ -51,6 +51,7 @@ export const Route = createFileRoute('/admin/settings/billing')({
       context.queryClient.ensureQueryData(billingQueries.overview()),
       context.queryClient.ensureQueryData(billingQueries.catalogue()).catch(() => null),
       context.queryClient.ensureQueryData(billingQueries.invoices()).catch(() => null),
+      context.queryClient.ensureQueryData(billingQueries.usage()).catch(() => []),
     ])
     return {}
   },


### PR DESCRIPTION
## Summary
The billing Usage card only rendered AI. Emails stay hidden when unlimited (all current cloud plans). Paid plans also cap API requests plus inventory like status components, custom roles, and sending domains.

This counts monthly REST API requests on the existing rate-limit path and renders every finite meter the current subscription actually has. Seats stay on the current-plan card.

## Test plan
- [ ] Open Plans & billing on a Pro workspace
- [ ] Confirm Usage shows AI, API requests, status components, custom roles, and sending domains
- [ ] Confirm seats are not duplicated in Usage
- [ ] Confirm Emails stays hidden while unlimited