### PR TITLE
feat(auth): add principal type `support` for Cloud join

### DIFF
--- a/apps/web/src/lib/server/audit/log.ts
+++ b/apps/web/src/lib/server/audit/log.ts
@@ -159,7 +159,7 @@ export type AuditEventType =
 
 export type AuditEventOutcome = 'success' | 'failure'
 
-export type AuditActorType = 'user' | 'service' | 'anonymous' | 'system' | 'api_key'
+export type AuditActorType = 'user' | 'service' | 'anonymous' | 'system' | 'api_key' | 'support'
 export type AuditAuthMethod = 'password' | 'sso' | 'magic_link' | 'ott' | 'api_key' | 'session'
 
 export interface AuditActor {

--- a/apps/web/src/lib/server/domains/conversation/conversation.notify.ts
+++ b/apps/web/src/lib/server/domains/conversation/conversation.notify.ts
@@ -227,7 +227,7 @@ export async function notifyVisitorMessage(opts: {
       })
       .from(principal)
       .leftJoin(user, eq(principal.userId, user.id))
-      .where(inArray(principal.role, ['admin', 'member']))
+      .where(and(eq(principal.type, 'user'), inArray(principal.role, ['admin', 'member'])))
 
     if (team.length === 0) return
 

--- a/apps/web/src/lib/server/domains/help-center/help-center.article.query.ts
+++ b/apps/web/src/lib/server/domains/help-center/help-center.article.query.ts
@@ -450,6 +450,7 @@ export async function listPublicCategoryEditors(): Promise<
       and(
         isNotNull(helpCenterArticles.publishedAt),
         isNull(helpCenterArticles.deletedAt),
+        eq(principal.type, 'user'),
         inArray(principal.role, ['admin', 'member'])
       )
     )

--- a/apps/web/src/lib/server/domains/principals/__tests__/list-team-seat-emails.db.test.ts
+++ b/apps/web/src/lib/server/domains/principals/__tests__/list-team-seat-emails.db.test.ts
@@ -31,7 +31,7 @@ const suffix = () => `${Date.now().toString(36)}-${Math.random().toString(36).sl
 
 async function seed(
   role: 'admin' | 'member' | 'user',
-  type: 'user' | 'anonymous' | 'service',
+  type: 'user' | 'anonymous' | 'service' | 'support',
   email: string | null
 ) {
   const userId = createId('user') as UserId
@@ -62,12 +62,14 @@ describe.skipIf(!fixture.available)('listTeamSeatEmails predicate', () => {
     await seed('admin', 'user', '   ')
     await seed('admin', 'user', null)
     await seed('admin', 'service', null)
+    await seed('admin', 'support', `support-${tag}@quackback.io`)
 
     const emails = await listTeamSeatEmails()
     expect(emails).toContain(`admin-${tag}@acme.test`)
     expect(emails).toContain(`member-${tag}@acme.test`)
     expect(emails).not.toContain(`voter-${tag}@public.test`)
     expect(emails).not.toContain(`temp-${tag}@anon.invalid`)
+    expect(emails).not.toContain(`support-${tag}@quackback.io`)
     expect(emails.filter((e) => e.includes(tag)).sort()).toEqual(
       [`admin-${tag}@acme.test`, `member-${tag}@acme.test`].sort()
     )

--- a/apps/web/src/lib/server/domains/principals/__tests__/principal-cache.test.ts
+++ b/apps/web/src/lib/server/domains/principals/__tests__/principal-cache.test.ts
@@ -93,6 +93,19 @@ describe('updateMemberRole', () => {
 
     expect(mockCacheDel).not.toHaveBeenCalled()
   })
+
+  it('refuses to change the role of a support principal', async () => {
+    mockFindFirst.mockResolvedValue({
+      id: TARGET,
+      userId: TARGET_USER,
+      type: 'support',
+      role: 'admin',
+    })
+    await expect(updateMemberRole(TARGET, 'member', ACTING)).rejects.toMatchObject({
+      code: 'MEMBER_NOT_FOUND',
+    })
+    expect(mockCacheDel).not.toHaveBeenCalled()
+  })
 })
 
 describe('removeTeamMember', () => {
@@ -107,5 +120,18 @@ describe('removeTeamMember', () => {
     await removeTeamMember(TARGET, ACTING)
 
     expect(mockCacheDel).toHaveBeenCalledWith(`principal:user:${TARGET_USER}`)
+  })
+
+  it('refuses to remove a support principal', async () => {
+    mockFindFirst.mockResolvedValue({
+      id: TARGET,
+      userId: TARGET_USER,
+      type: 'support',
+      role: 'admin',
+    })
+    await expect(removeTeamMember(TARGET, ACTING)).rejects.toMatchObject({
+      code: 'MEMBER_NOT_FOUND',
+    })
+    expect(mockCacheDel).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/lib/server/domains/principals/__tests__/seat-usage.db.test.ts
+++ b/apps/web/src/lib/server/domains/principals/__tests__/seat-usage.db.test.ts
@@ -74,6 +74,17 @@ async function seedServiceAdmin(): Promise<void> {
   })
 }
 
+async function seedSupportAdmin(): Promise<void> {
+  const userId = await seedUserOnly()
+  await testDb.insert(principal).values({
+    id: createId('principal') as PrincipalId,
+    userId,
+    role: 'admin',
+    type: 'support',
+    createdAt: new Date(),
+  })
+}
+
 async function seedInvite(
   kind: 'team' | 'portal',
   inviterId: UserId,
@@ -137,6 +148,7 @@ describe.skipIf(!fixture.available)('countSeatUsage', () => {
     await seedHuman('member')
     await seedHuman('user')
     await seedServiceAdmin()
+    await seedSupportAdmin()
     await seedInvite('team', inviterId)
     await seedInvite('team', inviterId)
     await seedInvite('portal', inviterId)

--- a/apps/web/src/lib/server/domains/principals/principal.factory.ts
+++ b/apps/web/src/lib/server/domains/principals/principal.factory.ts
@@ -52,7 +52,7 @@ function shouldSyncMembership(args: {
   fromRole?: string | null
   toRole: string
 }): boolean {
-  if (args.type === 'service' || args.type === 'anonymous') return false
+  if (args.type === 'service' || args.type === 'anonymous' || args.type === 'support') return false
   return isTeamMember(args.toRole) || isTeamMember(args.fromRole)
 }
 
@@ -149,7 +149,8 @@ export interface EnsurePrincipalInput extends ProfileFields {
  * it inserts with `onConflictDoNothing` (the partial unique index on `user_id`
  * is the backstop) and re-reads the winner on a lost race. Returns the existing
  * or newly-created principal plus whether it inserted. Busts the principal cache
- * only when it actually inserts.
+ * only when it actually inserts. An existing row is returned as-is — including
+ * `type='support'` — and is never rewritten to `type='user'`.
  */
 export async function ensurePrincipalForUser(
   input: EnsurePrincipalInput,
@@ -317,6 +318,9 @@ export async function setPrincipalRole(
       .where(whereClause)
       .limit(1)
       .for('update')
+  }
+  if (target?.type === 'support' || current?.type === 'support') {
+    throw new ForbiddenError('SUPPORT_PRINCIPAL', 'Cannot change the role of a support principal')
   }
   await exec.update(principal).set({ role }).where(whereClause)
   // Reconcile only when the role actually changed or an explicit assignment

--- a/apps/web/src/lib/server/domains/principals/principal.service.ts
+++ b/apps/web/src/lib/server/domains/principals/principal.service.ts
@@ -79,7 +79,7 @@ export {
  * Without the role guard a portal end-user (role='user', type='user') would
  * leak into team surfaces. People-facing pickers use searchPeople instead.
  */
-function teamMemberWhere() {
+export function teamMemberWhere() {
   return and(eq(principal.type, 'user'), ne(principal.role, 'user'))
 }
 

--- a/apps/web/src/lib/server/domains/principals/principal.service.ts
+++ b/apps/web/src/lib/server/domains/principals/principal.service.ts
@@ -268,8 +268,9 @@ export async function updateMemberRole(
       throw new NotFoundError('MEMBER_NOT_FOUND', 'Team member not found')
     }
 
-    // Ensure target is a team member (admin or member), not a portal user
-    if (!isTeamMember(targetMember.role)) {
+    // Ensure target is a customer teammate. Cloud support (type=support) is an
+    // admin for privilege but is not on the customer roster.
+    if (!isTeamMember(targetMember.role) || targetMember.type === 'support') {
       throw new NotFoundError('MEMBER_NOT_FOUND', 'Team member not found')
     }
 
@@ -348,8 +349,8 @@ export async function removeTeamMember(
       throw new NotFoundError('MEMBER_NOT_FOUND', 'Team member not found')
     }
 
-    // Ensure target is a team member (admin or member), not a portal user
-    if (!isTeamMember(targetMember.role)) {
+    // Ensure target is a customer teammate. Cloud support is not on the roster.
+    if (!isTeamMember(targetMember.role) || targetMember.type === 'support') {
       throw new NotFoundError('MEMBER_NOT_FOUND', 'Team member not found')
     }
 

--- a/apps/web/src/lib/server/domains/tickets/ticket-subscription.service.ts
+++ b/apps/web/src/lib/server/domains/tickets/ticket-subscription.service.ts
@@ -201,6 +201,7 @@ export async function getTicketAgentWatchersForEvent(ticketId: TicketId): Promis
       and(
         eq(ticketSubscriptions.ticketId, ticketId),
         notMuted(),
+        eq(principal.type, 'user'),
         inArray(principal.role, ['admin', 'member'])
       )
     )

--- a/apps/web/src/lib/server/events/envelope.ts
+++ b/apps/web/src/lib/server/events/envelope.ts
@@ -11,11 +11,11 @@ import type { EvtId } from '@quackback/ids'
 
 /**
  * Who or what caused an event.
- * Mirrors `principalType` ('user' | 'anonymous' | 'service'), plus 'system' for
- * non-attributable automated origins (scheduled sweeps, SLA deadline scans)
- * that carry no principal.
+ * Mirrors `principalType` ('user' | 'anonymous' | 'service' | 'support'), plus
+ * 'system' for non-attributable automated origins (scheduled sweeps, SLA
+ * deadline scans) that carry no principal.
  */
-export type EventActorType = 'user' | 'anonymous' | 'service' | 'system'
+export type EventActorType = 'user' | 'anonymous' | 'service' | 'support' | 'system'
 
 export interface EventContext {
   /** Request/trace id; propagated across events caused by this one. */

--- a/apps/web/src/lib/server/events/targets.ts
+++ b/apps/web/src/lib/server/events/targets.ts
@@ -1098,7 +1098,7 @@ export async function getMessageCreatedTargets(event: EventData): Promise<HookTa
   const team = await db
     .select({ principalId: principal.id })
     .from(principal)
-    .where(inArray(principal.role, ['admin', 'member']))
+    .where(and(eq(principal.type, 'user'), inArray(principal.role, ['admin', 'member'])))
   if (team.length === 0) return null
 
   const authorName = event.data.message.authorName ?? 'A visitor'

--- a/apps/web/src/lib/server/functions/__tests__/policy-actor-from-auth.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/policy-actor-from-auth.test.ts
@@ -9,7 +9,18 @@ vi.mock('@/lib/server/domains/segments/segment-membership.service', () => ({
   ),
 }))
 
-import { policyActorFromAuth } from '../auth-helpers'
+import { policyActorFromAuth, normalizePrincipalType } from '../auth-helpers'
+
+describe('normalizePrincipalType', () => {
+  it('preserves support and does not collapse it to user', () => {
+    expect(normalizePrincipalType('support')).toBe('support')
+    expect(normalizePrincipalType('user')).toBe('user')
+    expect(normalizePrincipalType('anonymous')).toBe('anonymous')
+    expect(normalizePrincipalType('service')).toBe('service')
+    expect(normalizePrincipalType('future_kind')).toBe('user')
+    expect(normalizePrincipalType(null)).toBe('user')
+  })
+})
 
 // Build a fully-typed AuthContext (no `as never`/`as unknown` casts).
 // principal.role is constrained to {admin, member, user} — service is a
@@ -76,6 +87,16 @@ describe('policyActorFromAuth', () => {
     )
     expect(actor.principalType).toBe('service')
     expect(actor.role).toBe('member')
+  })
+
+  it('preserves principalType=support for Cloud support admins', async () => {
+    // Collapsing this onto 'user' would make isIdentifiedHuman true and put
+    // the operator on people lists. Role stays admin so isTeamActor still admits /admin.
+    const actor = await policyActorFromAuth(
+      buildAuth({ principalType: 'support', principalRole: 'admin' })
+    )
+    expect(actor.principalType).toBe('support')
+    expect(actor.role).toBe('admin')
   })
 
   it('maps admin role through verbatim', async () => {

--- a/apps/web/src/lib/server/functions/auth-helpers.ts
+++ b/apps/web/src/lib/server/functions/auth-helpers.ts
@@ -283,14 +283,16 @@ import { ANONYMOUS_ACTOR } from '@/lib/server/policy/types'
 import { segmentIdsForPrincipal } from '@/lib/server/domains/segments/segment-membership.service'
 
 /**
- * Preserve all three principal types. Collapsing 'anonymous' onto 'user'
+ * Preserve known principal types. Collapsing 'anonymous' onto 'user'
  * is a security bug: a Better Auth anonymous session would satisfy
  * audience.kind='authenticated' and dodge the workspace requireApproval='anonymous'
- * moderation gate.
+ * moderation gate. Collapsing 'support' onto 'user' would put Cloud support
+ * back on people lists (`isIdentifiedHuman`).
  */
 export function normalizePrincipalType(raw: string | null | undefined): PrincipalType {
   if (raw === 'service') return 'service'
   if (raw === 'anonymous') return 'anonymous'
+  if (raw === 'support') return 'support'
   return 'user'
 }
 

--- a/apps/web/src/lib/server/functions/settings.ts
+++ b/apps/web/src/lib/server/functions/settings.ts
@@ -34,8 +34,9 @@ import {
 import { getPublicUrlOrNull } from '@/lib/server/storage/s3'
 import { actorFromAuth, recordAuditEvent, type AuditEventType } from '@/lib/server/audit/log'
 import { requireAuth } from './auth-helpers'
+import { teamMemberWhere } from '@/lib/server/domains/principals/principal.service'
 import { getSession } from '@/lib/server/auth/session'
-import { db, principal, user, invitation, account, eq, ne, and } from '@/lib/server/db'
+import { db, principal, user, invitation, account, eq, and } from '@/lib/server/db'
 import { PERMISSIONS } from '@/lib/shared/permissions'
 import { officeHoursScheduleSchema } from '@/lib/server/domains/settings/settings.office-hours'
 import { changelogSettingsSchema } from '@/lib/shared/changelog-settings'
@@ -143,7 +144,7 @@ export const fetchTeamMembersAndInvitations = createServerFn({ method: 'GET' }).
       .from(principal)
       .innerJoin(user, eq(principal.userId, user.id))
       .leftJoin(lastSession, eq(lastSession.userId, user.id))
-      .where(ne(principal.role, 'user'))
+      .where(teamMemberWhere())
 
     // Serialise to ISO string on the boundary so the client type
     // stays narrow (`string | null`). `toIsoStringOrNull` handles

--- a/apps/web/src/lib/server/telemetry/payload.ts
+++ b/apps/web/src/lib/server/telemetry/payload.ts
@@ -238,6 +238,7 @@ async function getSeats7d(): Promise<ScaleBracket> {
           INNER JOIN "principal" p ON p.user_id = s.user_id
           WHERE s.updated_at > now() - interval '7 days'
             AND p.role IN ('admin', 'member')
+            AND p.type = 'user'
             AND p.user_id IS NOT NULL`
     )
     const row = getExecuteRows<{ seats: number }>(result)[0]

--- a/apps/web/src/lib/shared/__tests__/roles.test.ts
+++ b/apps/web/src/lib/shared/__tests__/roles.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { isTeamMember, isAdmin } from '../roles'
+import { isTeamMember, isAdmin, isIdentifiedHuman } from '../roles'
 
 describe('isTeamMember', () => {
   it('returns true for admin', () => {
@@ -22,6 +22,16 @@ describe('isTeamMember', () => {
 
   it('returns false for undefined', () => {
     expect(isTeamMember(undefined)).toBe(false)
+  })
+})
+
+describe('isIdentifiedHuman', () => {
+  it('is true only for customer humans', () => {
+    expect(isIdentifiedHuman('user')).toBe(true)
+    expect(isIdentifiedHuman('anonymous')).toBe(false)
+    expect(isIdentifiedHuman('service')).toBe(false)
+    expect(isIdentifiedHuman('support')).toBe(false)
+    expect(isIdentifiedHuman(null)).toBe(false)
   })
 })
 

--- a/apps/web/src/lib/shared/roles.ts
+++ b/apps/web/src/lib/shared/roles.ts
@@ -9,16 +9,17 @@
  * The product runs two kinds of actor on one principal: teammates who operate
  * the workspace (role 'admin' or 'member') and end-users who use the portal
  * (role 'user'). `type` further separates an identified human ('user') from an
- * anonymous visitor ('anonymous') and a machine ('service'). The two axes share
- * one row, so "is this a teammate?" and "is this an end-user?" must be answered
- * the same way everywhere.
+ * anonymous visitor ('anonymous'), a machine ('service'), and Cloud support
+ * ('support') — a signed-in admin that is not a customer human. The two axes
+ * share one row, so "is this a teammate?" and "is this an end-user?" must be
+ * answered the same way everywhere.
  */
 
 /** Teammate/end-user tier carried on a principal. */
 export type Role = 'admin' | 'member' | 'user'
 
 /** What kind of actor a principal is. */
-export type PrincipalType = 'user' | 'anonymous' | 'service'
+export type PrincipalType = 'user' | 'anonymous' | 'service' | 'support'
 
 /** Role privilege order, low to high. Used to compare/escalate roles. */
 export const ROLE_RANK: Record<Role, number> = { user: 0, member: 1, admin: 2 }
@@ -43,7 +44,7 @@ export function isEndUser(role: string | null | undefined): boolean {
   return role === 'user'
 }
 
-/** True for an identified human principal (not an anonymous visitor or a machine). */
+/** True for an identified customer human (not anonymous, machine, or Cloud support). */
 export function isIdentifiedHuman(type: string | null | undefined): boolean {
   return type === 'user'
 }

--- a/packages/db/src/schema/audit-log.ts
+++ b/packages/db/src/schema/audit-log.ts
@@ -29,7 +29,7 @@ export const auditLog = pgTable(
     actorUserAgent: text('actor_user_agent'),
     /** Correlation handle — value of x-request-id / x-correlation-id header, if present. */
     requestId: text('request_id'),
-    /** Denormalised principal type at write time ('user' | 'service' | 'anonymous' | 'system' | 'api_key'). */
+    /** Denormalised principal type at write time ('user' | 'service' | 'anonymous' | 'system' | 'api_key' | 'support'). */
     actorType: text('actor_type'),
     /** Auth method used for sign-in events ('password' | 'sso' | 'magic_link' | 'ott' | 'api_key' | 'session'). */
     authMethod: text('auth_method'),

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -719,8 +719,12 @@ export type ServiceMetadata =
  * - 'user': Portal user access only, can vote/comment on public portal
  *
  * Principal types:
- * - 'user': Human user with a userId pointing to the user table
+ * - 'user': Identified customer human with a userId pointing to the user table
+ * - 'anonymous': Unidentified visitor
  * - 'service': Integration or API key actor (userId is null)
+ * - 'support': Cloud platform-support admin with a user row (can hold a session)
+ *   that is not a customer human — omitted from seats, membership sync, and
+ *   customer directories. Role still governs /admin privilege.
  *
  * The role determines access level: admin/member can access /admin dashboard,
  * while 'user' role can only interact with the public portal.
@@ -736,7 +740,7 @@ export const principal = pgTable(
     // Unified roles: 'admin' | 'member' | 'user'
     // 'user' role = portal users (public portal access only, no admin dashboard)
     role: text('role').default('member').notNull(),
-    // Principal type: 'user' (human), 'anonymous' (unidentified visitor), or 'service' (integration/API key)
+    // Principal type: 'user' | 'anonymous' | 'service' | 'support'
     type: text('type').default('user').notNull(),
     // Display name — always populated (humans synced from user.name, service principals set on creation)
     displayName: text('display_name'),

--- a/packages/db/src/schema/events.ts
+++ b/packages/db/src/schema/events.ts
@@ -44,7 +44,7 @@ export const events = pgTable(
     entityType: text('entity_type').notNull(),
     /** Branded TypeID of the subject aggregate. */
     entityId: text('entity_id').notNull(),
-    /** 'user' | 'anonymous' | 'service' | 'system'. */
+    /** 'user' | 'anonymous' | 'service' | 'support' | 'system'. */
     actorType: text('actor_type').notNull(),
     actorId: text('actor_id'),
     /** Validated against the catalogue zod schema before insert. Minimal snapshot. */


### PR DESCRIPTION
## Summary

Adds `principal.type = 'support'` so Cloud support can hold an admin session without counting as a customer human.

- Privilege stays on `role = 'admin'` (`isTeamMember` / `isTeamActor` unchanged)
- Directories, seats, and membership sync already key off `type = 'user'`, so support is omitted without an email denylist
- `normalizePrincipalType` must not collapse `support` to `user` (that would put operators back on people lists)
- Role-only teammate fan-outs (inbox notify, mentions-adjacent assignee/watchers, help-center author chips, telemetry seats) now also require `type = 'user'`
- `updateMemberRole` / `removeTeamMember` refuse a support principal

Companion CP PR seeds `support@quackback.io` and mints a short open-handoff. **Ship this image before operators click Add support.**

## Test plan

- [x] `roles.test.ts` — `isIdentifiedHuman('support')` is false
- [x] `policy-actor-from-auth.test.ts` — `normalizePrincipalType('support') === 'support'`
- [x] `principal-cache.test.ts` — role change / remove of support is `MEMBER_NOT_FOUND`
- [x] `seat-usage.db.test.ts` — support admin does not occupy a seat
- [x] `list-team-seat-emails.db.test.ts` — support email is not pushed to CP membership