### PR TITLE
fix(ai): hide OpenRouter reasoning on tool-less structured streams

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -198,6 +198,10 @@ AI_ASSISTANT_MODEL=
 # has no provider advertising response_format — output then relies on prompt
 # adherence and salvage parsing.
 AI_REQUIRE_PARAMETERS=
+# Hide OpenRouter reasoning tokens on tool-less structured streams (Ask AI).
+# Unset/false for models that do not advertise `reasoning` (require_parameters
+# would 404). Set true for reasoning models such as DeepSeek v4 Flash.
+AI_REASONING_EXCLUDE=
 
 # ============================================================================
 # File Storage (for image uploads)

--- a/apps/web/src/lib/server/config.ts
+++ b/apps/web/src/lib/server/config.ts
@@ -199,6 +199,7 @@ const configSchema = z
     aiInboxTranslationModel: z.string().optional(),
     aiClassificationModel: z.string().optional(),
     aiRequireParameters: envBoolean,
+    aiReasoningExclude: envBoolean,
 
     // Telemetry (optional)
     disableTelemetry: envBoolean,
@@ -324,6 +325,7 @@ function buildConfigFromEnv(): unknown {
     aiInboxTranslationModel: env('AI_INBOX_TRANSLATION_MODEL'),
     aiClassificationModel: env('AI_CLASSIFICATION_MODEL'),
     aiRequireParameters: env('AI_REQUIRE_PARAMETERS'),
+    aiReasoningExclude: env('AI_REASONING_EXCLUDE'),
 
     // Telemetry
     disableTelemetry: env('DISABLE_TELEMETRY'),
@@ -581,6 +583,9 @@ export const config = {
   },
   get aiRequireParameters() {
     return loadConfig().aiRequireParameters
+  },
+  get aiReasoningExclude() {
+    return loadConfig().aiReasoningExclude
   },
 
   // Telemetry

--- a/apps/web/src/lib/server/domains/ai/config.ts
+++ b/apps/web/src/lib/server/domains/ai/config.ts
@@ -129,3 +129,20 @@ export function structuredOutputProviderOptions(): {
     ? { provider: { require_parameters: true } }
     : {}
 }
+
+/**
+ * Hide reasoning tokens on the OpenRouter wire.
+ *
+ * Same shape as {@link structuredOutputProviderOptions}: an explicit boolean
+ * on an OpenRouter-only extra. Unset is off — `require_parameters` 404s
+ * models whose providers do not advertise `reasoning` (GLM 5.3 Flash). Set
+ * `AI_REASONING_EXCLUDE=true` for reasoning models such as DeepSeek v4 Flash,
+ * whose json_schema streams otherwise prefix thinking as whitespace and kill
+ * Ask AI. Callers that must round-trip `reasoning_details` (Quinn's tool loop)
+ * should skip this helper.
+ */
+export function reasoningExcludeProviderOptions(): { reasoning?: { exclude: true } } {
+  return config.openaiBaseUrl?.includes('openrouter.ai') && config.aiReasoningExclude === true
+    ? { reasoning: { exclude: true } }
+    : {}
+}

--- a/apps/web/src/lib/server/domains/assistant/__tests__/synthesis-core.transport-retry.test.ts
+++ b/apps/web/src/lib/server/domains/assistant/__tests__/synthesis-core.transport-retry.test.ts
@@ -24,6 +24,7 @@ const mockAdapterFactory = vi.fn((..._args: unknown[]) => ({ kind: 'text' }))
 const mockConfig = vi.hoisted(() => ({
   openaiApiKey: 'test-key' as string | undefined,
   openaiBaseUrl: 'http://localhost:9999/v1' as string | undefined,
+  aiReasoningExclude: undefined as boolean | undefined,
 }))
 
 vi.mock('@/lib/server/config', () => ({ config: mockConfig }))
@@ -43,10 +44,14 @@ vi.mock('@tanstack/ai-openai/compatible', () => ({
   openaiCompatibleText: (...args: unknown[]) => mockAdapterFactory(...args),
 }))
 
-vi.mock('@/lib/server/domains/ai/config', () => ({
-  stripCodeFences: (s: string) => s,
-  structuredOutputProviderOptions: () => ({}),
-}))
+vi.mock('@/lib/server/domains/ai/config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/server/domains/ai/config')>()
+  return {
+    ...actual,
+    stripCodeFences: (s: string) => s,
+    structuredOutputProviderOptions: () => ({}),
+  }
+})
 
 const mockWithUsageLogging = vi.fn()
 vi.mock('@/lib/server/domains/ai/usage-log', () => ({
@@ -150,6 +155,7 @@ beforeEach(() => {
   vi.useFakeTimers()
   mockConfig.openaiApiKey = 'test-key'
   mockConfig.openaiBaseUrl = 'http://localhost:9999/v1'
+  mockConfig.aiReasoningExclude = undefined
   mockWithUsageLogging.mockImplementation(
     async (
       _params: unknown,
@@ -227,8 +233,9 @@ describe('transport retry — pristine RUN_ERROR (real adapter shape)', () => {
     expect(mockChat).toHaveBeenCalledTimes(2)
   })
 
-  it('hides OpenRouter reasoning tokens on tool-less structured streams', async () => {
+  it('hides OpenRouter reasoning tokens when AI_REASONING_EXCLUDE is on', async () => {
     mockConfig.openaiBaseUrl = 'https://openrouter.ai/api/v1'
+    mockConfig.aiReasoningExclude = true
     mockChat.mockReturnValueOnce(goodStream('ok'))
 
     await settle(runSynthesis(baseOptions({ transportRetries: 0 })))
@@ -240,8 +247,19 @@ describe('transport retry — pristine RUN_ERROR (real adapter shape)', () => {
     expect(call.modelOptions?.reasoning).toEqual({ exclude: true })
   })
 
+  it('does not hide reasoning on OpenRouter when AI_REASONING_EXCLUDE is unset', async () => {
+    mockConfig.openaiBaseUrl = 'https://openrouter.ai/api/v1'
+    mockChat.mockReturnValueOnce(goodStream('ok'))
+
+    await settle(runSynthesis(baseOptions({ transportRetries: 0 })))
+
+    const call = mockChat.mock.calls[0]![0] as { modelOptions?: { reasoning?: unknown } }
+    expect(call.modelOptions?.reasoning).toBeUndefined()
+  })
+
   it('does not hide reasoning on tool-using OpenRouter streams', async () => {
     mockConfig.openaiBaseUrl = 'https://openrouter.ai/api/v1'
+    mockConfig.aiReasoningExclude = true
     mockChat.mockReturnValueOnce(goodStream('ok'))
 
     await settle(

--- a/apps/web/src/lib/server/domains/assistant/__tests__/synthesis-core.transport-retry.test.ts
+++ b/apps/web/src/lib/server/domains/assistant/__tests__/synthesis-core.transport-retry.test.ts
@@ -74,6 +74,16 @@ function emptyTextThenError(message: string) {
   })()
 }
 
+/** RUN_STARTED, a whitespace-only text delta (DeepSeek json_schema prefix),
+ *  then RUN_ERROR: still pristine — a space does not commit. */
+function whitespaceTextThenError(message: string) {
+  return (async function* () {
+    yield { type: 'RUN_STARTED' }
+    yield { type: 'TEXT_MESSAGE_CONTENT', delta: ' ' }
+    yield { type: 'RUN_ERROR', message }
+  })()
+}
+
 /** RUN_STARTED, a non-empty text delta (streamed to the caller), then RUN_ERROR:
  *  COMMITTED — re-dialing would double-emit. */
 function textThenError(message: string) {
@@ -205,6 +215,51 @@ describe('transport retry — pristine RUN_ERROR (real adapter shape)', () => {
     const result = await settle(runSynthesis(baseOptions()))
     expect((result as { final: unknown }).final).toEqual({ text: 'ok' })
     expect(mockChat).toHaveBeenCalledTimes(2)
+  })
+
+  it('treats a whitespace-only text delta as still pristine and retries', async () => {
+    mockChat
+      .mockReturnValueOnce(whitespaceTextThenError('429 rate limit'))
+      .mockReturnValueOnce(goodStream('ok'))
+
+    const result = await settle(runSynthesis(baseOptions()))
+    expect((result as { final: unknown }).final).toEqual({ text: 'ok' })
+    expect(mockChat).toHaveBeenCalledTimes(2)
+  })
+
+  it('hides OpenRouter reasoning tokens on tool-less structured streams', async () => {
+    mockConfig.openaiBaseUrl = 'https://openrouter.ai/api/v1'
+    mockChat.mockReturnValueOnce(goodStream('ok'))
+
+    await settle(runSynthesis(baseOptions({ transportRetries: 0 })))
+
+    expect(mockChat).toHaveBeenCalledTimes(1)
+    const call = mockChat.mock.calls[0]![0] as {
+      modelOptions?: { reasoning?: { exclude?: boolean } }
+    }
+    expect(call.modelOptions?.reasoning).toEqual({ exclude: true })
+  })
+
+  it('does not hide reasoning on tool-using OpenRouter streams', async () => {
+    mockConfig.openaiBaseUrl = 'https://openrouter.ai/api/v1'
+    mockChat.mockReturnValueOnce(goodStream('ok'))
+
+    await settle(
+      runSynthesis(
+        baseOptions({
+          transportRetries: 0,
+          tools: {
+            specs: [],
+            context: {},
+            agentLoopStrategy: {} as never,
+            names: new Set(),
+          },
+        })
+      )
+    )
+
+    const call = mockChat.mock.calls[0]![0] as { modelOptions?: { reasoning?: unknown } }
+    expect(call.modelOptions?.reasoning).toBeUndefined()
   })
 
   it('retries a pristine RUN_ERROR in strict mode too', async () => {

--- a/apps/web/src/lib/server/domains/assistant/__tests__/synthesis-core.wire-sink.test.ts
+++ b/apps/web/src/lib/server/domains/assistant/__tests__/synthesis-core.wire-sink.test.ts
@@ -41,10 +41,14 @@ vi.mock('@tanstack/ai-openai/compatible', () => ({
   openaiCompatibleText: (...args: unknown[]) => mockAdapterFactory(...args),
 }))
 
-vi.mock('@/lib/server/domains/ai/config', () => ({
-  stripCodeFences: (s: string) => s,
-  structuredOutputProviderOptions: () => ({}),
-}))
+vi.mock('@/lib/server/domains/ai/config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/server/domains/ai/config')>()
+  return {
+    ...actual,
+    stripCodeFences: (s: string) => s,
+    structuredOutputProviderOptions: () => ({}),
+  }
+})
 
 const mockWithUsageLogging = vi.fn()
 vi.mock('@/lib/server/domains/ai/usage-log', () => ({

--- a/apps/web/src/lib/server/domains/assistant/synthesis-core.ts
+++ b/apps/web/src/lib/server/domains/assistant/synthesis-core.ts
@@ -212,11 +212,13 @@ class CommittedStreamError extends Error {
  * the transport the failure happened.
  *
  * `committed` flips on the first meaningful chunk: TEXT_MESSAGE_CONTENT with a
- * non-empty delta (answer text reached the caller via onTextDelta), any
+ * non-whitespace delta (answer text reached the caller via onTextDelta), any
  * TOOL_CALL_* chunk (a tool is executing, with persisted side effects), or the
  * structured-output CUSTOM chunk (the decoded answer). Envelope chunks —
- * RUN_STARTED, TEXT_MESSAGE_START, STEP_* — do NOT commit: nothing has streamed
- * and no tool has run, so a re-dial is safe.
+ * RUN_STARTED, TEXT_MESSAGE_START, STEP_*, empty or whitespace-only text
+ * deltas — do NOT commit: nothing has streamed and no tool has run, so a
+ * re-dial is safe. DeepSeek v4 Flash prefixes structured JSON with a space;
+ * treating that as a commit made a later RUN_ERROR un-retryable.
  *
  * A RUN_ERROR seen while still pristine is therefore a candidate transport
  * failure: it exits as a plain throw so withRetry can classify it via
@@ -260,6 +262,14 @@ async function streamOnce<TContext>(
     // advertise silently shrinks the pool to none and the turn dies with no
     // output.
     ...structuredOutputProviderOptions(),
+    // Tool-less structured streams (Ask AI) must not emit reasoning tokens on
+    // the content channel. DeepSeek v4 Flash via OpenRouter otherwise spends
+    // the first seconds on thinking/whitespace, which commits the SSE on a
+    // single space and then looks idle to the edge proxy. Quinn's tool loop
+    // keeps reasoning so it can round-trip reasoning_details across calls.
+    ...(config.openaiBaseUrl?.includes('openrouter.ai') && !opts.tools
+      ? { reasoning: { exclude: true } }
+      : {}),
   }
 
   const tools = opts.tools
@@ -334,10 +344,12 @@ async function streamOnce<TContext>(
       if (chunk.type.startsWith('TOOL_CALL')) committed = true
       switch (chunk.type) {
         case 'TEXT_MESSAGE_CONTENT': {
-          // A non-empty delta is the first byte of the answer reaching the
-          // caller (streamed via onTextDelta below): a meaningful commit. An
-          // empty delta is an envelope tick and leaves the stream pristine.
-          if (chunk.delta.length > 0) committed = true
+          // A non-whitespace delta is the first byte of the answer reaching
+          // the caller (streamed via onTextDelta below): a meaningful commit.
+          // Empty or whitespace-only deltas are envelope ticks (DeepSeek v4
+          // Flash prefixes json_schema streams with a space) and leave the
+          // stream pristine so a later RUN_ERROR can still re-dial.
+          if (chunk.delta.trim().length > 0) committed = true
           // Deltas are raw JSON; surface only the growth of the target field
           // so consumers stream clean text, not the JSON envelope.
           raw += chunk.delta

--- a/apps/web/src/lib/server/domains/assistant/synthesis-core.ts
+++ b/apps/web/src/lib/server/domains/assistant/synthesis-core.ts
@@ -30,7 +30,11 @@ import { openaiCompatibleText } from '@tanstack/ai-openai/compatible'
 import { jsonrepair } from 'jsonrepair'
 import type { z } from 'zod'
 import { config } from '@/lib/server/config'
-import { stripCodeFences, structuredOutputProviderOptions } from '@/lib/server/domains/ai/config'
+import {
+  stripCodeFences,
+  structuredOutputProviderOptions,
+  reasoningExcludeProviderOptions,
+} from '@/lib/server/domains/ai/config'
 import { withRetry } from '@/lib/server/domains/ai/retry'
 import { withUsageLogging, type AiAnswerKind } from '@/lib/server/domains/ai/usage-log'
 import { isWireForwardable } from './agui'
@@ -262,14 +266,10 @@ async function streamOnce<TContext>(
     // advertise silently shrinks the pool to none and the turn dies with no
     // output.
     ...structuredOutputProviderOptions(),
-    // Tool-less structured streams (Ask AI) must not emit reasoning tokens on
-    // the content channel. DeepSeek v4 Flash via OpenRouter otherwise spends
-    // the first seconds on thinking/whitespace, which commits the SSE on a
-    // single space and then looks idle to the edge proxy. Quinn's tool loop
-    // keeps reasoning so it can round-trip reasoning_details across calls.
-    ...(config.openaiBaseUrl?.includes('openrouter.ai') && !opts.tools
-      ? { reasoning: { exclude: true } }
-      : {}),
+    // Tool-less only: Quinn's tool loop still needs reasoning_details on the
+    // wire. AI_REASONING_EXCLUDE is opt-in because require_parameters 404s
+    // models whose providers do not advertise `reasoning`.
+    ...(opts.tools ? {} : reasoningExcludeProviderOptions()),
   }
 
   const tools = opts.tools

--- a/apps/web/src/lib/shared/platform-schema.generated.json
+++ b/apps/web/src/lib/shared/platform-schema.generated.json
@@ -103,6 +103,12 @@
         "kind": "tristate",
         "group": "advanced",
         "sensitive": false
+      },
+      {
+        "key": "AI_REASONING_EXCLUDE",
+        "kind": "tristate",
+        "group": "advanced",
+        "sensitive": false
       }
     ]
   },


### PR DESCRIPTION
## Why

Ask AI on Cloud (`deepseek/deepseek-v4-flash-0731` via OpenRouter) streamed a single space then died. The help-center UI reported "We couldn't generate an answer right now."

OpenInference prefixes json_schema streams with thinking tokens. Those landed as whitespace on `delta.content`, which committed the synthesis stream and left the public SSE idle until the edge closed it.

`reasoning: { exclude: true }` fixes DeepSeek, but sending that parameter on every OpenRouter tool-less call 404s `require_parameters` routing for models that do not advertise `reasoning` (e.g. GLM 5.3 Flash).

## What

- `AI_REASONING_EXCLUDE` is an opt-in boolean, same shape as `AI_REQUIRE_PARAMETERS` (`true`/`false`/`1`/`0`). Unset is off.
- When true, tool-less OpenRouter structured calls send `reasoning.exclude`. Quinn's tool loop is unchanged.
- Whitespace-only text deltas stay pristine for transport retry.

## Test plan

- [x] `synthesis-core.transport-retry` (whitespace retry + flag on/off + tools skip)
- [ ] After merge + image: `AI_CHAT_MODEL=deepseek/deepseek-v4-flash-0731` and `AI_REASONING_EXCLUDE=true`, then `POST /api/widget/kb-ask` on dogfood until `RUN_FINISHED`