### PR TITLE
fix(help-center): keep Ask AI SSE alive during model think time

### DIFF
--- a/apps/web/src/lib/server/domains/assistant/__tests__/agui-keepalive.test.ts
+++ b/apps/web/src/lib/server/domains/assistant/__tests__/agui-keepalive.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { withSseKeepalive } from '../agui'
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('withSseKeepalive', () => {
+  it('injects SSE comments while the inner body is idle', async () => {
+    vi.useFakeTimers()
+    const inner = new ReadableStream<Uint8Array>({
+      start() {
+        // Stay open so the wrapper's interval can fire.
+      },
+      cancel() {},
+    })
+    const wrapped = withSseKeepalive(
+      new Response(inner, { headers: { 'content-type': 'text/event-stream' } }),
+      2_000
+    )
+    const reader = wrapped.body!.getReader()
+    const decoded = reader.read().then((r) => new TextDecoder().decode(r.value))
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(await decoded).toBe(': keepalive\n\n')
+    await reader.cancel()
+  })
+})

--- a/apps/web/src/lib/server/domains/assistant/agui.ts
+++ b/apps/web/src/lib/server/domains/assistant/agui.ts
@@ -275,6 +275,70 @@ export function streamSynthesisToWire<T>(options: {
   return queue.stream()
 }
 
+/** SSE comment interval so an idle synthesis wait cannot look dead to the edge. */
+export const SSE_KEEPALIVE_INTERVAL_MS = 2_000
+
+const SSE_KEEPALIVE_FRAME = new TextEncoder().encode(': keepalive\n\n')
+
+/**
+ * Wrap an SSE Response so silence longer than {@link SSE_KEEPALIVE_INTERVAL_MS}
+ * still sends bytes. Ask AI buffers model chunks until the attempt commits;
+ * DeepSeek v4 Flash can think for several seconds first, and the public edge
+ * closes an idle event-stream before RUN_FINISHED.
+ */
+export function withSseKeepalive(
+  res: Response,
+  intervalMs: number = SSE_KEEPALIVE_INTERVAL_MS
+): Response {
+  const src = res.body
+  if (!src) return res
+  const reader = src.getReader()
+  let timer: ReturnType<typeof setInterval> | null = null
+  let stopped = false
+  const stop = () => {
+    if (stopped) return
+    stopped = true
+    if (timer !== null) {
+      clearInterval(timer)
+      timer = null
+    }
+  }
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      timer = setInterval(() => {
+        try {
+          controller.enqueue(SSE_KEEPALIVE_FRAME)
+        } catch {
+          stop()
+        }
+      }, intervalMs)
+      void (async () => {
+        try {
+          while (true) {
+            const { done, value } = await reader.read()
+            if (done) break
+            if (value) controller.enqueue(value)
+          }
+          controller.close()
+        } catch (err) {
+          controller.error(err)
+        } finally {
+          stop()
+        }
+      })()
+    },
+    cancel() {
+      stop()
+      void reader.cancel()
+    },
+  })
+  return new Response(stream, {
+    status: res.status,
+    statusText: res.statusText,
+    headers: res.headers,
+  })
+}
+
 export function createChunkQueue(): ChunkQueue {
   const buffered: StreamChunk[] = []
   let done = false

--- a/apps/web/src/routes/api/widget/kb-ask.ts
+++ b/apps/web/src/routes/api/widget/kb-ask.ts
@@ -41,6 +41,7 @@ import {
   runFinishedChunk,
   runErrorChunk,
   stateSnapshotChunk,
+  withSseKeepalive,
 } from '@/lib/server/domains/assistant/agui'
 import type {
   KbAskFinalPayload,
@@ -308,7 +309,9 @@ export async function handleKbAsk({ request }: { request: Request }): Promise<Re
     }
   })()
 
-  return toServerSentEventsResponse(queue.stream(), { headers: widgetCorsHeaders() })
+  return withSseKeepalive(
+    toServerSentEventsResponse(queue.stream(), { headers: widgetCorsHeaders() })
+  )
 }
 
 export const Route = createFileRoute('/api/widget/kb-ask')({


### PR DESCRIPTION
## Why

Even with `AI_REASONING_EXCLUDE=true`, DeepSeek still thinks internally before the first json_schema content token. Ask AI only forwards model chunks after commit, so the public `/api/widget/kb-ask` stream sat idle after `STATE_SNAPSHOT` and Railway Hikari closed it (~8–10s). The UI then showed the generic Ask AI error.

## What

Wrap the Ask AI SSE response with comment keepalives (`: keepalive`) every 2s. EventSource and the Ask AI client ignore comments; `parseAguiSse` already skips them.

## Test plan

- [x] keepalive wrapper unit test
- [x] existing kb-ask SSE tests
- [ ] After merge: DeepSeek Flash Ask AI on feedback.quackback.io reaches `RUN_FINISHED`