### PR TITLE
feat(email): let self-hosters brand transactional emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,12 @@ EMAIL_SES_REGION=
 # Format (no quotes): Your App <noreply@yourdomain.com>
 EMAIL_FROM=
 
+# Product name shown inside transactional emails — the sign-in, invite, welcome,
+# and password-reset subjects and headings. Defaults to "Quackback". Set this if
+# you run under your own brand so those emails say your name, not ours. This is
+# the product name, separate from each workspace's own name.
+# EMAIL_BRAND_NAME=Your App
+
 # ============================================================================
 # Inbound email (optional) — conversation email channel
 # ============================================================================

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -52,6 +52,9 @@ EMAIL_SMTP_PORT=587
 EMAIL_SMTP_USER=
 EMAIL_SMTP_PASS=
 EMAIL_FROM=Quackback <noreply@example.com>
+# Product name shown inside transactional emails (subjects and headings).
+# Defaults to "Quackback"; set it to run those emails under your own brand.
+# EMAIL_BRAND_NAME=Quackback
 # Or use the Amazon SES API instead of SMTP. All three are required: the
 # region is the one the sending identity is verified in, and there is no
 # default because a verified identity is regional.

--- a/packages/email/src/__tests__/email-brand-name.test.ts
+++ b/packages/email/src/__tests__/email-brand-name.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@react-email/components'
+import { WelcomeEmail } from '../templates/welcome'
+import { InvitationEmail } from '../templates/invitation'
+import { MagicLinkEmail } from '../templates/magic-link'
+import { PasswordResetEmail } from '../templates/password-reset'
+
+const BRAND = 'Acme Feedback'
+
+// React Email emits an empty comment between static text and an interpolated
+// expression (`Sign in to {brandName}` → `Sign in to <!-- -->Acme Feedback`).
+// Drop it so a heading reads as the plain phrase a recipient sees. This does not
+// touch the "Powered by Quackback" footer, which is the separate attribution
+// link and is expected to stay regardless of the brand name.
+const phrases = (html: string) => html.replace(/<!-- -->/g, '')
+
+describe('templates speak in the configured brand name', () => {
+  it('WelcomeEmail uses the brand in the heading and sign-off', async () => {
+    const html = phrases(
+      await render(
+        WelcomeEmail({
+          name: 'Alice',
+          workspaceName: 'Acme',
+          dashboardUrl: 'https://example.com/dashboard',
+          brandName: BRAND,
+        })
+      )
+    )
+    expect(html).toContain(`Welcome to ${BRAND}!`)
+    expect(html).toContain(`The ${BRAND} Team`)
+    expect(html).not.toContain('Welcome to Quackback!')
+    expect(html).not.toContain('The Quackback Team')
+  })
+
+  it('InvitationEmail names the brand alongside the workspace', async () => {
+    const html = phrases(
+      await render(
+        InvitationEmail({
+          invitedByName: 'Bob',
+          organizationName: 'Acme',
+          inviteLink: 'https://example.com/invite',
+          brandName: BRAND,
+        })
+      )
+    )
+    // Both halves stay distinct: the workspace is Acme, the product is the brand.
+    expect(html).toContain('Acme')
+    expect(html).toContain(`on ${BRAND}.`)
+  })
+
+  it('MagicLinkEmail uses the brand in the heading', async () => {
+    const html = phrases(
+      await render(
+        MagicLinkEmail({
+          signInUrl: 'https://example.com/verify-magic-link?token=abc',
+          code: '123456',
+          brandName: BRAND,
+        })
+      )
+    )
+    expect(html).toContain(`Sign in to ${BRAND}`)
+    expect(html).not.toContain('Sign in to Quackback')
+  })
+
+  it('PasswordResetEmail uses the brand in the preview', async () => {
+    const html = phrases(
+      await render(PasswordResetEmail({ resetLink: 'https://example.com/reset', brandName: BRAND }))
+    )
+    expect(html).toContain(`Reset your ${BRAND} password`)
+    expect(html).not.toContain('Reset your Quackback password')
+  })
+})
+
+describe('templates default to Quackback when no brand is set', () => {
+  it('WelcomeEmail falls back to Quackback', async () => {
+    const html = phrases(
+      await render(
+        WelcomeEmail({
+          name: 'Alice',
+          workspaceName: 'Acme',
+          dashboardUrl: 'https://example.com/dashboard',
+        })
+      )
+    )
+    expect(html).toContain('Welcome to Quackback!')
+    expect(html).toContain('The Quackback Team')
+  })
+
+  it('MagicLinkEmail falls back to Quackback', async () => {
+    const html = phrases(
+      await render(
+        MagicLinkEmail({
+          signInUrl: 'https://example.com/verify-magic-link?token=abc',
+          code: '123456',
+        })
+      )
+    )
+    expect(html).toContain('Sign in to Quackback')
+  })
+
+  it('PasswordResetEmail falls back to Quackback', async () => {
+    const html = phrases(
+      await render(PasswordResetEmail({ resetLink: 'https://example.com/reset' }))
+    )
+    expect(html).toContain('Reset your Quackback password')
+  })
+})

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -72,6 +72,21 @@ function getEnv(key: string): string | undefined {
 }
 
 /**
+ * The product name that transactional subjects and headings speak in.
+ *
+ * Defaults to Quackback, which is what the hosted service and every existing
+ * install already say. A self-hoster running under their own brand sets
+ * `EMAIL_BRAND_NAME` once, and the sign-in, invite, welcome, and reset mails
+ * then carry that name instead — the inbox being the one surface that in-app
+ * theming, a custom logo, and a custom domain never reach. This is the product
+ * name, not the per-workspace name: `workspaceName` still names the board the
+ * mail is about, so "join Acme on Quackback" keeps both halves distinct.
+ */
+function productName(): string {
+  return getEnv('EMAIL_BRAND_NAME') || 'Quackback'
+}
+
+/**
  * A send refused because the install is not configured for it.
  *
  * Declares itself permanent for the same reason the transport's own errors do.
@@ -560,13 +575,14 @@ export async function sendInvitationEmail(params: SendInvitationParams): Promise
 
   return sendEmail({
     to,
-    subject: `You've been invited to join ${workspaceName} on Quackback`,
+    subject: `You've been invited to join ${workspaceName} on ${productName()}`,
     react: InvitationEmail({
       invitedByName,
       inviteeName,
       organizationName: workspaceName,
       inviteLink,
       logoUrl,
+      brandName: productName(),
     }),
     emailType: 'InvitationEmail',
     preview: { inviteLink },
@@ -614,8 +630,8 @@ export async function sendWelcomeEmail(params: SendWelcomeParams): Promise<Email
 
   return sendEmail({
     to,
-    subject: `Welcome to ${workspaceName} on Quackback!`,
-    react: WelcomeEmail({ name, workspaceName, dashboardUrl, logoUrl }),
+    subject: `Welcome to ${workspaceName} on ${productName()}!`,
+    react: WelcomeEmail({ name, workspaceName, dashboardUrl, logoUrl, brandName: productName() }),
     emailType: 'WelcomeEmail',
     preview: { dashboardUrl },
   })
@@ -638,8 +654,8 @@ export async function sendMagicLinkEmail(params: SendMagicLinkParams): Promise<E
   log.debug('sending sign-in email')
   return sendEmail({
     to,
-    subject: 'Your Quackback sign-in link',
-    react: MagicLinkEmail({ signInUrl, code, logoUrl }),
+    subject: `Your ${productName()} sign-in link`,
+    react: MagicLinkEmail({ signInUrl, code, logoUrl, brandName: productName() }),
     emailType: 'MagicLinkEmail',
     preview: { signInUrl, code },
   })
@@ -674,7 +690,7 @@ export async function sendSignupNotAllowedEmail(
   log.debug('sending sign-in refusal email')
   return sendEmail({
     to,
-    subject: 'About your Quackback sign-in request',
+    subject: `About your ${productName()} sign-in request`,
     react: SignupNotAllowedEmail({ workspaceName, logoUrl }),
     emailType: 'SignupNotAllowedEmail',
   })
@@ -698,8 +714,8 @@ export async function sendPasswordResetEmail(
   log.debug('sending password reset email')
   return sendEmail({
     to,
-    subject: 'Reset your Quackback password',
-    react: PasswordResetEmail({ resetLink, logoUrl }),
+    subject: `Reset your ${productName()} password`,
+    react: PasswordResetEmail({ resetLink, logoUrl, brandName: productName() }),
     emailType: 'PasswordResetEmail',
     preview: { resetLink },
   })

--- a/packages/email/src/templates/invitation.tsx
+++ b/packages/email/src/templates/invitation.tsx
@@ -8,6 +8,7 @@ interface InvitationEmailProps {
   organizationName: string
   inviteLink: string
   logoUrl?: string
+  brandName?: string
 }
 
 export function InvitationEmail({
@@ -16,10 +17,11 @@ export function InvitationEmail({
   organizationName,
   inviteLink,
   logoUrl,
+  brandName = 'Quackback',
 }: InvitationEmailProps) {
   return (
     <EmailLayout
-      preview={`Join ${organizationName} on Quackback`}
+      preview={`Join ${organizationName} on ${brandName}`}
       logoUrl={logoUrl}
       logoAlt={organizationName}
     >
@@ -29,7 +31,7 @@ export function InvitationEmail({
       </Heading>
       <Text style={typography.text}>
         <strong>{invitedByName}</strong> has invited you to join <strong>{organizationName}</strong>{' '}
-        on Quackback.
+        on {brandName}.
       </Text>
 
       {/* CTA Button */}

--- a/packages/email/src/templates/magic-link.tsx
+++ b/packages/email/src/templates/magic-link.tsx
@@ -6,6 +6,7 @@ interface MagicLinkEmailProps {
   signInUrl: string
   code: string
   logoUrl?: string
+  brandName?: string
 }
 
 /**
@@ -17,10 +18,15 @@ interface MagicLinkEmailProps {
  * verification record on the server, so the user can pick whichever is
  * convenient.
  */
-export function MagicLinkEmail({ signInUrl, code, logoUrl }: MagicLinkEmailProps) {
+export function MagicLinkEmail({
+  signInUrl,
+  code,
+  logoUrl,
+  brandName = 'Quackback',
+}: MagicLinkEmailProps) {
   return (
-    <EmailLayout preview="Your sign-in link" logoUrl={logoUrl}>
-      <Heading style={{ ...typography.h1, textAlign: 'center' }}>Sign in to Quackback</Heading>
+    <EmailLayout preview="Your sign-in link" logoUrl={logoUrl} logoAlt={brandName}>
+      <Heading style={{ ...typography.h1, textAlign: 'center' }}>Sign in to {brandName}</Heading>
       <Text style={{ ...typography.text, textAlign: 'center' }}>
         Click the button below to finish signing in.
       </Text>

--- a/packages/email/src/templates/password-reset.tsx
+++ b/packages/email/src/templates/password-reset.tsx
@@ -5,11 +5,16 @@ import { typography, button, utils } from './shared-styles'
 interface PasswordResetEmailProps {
   resetLink: string
   logoUrl?: string
+  brandName?: string
 }
 
-export function PasswordResetEmail({ resetLink, logoUrl }: PasswordResetEmailProps) {
+export function PasswordResetEmail({
+  resetLink,
+  logoUrl,
+  brandName = 'Quackback',
+}: PasswordResetEmailProps) {
   return (
-    <EmailLayout preview="Reset your Quackback password" logoUrl={logoUrl}>
+    <EmailLayout preview={`Reset your ${brandName} password`} logoUrl={logoUrl} logoAlt={brandName}>
       {/* Content */}
       <Heading style={{ ...typography.h1, textAlign: 'center' }}>Reset your password</Heading>
       <Text style={{ ...typography.text, textAlign: 'center' }}>

--- a/packages/email/src/templates/welcome.tsx
+++ b/packages/email/src/templates/welcome.tsx
@@ -7,17 +7,24 @@ interface WelcomeEmailProps {
   workspaceName: string
   dashboardUrl: string
   logoUrl?: string
+  brandName?: string
 }
 
-export function WelcomeEmail({ name, workspaceName, dashboardUrl, logoUrl }: WelcomeEmailProps) {
+export function WelcomeEmail({
+  name,
+  workspaceName,
+  dashboardUrl,
+  logoUrl,
+  brandName = 'Quackback',
+}: WelcomeEmailProps) {
   return (
     <EmailLayout
-      preview={`Welcome to ${workspaceName} on Quackback`}
+      preview={`Welcome to ${workspaceName} on ${brandName}`}
       logoUrl={logoUrl}
       logoAlt={workspaceName}
     >
       {/* Content */}
-      <Heading style={typography.h1}>Welcome to Quackback!</Heading>
+      <Heading style={typography.h1}>Welcome to {brandName}!</Heading>
       <Text style={typography.text}>
         Hi {name}, your workspace <strong>{workspaceName}</strong> is ready. Start collecting and
         managing customer feedback today.
@@ -53,7 +60,7 @@ export function WelcomeEmail({ name, workspaceName, dashboardUrl, logoUrl }: Wel
       <TransactionalFooter>
         Happy collecting!
         <br />
-        The Quackback Team
+        The {brandName} Team
       </TransactionalFooter>
     </EmailLayout>
   )


### PR DESCRIPTION
Fixes #444.

Most of Quackback white-labels fine already: workspace name, logo, colors, custom domain. The transactional emails were the gap. A handful of them hardcode "Quackback" in the subject and the heading, so an install running under its own brand still sends sign-in and password-reset mail that names the platform in the recipient's inbox, the one surface none of the in-app theming reaches.

The notification emails (status change, new comment, changelog) already read the workspace name and were fine. This only touches the auth and onboarding set.

### What changed

A new `EMAIL_BRAND_NAME` env var, defaulting to `"Quackback"`. When set, it replaces the hardcoded product name in:

- Subjects: sign-in link, sign-in refusal, password reset, invitation, welcome
- Headings and body: "Sign in to X", "Welcome to X!", "The X Team", "Reset your X password", "invited to join Acme on X"

It's passed as a `brandName` prop into the templates (default `"Quackback"`), so the components stay self-contained and existing installs render exactly as before.

I kept it separate from `workspaceName` on purpose. `workspaceName` is the board the mail is about; the brand name is the product it's sent from. Keeping them distinct means "join Acme on Quackback" still reads right instead of collapsing to "join Acme on Acme".

I left the "Powered by Quackback" footer alone, since that's the existing attribution link with its own toggle and seemed out of scope here.

### On the config surface

I went with an env var because the email package is already env-configured (EMAIL_FROM, SMTP, SES), and it keeps the change contained with no call-site changes. If you'd rather source the name from `settings` so it can be set in the admin UI, I'm glad to switch it over. Just say so.

### Testing

- New `email-brand-name.test.ts` covering the custom brand and the "Quackback" default for each affected template
- Full email package suite passes (184 tests), including the existing logo and signup tests
- `prettier`, `oxlint`, and the email package `tsc --noEmit` are clean

Documented the var in `.env.example` and `.env.prod.example`.
