### PR TITLE
ci(docker): stop publishing Cosign sha256-*.sig package tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,11 +7,11 @@ on:
   workflow_dispatch:
     inputs:
       sha:
-        description: "Commit SHA or ref to build (e.g. a release tag's commit). Lets you re-release a signed image from an exact source commit without moving the git tag. Leave blank to build the branch you dispatched from."
+        description: "Commit SHA or ref to build (e.g. a release tag's commit). Use with image_tag to republish that commit. Leave blank to build the branch you dispatched from."
         required: false
         default: ''
       image_tag:
-        description: 'Image tag to publish as (e.g. 0.10.5). Leave blank to tag with the branch name (or sha-<short> when a sha is given).'
+        description: 'Image tag to publish as (e.g. 0.10.5). Leave blank to tag with the branch name. Required when sha is set, so a dispatch does not mint a sha-* package tag.'
         required: false
         default: ''
 
@@ -94,14 +94,16 @@ jobs:
           retention-days: 1
 
   # Assemble the multi-arch manifest list (OCI image index) from the per-arch
-  # digests, apply the real tags, then keyless-sign the index digest.
+  # digests and apply the moving tags (`main` on branch pushes, `X.Y.Z` +
+  # `latest` on v* tags). Cosign/Kyverno signature tags are gone: Cloud runs
+  # on Railway and digest-pins the index, so `sha256-*.sig` package tags were
+  # only noise.
   merge:
     runs-on: ubuntu-latest
     needs: [build]
     permissions:
       contents: read
       packages: write
-      id-token: write # keyless cosign signing via GitHub OIDC
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -131,7 +133,15 @@ jobs:
             type=semver,pattern={{version}}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=raw,value=${{ github.event.inputs.image_tag }},enable=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.image_tag != '' }}
-            type=sha,enable=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.image_tag == '' && github.event.inputs.sha != '' }}
+
+      - name: Require a publish tag
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          if [ -z "$TAGS" ]; then
+            echo 'docker/metadata-action produced no tags. For workflow_dispatch with sha, pass image_tag (e.g. 0.13.2).'
+            exit 1
+          fi
 
       - name: Create manifest list and push
         working-directory: /tmp/digests
@@ -147,16 +157,3 @@ jobs:
         run: |
           DIGEST=$(docker buildx imagetools inspect "${IMAGE}:${VERSION}" --format '{{json .Manifest.Digest}}' | tr -d '"')
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
-
-      - name: Install cosign
-        uses: sigstore/cosign-installer@f713795cb21599bc4e5c4b58cbad1da852d7eeb9 # v3
-
-      # Keyless cosign signature over the pushed index digest, required by the
-      # cluster's Kyverno verify-images ClusterPolicy (keyless, GitHub OIDC
-      # issuer + QuackbackIO workflow subject). --recursive signs the OCI index
-      # AND each per-arch child manifest, so policy can verify either the index
-      # or a resolved per-arch digest.
-      - name: Sign image index (keyless)
-        env:
-          IMAGE_DIGEST: ${{ steps.index.outputs.digest }}
-        run: cosign sign --yes --recursive "${IMAGE}@${IMAGE_DIGEST}"


### PR DESCRIPTION
## Summary

Cloud is on Railway and digest-pins the image index. Cosign keyless signing (`--recursive`) was leftover from the Kyverno verify-images policy and published a `sha256-<digest>.sig` GHCR tag for the index plus each per-arch child on every build.

This drops Cosign. Moving tags stay `main` on branch pushes and `X.Y.Z` + `latest` on `v*` releases. `workflow_dispatch` with a sha now requires `image_tag` instead of minting `sha-<short>`.

Existing `.sig` versions on the package are unchanged; GHCR will stop growing them after this merges.