### PR TITLE
chore(release): 0.14.0

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quackback/web",
-  "version": "0.13.2",
+  "version": "0.14.0",
   "private": true,
   "license": "AGPL-3.0",
   "type": "module",


### PR DESCRIPTION
Bump `apps/web/package.json` `version` to 0.14.0 so the GitHub release tag bakes the right `__APP_VERSION__` into the image.

This is the version bump only. After merge: `gh release create v0.14.0 --target main`.