### PR TITLE
fix(ci): record 0271 in the fleet gate and contract snapshot

### DIFF
--- a/apps/web/src/lib/server/fleet/__tests__/migrator-gate.test.ts
+++ b/apps/web/src/lib/server/fleet/__tests__/migrator-gate.test.ts
@@ -345,6 +345,7 @@ describe('replayGateVerdict', () => {
       '0268_cloud_identity_projection',
       '0269_messenger_ai_default_on',
       '0270_github_channel',
+      '0271_widget_installed_sdk_version',
     ])
     const verdict = replayGateVerdict(before, verdictsFor(replaySetFor(before)), false)
     expect(verdict.ok).toBe(false)

--- a/apps/web/src/lib/server/policy/migration-contract/CONTRACT.md
+++ b/apps/web/src/lib/server/policy/migration-contract/CONTRACT.md
@@ -6,7 +6,7 @@ Regenerate with `bunx vitest run apps/web/src/lib/server/policy/migration-contra
 
 ## Summary
 
-Migrations scanned: 248. Migrations with destructive DDL: 33.
+Migrations scanned: 249. Migrations with destructive DDL: 33.
 
 | Kind | Occurrences |
 | --- | --- |


### PR DESCRIPTION
## Summary
- #446 added additive migration `0271_widget_installed_sdk_version` but did not update the two fixtures that enumerate the bundled schema.
- `test (1/4)` failed the golden `CONTRACT.md` snapshot (248 → 249 scanned migrations; still 33 destructive).
- `test (2/4)` failed the post-0248 replay-set assertion, which is meant to turn red whenever a new migration lands so the operator path stays documented.

## Test plan
- [x] Regenerated `CONTRACT.md` with `bunx vitest run apps/web/src/lib/server/policy/migration-contract -u` (103 tests)
- [x] `bunx vitest run apps/web/src/lib/server/fleet/__tests__/migrator-gate.test.ts` (22 tests)