### PR TITLE
fix(dev): stop server-only deps forcing a client re-optimise reload (blank /admin)

### DIFF
--- a/apps/web/src/lib/server/domains/billing/usage-counts.ts
+++ b/apps/web/src/lib/server/domains/billing/usage-counts.ts
@@ -1,0 +1,82 @@
+/**
+ * Current-usage counters for the plan's finite quotas, keyed by tier-limit
+ * name so they line up with `getTierLimits()` and `freeDowngradeIssues()`.
+ *
+ * Server-only: this talks to the database directly. It deliberately lives
+ * outside `lib/server/functions/billing.ts` — anything declared at module
+ * scope in a server-function file (rather than inside a `.handler()`) is
+ * kept in the client half of that module by the Start compiler, and its
+ * `import('@/lib/server/db')` was pulling the whole database/auth graph into
+ * the browser's dev module graph (import-protection errors, a Vite
+ * dependency re-optimisation and forced reload mid-navigation).
+ */
+
+import {
+  db,
+  eq,
+  isNull,
+  sql,
+  posts,
+  boards,
+  roles,
+  statusComponents,
+  emailSendingDomains,
+} from '@/lib/server/db'
+import { aiTokensThisMonth } from '@/lib/server/domains/ai/usage-counter'
+import { countSeatUsage } from '@/lib/server/domains/principals/seat-usage'
+import { emailsSentThisMonth } from '@/lib/server/email/email-budget'
+import { apiRequestsThisMonth } from '@/lib/server/domains/api/monthly-usage'
+import { freeDowngradeIssues } from '@/lib/shared/billing/free-downgrade'
+
+export async function loadUsageCounts(): Promise<Record<string, number>> {
+  const [
+    boardRow,
+    postRow,
+    seats,
+    statusRow,
+    roleRow,
+    domainRow,
+    aiTokens,
+    emailsSent,
+    apiRequests,
+  ] = await Promise.all([
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(boards)
+      .where(isNull(boards.deletedAt)),
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(posts)
+      .where(isNull(posts.deletedAt)),
+    countSeatUsage(),
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(statusComponents)
+      .where(isNull(statusComponents.deletedAt)),
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(roles)
+      .where(eq(roles.isSystem, false)),
+    db.select({ count: sql<number>`count(*)::int` }).from(emailSendingDomains),
+    aiTokensThisMonth(),
+    emailsSentThisMonth(),
+    apiRequestsThisMonth(),
+  ])
+  return {
+    maxBoards: boardRow[0]?.count ?? 0,
+    maxPosts: postRow[0]?.count ?? 0,
+    maxTeamSeats: seats.used,
+    maxStatusComponents: statusRow[0]?.count ?? 0,
+    maxCustomRoles: roleRow[0]?.count ?? 0,
+    maxSendingDomains: domainRow[0]?.count ?? 0,
+    aiTokensPerMonth: aiTokens,
+    emailsPerMonth: emailsSent,
+    apiRequestsPerMonth: apiRequests,
+  }
+}
+
+/** Throws `over_free_limits` when current usage would not fit the free plan. */
+export async function assertFitsFreePlan(): Promise<void> {
+  const used = await loadUsageCounts()
+  if (freeDowngradeIssues(used).length > 0) throw new Error('over_free_limits')
+}

--- a/apps/web/src/lib/server/functions/billing.ts
+++ b/apps/web/src/lib/server/functions/billing.ts
@@ -45,63 +45,18 @@ export const fetchSeatsPreviewFn = createServerFn({ method: 'GET' })
     }
   })
 
-async function loadUsageCounts(): Promise<Record<string, number>> {
-  const { aiTokensThisMonth } = await import('@/lib/server/domains/ai/usage-counter')
-  const { db, eq, isNull, sql, posts, boards, roles, statusComponents, emailSendingDomains } =
-    await import('@/lib/server/db')
-  const { countSeatUsage } = await import('@/lib/server/domains/principals/seat-usage')
-  const { emailsSentThisMonth } = await import('@/lib/server/email/email-budget')
-  const { apiRequestsThisMonth } = await import('@/lib/server/domains/api/monthly-usage')
-  const [
-    boardRow,
-    postRow,
-    seats,
-    statusRow,
-    roleRow,
-    domainRow,
-    aiTokens,
-    emailsSent,
-    apiRequests,
-  ] = await Promise.all([
-    db
-      .select({ count: sql<number>`count(*)::int` })
-      .from(boards)
-      .where(isNull(boards.deletedAt)),
-    db
-      .select({ count: sql<number>`count(*)::int` })
-      .from(posts)
-      .where(isNull(posts.deletedAt)),
-    countSeatUsage(),
-    db
-      .select({ count: sql<number>`count(*)::int` })
-      .from(statusComponents)
-      .where(isNull(statusComponents.deletedAt)),
-    db
-      .select({ count: sql<number>`count(*)::int` })
-      .from(roles)
-      .where(eq(roles.isSystem, false)),
-    db.select({ count: sql<number>`count(*)::int` }).from(emailSendingDomains),
-    aiTokensThisMonth(),
-    emailsSentThisMonth(),
-    apiRequestsThisMonth(),
-  ])
-  return {
-    maxBoards: boardRow[0]?.count ?? 0,
-    maxPosts: postRow[0]?.count ?? 0,
-    maxTeamSeats: seats.used,
-    maxStatusComponents: statusRow[0]?.count ?? 0,
-    maxCustomRoles: roleRow[0]?.count ?? 0,
-    maxSendingDomains: domainRow[0]?.count ?? 0,
-    aiTokensPerMonth: aiTokens,
-    emailsPerMonth: emailsSent,
-    apiRequestsPerMonth: apiRequests,
-  }
-}
+// This module is imported by the client for its RPC stubs: only `.handler()`
+// bodies are stripped, and any module-scope helper an export still reaches
+// ships to the browser with its imports. Helpers that touch the database
+// therefore live in `@/lib/server/domains/billing/usage-counts` and are
+// imported from inside the handlers like every other server dependency
+// (guarded by policy/__tests__/server-fn-client-half.test.ts).
 
 export const fetchPlanUsageFn = createServerFn({ method: 'GET' }).handler(async () => {
   await requireAuth({ permission: PERMISSIONS.BILLING_MANAGE })
   const { getTierLimits } = await import('@/lib/server/domains/settings/tier-limits.service')
   const { finiteUsageLines } = await import('@/lib/server/domains/billing/plan-usage')
+  const { loadUsageCounts } = await import('@/lib/server/domains/billing/usage-counts')
   const [limits, used] = await Promise.all([getTierLimits(), loadUsageCounts()])
   return finiteUsageLines([
     { key: 'maxBoards', label: 'boards', used: used.maxBoards ?? 0, limit: limits.maxBoards },
@@ -155,6 +110,7 @@ export const fetchFreeDowngradePreviewFn = createServerFn({ method: 'GET' }).han
   await requireAuth({ permission: PERMISSIONS.BILLING_MANAGE })
   const { getBillingProjectionOverview } =
     await import('@/lib/server/domains/billing/projection-overview')
+  const { loadUsageCounts } = await import('@/lib/server/domains/billing/usage-counts')
   const [overview, used] = await Promise.all([getBillingProjectionOverview(), loadUsageCounts()])
   const { freeDowngradeIssues, featuresDisabledOnFree } =
     await import('@/lib/shared/billing/free-downgrade')
@@ -163,9 +119,3 @@ export const fetchFreeDowngradePreviewFn = createServerFn({ method: 'GET' }).han
     featuresDisabled: featuresDisabledOnFree(overview?.trialPlanId ?? overview?.plan),
   }
 })
-
-export async function assertFitsFreePlan(): Promise<void> {
-  const used = await loadUsageCounts()
-  const { freeDowngradeIssues } = await import('@/lib/shared/billing/free-downgrade')
-  if (freeDowngradeIssues(used).length > 0) throw new Error('over_free_limits')
-}

--- a/apps/web/src/lib/server/policy/__tests__/server-fn-client-half.test.ts
+++ b/apps/web/src/lib/server/policy/__tests__/server-fn-client-half.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Server-function modules ship to the browser.
+ *
+ * `lib/server/functions/*.ts` is imported by client code (route loaders, query
+ * options, components) to get the RPC stubs. The Start compiler strips the
+ * body of every `.handler()` (and `createMiddleware().server()` /
+ * `createServerOnlyFn()`) from the client half, then drops module-scope
+ * bindings nothing else references any more. What survives is every export
+ * and whatever those exports reach — including plain helper functions and
+ * their `await import('@/lib/server/…')` calls, which drag the database/auth
+ * graph into the browser's module graph. In dev that surfaces as
+ * import-protection errors and a Vite dependency re-optimisation + forced
+ * reload mid-navigation (a blank /admin page); in a production build it ships
+ * whatever the tree-shaker cannot prove dead.
+ *
+ * So: in a server-function module, a dynamic import of a server-only module
+ * must either sit inside a server-stripped scope or be unreachable from the
+ * module's exports once those scopes are gone. Server-only helpers belong in a
+ * domain module (`lib/server/domains/...`) and get imported from the handler.
+ *
+ * The reachability here is a syntactic approximation of the compiler's
+ * dead-code elimination: top-level declarations form the nodes, identifier
+ * mentions outside stripped scopes form the edges, exports and bare top-level
+ * statements are the roots.
+ */
+import { describe, it, expect } from 'vitest'
+import * as ts from '@typescript/typescript6'
+import { readFileSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { walkSourceFiles } from '../source-files'
+
+const SRC_ROOT = join(__dirname, '../../../..') // apps/web/src
+const FUNCTIONS_ROOT = join(SRC_ROOT, 'lib/server/functions')
+
+/** Modules that must never be reachable from the client half of a server-function file. */
+export function isServerOnlySpecifier(spec: string): boolean {
+  if (spec.startsWith('@/lib/server/functions/')) return false
+  if (spec.startsWith('@/lib/server/')) return true
+  return spec === '@quackback/db' || spec.startsWith('@quackback/db/')
+}
+
+/** Callee names whose function arguments the Start compiler removes from the client half. */
+const SERVER_STRIPPED_CALLS = new Set(['handler', 'server', 'createServerOnlyFn'])
+
+function isServerStrippedCall(node: ts.Node): boolean {
+  if (!ts.isCallExpression(node)) return false
+  const callee = node.expression
+  if (ts.isPropertyAccessExpression(callee)) return SERVER_STRIPPED_CALLS.has(callee.name.text)
+  if (ts.isIdentifier(callee)) return SERVER_STRIPPED_CALLS.has(callee.text)
+  return false
+}
+
+export interface LeakedImport {
+  file: string
+  line: number
+  specifier: string
+}
+
+function hasExportModifier(node: ts.Node): boolean {
+  return (
+    ts.canHaveModifiers(node) &&
+    (ts.getModifiers(node) ?? []).some((m) => m.kind === ts.SyntaxKind.ExportKeyword)
+  )
+}
+
+function declaredNames(node: ts.Node): string[] {
+  if (ts.isFunctionDeclaration(node) || ts.isClassDeclaration(node)) {
+    return node.name ? [node.name.text] : []
+  }
+  if (ts.isVariableStatement(node)) {
+    const names: string[] = []
+    const collect = (binding: ts.BindingName): void => {
+      if (ts.isIdentifier(binding)) names.push(binding.text)
+      else for (const el of binding.elements) if (ts.isBindingElement(el)) collect(el.name)
+    }
+    for (const decl of node.declarationList.declarations) collect(decl.name)
+    return names
+  }
+  return []
+}
+
+/** Identifiers mentioned in `node`, skipping anything the compiler strips from the client half. */
+function identifiersOutsideStrippedScopes(node: ts.Node): Set<string> {
+  const names = new Set<string>()
+  const visit = (n: ts.Node): void => {
+    if (ts.isCallExpression(n) && isServerStrippedCall(n)) {
+      // The callee chain (`createServerFn().handler`) stays; the arguments go.
+      visit(n.expression)
+      return
+    }
+    if (ts.isIdentifier(n)) names.add(n.text)
+    ts.forEachChild(n, visit)
+  }
+  visit(node)
+  return names
+}
+
+function serverOnlyDynamicImports(sf: ts.SourceFile, root: ts.Node): ts.CallExpression[] {
+  const found: ts.CallExpression[] = []
+  const visit = (n: ts.Node): void => {
+    if (isServerStrippedCall(n)) return
+    if (
+      ts.isCallExpression(n) &&
+      n.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      n.arguments[0] &&
+      ts.isStringLiteral(n.arguments[0]) &&
+      isServerOnlySpecifier(n.arguments[0].text)
+    ) {
+      found.push(n)
+    }
+    ts.forEachChild(n, visit)
+  }
+  visit(root)
+  return found
+}
+
+export function findLeakedServerImports(relPath: string, text: string): LeakedImport[] {
+  const sf = ts.createSourceFile(relPath, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS)
+
+  const byName = new Map<string, ts.Statement>()
+  const roots: ts.Statement[] = []
+  const exportedNames = new Set<string>()
+  for (const stmt of sf.statements) {
+    if (ts.isImportDeclaration(stmt)) continue
+    if (ts.isExportDeclaration(stmt) && stmt.exportClause && ts.isNamedExports(stmt.exportClause)) {
+      for (const el of stmt.exportClause.elements) {
+        exportedNames.add((el.propertyName ?? el.name).text)
+      }
+      continue
+    }
+    if (ts.isExportAssignment(stmt)) {
+      roots.push(stmt)
+      continue
+    }
+    const names = declaredNames(stmt)
+    if (names.length === 0) {
+      // Bare top-level statement (side effect): always in the client half.
+      roots.push(stmt)
+      continue
+    }
+    for (const name of names) byName.set(name, stmt)
+    if (hasExportModifier(stmt)) roots.push(stmt)
+  }
+  for (const name of exportedNames) {
+    const stmt = byName.get(name)
+    if (stmt) roots.push(stmt)
+  }
+
+  const reachable = new Set<ts.Statement>()
+  const queue = [...roots]
+  while (queue.length > 0) {
+    const stmt = queue.pop()!
+    if (reachable.has(stmt)) continue
+    reachable.add(stmt)
+    for (const name of identifiersOutsideStrippedScopes(stmt)) {
+      const dep = byName.get(name)
+      if (dep && !reachable.has(dep)) queue.push(dep)
+    }
+  }
+
+  const leaks: LeakedImport[] = []
+  for (const stmt of sf.statements) {
+    if (!reachable.has(stmt)) continue
+    for (const call of serverOnlyDynamicImports(sf, stmt)) {
+      const { line } = sf.getLineAndCharacterOfPosition(call.getStart(sf))
+      leaks.push({
+        file: relPath,
+        line: line + 1,
+        specifier: (call.arguments[0] as ts.StringLiteral).text,
+      })
+    }
+  }
+  return leaks
+}
+
+describe('findLeakedServerImports', () => {
+  it('accepts a server import inside .handler()', () => {
+    const src = `
+      export const fn = createServerFn().handler(async () => {
+        const { db } = await import('@/lib/server/db')
+        return db
+      })
+    `
+    expect(findLeakedServerImports('x.ts', src)).toEqual([])
+  })
+
+  it('accepts server imports inside createMiddleware().server() and createServerOnlyFn()', () => {
+    const src = `
+      export const mw = createMiddleware().server(async ({ next }) => {
+        await import('@/lib/server/auth')
+        return next()
+      })
+      export const only = createServerOnlyFn(async () => import('@/lib/server/db'))
+    `
+    expect(findLeakedServerImports('x.ts', src)).toEqual([])
+  })
+
+  it('accepts a helper only handlers reach: the compiler drops it from the client half', () => {
+    const src = `
+      async function loadCounts() {
+        const { db } = await import('@/lib/server/db')
+        return db
+      }
+      export const fn = createServerFn().handler(() => loadCounts())
+    `
+    expect(findLeakedServerImports('x.ts', src)).toEqual([])
+  })
+
+  it('flags an exported helper with a server import', () => {
+    const src = `
+      export async function assertFits() {
+        const { db } = await import('@/lib/server/db')
+        return db
+      }
+    `
+    expect(findLeakedServerImports('x.ts', src)).toEqual([
+      { file: 'x.ts', line: 3, specifier: '@/lib/server/db' },
+    ])
+  })
+
+  it('follows references from exports into private helpers', () => {
+    const src = `
+      async function loadCounts() {
+        const { db } = await import('@/lib/server/db')
+        return db
+      }
+      export async function assertFits() {
+        return loadCounts()
+      }
+    `
+    expect(findLeakedServerImports('x.ts', src)).toEqual([
+      { file: 'x.ts', line: 3, specifier: '@/lib/server/db' },
+    ])
+  })
+
+  it('honours export lists and treats bare top-level statements as roots', () => {
+    const listed = `
+      async function viaList() { await import('@/lib/server/db') }
+      export { viaList }
+    `
+    expect(findLeakedServerImports('x.ts', listed)).toHaveLength(1)
+
+    const sideEffect = `
+      async function warm() { await import('@/lib/server/cache') }
+      void warm()
+    `
+    expect(findLeakedServerImports('x.ts', sideEffect)).toHaveLength(1)
+  })
+
+  it('ignores imports of other server-function modules and of shared code', () => {
+    const src = `
+      export async function helper() {
+        await import('@/lib/server/functions/other')
+        await import('@/lib/shared/permissions')
+      }
+    `
+    expect(findLeakedServerImports('x.ts', src)).toEqual([])
+  })
+})
+
+/**
+ * Only modules that declare server functions are imported by the client for
+ * their RPC stubs. A few server-only helper modules also live under
+ * `functions/` (e.g. `origin-transfer.ts`, reached solely through
+ * `createServerOnlyFn`) and never get a client half, so they are out of scope.
+ */
+function declaresServerFunctions(text: string): boolean {
+  return /\bcreateServerFn\s*\(/.test(text)
+}
+
+describe('lib/server/functions client half', () => {
+  it('never imports server-only modules outside a server-stripped scope', () => {
+    const leaks = walkSourceFiles(FUNCTIONS_ROOT).flatMap((file) => {
+      const text = readFileSync(file, 'utf8')
+      if (!declaresServerFunctions(text)) return []
+      return findLeakedServerImports(relative(SRC_ROOT, file), text)
+    })
+    const report = leaks.map((l) => `  ${l.file}:${l.line}  import('${l.specifier}')`).join('\n')
+    expect(
+      leaks,
+      `Server-only imports outside .handler() in server-function modules — these ship to the browser.\n` +
+        `Move the helper into lib/server/domains and import it from inside the handler.\n${report}`
+    ).toEqual([])
+  })
+})

--- a/apps/web/src/lib/server/policy/__tests__/server-fn-client-half.test.ts
+++ b/apps/web/src/lib/server/policy/__tests__/server-fn-client-half.test.ts
@@ -28,26 +28,73 @@ import * as ts from '@typescript/typescript6'
 import { readFileSync } from 'node:fs'
 import { join, relative, posix } from 'node:path'
 import { walkSourceFiles } from '../source-files'
+import { isClientProtectedSpecifier } from '../client-import-protection'
 
 const SRC_ROOT = join(__dirname, '../../../..') // apps/web/src
 const FUNCTIONS_ROOT = join(SRC_ROOT, 'lib/server/functions')
+
+/** `src/`-relative module path (no extension) of a `@/` or relative specifier; null for bare packages. */
+function resolveLocalSpecifier(spec: string, relPath: string): string | null {
+  let path: string
+  if (spec.startsWith('@/')) path = spec.slice(2)
+  else if (spec.startsWith('.')) path = posix.join(posix.dirname(relPath.replace(/\\/g, '/')), spec)
+  else return null
+  return path.replace(/\.tsx?$/, '')
+}
 
 /**
  * Modules that must never be reachable from the client half of a
  * server-function file. `relPath` is the importing file relative to `src/`,
  * so relative specifiers (`'../storage/s3'` from `lib/server/functions/…`)
  * are classified by where they land, not by how they are spelled.
+ *
+ * Under `lib/server/functions/` only modules that themselves declare server
+ * functions are client-safe: they get their own client half (and their own run
+ * of this guard). Helper-only siblings such as `auth-helpers.ts` are plain
+ * server modules — importing them from the browser drags in `@/lib/server/db`.
  */
-export function isServerOnlySpecifier(spec: string, relPath: string): boolean {
-  let path: string
-  if (spec.startsWith('@/')) path = spec.slice(2)
-  else if (spec.startsWith('.')) path = posix.join(posix.dirname(relPath.replace(/\\/g, '/')), spec)
-  else return spec === '@quackback/db' || spec.startsWith('@quackback/db/')
-  if (path.startsWith('lib/server/functions/')) return false
+export function isServerOnlySpecifier(
+  spec: string,
+  relPath: string,
+  isServerFnModule: (path: string) => boolean
+): boolean {
+  const path = resolveLocalSpecifier(spec, relPath)
+  if (path === null) return isClientProtectedSpecifier(spec)
+  if (path.startsWith('lib/server/functions/')) return !isServerFnModule(path)
   // vite.config.ts swaps these for a no-op stub in the client environment
   // (`stubServerLoggerInClient`), so module-scope `logger.child(...)` is fine.
-  if (/^lib\/server\/(logger|log-context)(\.ts)?$/.test(path)) return false
+  if (path === 'lib/server/logger' || path === 'lib/server/log-context') return false
   return path.startsWith('lib/server/')
+}
+
+const START_PACKAGES = new Set(['@tanstack/react-start', '@tanstack/react-start/server'])
+
+/** Local names bound to each Start builder, so `import { createServerFn as fn }` is seen through. */
+interface StartBuilders {
+  serverFn: Set<string>
+  middleware: Set<string>
+  serverOnlyFn: Set<string>
+}
+
+function collectStartBuilders(sf: ts.SourceFile): StartBuilders {
+  const builders: StartBuilders = {
+    serverFn: new Set(),
+    middleware: new Set(),
+    serverOnlyFn: new Set(),
+  }
+  for (const stmt of sf.statements) {
+    if (!ts.isImportDeclaration(stmt) || !ts.isStringLiteral(stmt.moduleSpecifier)) continue
+    if (!START_PACKAGES.has(stmt.moduleSpecifier.text)) continue
+    const bindings = stmt.importClause?.namedBindings
+    if (!bindings || !ts.isNamedImports(bindings)) continue
+    for (const el of bindings.elements) {
+      const imported = (el.propertyName ?? el.name).text
+      if (imported === 'createServerFn') builders.serverFn.add(el.name.text)
+      else if (imported === 'createMiddleware') builders.middleware.add(el.name.text)
+      else if (imported === 'createServerOnlyFn') builders.serverOnlyFn.add(el.name.text)
+    }
+  }
+  return builders
 }
 
 /** The identifier a builder chain like `createServerFn(...).validator(...).handler(...)` starts from. */
@@ -67,14 +114,41 @@ function chainRootName(callee: ts.Expression): string | null {
  * `createMiddleware()` only `.server(...)` is stripped (`.client(...)` runs in
  * the browser). `createServerOnlyFn(...)` drops its argument outright.
  */
-function isServerStrippedCall(node: ts.CallExpression): boolean {
+function isServerStrippedCall(node: ts.CallExpression, builders: StartBuilders): boolean {
   const callee = node.expression
-  if (ts.isIdentifier(callee)) return callee.text === 'createServerOnlyFn'
+  if (ts.isIdentifier(callee)) return builders.serverOnlyFn.has(callee.text)
   if (!ts.isPropertyAccessExpression(callee)) return false
   const root = chainRootName(callee)
-  if (root === 'createServerFn') return true
-  if (root === 'createMiddleware') return callee.name.text === 'server'
+  if (root === null) return false
+  if (builders.serverFn.has(root)) return true
+  if (builders.middleware.has(root)) return callee.name.text === 'server'
   return false
+}
+
+/**
+ * Whether the module declares server functions, i.e. gets a client half of RPC
+ * stubs that browser code imports. Server-only helper modules that also live
+ * under `functions/` (e.g. `origin-transfer.ts`, reached solely through
+ * `createServerOnlyFn`) never do, and are out of scope.
+ */
+export function declaresServerFunctions(sf: ts.SourceFile): boolean {
+  const { serverFn } = collectStartBuilders(sf)
+  if (serverFn.size === 0) return false
+  let found = false
+  const visit = (n: ts.Node): void => {
+    if (found) return
+    if (
+      ts.isCallExpression(n) &&
+      ts.isIdentifier(n.expression) &&
+      serverFn.has(n.expression.text)
+    ) {
+      found = true
+      return
+    }
+    ts.forEachChild(n, visit)
+  }
+  visit(sf)
+  return found
 }
 
 /** Interfaces, type aliases and `declare` blocks are erased; they cannot reach anything. */
@@ -119,11 +193,11 @@ function declaredNames(node: ts.Node): string[] {
  * Identifiers mentioned in `node` at runtime, skipping anything the compiler
  * strips from the client half and anything TypeScript erases (type positions).
  */
-function identifiersOutsideStrippedScopes(node: ts.Node): Set<string> {
+function identifiersOutsideStrippedScopes(node: ts.Node, builders: StartBuilders): Set<string> {
   const names = new Set<string>()
   const visit = (n: ts.Node): void => {
     if (ts.isTypeNode(n)) return
-    if (ts.isCallExpression(n) && isServerStrippedCall(n)) {
+    if (ts.isCallExpression(n) && isServerStrippedCall(n, builders)) {
       // The callee chain (`createServerFn().handler`) stays; the arguments go.
       visit(n.expression)
       return
@@ -135,17 +209,22 @@ function identifiersOutsideStrippedScopes(node: ts.Node): Set<string> {
   return names
 }
 
-function serverOnlyDynamicImports(sf: ts.SourceFile, root: ts.Node): ts.CallExpression[] {
-  const relPath = sf.fileName
+interface Analysis {
+  sf: ts.SourceFile
+  builders: StartBuilders
+  isServerOnly: (spec: string) => boolean
+}
+
+function serverOnlyDynamicImports(a: Analysis, root: ts.Node): ts.CallExpression[] {
   const found: ts.CallExpression[] = []
   const visit = (n: ts.Node): void => {
-    if (ts.isCallExpression(n) && isServerStrippedCall(n)) return
+    if (ts.isCallExpression(n) && isServerStrippedCall(n, a.builders)) return
     if (
       ts.isCallExpression(n) &&
       n.expression.kind === ts.SyntaxKind.ImportKeyword &&
       n.arguments[0] &&
       ts.isStringLiteral(n.arguments[0]) &&
-      isServerOnlySpecifier(n.arguments[0].text, relPath)
+      a.isServerOnly(n.arguments[0].text)
     ) {
       found.push(n)
     }
@@ -155,8 +234,17 @@ function serverOnlyDynamicImports(sf: ts.SourceFile, root: ts.Node): ts.CallExpr
   return found
 }
 
-export function findLeakedServerImports(relPath: string, text: string): LeakedImport[] {
+export function findLeakedServerImports(
+  relPath: string,
+  text: string,
+  isServerFnModule: (path: string) => boolean = () => false
+): LeakedImport[] {
   const sf = ts.createSourceFile(relPath, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS)
+  const a: Analysis = {
+    sf,
+    builders: collectStartBuilders(sf),
+    isServerOnly: (spec) => isServerOnlySpecifier(spec, relPath, isServerFnModule),
+  }
 
   const byName = new Map<string, ts.Statement>()
   const roots: ts.Statement[] = []
@@ -168,7 +256,7 @@ export function findLeakedServerImports(relPath: string, text: string): LeakedIm
     if (ts.isImportDeclaration(stmt)) {
       if (!ts.isStringLiteral(stmt.moduleSpecifier)) continue
       const spec = stmt.moduleSpecifier.text
-      if (!isServerOnlySpecifier(spec, relPath)) continue
+      if (!a.isServerOnly(spec)) continue
       const clause = stmt.importClause
       // `import type` and side-effect imports leave no runtime binding to reach;
       // a bare `import '@/lib/server/x'` always runs, so it is a root.
@@ -197,7 +285,7 @@ export function findLeakedServerImports(relPath: string, text: string): LeakedIm
     if (ts.isExportDeclaration(stmt)) {
       if (stmt.moduleSpecifier && ts.isStringLiteral(stmt.moduleSpecifier)) {
         // `export … from '@/lib/server/x'` re-exports the server module itself.
-        if (!stmt.isTypeOnly && isServerOnlySpecifier(stmt.moduleSpecifier.text, relPath)) {
+        if (!stmt.isTypeOnly && a.isServerOnly(stmt.moduleSpecifier.text)) {
           roots.push(stmt)
           serverOnlyStaticImports.set(stmt, stmt.moduleSpecifier.text)
         }
@@ -235,7 +323,7 @@ export function findLeakedServerImports(relPath: string, text: string): LeakedIm
     const stmt = queue.pop()!
     if (reachable.has(stmt)) continue
     reachable.add(stmt)
-    for (const name of identifiersOutsideStrippedScopes(stmt)) {
+    for (const name of identifiersOutsideStrippedScopes(stmt, a.builders)) {
       const dep = byName.get(name)
       if (dep && !reachable.has(dep)) queue.push(dep)
     }
@@ -250,7 +338,7 @@ export function findLeakedServerImports(relPath: string, text: string): LeakedIm
       leaks.push({ file: relPath, line: line + 1, specifier: staticSpec })
       continue
     }
-    for (const call of serverOnlyDynamicImports(sf, stmt)) {
+    for (const call of serverOnlyDynamicImports(a, stmt)) {
       const { line } = sf.getLineAndCharacterOfPosition(call.getStart(sf))
       leaks.push({
         file: relPath,
@@ -262,7 +350,60 @@ export function findLeakedServerImports(relPath: string, text: string): LeakedIm
   return leaks
 }
 
+const START_IMPORT = `import { createServerFn, createMiddleware, createServerOnlyFn } from '@tanstack/react-start'\n`
+
+/** Samples assume the canonical builder imports; prepend them (one line, so line numbers shift by 1). */
+function leaks(file: string, src: string, isServerFnModule?: (path: string) => boolean) {
+  return findLeakedServerImports(file, START_IMPORT + src, isServerFnModule)
+}
+
 describe('findLeakedServerImports', () => {
+  it('recognises builders by their import binding, including aliases', () => {
+    const aliased = `
+      import { createServerFn as serverFn, createServerOnlyFn as onServer } from '@tanstack/react-start'
+      export const fn = serverFn().handler(async () => import('@/lib/server/db'))
+      export const only = onServer(async () => import('@/lib/server/auth'))
+    `
+    expect(findLeakedServerImports('x.ts', aliased)).toEqual([])
+    const sf = ts.createSourceFile('x.ts', aliased, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS)
+    expect(declaresServerFunctions(sf)).toBe(true)
+
+    // A same-named local function is not the compiler's builder: nothing is stripped.
+    const homonym = `
+      const createServerFn = () => ({ handler: (f: unknown) => f })
+      export const fn = createServerFn().handler(async () => import('@/lib/server/db'))
+    `
+    expect(findLeakedServerImports('x.ts', homonym)).toHaveLength(1)
+    expect(
+      declaresServerFunctions(
+        ts.createSourceFile('x.ts', homonym, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS)
+      )
+    ).toBe(false)
+  })
+
+  it('flags the bare packages vite.config.ts import-protects', () => {
+    const src = `
+      import postgres from 'postgres'
+      export async function ai() {
+        const { default: OpenAI } = await import('openai')
+        const { default: pino } = await import('pino/file')
+        return [postgres, OpenAI, pino]
+      }
+    `
+    expect(leaks('x.ts', src).map((l) => l.specifier)).toEqual(['postgres', 'openai', 'pino/file'])
+  })
+
+  it('only exempts functions/ siblings that declare server functions themselves', () => {
+    const file = 'lib/server/functions/posts.ts'
+    const src = `
+      import { requireAuth } from './auth-helpers'
+      import { fetchBoardsFn } from '@/lib/server/functions/boards'
+      export const check = () => [requireAuth, fetchBoardsFn]
+    `
+    const isServerFnModule = (p: string) => p === 'lib/server/functions/boards'
+    expect(leaks(file, src, isServerFnModule).map((l) => l.specifier)).toEqual(['./auth-helpers'])
+  })
+
   it('accepts a server import inside .handler()', () => {
     const src = `
       export const fn = createServerFn().handler(async () => {
@@ -270,7 +411,7 @@ describe('findLeakedServerImports', () => {
         return db
       })
     `
-    expect(findLeakedServerImports('x.ts', src)).toEqual([])
+    expect(leaks('x.ts', src)).toEqual([])
   })
 
   it('accepts server imports inside createMiddleware().server() and createServerOnlyFn()', () => {
@@ -281,7 +422,7 @@ describe('findLeakedServerImports', () => {
       })
       export const only = createServerOnlyFn(async () => import('@/lib/server/db'))
     `
-    expect(findLeakedServerImports('x.ts', src)).toEqual([])
+    expect(leaks('x.ts', src)).toEqual([])
   })
 
   it('treats the whole createServerFn chain as stripped: validators and middleware go too', () => {
@@ -294,7 +435,7 @@ describe('findLeakedServerImports', () => {
         .validator(z.object({ outcome: outcomeSchema }))
         .handler(async ({ data }) => data)
     `
-    expect(findLeakedServerImports('x.ts', src)).toEqual([])
+    expect(leaks('x.ts', src)).toEqual([])
   })
 
   it('keeps createMiddleware().client() and ignores type positions', () => {
@@ -302,14 +443,14 @@ describe('findLeakedServerImports', () => {
       import { db } from '@/lib/server/db'
       export const mw = createMiddleware().client(async ({ next }) => { db; return next() })
     `
-    expect(findLeakedServerImports('x.ts', client)).toHaveLength(1)
+    expect(leaks('x.ts', client)).toHaveLength(1)
 
     const typesOnly = `
       import { actorFromAuth } from '@/lib/server/audit/log'
       export interface Input { actor: ReturnType<typeof actorFromAuth> }
       export function shape(x: ReturnType<typeof actorFromAuth>): string { return String(x) }
     `
-    expect(findLeakedServerImports('x.ts', typesOnly)).toEqual([])
+    expect(leaks('x.ts', typesOnly)).toEqual([])
   })
 
   it('accepts a helper only handlers reach: the compiler drops it from the client half', () => {
@@ -320,7 +461,7 @@ describe('findLeakedServerImports', () => {
       }
       export const fn = createServerFn().handler(() => loadCounts())
     `
-    expect(findLeakedServerImports('x.ts', src)).toEqual([])
+    expect(leaks('x.ts', src)).toEqual([])
   })
 
   it('flags an exported helper with a server import', () => {
@@ -330,9 +471,7 @@ describe('findLeakedServerImports', () => {
         return db
       }
     `
-    expect(findLeakedServerImports('x.ts', src)).toEqual([
-      { file: 'x.ts', line: 3, specifier: '@/lib/server/db' },
-    ])
+    expect(leaks('x.ts', src)).toEqual([{ file: 'x.ts', line: 4, specifier: '@/lib/server/db' }])
   })
 
   it('follows references from exports into private helpers', () => {
@@ -345,9 +484,7 @@ describe('findLeakedServerImports', () => {
         return loadCounts()
       }
     `
-    expect(findLeakedServerImports('x.ts', src)).toEqual([
-      { file: 'x.ts', line: 3, specifier: '@/lib/server/db' },
-    ])
+    expect(leaks('x.ts', src)).toEqual([{ file: 'x.ts', line: 4, specifier: '@/lib/server/db' }])
   })
 
   it('honours export lists and treats bare top-level statements as roots', () => {
@@ -355,13 +492,13 @@ describe('findLeakedServerImports', () => {
       async function viaList() { await import('@/lib/server/db') }
       export { viaList }
     `
-    expect(findLeakedServerImports('x.ts', listed)).toHaveLength(1)
+    expect(leaks('x.ts', listed)).toHaveLength(1)
 
     const sideEffect = `
       async function warm() { await import('@/lib/server/cache') }
       void warm()
     `
-    expect(findLeakedServerImports('x.ts', sideEffect)).toHaveLength(1)
+    expect(leaks('x.ts', sideEffect)).toHaveLength(1)
   })
 
   it('flags a static server import that an export still references', () => {
@@ -371,9 +508,7 @@ describe('findLeakedServerImports', () => {
         return db.select()
       }
     `
-    expect(findLeakedServerImports('x.ts', src)).toEqual([
-      { file: 'x.ts', line: 2, specifier: '@/lib/server/db' },
-    ])
+    expect(leaks('x.ts', src)).toEqual([{ file: 'x.ts', line: 3, specifier: '@/lib/server/db' }])
   })
 
   it('accepts a static server import used only inside handlers, and type-only imports', () => {
@@ -384,7 +519,7 @@ describe('findLeakedServerImports', () => {
       export const fn = createServerFn().handler(async () => db.select())
       export type Out = Row
     `
-    expect(findLeakedServerImports('x.ts', src)).toEqual([])
+    expect(leaks('x.ts', src)).toEqual([])
   })
 
   it('flags namespace/default bindings, side-effect imports and re-exports of server modules', () => {
@@ -392,16 +527,16 @@ describe('findLeakedServerImports', () => {
       import * as auth from '@/lib/server/auth'
       export const check = () => auth.verify()
     `
-    expect(findLeakedServerImports('x.ts', ns)).toHaveLength(1)
+    expect(leaks('x.ts', ns)).toHaveLength(1)
 
     const sideEffect = `import '@/lib/server/db'`
-    expect(findLeakedServerImports('x.ts', sideEffect)).toHaveLength(1)
+    expect(leaks('x.ts', sideEffect)).toHaveLength(1)
 
     const reexport = `export { db } from '@/lib/server/db'`
-    expect(findLeakedServerImports('x.ts', reexport)).toHaveLength(1)
+    expect(leaks('x.ts', reexport)).toHaveLength(1)
 
     const typeReexport = `export type { Database } from '@/lib/server/db'`
-    expect(findLeakedServerImports('x.ts', typeReexport)).toEqual([])
+    expect(leaks('x.ts', typeReexport)).toEqual([])
   })
 
   it('classifies relative specifiers by where they resolve', () => {
@@ -413,19 +548,20 @@ describe('findLeakedServerImports', () => {
         return presign()
       }
     `
-    expect(findLeakedServerImports(file, leaky).map((l) => l.specifier)).toEqual([
+    expect(leaks(file, leaky).map((l) => l.specifier)).toEqual([
       '../storage/s3',
       '../integrations/save',
     ])
 
     const fine = `
-      import { requireAuth } from './auth-helpers'
+      import { fetchBoardsFn } from './boards'
       import { schema } from '../../shared/schemas/boards'
       import { logger } from '@/lib/server/logger'
       const log = logger.child({ component: 'uploads' })
-      export const check = () => [requireAuth, schema, log]
+      export const check = () => [fetchBoardsFn, schema, log]
     `
-    expect(findLeakedServerImports(file, fine)).toEqual([])
+    const isServerFnModule = (p: string) => p === 'lib/server/functions/boards'
+    expect(leaks(file, fine, isServerFnModule)).toEqual([])
   })
 
   it('ignores imports of other server-function modules and of shared code', () => {
@@ -435,27 +571,27 @@ describe('findLeakedServerImports', () => {
         await import('@/lib/shared/permissions')
       }
     `
-    expect(findLeakedServerImports('x.ts', src)).toEqual([])
+    const isServerFnModule = (p: string) => p === 'lib/server/functions/other'
+    expect(leaks('x.ts', src, isServerFnModule)).toEqual([])
   })
 })
 
-/**
- * Only modules that declare server functions are imported by the client for
- * their RPC stubs. A few server-only helper modules also live under
- * `functions/` (e.g. `origin-transfer.ts`, reached solely through
- * `createServerOnlyFn`) and never get a client half, so they are out of scope.
- */
-function declaresServerFunctions(text: string): boolean {
-  return /\bcreateServerFn\s*\(/.test(text)
-}
-
 describe('lib/server/functions client half', () => {
   it('never imports server-only modules outside a server-stripped scope', () => {
-    const leaks = walkSourceFiles(FUNCTIONS_ROOT).flatMap((file) => {
+    const modules = walkSourceFiles(FUNCTIONS_ROOT).map((file) => {
+      const relPath = relative(SRC_ROOT, file).replace(/\\/g, '/')
       const text = readFileSync(file, 'utf8')
-      if (!declaresServerFunctions(text)) return []
-      return findLeakedServerImports(relative(SRC_ROOT, file), text)
+      const sf = ts.createSourceFile(relPath, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS)
+      return { relPath, text, isServerFnModule: declaresServerFunctions(sf) }
     })
+    const serverFnModules = new Set(
+      modules.filter((m) => m.isServerFnModule).map((m) => m.relPath.replace(/\.tsx?$/, ''))
+    )
+    expect(serverFnModules.size).toBeGreaterThan(20)
+
+    const leaks = modules
+      .filter((m) => m.isServerFnModule)
+      .flatMap((m) => findLeakedServerImports(m.relPath, m.text, (p) => serverFnModules.has(p)))
     const report = leaks.map((l) => `  ${l.file}:${l.line}  import('${l.specifier}')`).join('\n')
     expect(
       leaks,

--- a/apps/web/src/lib/server/policy/__tests__/server-fn-client-half.test.ts
+++ b/apps/web/src/lib/server/policy/__tests__/server-fn-client-half.test.ts
@@ -39,15 +39,40 @@ export function isServerOnlySpecifier(spec: string): boolean {
   return spec === '@quackback/db' || spec.startsWith('@quackback/db/')
 }
 
-/** Callee names whose function arguments the Start compiler removes from the client half. */
-const SERVER_STRIPPED_CALLS = new Set(['handler', 'server', 'createServerOnlyFn'])
+/** The identifier a builder chain like `createServerFn(...).validator(...).handler(...)` starts from. */
+function chainRootName(callee: ts.Expression): string | null {
+  let cur: ts.Expression = callee
+  for (;;) {
+    if (ts.isPropertyAccessExpression(cur)) cur = cur.expression
+    else if (ts.isCallExpression(cur)) cur = cur.expression
+    else return ts.isIdentifier(cur) ? cur.text : null
+  }
+}
 
-function isServerStrippedCall(node: ts.Node): boolean {
-  if (!ts.isCallExpression(node)) return false
+/**
+ * Calls whose arguments the Start compiler removes from the client half. The
+ * whole `createServerFn(...)` chain collapses to `.handler(createClientRpc(id))`
+ * — validators and middleware go too, not just the handler — while for
+ * `createMiddleware()` only `.server(...)` is stripped (`.client(...)` runs in
+ * the browser). `createServerOnlyFn(...)` drops its argument outright.
+ */
+function isServerStrippedCall(node: ts.CallExpression): boolean {
   const callee = node.expression
-  if (ts.isPropertyAccessExpression(callee)) return SERVER_STRIPPED_CALLS.has(callee.name.text)
-  if (ts.isIdentifier(callee)) return SERVER_STRIPPED_CALLS.has(callee.text)
+  if (ts.isIdentifier(callee)) return callee.text === 'createServerOnlyFn'
+  if (!ts.isPropertyAccessExpression(callee)) return false
+  const root = chainRootName(callee)
+  if (root === 'createServerFn') return true
+  if (root === 'createMiddleware') return callee.name.text === 'server'
   return false
+}
+
+/** Interfaces, type aliases and `declare` blocks are erased; they cannot reach anything. */
+function isTypeLevelStatement(stmt: ts.Statement): boolean {
+  return (
+    ts.isInterfaceDeclaration(stmt) ||
+    ts.isTypeAliasDeclaration(stmt) ||
+    ts.isModuleDeclaration(stmt)
+  )
 }
 
 export interface LeakedImport {
@@ -79,10 +104,14 @@ function declaredNames(node: ts.Node): string[] {
   return []
 }
 
-/** Identifiers mentioned in `node`, skipping anything the compiler strips from the client half. */
+/**
+ * Identifiers mentioned in `node` at runtime, skipping anything the compiler
+ * strips from the client half and anything TypeScript erases (type positions).
+ */
 function identifiersOutsideStrippedScopes(node: ts.Node): Set<string> {
   const names = new Set<string>()
   const visit = (n: ts.Node): void => {
+    if (ts.isTypeNode(n)) return
     if (ts.isCallExpression(n) && isServerStrippedCall(n)) {
       // The callee chain (`createServerFn().handler`) stays; the arguments go.
       visit(n.expression)
@@ -98,7 +127,7 @@ function identifiersOutsideStrippedScopes(node: ts.Node): Set<string> {
 function serverOnlyDynamicImports(sf: ts.SourceFile, root: ts.Node): ts.CallExpression[] {
   const found: ts.CallExpression[] = []
   const visit = (n: ts.Node): void => {
-    if (isServerStrippedCall(n)) return
+    if (ts.isCallExpression(n) && isServerStrippedCall(n)) return
     if (
       ts.isCallExpression(n) &&
       n.expression.kind === ts.SyntaxKind.ImportKeyword &&
@@ -120,11 +149,52 @@ export function findLeakedServerImports(relPath: string, text: string): LeakedIm
   const byName = new Map<string, ts.Statement>()
   const roots: ts.Statement[] = []
   const exportedNames = new Set<string>()
+  // Static imports of server-only modules, keyed by statement: reachable via
+  // any of their runtime bindings, exactly like a helper declaration.
+  const serverOnlyStaticImports = new Map<ts.Statement, string>()
   for (const stmt of sf.statements) {
-    if (ts.isImportDeclaration(stmt)) continue
-    if (ts.isExportDeclaration(stmt) && stmt.exportClause && ts.isNamedExports(stmt.exportClause)) {
-      for (const el of stmt.exportClause.elements) {
-        exportedNames.add((el.propertyName ?? el.name).text)
+    if (ts.isImportDeclaration(stmt)) {
+      if (!ts.isStringLiteral(stmt.moduleSpecifier)) continue
+      const spec = stmt.moduleSpecifier.text
+      if (!isServerOnlySpecifier(spec)) continue
+      const clause = stmt.importClause
+      // `import type` and side-effect imports leave no runtime binding to reach;
+      // a bare `import '@/lib/server/x'` always runs, so it is a root.
+      if (!clause) {
+        roots.push(stmt)
+        serverOnlyStaticImports.set(stmt, spec)
+        continue
+      }
+      if (clause.isTypeOnly) continue
+      const bindings: string[] = []
+      if (clause.name) bindings.push(clause.name.text)
+      if (clause.namedBindings) {
+        if (ts.isNamespaceImport(clause.namedBindings)) {
+          bindings.push(clause.namedBindings.name.text)
+        } else {
+          for (const el of clause.namedBindings.elements) {
+            if (!el.isTypeOnly) bindings.push(el.name.text)
+          }
+        }
+      }
+      if (bindings.length === 0) continue
+      for (const name of bindings) byName.set(name, stmt)
+      serverOnlyStaticImports.set(stmt, spec)
+      continue
+    }
+    if (ts.isExportDeclaration(stmt)) {
+      if (stmt.moduleSpecifier && ts.isStringLiteral(stmt.moduleSpecifier)) {
+        // `export … from '@/lib/server/x'` re-exports the server module itself.
+        if (!stmt.isTypeOnly && isServerOnlySpecifier(stmt.moduleSpecifier.text)) {
+          roots.push(stmt)
+          serverOnlyStaticImports.set(stmt, stmt.moduleSpecifier.text)
+        }
+        continue
+      }
+      if (stmt.exportClause && ts.isNamedExports(stmt.exportClause)) {
+        for (const el of stmt.exportClause.elements) {
+          exportedNames.add((el.propertyName ?? el.name).text)
+        }
       }
       continue
     }
@@ -132,6 +202,7 @@ export function findLeakedServerImports(relPath: string, text: string): LeakedIm
       roots.push(stmt)
       continue
     }
+    if (isTypeLevelStatement(stmt)) continue
     const names = declaredNames(stmt)
     if (names.length === 0) {
       // Bare top-level statement (side effect): always in the client half.
@@ -161,6 +232,12 @@ export function findLeakedServerImports(relPath: string, text: string): LeakedIm
   const leaks: LeakedImport[] = []
   for (const stmt of sf.statements) {
     if (!reachable.has(stmt)) continue
+    const staticSpec = serverOnlyStaticImports.get(stmt)
+    if (staticSpec !== undefined) {
+      const { line } = sf.getLineAndCharacterOfPosition(stmt.getStart(sf))
+      leaks.push({ file: relPath, line: line + 1, specifier: staticSpec })
+      continue
+    }
     for (const call of serverOnlyDynamicImports(sf, stmt)) {
       const { line } = sf.getLineAndCharacterOfPosition(call.getStart(sf))
       leaks.push({
@@ -193,6 +270,34 @@ describe('findLeakedServerImports', () => {
       export const only = createServerOnlyFn(async () => import('@/lib/server/db'))
     `
     expect(findLeakedServerImports('x.ts', src)).toEqual([])
+  })
+
+  it('treats the whole createServerFn chain as stripped: validators and middleware go too', () => {
+    const src = `
+      import { ONBOARDING_OUTCOMES } from '@/lib/server/db'
+      import { requireAdmin } from '@/lib/server/auth/guards'
+      const outcomeSchema = z.enum(ONBOARDING_OUTCOMES)
+      export const fn = createServerFn({ method: 'POST' })
+        .middleware([requireAdmin])
+        .validator(z.object({ outcome: outcomeSchema }))
+        .handler(async ({ data }) => data)
+    `
+    expect(findLeakedServerImports('x.ts', src)).toEqual([])
+  })
+
+  it('keeps createMiddleware().client() and ignores type positions', () => {
+    const client = `
+      import { db } from '@/lib/server/db'
+      export const mw = createMiddleware().client(async ({ next }) => { db; return next() })
+    `
+    expect(findLeakedServerImports('x.ts', client)).toHaveLength(1)
+
+    const typesOnly = `
+      import { actorFromAuth } from '@/lib/server/audit/log'
+      export interface Input { actor: ReturnType<typeof actorFromAuth> }
+      export function shape(x: ReturnType<typeof actorFromAuth>): string { return String(x) }
+    `
+    expect(findLeakedServerImports('x.ts', typesOnly)).toEqual([])
   })
 
   it('accepts a helper only handlers reach: the compiler drops it from the client half', () => {
@@ -245,6 +350,46 @@ describe('findLeakedServerImports', () => {
       void warm()
     `
     expect(findLeakedServerImports('x.ts', sideEffect)).toHaveLength(1)
+  })
+
+  it('flags a static server import that an export still references', () => {
+    const src = `
+      import { db } from '@/lib/server/db'
+      export async function count() {
+        return db.select()
+      }
+    `
+    expect(findLeakedServerImports('x.ts', src)).toEqual([
+      { file: 'x.ts', line: 2, specifier: '@/lib/server/db' },
+    ])
+  })
+
+  it('accepts a static server import used only inside handlers, and type-only imports', () => {
+    const src = `
+      import { db } from '@/lib/server/db'
+      import type { Row } from '@/lib/server/db'
+      import { type Other, requireAuth } from '@/lib/server/functions/auth-helpers'
+      export const fn = createServerFn().handler(async () => db.select())
+      export type Out = Row
+    `
+    expect(findLeakedServerImports('x.ts', src)).toEqual([])
+  })
+
+  it('flags namespace/default bindings, side-effect imports and re-exports of server modules', () => {
+    const ns = `
+      import * as auth from '@/lib/server/auth'
+      export const check = () => auth.verify()
+    `
+    expect(findLeakedServerImports('x.ts', ns)).toHaveLength(1)
+
+    const sideEffect = `import '@/lib/server/db'`
+    expect(findLeakedServerImports('x.ts', sideEffect)).toHaveLength(1)
+
+    const reexport = `export { db } from '@/lib/server/db'`
+    expect(findLeakedServerImports('x.ts', reexport)).toHaveLength(1)
+
+    const typeReexport = `export type { Database } from '@/lib/server/db'`
+    expect(findLeakedServerImports('x.ts', typeReexport)).toEqual([])
   })
 
   it('ignores imports of other server-function modules and of shared code', () => {

--- a/apps/web/src/lib/server/policy/__tests__/server-fn-client-half.test.ts
+++ b/apps/web/src/lib/server/policy/__tests__/server-fn-client-half.test.ts
@@ -26,17 +26,28 @@
 import { describe, it, expect } from 'vitest'
 import * as ts from '@typescript/typescript6'
 import { readFileSync } from 'node:fs'
-import { join, relative } from 'node:path'
+import { join, relative, posix } from 'node:path'
 import { walkSourceFiles } from '../source-files'
 
 const SRC_ROOT = join(__dirname, '../../../..') // apps/web/src
 const FUNCTIONS_ROOT = join(SRC_ROOT, 'lib/server/functions')
 
-/** Modules that must never be reachable from the client half of a server-function file. */
-export function isServerOnlySpecifier(spec: string): boolean {
-  if (spec.startsWith('@/lib/server/functions/')) return false
-  if (spec.startsWith('@/lib/server/')) return true
-  return spec === '@quackback/db' || spec.startsWith('@quackback/db/')
+/**
+ * Modules that must never be reachable from the client half of a
+ * server-function file. `relPath` is the importing file relative to `src/`,
+ * so relative specifiers (`'../storage/s3'` from `lib/server/functions/…`)
+ * are classified by where they land, not by how they are spelled.
+ */
+export function isServerOnlySpecifier(spec: string, relPath: string): boolean {
+  let path: string
+  if (spec.startsWith('@/')) path = spec.slice(2)
+  else if (spec.startsWith('.')) path = posix.join(posix.dirname(relPath.replace(/\\/g, '/')), spec)
+  else return spec === '@quackback/db' || spec.startsWith('@quackback/db/')
+  if (path.startsWith('lib/server/functions/')) return false
+  // vite.config.ts swaps these for a no-op stub in the client environment
+  // (`stubServerLoggerInClient`), so module-scope `logger.child(...)` is fine.
+  if (/^lib\/server\/(logger|log-context)(\.ts)?$/.test(path)) return false
+  return path.startsWith('lib/server/')
 }
 
 /** The identifier a builder chain like `createServerFn(...).validator(...).handler(...)` starts from. */
@@ -125,6 +136,7 @@ function identifiersOutsideStrippedScopes(node: ts.Node): Set<string> {
 }
 
 function serverOnlyDynamicImports(sf: ts.SourceFile, root: ts.Node): ts.CallExpression[] {
+  const relPath = sf.fileName
   const found: ts.CallExpression[] = []
   const visit = (n: ts.Node): void => {
     if (ts.isCallExpression(n) && isServerStrippedCall(n)) return
@@ -133,7 +145,7 @@ function serverOnlyDynamicImports(sf: ts.SourceFile, root: ts.Node): ts.CallExpr
       n.expression.kind === ts.SyntaxKind.ImportKeyword &&
       n.arguments[0] &&
       ts.isStringLiteral(n.arguments[0]) &&
-      isServerOnlySpecifier(n.arguments[0].text)
+      isServerOnlySpecifier(n.arguments[0].text, relPath)
     ) {
       found.push(n)
     }
@@ -156,7 +168,7 @@ export function findLeakedServerImports(relPath: string, text: string): LeakedIm
     if (ts.isImportDeclaration(stmt)) {
       if (!ts.isStringLiteral(stmt.moduleSpecifier)) continue
       const spec = stmt.moduleSpecifier.text
-      if (!isServerOnlySpecifier(spec)) continue
+      if (!isServerOnlySpecifier(spec, relPath)) continue
       const clause = stmt.importClause
       // `import type` and side-effect imports leave no runtime binding to reach;
       // a bare `import '@/lib/server/x'` always runs, so it is a root.
@@ -185,7 +197,7 @@ export function findLeakedServerImports(relPath: string, text: string): LeakedIm
     if (ts.isExportDeclaration(stmt)) {
       if (stmt.moduleSpecifier && ts.isStringLiteral(stmt.moduleSpecifier)) {
         // `export … from '@/lib/server/x'` re-exports the server module itself.
-        if (!stmt.isTypeOnly && isServerOnlySpecifier(stmt.moduleSpecifier.text)) {
+        if (!stmt.isTypeOnly && isServerOnlySpecifier(stmt.moduleSpecifier.text, relPath)) {
           roots.push(stmt)
           serverOnlyStaticImports.set(stmt, stmt.moduleSpecifier.text)
         }
@@ -390,6 +402,30 @@ describe('findLeakedServerImports', () => {
 
     const typeReexport = `export type { Database } from '@/lib/server/db'`
     expect(findLeakedServerImports('x.ts', typeReexport)).toEqual([])
+  })
+
+  it('classifies relative specifiers by where they resolve', () => {
+    const file = 'lib/server/functions/uploads.ts'
+    const leaky = `
+      import { presign } from '../storage/s3'
+      export async function url() {
+        await import('../integrations/save')
+        return presign()
+      }
+    `
+    expect(findLeakedServerImports(file, leaky).map((l) => l.specifier)).toEqual([
+      '../storage/s3',
+      '../integrations/save',
+    ])
+
+    const fine = `
+      import { requireAuth } from './auth-helpers'
+      import { schema } from '../../shared/schemas/boards'
+      import { logger } from '@/lib/server/logger'
+      const log = logger.child({ component: 'uploads' })
+      export const check = () => [requireAuth, schema, log]
+    `
+    expect(findLeakedServerImports(file, fine)).toEqual([])
   })
 
   it('ignores imports of other server-function modules and of shared code', () => {

--- a/apps/web/src/lib/server/policy/client-import-protection.ts
+++ b/apps/web/src/lib/server/policy/client-import-protection.ts
@@ -1,0 +1,23 @@
+/**
+ * Bare package specifiers the client environment must never import.
+ *
+ * Fed to TanStack Start's `importProtection` in `vite.config.ts` (which fails
+ * the dev server / build on a real client import) and to the
+ * `server-fn-client-half` policy test (which catches the same packages while
+ * they are still reachable only from an exported helper in a server-function
+ * module — before Vite's optimizer gets a chance to trip over them).
+ */
+export const CLIENT_PROTECTED_SPECIFIERS = [
+  'postgres',
+  '@quackback/db',
+  '@quackback/db/client',
+  '@quackback/db/schema',
+  'openai',
+  '@quackback/logger',
+  'pino',
+] as const
+
+/** True for a protected package or any of its subpaths (`pino/file`, `@quackback/db/x`). */
+export function isClientProtectedSpecifier(spec: string): boolean {
+  return CLIENT_PROTECTED_SPECIFIERS.some((p) => spec === p || spec.startsWith(`${p}/`))
+}

--- a/apps/web/src/lib/server/policy/dep-graph/GRAPH.md
+++ b/apps/web/src/lib/server/policy/dep-graph/GRAPH.md
@@ -57,7 +57,7 @@ Edges (26):
 ## 3. Server domains (lib/server/domains)
 
 Nodes (49): activity, ai, analytics, api, api-keys, assistant, billing, boards, changelog, channel-accounts, channels, comments, companies, company-attributes, conversation, conversation-attributes, conversation-views, embeddings, export, help-center, import, inbox, macros, merge-suggestions, moderation, notifications, office-hours, platform-credentials, post-tags, post-views, posts, principals, push-devices, roadmaps, roles, segments, sentiment, settings, sla, status, statuses, subscriptions, summary, teams, tickets, user-attributes, users, webhooks, workflows
-Edges (112):
+Edges (113):
 
 - analytics -> api
 - analytics -> assistant
@@ -80,6 +80,7 @@ Edges (112):
 - assistant -> tickets
 - assistant -> workflows
 - billing -> ai
+- billing -> api
 - billing -> principals
 - billing -> settings
 - boards -> posts

--- a/apps/web/src/routes/api/billing/session.ts
+++ b/apps/web/src/routes/api/billing/session.ts
@@ -94,7 +94,7 @@ export const Route = createFileRoute('/api/billing/session')({
             return billingFormErrorResponse(null, 'unavailable')
           }
           if (parsed.data.action === 'downgrade') {
-            const { assertFitsFreePlan } = await import('@/lib/server/functions/billing')
+            const { assertFitsFreePlan } = await import('@/lib/server/domains/billing/usage-counts')
             await assertFitsFreePlan()
           }
           const { createHostedBillingSession } = await import('@/lib/server/control-plane/client')

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -6,6 +6,7 @@ import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
 import { execSync } from 'child_process'
 import { readFileSync } from 'fs'
+import { CLIENT_PROTECTED_SPECIFIERS } from './src/lib/server/policy/client-import-protection'
 
 /**
  * Replace the server-only structured logger with a no-op stub in the CLIENT
@@ -167,17 +168,7 @@ export default defineConfig(({ mode }) => {
         },
         importProtection: {
           behavior: { dev: 'error', build: 'error' },
-          client: {
-            specifiers: [
-              'postgres',
-              '@quackback/db',
-              '@quackback/db/client',
-              '@quackback/db/schema',
-              'openai',
-              '@quackback/logger',
-              'pino',
-            ],
-          },
+          client: { specifiers: [...CLIENT_PROTECTED_SPECIFIERS] },
         },
       }),
       viteReact(),

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -37,6 +37,60 @@ function stubServerLoggerInClient(): PluginOption {
   }
 }
 
+/**
+ * Dev only: keep SSR-only bare imports out of the CLIENT dependency optimizer.
+ *
+ * To inline route CSS into dev SSR HTML, TanStack Start's dev-server plugin
+ * serves `/@tanstack-start/styles.css?routes=…` by crawling the SSR module
+ * graph (`start-plugin-core/src/vite/dev-server-plugin/dev-styles.ts`,
+ * `findModuleDeps`). It looks every SSR dep up through the mixed
+ * `server.moduleGraph.getModuleByUrl`, which resolves the URL in the client
+ * environment as well. Server-only packages reached that way (`pino`,
+ * `jose/errors`, `postgres`, …) have no client importer, but Vite's resolver
+ * still registers them as newly discovered client deps → re-bundle →
+ * "optimized dependencies changed. reloading". Any route chunk in flight at
+ * that moment fails with `504 Outdated Optimize Dep` / "Failed to fetch
+ * dynamically imported module", which is the blank page seen when clicking
+ * into /admin from the portal right after the dev server starts or the deps
+ * cache is invalidated.
+ *
+ * A real client import always carries its importing module, whereas Vite's
+ * plugin container substitutes `<root>/index.html` when a lookup has no
+ * importer (`EnvironmentPluginContainer.resolveId`); the optimizer's own scan
+ * additionally passes `scan: true`. So a bare specifier resolved in the client
+ * environment with that placeholder importer and no scan flag can only be the
+ * crawl. Answer it with an inert virtual module: the crawl still gets a node
+ * (with nothing to descend into) and the optimizer never hears about the
+ * package. Stylesheet specifiers are left alone — the crawl needs those (e.g.
+ * `@fontsource/…/400.css`) to resolve to real files so the CSS is inlined — as
+ * are ids with a scheme (`virtual:`, `node:`), which belong to other plugins
+ * or the browser-external shim. Production builds are untouched (`apply:
+ * 'serve'`); the upstream fix is for the crawl to use the SSR environment's
+ * own module graph.
+ */
+function keepSsrOnlyDepsOutOfClientOptimizer(): PluginOption {
+  const VIRTUAL_PREFIX = '\0quackback:ssr-only-dep:'
+  // Same shape as Vite's bareImportRE: a package name, not a path.
+  const bareSpecifierRE = /^[\w@][^:]*$/
+  const stylesheetRE = /\.(css|less|sass|scss|styl|stylus|pcss|postcss|sss)(?:$|\?)/
+  return {
+    name: 'quackback:keep-ssr-only-deps-out-of-client-optimizer',
+    apply: 'serve',
+    enforce: 'pre',
+    resolveId(id, importer, options) {
+      if (this.environment?.name !== 'client' || options.scan) return null
+      const placeholderImporter = path.join(this.environment.config.root, 'index.html')
+      if (importer !== undefined && importer !== placeholderImporter) return null
+      if (!bareSpecifierRE.test(id) || stylesheetRE.test(id)) return null
+      return VIRTUAL_PREFIX + id
+    },
+    load(id) {
+      if (id.startsWith(VIRTUAL_PREFIX)) return 'export {}'
+      return null
+    },
+  }
+}
+
 function getBuildInfo() {
   const pkg = JSON.parse(readFileSync(path.resolve(__dirname, 'package.json'), 'utf-8'))
   let gitCommit = 'unknown'
@@ -99,6 +153,7 @@ export default defineConfig(({ mode }) => {
       tsconfigPaths: true,
     },
     plugins: [
+      keepSsrOnlyDepsOutOfClientOptimizer(),
       stubServerLoggerInClient(),
       tailwindcss(),
       nitro({


### PR DESCRIPTION
## Summary

Clicking **Admin** on the portal (or otherwise navigating into `/admin`) in dev often produced a white page with `Failed to fetch dynamically imported module` / `504 (Outdated Optimize Dep)`. Reproduced headlessly on a cold dev server: on the first page load Vite logs `(client) dependencies optimized: jose/errors, pino` → `optimized dependencies changed. reloading`, and any route chunk in flight dies.

Two sources were feeding **server-only** code into the **client** module graph:

1. **TanStack Start's dev-styles collector** (`start-plugin-core/…/dev-styles.ts`, `findModuleDeps`). To inline route CSS into dev SSR HTML it crawls the SSR module graph, but resolves every dep through the mixed `server.moduleGraph.getModuleByUrl`, which resolves in the client environment too. Server-only packages reached that way (`pino`, `jose/errors`, …) have no client importer, yet Vite's resolver registers them as newly discovered client deps → re-bundle → forced reload. Fix: a small dev-only Vite plugin (`keepSsrOnlyDepsOutOfClientOptimizer`) answers importer-less bare lookups in the client environment with an inert virtual module. Stylesheet specifiers and scheme-prefixed ids are left alone; `/@tanstack-start/styles.css` output is byte-identical before/after. Upstream `main` still has the same code — the proper fix is for the crawl to use the SSR environment's own module graph.

2. **`functions/billing.ts`** kept `loadUsageCounts`/`assertFitsFreePlan` at module scope, reachable from an export, so the Start compiler left them (and their `import('@/lib/server/db')` etc.) in the client half — import-protection denials in dev and the DB/auth graph in the browser's module graph. Moved to `domains/billing/usage-counts.ts`; handlers and `api/billing/session.ts` import from there.

Also adds `policy/__tests__/server-fn-client-half.test.ts`: a TS-AST check mirroring the compiler's DCE (exports and bare top-level statements as roots, references from inside stripped `.handler()`/`.server()`/`createServerOnlyFn()` scopes ignored) that fails when a server-function module lets a server-only dynamic import reach the client half. It passes on this tree and fails on the pre-fix `billing.ts`. `GRAPH.md` picks up the resulting `billing -> api` domain edge.

## Test plan

- [x] Cold dev server (`.vite` cache cleared): log in → portal → click Admin, 3/3 runs land on `/admin/feedback` with no console/page errors; no `dependencies optimized` / `reloading` in the server log (before: reload + 504s every cold start)
- [x] Direct SSR load of `/admin/settings/billing` + its `/@tanstack-start/styles.css` request: no dep discovery
- [x] Dev styles output for the portal route identical before/after (same 76 CSS files, same byte size)
- [x] `bun run typecheck`, `bun run lint`, `bun run build`, dep-graph + policy + billing tests

Made with [Cursor](https://cursor.com)