### PR TITLE
feat(widget): preview the launcher stack and report SDK version

### DIFF
--- a/apps/web/src/components/admin/settings/widget/__tests__/widget-last-detected.test.tsx
+++ b/apps/web/src/components/admin/settings/widget/__tests__/widget-last-detected.test.tsx
@@ -1,0 +1,17 @@
+// @vitest-environment happy-dom
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { WidgetLastDetected } from '../widget-last-detected'
+
+describe('WidgetLastDetected', () => {
+  it('renders nothing without a date', () => {
+    const { container } = render(<WidgetLastDetected at={null} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders a relative last-detected time', () => {
+    render(<WidgetLastDetected at={new Date().toISOString()} />)
+    expect(screen.getByText(/Last detected/)).toBeInTheDocument()
+    expect(screen.getByText(/ago/)).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/admin/settings/widget/__tests__/widget-preview.test.tsx
+++ b/apps/web/src/components/admin/settings/widget/__tests__/widget-preview.test.tsx
@@ -7,6 +7,8 @@
  * the host chrome the SDK provides on a customer page:
  *   - The iframe targets /widget with the selected theme forced via ?theme=.
  *   - The launcher button toggles the panel open/closed.
+ *   - Panel and launcher share a bottom corner (panel above, button below).
+ *   - An optional greeting bubble sits above the closed launcher.
  *   - The widget's own close button messages its host (quackback:close);
  *     the preview honours it like the SDK would, but only from its own origin.
  */
@@ -29,7 +31,7 @@ describe('WidgetPreview', () => {
   it('toggles the panel via the launcher button', () => {
     render(<WidgetPreview position="bottom-right" />)
 
-    const launcher = screen.getByRole('button')
+    const launcher = screen.getByRole('button', { name: /feedback widget/i })
     fireEvent.click(launcher)
     expect(screen.queryByTitle('Widget preview')).toBeNull()
 
@@ -54,6 +56,45 @@ describe('WidgetPreview', () => {
   it('places the launcher on the configured side', () => {
     render(<WidgetPreview position="bottom-left" />)
 
-    expect(screen.getByRole('button').className).toContain('left-4')
+    expect(screen.getByRole('button', { name: /feedback widget/i }).className).toContain('left-6')
+  })
+
+  it('stacks the open panel above the launcher in the same corner', () => {
+    render(<WidgetPreview position="bottom-right" />)
+
+    const panel = screen.getByTitle('Widget preview').parentElement
+    const launcher = screen.getByRole('button', { name: /feedback widget/i })
+    expect(panel?.className).toContain('bottom-[88px]')
+    expect(panel?.className).toContain('right-6')
+    expect(launcher.className).toContain('bottom-6')
+    expect(launcher.className).toContain('right-6')
+  })
+
+  it('shows the launcher greeting bubble while the panel is closed', () => {
+    render(<WidgetPreview position="bottom-right" greeting="Need a hand?" />)
+
+    expect(screen.queryByText('Need a hand?')).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: /feedback widget/i }))
+    expect(screen.getByText('Need a hand?')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss greeting' }))
+    expect(screen.queryByText('Need a hand?')).toBeNull()
+  })
+
+  it('opens the panel when the greeting bubble is clicked', () => {
+    render(<WidgetPreview position="bottom-right" greeting="Hi there" />)
+
+    fireEvent.click(screen.getByRole('button', { name: /feedback widget/i }))
+    expect(screen.queryByTitle('Widget preview')).toBeNull()
+
+    fireEvent.click(screen.getByText('Hi there'))
+    expect(screen.getByTitle('Widget preview')).toBeTruthy()
+    expect(screen.queryByText('Hi there')).toBeNull()
+  })
+
+  it('places the greeting bubble on the same side as the launcher', () => {
+    render(<WidgetPreview position="bottom-left" greeting="Hello" />)
+
+    fireEvent.click(screen.getByRole('button', { name: /feedback widget/i }))
+    expect(screen.getByText('Hello').parentElement?.className).toContain('left-6')
   })
 })

--- a/apps/web/src/components/admin/settings/widget/widget-last-detected.tsx
+++ b/apps/web/src/components/admin/settings/widget/widget-last-detected.tsx
@@ -1,0 +1,13 @@
+import { TimeAgo } from '@/components/ui/time-ago'
+
+/** Relative “Last detected …” line for the widget install ping. */
+export function WidgetLastDetected({ at }: { at?: string | null }) {
+  if (!at) return null
+  const parsed = new Date(at)
+  if (Number.isNaN(parsed.getTime())) return null
+  return (
+    <p className="text-xs text-muted-foreground" title={parsed.toLocaleString()}>
+      Last detected <TimeAgo date={at} />
+    </p>
+  )
+}

--- a/apps/web/src/components/admin/settings/widget/widget-preview.tsx
+++ b/apps/web/src/components/admin/settings/widget/widget-preview.tsx
@@ -6,6 +6,8 @@ interface WidgetPreviewProps {
   position: 'bottom-right' | 'bottom-left'
   /** Launcher button label — the trigger renders as a pill when set. */
   label?: string
+  /** Proactive greeting bubble beside the launcher. Hidden when empty. */
+  greeting?: string
   /** Preview theme — forwarded to the widget iframe as a forced theme. */
   theme?: 'light' | 'dark'
   /**
@@ -25,10 +27,22 @@ interface WidgetPreviewProps {
 export function WidgetPreview({
   position,
   label,
+  greeting,
   theme = 'light',
   refreshKey,
 }: WidgetPreviewProps) {
   const [isOpen, setIsOpen] = useState(true)
+  const [greetingDismissed, setGreetingDismissed] = useState(false)
+  const greetingText = greeting?.trim() || ''
+  const onRight = position !== 'bottom-left'
+  // Same corner stack as the SDK: greeting sits above the launcher, and the
+  // open panel covers that corner so the bubble hides.
+  const showGreeting = greetingText.length > 0 && !greetingDismissed && !isOpen
+  const corner = onRight ? 'right-6' : 'left-6'
+
+  useEffect(() => {
+    setGreetingDismissed(false)
+  }, [greetingText])
 
   // The widget's in-panel close button messages its host (the SDK on a real
   // page); here the preview is the host, so honour it the same way.
@@ -44,14 +58,21 @@ export function WidgetPreview({
 
   return (
     <div className={cn('h-full', theme === 'dark' && 'dark')}>
-      <div className="relative flex h-full min-h-[560px] items-center justify-center rounded-xl border border-border bg-muted/30 overflow-hidden text-foreground">
+      <div className="relative h-full min-h-[560px] rounded-xl border border-border bg-muted/30 overflow-hidden text-foreground">
         {/* Simulated page background */}
         <PageBackdrop />
 
-        {/* Widget panel — centered in the pane so it never feels cramped.
-            Sized like the SDK's panel (400px wide, 600px tall). */}
+        {/* Widget panel — same corner as the launcher, sitting just above it
+            (SDK: bottom 88px, side 24px, 400×600). */}
         {isOpen && (
-          <div className="relative z-10 w-[400px] max-w-[calc(100%-2rem)] h-[600px] max-h-[calc(100%-5rem)] rounded-2xl border border-border bg-background shadow-2xl overflow-hidden">
+          <div
+            className={cn(
+              'absolute z-10 w-[400px] max-w-[calc(100%-3rem)] h-[600px] max-h-[calc(100%-7rem)]',
+              'rounded-2xl border border-border bg-background shadow-2xl overflow-hidden',
+              'bottom-[88px]',
+              corner
+            )}
+          >
             <iframe
               key={refreshKey}
               src={`/widget?theme=${theme}`}
@@ -62,17 +83,46 @@ export function WidgetPreview({
           </div>
         )}
 
-        {/* Trigger button — mirrors the SDK launcher: icon-only circle, or an
-            icon+label pill when the workspace sets a button label. */}
+        {/* Greeting bubble — same corner, just above the launcher. Hidden
+            while the panel is open, matching the host-page SDK. */}
+        {showGreeting && (
+          <div
+            className={cn(
+              'absolute bottom-[84px] z-10 flex max-w-[220px] items-center gap-2 rounded-[14px] px-3 py-2.5',
+              'bg-white text-[13px] leading-snug text-zinc-900 shadow-lg',
+              corner
+            )}
+          >
+            <button
+              type="button"
+              className="min-w-0 flex-1 cursor-pointer text-start"
+              onClick={() => setIsOpen(true)}
+            >
+              {greetingText}
+            </button>
+            <button
+              type="button"
+              aria-label="Dismiss greeting"
+              onClick={() => setGreetingDismissed(true)}
+              className="flex size-[18px] shrink-0 items-center justify-center rounded-full text-base leading-none text-zinc-400 hover:text-zinc-600"
+            >
+              ×
+            </button>
+          </div>
+        )}
+
+        {/* Trigger button — bottom of the same corner, below the open panel. */}
         <button
           type="button"
+          aria-label={isOpen ? 'Close feedback widget' : 'Open feedback widget'}
+          aria-expanded={isOpen}
           onClick={() => setIsOpen(!isOpen)}
           className={cn(
-            'absolute bottom-4 flex items-center justify-center h-10 rounded-full',
+            'absolute bottom-6 z-20 flex items-center justify-center h-12 rounded-full',
             'bg-primary text-primary-foreground shadow-md',
             'transition-all hover:shadow-lg hover:-translate-y-0.5',
-            label ? 'gap-1.5 ps-2.5 pe-3.5 text-xs font-semibold' : 'w-10',
-            position === 'bottom-left' ? 'left-4' : 'right-4'
+            label ? 'gap-1.5 ps-3 pe-4 text-xs font-semibold' : 'w-12',
+            corner
           )}
         >
           <ChatBubbleOvalLeftEllipsisIcon className="w-5 h-5 shrink-0" />

--- a/apps/web/src/lib/server/domains/settings/__tests__/widget-observation-write.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/widget-observation-write.test.ts
@@ -38,11 +38,14 @@ vi.mock('@/lib/server/storage/s3', () => ({
 
 const { observeExternalWidgetRequest } = await import('../settings.widget')
 
-function requestWithOrigin(origin: string): Request {
+function requestWithOrigin(
+  origin: string,
+  url = 'https://app.quackback.test/api/widget/config.json'
+): Request {
   // happy-dom drops `origin` from init headers (forbidden-header list); set it
   // after construction to emulate the browser-set header — see
   // widget-observation.test.ts.
-  const req = new Request('https://app.quackback.test/api/widget/config.json')
+  const req = new Request(url)
   req.headers.set('origin', origin)
   return req
 }
@@ -67,6 +70,7 @@ describe('observeExternalWidgetRequest writes', () => {
         widgetInstalledLastSeenAt: now,
         widgetInstalledOriginHost: 'customer.example',
         widgetInstalledFirstSeenAt: expect.anything(),
+        widgetInstalledSdkVersion: null,
       })
     )
     expect(hoisted.invalidate).not.toHaveBeenCalled()
@@ -79,6 +83,30 @@ describe('observeExternalWidgetRequest writes', () => {
     expect(observed).toBe(false)
     expect(hoisted.findSettings).not.toHaveBeenCalled()
     expect(hoisted.updateSettings).not.toHaveBeenCalled()
+  })
+
+  it('stores the sdk query param from a config.json ping', async () => {
+    await observeExternalWidgetRequest(
+      requestWithOrigin(
+        'https://customer.example',
+        'https://app.quackback.test/api/widget/config.json?sdk=0.1.5'
+      ),
+      new Date('2026-07-13T12:00:00.000Z')
+    )
+    expect(hoisted.setValues).toHaveBeenCalledWith(
+      expect.objectContaining({ widgetInstalledSdkVersion: '0.1.5' })
+    )
+  })
+
+  it('records the instance SDK version for a script-tag sdk.js fetch', async () => {
+    const req = new Request('https://app.quackback.test/api/widget/sdk.js')
+    req.headers.set('origin', 'https://customer.example')
+    await observeExternalWidgetRequest(req, new Date('2026-07-13T12:00:00.000Z'))
+    expect(hoisted.setValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        widgetInstalledSdkVersion: expect.stringMatching(/^\d+\.\d+\.\d+/),
+      })
+    )
   })
 
   it('reports a throttled no-op when the conditional update changes no row', async () => {

--- a/apps/web/src/lib/server/domains/settings/settings.widget.ts
+++ b/apps/web/src/lib/server/domains/settings/settings.widget.ts
@@ -1,5 +1,9 @@
 import { randomBytes } from 'crypto'
 import { db, and, eq, lte, or, isNull, sql, settings } from '@/lib/server/db'
+import {
+  CURRENT_WIDGET_SDK_VERSION,
+  sdkVersionFromWidgetRequest,
+} from '@/lib/shared/widget/sdk-version'
 import { logger } from '@/lib/server/logger'
 import { absolutizeOffHostAssetUrl } from '@/lib/server/storage/asset-url'
 import { deleteObject, getPublicUrlOrNull } from '@/lib/server/storage/s3'
@@ -93,6 +97,7 @@ export async function observeExternalWidgetRequest(
   const org = await db.query.settings.findFirst({ columns: { id: true } })
   if (!org) return false
 
+  const sdkVersion = sdkVersionFromWidgetRequest(request, CURRENT_WIDGET_SDK_VERSION)
   const staleBefore = new Date(now.getTime() - WIDGET_OBSERVATION_THROTTLE_MS)
   const updated = await db
     .update(settings)
@@ -100,6 +105,7 @@ export async function observeExternalWidgetRequest(
       widgetInstalledFirstSeenAt: sql`coalesce(${settings.widgetInstalledFirstSeenAt}, now())`,
       widgetInstalledLastSeenAt: now,
       widgetInstalledOriginHost: hostname,
+      widgetInstalledSdkVersion: sdkVersion,
     })
     .where(
       and(
@@ -107,7 +113,10 @@ export async function observeExternalWidgetRequest(
         or(
           isNull(settings.widgetInstalledFirstSeenAt),
           isNull(settings.widgetInstalledLastSeenAt),
-          lte(settings.widgetInstalledLastSeenAt, staleBefore)
+          lte(settings.widgetInstalledLastSeenAt, staleBefore),
+          // A newly reported (or newly missing) version is recorded immediately
+          // so the admin "SDK update" hint does not wait out the 15-minute throttle.
+          sql`${settings.widgetInstalledSdkVersion} is distinct from ${sdkVersion}`
         )
       )
     )

--- a/apps/web/src/lib/server/functions/admin.ts
+++ b/apps/web/src/lib/server/functions/admin.ts
@@ -31,6 +31,7 @@ import {
 } from '@/lib/server/domains/principals/bootstrap-admin'
 import { isAdmin } from '@/lib/shared/roles'
 import { PERMISSIONS } from '@/lib/shared/permissions'
+import { CURRENT_WIDGET_SDK_VERSION, widgetSdkNeedsUpdate } from '@/lib/shared/widget/sdk-version'
 import { listInboxPosts } from '@/lib/server/domains/posts/post.inbox'
 import { listPostTags } from '@/lib/server/domains/post-tags/post-tag.service'
 import { listStatuses } from '@/lib/server/domains/statuses/status.service'
@@ -423,6 +424,14 @@ export const fetchOnboardingStatus = createServerFn({ method: 'GET' }).handler(a
     hasBranding,
     hasWidgetInstalled: Boolean(orgSettings?.widgetInstalledFirstSeenAt),
     widgetOriginHost: orgSettings?.widgetInstalledOriginHost ?? null,
+    widgetLastDetectedAt: orgSettings?.widgetInstalledLastSeenAt
+      ? orgSettings.widgetInstalledLastSeenAt.toISOString()
+      : null,
+    widgetSdkVersion: orgSettings?.widgetInstalledSdkVersion ?? null,
+    currentWidgetSdkVersion: CURRENT_WIDGET_SDK_VERSION,
+    widgetSdkNeedsUpdate:
+      Boolean(orgSettings?.widgetInstalledFirstSeenAt) &&
+      widgetSdkNeedsUpdate(orgSettings?.widgetInstalledSdkVersion, CURRENT_WIDGET_SDK_VERSION),
     hasWidgetEnabled,
     hasMessengerEnabled,
     hasHelpArticle: Boolean(helpArticle),

--- a/apps/web/src/lib/shared/launch-checklist.ts
+++ b/apps/web/src/lib/shared/launch-checklist.ts
@@ -29,6 +29,10 @@ export interface LaunchStatus {
   hasBranding: boolean
   hasWidgetInstalled?: boolean
   widgetOriginHost?: string | null
+  widgetLastDetectedAt?: string | null
+  widgetSdkVersion?: string | null
+  currentWidgetSdkVersion?: string
+  widgetSdkNeedsUpdate?: boolean
   hasWidgetEnabled?: boolean
   hasMessengerEnabled?: boolean
   hasHelpArticle?: boolean

--- a/apps/web/src/lib/shared/widget/__tests__/sdk-version.test.ts
+++ b/apps/web/src/lib/shared/widget/__tests__/sdk-version.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { SDK_VERSION } from '../../../../../../../packages/widget/src/version'
+import {
+  CURRENT_WIDGET_SDK_VERSION,
+  parseWidgetSdkVersion,
+  sdkVersionFromWidgetRequest,
+  widgetConnectedStatusLabel,
+  widgetSdkNeedsUpdate,
+  widgetSdkUpdateDescription,
+} from '../sdk-version'
+
+function req(url: string): Request {
+  return new Request(url)
+}
+
+describe('parseWidgetSdkVersion', () => {
+  it('accepts core semver and drops junk', () => {
+    expect(parseWidgetSdkVersion('0.1.6')).toBe('0.1.6')
+    expect(parseWidgetSdkVersion(' 1.2.3-dev ')).toBe('1.2.3-dev')
+    expect(parseWidgetSdkVersion('')).toBeNull()
+    expect(parseWidgetSdkVersion('latest')).toBeNull()
+    expect(parseWidgetSdkVersion('0.1')).toBeNull()
+  })
+})
+
+describe('sdkVersionFromWidgetRequest', () => {
+  it('treats instance-served sdk.js as current', () => {
+    expect(sdkVersionFromWidgetRequest(req('https://app.example/api/widget/sdk.js'), '0.1.6')).toBe(
+      '0.1.6'
+    )
+  })
+
+  it('reads ?sdk= from the config.json ping', () => {
+    expect(
+      sdkVersionFromWidgetRequest(
+        req('https://app.example/api/widget/config.json?sdk=0.1.5'),
+        '0.1.6'
+      )
+    ).toBe('0.1.5')
+  })
+
+  it('treats a config.json ping without sdk as unknown', () => {
+    expect(
+      sdkVersionFromWidgetRequest(req('https://app.example/api/widget/config.json'), '0.1.6')
+    ).toBeNull()
+  })
+})
+
+describe('widgetSdkNeedsUpdate', () => {
+  it('flags missing and older versions', () => {
+    expect(widgetSdkNeedsUpdate(null, '0.1.6')).toBe(true)
+    expect(widgetSdkNeedsUpdate('0.1.5', '0.1.6')).toBe(true)
+    expect(widgetSdkNeedsUpdate('0.1.6', '0.1.6')).toBe(false)
+    expect(widgetSdkNeedsUpdate('0.2.0', '0.1.6')).toBe(false)
+  })
+})
+
+describe('copy', () => {
+  it('names the connected and update states', () => {
+    expect(widgetConnectedStatusLabel({})).toBe('Not detected yet')
+    expect(widgetConnectedStatusLabel({ hasWidgetInstalled: true })).toBe('Widget connected')
+    expect(
+      widgetConnectedStatusLabel({ hasWidgetInstalled: true, widgetSdkNeedsUpdate: true })
+    ).toBe('Widget connected · SDK update available')
+    expect(widgetSdkUpdateDescription('0.1.5', '0.1.6')).toBe(
+      'Installed SDK 0.1.5. Update your embed to 0.1.6.'
+    )
+  })
+
+  it('re-exports the widget package version', () => {
+    expect(CURRENT_WIDGET_SDK_VERSION).toBe(SDK_VERSION)
+  })
+})

--- a/apps/web/src/lib/shared/widget/sdk-version.ts
+++ b/apps/web/src/lib/shared/widget/sdk-version.ts
@@ -1,0 +1,72 @@
+import { SDK_VERSION } from '../../../../../../packages/widget/src/version'
+
+export { SDK_VERSION as CURRENT_WIDGET_SDK_VERSION }
+
+/** Loose semver: `1.2.3`, optional `-prerelease` / `+build`, max 32 chars. */
+const SDK_VERSION_RE = /^\d{1,3}\.\d{1,3}\.\d{1,3}(?:[-+][0-9A-Za-z.]+)?$/
+
+export function parseWidgetSdkVersion(raw: string | null | undefined): string | null {
+  if (typeof raw !== 'string') return null
+  const value = raw.trim()
+  if (!value || value.length > 32) return null
+  return SDK_VERSION_RE.test(value) ? value : null
+}
+
+/**
+ * Version to persist from an install ping.
+ *
+ * - `/api/widget/sdk.js` is served by this instance, so the embed is current.
+ * - `/api/widget/config.json?sdk=` is the npm/file SDK reporting its own version.
+ *   Missing/invalid `sdk` means a pre-0.1.6 client.
+ */
+export function sdkVersionFromWidgetRequest(request: Request, current: string): string | null {
+  let path = ''
+  let sdkParam: string | null = null
+  try {
+    const url = new URL(request.url)
+    path = url.pathname
+    sdkParam = url.searchParams.get('sdk')
+  } catch {
+    return null
+  }
+  if (path.endsWith('/sdk.js')) return current
+  return parseWidgetSdkVersion(sdkParam)
+}
+
+function coreParts(version: string): [number, number, number] | null {
+  const match = version.trim().match(/^(\d+)\.(\d+)\.(\d+)/)
+  if (!match) return null
+  return [Number(match[1]), Number(match[2]), Number(match[3])]
+}
+
+/** True when the embed is missing a version or older than this instance's SDK. */
+export function widgetSdkNeedsUpdate(
+  reported: string | null | undefined,
+  current: string
+): boolean {
+  if (!reported) return true
+  const installed = coreParts(reported)
+  const latest = coreParts(current)
+  if (!installed || !latest) return true
+  if (latest[0] !== installed[0]) return latest[0] > installed[0]
+  if (latest[1] !== installed[1]) return latest[1] > installed[1]
+  return latest[2] > installed[2]
+}
+
+export function widgetConnectedStatusLabel(opts: {
+  hasWidgetInstalled?: boolean
+  widgetSdkNeedsUpdate?: boolean
+}): string {
+  if (!opts.hasWidgetInstalled) return 'Not detected yet'
+  if (opts.widgetSdkNeedsUpdate) return 'Widget connected · SDK update available'
+  return 'Widget connected'
+}
+
+export function widgetSdkUpdateDescription(
+  installed: string | null | undefined,
+  current: string | undefined
+): string {
+  const reported = installed?.trim() || 'unknown'
+  const latest = current?.trim() || 'the latest SDK'
+  return `Installed SDK ${reported}. Update your embed to ${latest}.`
+}

--- a/apps/web/src/routes/admin/__tests__/settings.widget-modules.test.tsx
+++ b/apps/web/src/routes/admin/__tests__/settings.widget-modules.test.tsx
@@ -39,6 +39,8 @@ function renderModules(
       onPositionChange={vi.fn()}
       launcherLabel=""
       onLabelChange={vi.fn()}
+      launcherGreeting=""
+      onGreetingChange={vi.fn()}
       helpCenterFlagEnabled={flags.helpCenterFlagEnabled ?? false}
       supportInboxFlagEnabled={flags.supportInboxFlagEnabled ?? true}
       feedbackFlagEnabled={flags.feedbackFlagEnabled ?? true}
@@ -49,6 +51,12 @@ function renderModules(
 }
 
 describe('Widget Modules card', () => {
+  it('exposes launcher chrome fields separately from the Home greeting', () => {
+    renderModules()
+    expect(screen.getByLabelText('Launcher greeting')).toBeInTheDocument()
+    expect(screen.getByLabelText('Button label')).toBeInTheDocument()
+  })
+
   it('has no Messages row and lists Feedback and Changelog when those products are on', () => {
     renderModules()
     expect(screen.queryByRole('switch', { name: 'Messages tab' })).not.toBeInTheDocument()

--- a/apps/web/src/routes/admin/settings.widget.install.tsx
+++ b/apps/web/src/routes/admin/settings.widget.install.tsx
@@ -14,7 +14,9 @@ import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import { PageHeader } from '@/components/shared/page-header'
+import { WarningBox } from '@/components/shared/warning-box'
 import { SettingsCard } from '@/components/admin/settings/settings-card'
+import { WidgetLastDetected } from '@/components/admin/settings/widget/widget-last-detected'
 import { copyWithFallback } from '@/components/admin/activation-action-button'
 import { CopyAgentPromptButton } from '@/components/admin/settings/widget/copy-agent-prompt-button'
 import {
@@ -24,6 +26,10 @@ import {
   maskWidgetSecretInPrompt,
 } from '@/lib/shared/widget/install-prompt'
 import { widgetInstallPresence, widgetOriginVerifiedLabel } from '@/lib/shared/widget/widget-origin'
+import {
+  widgetConnectedStatusLabel,
+  widgetSdkUpdateDescription,
+} from '@/lib/shared/widget/sdk-version'
 import { settingsQueries } from '@/lib/client/queries/settings'
 import { adminQueries } from '@/lib/client/queries/admin'
 import { PERMISSIONS } from '@/lib/shared/permissions'
@@ -45,7 +51,12 @@ function WidgetInstallPage() {
   const secretQuery = useSuspenseQuery(settingsQueries.widgetSecret())
   const statusQuery = useQuery({
     ...adminQueries.onboardingStatus(),
-    refetchInterval: (query) => (query.state.data?.hasWidgetInstalled ? false : 5_000),
+    refetchInterval: (query) => {
+      const data = query.state.data
+      if (!data?.hasWidgetInstalled) return 5_000
+      if (data.widgetSdkNeedsUpdate) return 15_000
+      return false
+    },
   })
   const status = statusQuery.data!
   const mode = status.useCase === 'customer_support' ? 'messenger' : 'feedback'
@@ -179,21 +190,41 @@ function WidgetInstallPage() {
         description={
           presence.tone === 'idle'
             ? 'Waiting for the first request from your deployed site. Checking every five seconds.'
-            : widgetOriginVerifiedLabel(status.widgetOriginHost)
+            : status.widgetSdkNeedsUpdate
+              ? widgetSdkUpdateDescription(status.widgetSdkVersion, status.currentWidgetSdkVersion)
+              : widgetOriginVerifiedLabel(status.widgetOriginHost)
         }
       >
-        {presence.tone === 'live' ? (
-          <p className="flex items-center gap-2 text-sm text-emerald-600 dark:text-emerald-400">
-            <CheckCircleIcon className="h-5 w-5" /> Widget connection verified
-          </p>
-        ) : presence.tone === 'detected' ? (
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <p className="text-sm text-muted-foreground">
-              The SDK is installed. Turn on Show on your website so visitors can see it.
+        {presence.tone === 'live' && status.widgetSdkNeedsUpdate ? (
+          <div className="space-y-2">
+            <WarningBox
+              variant="warning"
+              title={widgetConnectedStatusLabel({
+                hasWidgetInstalled: true,
+                widgetSdkNeedsUpdate: true,
+              })}
+              description="Reinstall with the snippet above so the launcher picks up current features."
+            />
+            <WidgetLastDetected at={status.widgetLastDetectedAt} />
+          </div>
+        ) : presence.tone === 'live' ? (
+          <div className="space-y-0.5">
+            <p className="flex items-center gap-2 text-sm text-emerald-600 dark:text-emerald-400">
+              <CheckCircleIcon className="h-5 w-5" /> Widget connection verified
             </p>
-            <Button asChild size="sm" variant="outline">
-              <Link to="/admin/settings/widget">Widget settings</Link>
-            </Button>
+            <WidgetLastDetected at={status.widgetLastDetectedAt} />
+          </div>
+        ) : presence.tone === 'detected' ? (
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <p className="text-sm text-muted-foreground">
+                The SDK is installed. Turn on Show on your website so visitors can see it.
+              </p>
+              <Button asChild size="sm" variant="outline">
+                <Link to="/admin/settings/widget">Widget settings</Link>
+              </Button>
+            </div>
+            <WidgetLastDetected at={status.widgetLastDetectedAt} />
           </div>
         ) : (
           <p className="flex items-center gap-2 text-sm text-muted-foreground">

--- a/apps/web/src/routes/admin/settings.widget.tsx
+++ b/apps/web/src/routes/admin/settings.widget.tsx
@@ -45,6 +45,7 @@ import { BackLink } from '@/components/ui/back-link'
 import { PageHeader } from '@/components/shared/page-header'
 import { SettingsCard } from '@/components/admin/settings/settings-card'
 import { WidgetPreview } from '@/components/admin/settings/widget/widget-preview'
+import { WidgetLastDetected } from '@/components/admin/settings/widget/widget-last-detected'
 import { PreviewToggleButton } from '@/components/admin/settings/preview-toggle'
 import { InlineSpinner } from '@/components/admin/settings/inline-spinner'
 import { Label } from '@/components/ui/label'
@@ -79,6 +80,10 @@ import {
   type WidgetTranslations,
 } from '@/lib/shared/widget/translations'
 import { widgetInstallPresence } from '@/lib/shared/widget/widget-origin'
+import {
+  widgetConnectedStatusLabel,
+  widgetSdkUpdateDescription,
+} from '@/lib/shared/widget/sdk-version'
 import { DEFAULT_WIDGET_HOME_CARDS } from '@/lib/shared/types/settings'
 import { WIDGET_HERO_PATTERNS, heroBackdropStyle } from '@/lib/shared/widget/hero-style'
 import { ColorPickerGrid, ColorHexInput } from '@/components/shared/color-picker'
@@ -127,6 +132,7 @@ function WidgetSettingsPage() {
   )
   // Draft label — mirrors into the preview live; persisted on blur.
   const [launcherLabel, setLauncherLabel] = useState(config.launcherLabel ?? '')
+  const [launcherGreeting, setLauncherGreeting] = useState(config.launcherGreeting ?? '')
   const [homeDraft, setHomeDraft] = useState<WidgetHomeConfig>(config.home ?? {})
 
   // The preview theme follows the admin's own theme until the toggle overrides
@@ -171,6 +177,8 @@ function WidgetSettingsPage() {
             onPositionChange={setPosition}
             launcherLabel={launcherLabel}
             onLabelChange={setLauncherLabel}
+            launcherGreeting={launcherGreeting}
+            onGreetingChange={setLauncherGreeting}
             helpCenterFlagEnabled={helpCenterFlagEnabled}
             supportInboxFlagEnabled={supportInboxFlagEnabled}
             feedbackFlagEnabled={feedbackFlagEnabled}
@@ -215,6 +223,7 @@ function WidgetSettingsPage() {
               <WidgetPreview
                 position={position}
                 label={launcherLabel.trim() || undefined}
+                greeting={launcherGreeting.trim() || undefined}
                 theme={previewTheme}
                 refreshKey={previewRefreshKey}
               />
@@ -231,7 +240,14 @@ function WidgetSiteCard({
   status,
 }: {
   initialEnabled: boolean
-  status: { hasWidgetInstalled?: boolean; widgetOriginHost?: string | null }
+  status: {
+    hasWidgetInstalled?: boolean
+    widgetOriginHost?: string | null
+    widgetLastDetectedAt?: string | null
+    widgetSdkVersion?: string | null
+    currentWidgetSdkVersion?: string
+    widgetSdkNeedsUpdate?: boolean
+  }
 }) {
   const router = useRouter()
   const updateWidgetConfig = useUpdateWidgetConfig()
@@ -243,6 +259,17 @@ function WidgetSiteCard({
     enabled,
     originHost: status.widgetOriginHost,
   })
+  const needsUpdate = Boolean(status.hasWidgetInstalled && status.widgetSdkNeedsUpdate)
+  const statusTitle = needsUpdate
+    ? widgetConnectedStatusLabel({
+        hasWidgetInstalled: true,
+        widgetSdkNeedsUpdate: true,
+      })
+    : presence.title
+  const statusDescription = needsUpdate
+    ? widgetSdkUpdateDescription(status.widgetSdkVersion, status.currentWidgetSdkVersion)
+    : presence.description
+  const statusTone = needsUpdate ? 'detected' : presence.tone
 
   async function handleToggle(checked: boolean) {
     const previous = enabled
@@ -289,14 +316,14 @@ function WidgetSiteCard({
               <span
                 className={cn(
                   'h-2 w-2 shrink-0 rounded-full',
-                  presence.tone === 'live'
+                  statusTone === 'live'
                     ? 'bg-emerald-500'
-                    : presence.tone === 'detected'
+                    : statusTone === 'detected'
                       ? 'bg-amber-500'
                       : 'bg-muted-foreground/40'
                 )}
               />
-              {presence.title}
+              {statusTitle}
             </p>
             <Button asChild size="sm" variant="ghost" className="shrink-0">
               <Link to="/admin/settings/widget/install">
@@ -305,7 +332,8 @@ function WidgetSiteCard({
               </Link>
             </Button>
           </div>
-          <p className="text-xs text-muted-foreground mt-0.5">{presence.description}</p>
+          <p className="text-xs text-muted-foreground mt-0.5">{statusDescription}</p>
+          {status.hasWidgetInstalled && <WidgetLastDetected at={status.widgetLastDetectedAt} />}
         </div>
       </div>
     </SettingsCard>
@@ -319,6 +347,8 @@ export function ModulesCard({
   onPositionChange,
   launcherLabel,
   onLabelChange,
+  launcherGreeting,
+  onGreetingChange,
   helpCenterFlagEnabled,
   supportInboxFlagEnabled,
   feedbackFlagEnabled,
@@ -342,6 +372,8 @@ export function ModulesCard({
   onPositionChange: (val: 'bottom-right' | 'bottom-left') => void
   launcherLabel: string
   onLabelChange: (val: string) => void
+  launcherGreeting: string
+  onGreetingChange: (val: string) => void
   helpCenterFlagEnabled: boolean
   supportInboxFlagEnabled: boolean
   feedbackFlagEnabled: boolean
@@ -521,10 +553,11 @@ export function ModulesCard({
         </Label>
         <Input
           id="launcher-greeting"
-          defaultValue={config.launcherGreeting ?? ''}
+          value={launcherGreeting}
           maxLength={120}
           placeholder="e.g. Need a hand?"
           disabled={isBusy}
+          onChange={(e) => onGreetingChange(e.target.value)}
           onBlur={(e) => {
             const value = e.target.value.trim()
             if (value === (config.launcherGreeting ?? '')) return
@@ -532,7 +565,7 @@ export function ModulesCard({
           }}
         />
         <p className="text-[11px] text-muted-foreground/70">
-          Shown in a bubble beside the closed launcher to invite a chat. Leave blank for none.
+          Shown in a bubble beside the launcher to invite a chat. Leave blank for none.
         </p>
       </div>
 

--- a/packages/db/drizzle/0271_widget_installed_sdk_version.sql
+++ b/packages/db/drizzle/0271_widget_installed_sdk_version.sql
@@ -1,0 +1,4 @@
+-- Last widget SDK version observed on an external install ping.
+-- Nullable: workspaces detected before this column, and npm embeds older than
+-- 0.1.6 (no `?sdk=`), have no version. Expand-only.
+ALTER TABLE "settings" ADD COLUMN IF NOT EXISTS "widget_installed_sdk_version" text;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1737,6 +1737,13 @@
       "when": 1785700000028,
       "tag": "0270_github_channel",
       "breakpoints": true
+    },
+    {
+      "idx": 248,
+      "version": "7",
+      "when": 1785700000029,
+      "tag": "0271_widget_installed_sdk_version",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/__tests__/widget-installation-schema.test.ts
+++ b/packages/db/src/__tests__/widget-installation-schema.test.ts
@@ -3,17 +3,19 @@ import { getTableColumns } from 'drizzle-orm'
 import { settings } from '../schema/auth'
 
 describe('widget installation evidence schema', () => {
-  it('stores only first seen, last seen, and a normalized origin hostname', () => {
+  it('stores first seen, last seen, origin hostname, and last SDK version', () => {
     const columns = getTableColumns(settings)
     expect(Object.keys(columns)).toEqual(
       expect.arrayContaining([
         'widgetInstalledFirstSeenAt',
         'widgetInstalledLastSeenAt',
         'widgetInstalledOriginHost',
+        'widgetInstalledSdkVersion',
       ])
     )
     expect(columns.widgetInstalledFirstSeenAt.dataType).toBe('date')
     expect(columns.widgetInstalledLastSeenAt.dataType).toBe('date')
     expect(columns.widgetInstalledOriginHost.dataType).toBe('string')
+    expect(columns.widgetInstalledSdkVersion.dataType).toBe('string')
   })
 })

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -456,6 +456,8 @@ export const settings = pgTable('settings', {
   widgetInstalledLastSeenAt: timestamp('widget_installed_last_seen_at', { withTimezone: true }),
   /** Normalized external Origin hostname only (no path, query, port, or scheme). */
   widgetInstalledOriginHost: text('widget_installed_origin_host'),
+  /** Last SDK version reported on an install ping (`?sdk=` or instance-served sdk.js). */
+  widgetInstalledSdkVersion: text('widget_installed_sdk_version'),
   /** Feature flags for experimental features (JSON) */
   featureFlags: text('feature_flags'),
   /**

--- a/packages/widget/CHANGELOG.md
+++ b/packages/widget/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @quackback/widget
 
+## 0.1.6 - 2026-08-31
+
+- The config.json install ping now includes `?sdk=<version>` so the instance can tell an npm/file embed is behind and prompt an update on the widget settings page.
+- `Quackback.version` / `SDK_VERSION` expose the package version to host apps.
+
 ## 0.1.5 - 2026-05-18
 
 - Fix: `Quackback("init", { launcher: false, placement: "left" })` from a script-tag install now applies your options instead of silently keeping the default launcher and right-side placement. A repeat `init` call also reconfigures cleanly.

--- a/packages/widget/__tests__/config.test.ts
+++ b/packages/widget/__tests__/config.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { fetchServerConfig } from '../src/core/config'
+import { SDK_VERSION } from '../src/version'
 
 describe('config.fetchServerConfig', () => {
   beforeEach(() => {
@@ -13,7 +14,9 @@ describe('config.fetchServerConfig', () => {
     }))
     vi.stubGlobal('fetch', mock)
     const cfg = await fetchServerConfig('https://feedback.acme.com')
-    expect(mock).toHaveBeenCalledWith('https://feedback.acme.com/api/widget/config.json')
+    expect(mock).toHaveBeenCalledWith(
+      `https://feedback.acme.com/api/widget/config.json?sdk=${SDK_VERSION}`
+    )
     expect(cfg.theme?.lightPrimary).toBe('#ff0000')
   })
 

--- a/packages/widget/__tests__/index.test.ts
+++ b/packages/widget/__tests__/index.test.ts
@@ -17,6 +17,7 @@ describe('public API', () => {
     expect(typeof Quackback.off).toBe('function')
     expect(typeof Quackback.metadata).toBe('function')
     expect(typeof Quackback.destroy).toBe('function')
+    expect(typeof Quackback.version).toBe('string')
   })
 
   it('init throws when instanceUrl is missing', () => {

--- a/packages/widget/__tests__/version.test.ts
+++ b/packages/widget/__tests__/version.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { SDK_VERSION } from '../src/version'
+import Quackback from '../src/index'
+
+describe('SDK_VERSION', () => {
+  it('matches package.json version', () => {
+    const pkg = JSON.parse(
+      readFileSync(join(dirname(fileURLToPath(import.meta.url)), '../package.json'), 'utf8')
+    ) as { version: string }
+    expect(SDK_VERSION).toBe(pkg.version)
+  })
+
+  it('is exposed on the Quackback singleton', () => {
+    expect(Quackback.version).toBe(SDK_VERSION)
+  })
+})

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quackback/widget",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "license": "AGPL-3.0",
   "description": "Official SDK for the Quackback feedback widget. Embed Quackback in your app.",
   "type": "module",
@@ -10,15 +10,21 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "development": "./src/index.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.cjs",
-      "development": "./src/index.ts"
+      "require": "./dist/index.cjs"
     },
     "./react": {
       "types": "./dist/react/index.d.ts",
+      "development": "./src/react/index.ts",
       "import": "./dist/react/index.js",
-      "require": "./dist/react/index.cjs",
-      "development": "./src/react/index.ts"
+      "require": "./dist/react/index.cjs"
+    },
+    "./version": {
+      "types": "./dist/version.d.ts",
+      "development": "./src/version.ts",
+      "import": "./dist/version.js",
+      "require": "./dist/version.cjs"
     },
     "./browser.js": "./dist/browser.js"
   },

--- a/packages/widget/src/core/config.ts
+++ b/packages/widget/src/core/config.ts
@@ -1,3 +1,5 @@
+import { SDK_VERSION } from '../version'
+
 /** Server config shape returned from `/api/widget/config.json`. */
 export interface ServerConfig {
   /**
@@ -34,9 +36,14 @@ export interface ServerConfig {
   position?: 'left' | 'right'
 }
 
+/** Public config ping. `sdk` is the embed's package version so the instance
+ *  can tell an npm/file install is behind the workspace's current SDK. */
 export async function fetchServerConfig(instanceUrl: string): Promise<ServerConfig> {
   try {
-    const res = await fetch(`${instanceUrl}/api/widget/config.json`)
+    // Query param, not a custom header: a header would CORS-preflight this
+    // cross-origin GET and break embeds that only allow simple requests.
+    const url = `${instanceUrl}/api/widget/config.json?sdk=${encodeURIComponent(SDK_VERSION)}`
+    const res = await fetch(url)
     if (!res.ok) return {}
     return (await res.json()) as ServerConfig
   } catch {

--- a/packages/widget/src/index.ts
+++ b/packages/widget/src/index.ts
@@ -10,6 +10,9 @@ import type {
   Unsubscribe,
 } from './types'
 
+import { SDK_VERSION } from './version'
+
+export { SDK_VERSION }
 export type {
   InitOptions,
   Identity,
@@ -24,6 +27,7 @@ export type {
 const sdk = createSDK()
 
 export const Quackback = {
+  version: SDK_VERSION,
   init(options: InitOptions): void {
     sdk.dispatch('init', options)
   },

--- a/packages/widget/src/version.ts
+++ b/packages/widget/src/version.ts
@@ -1,0 +1,6 @@
+/**
+ * Widget SDK version. Keep in lockstep with `package.json` `version`
+ * (`__tests__/version.test.ts` pins the pair). Sent on the config.json
+ * install ping so the instance can tell an npm/file embed is behind.
+ */
+export const SDK_VERSION = '0.1.6'

--- a/packages/widget/tsup.config.ts
+++ b/packages/widget/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig([
     entry: {
       index: 'src/index.ts',
       'react/index': 'src/react/index.ts',
+      version: 'src/version.ts',
     },
     format: ['esm', 'cjs'],
     // Declarations come from `tsc --emitDeclarationOnly` (TypeScript 7).


### PR DESCRIPTION
## Summary

Make the widget settings preview match a real host page, and surface whether the installed SDK is current.

- Live preview stacks the panel above the launcher in the configured corner (button below the widget). The greeting bubble shows on the closed launcher.
- Launcher greeting stays a first-class setting and drafts live into the preview.
- npm/file embeds ping `/api/widget/config.json?sdk=<version>`. Settings shows **SDK update available** when the embed is behind, plus **Last detected**.
- Migration `0271_widget_installed_sdk_version` stores the last reported version. Widget package is `0.1.6`.

## Test plan

- [x] Unit: preview layout + greeting, modules card, observation writes, sdk-version parse/compare, widget package tests
- [x] Manual: settings preview — panel above launcher, greeting after close
- [ ] CI unit + typecheck
- [ ] Apply `0271_widget_installed_sdk_version` on deploy