### PR TITLE
revert: chore(release): 0.14.0

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quackback/web",
-  "version": "0.14.0",
+  "version": "0.13.2",
   "private": true,
   "license": "AGPL-3.0",
   "type": "module",


### PR DESCRIPTION
Revert the accidental 0.14.0 version bump. The GitHub release and `v0.14.0` tag are already deleted. Fleet should keep tracking `main`.