### PR TITLE
fix(storage): classify portal images as public after read tokens

### DIFF
--- a/apps/web/src/lib/server/content/__tests__/storage-read-urls.test.ts
+++ b/apps/web/src/lib/server/content/__tests__/storage-read-urls.test.ts
@@ -97,4 +97,10 @@ describe('withCurrentStorageReadTokens', () => {
     )
     expect(rewritten.content?.[0]?.attrs?.src).toBe('https://cdn.example.com/b.png')
   })
+
+  it('leaves an unsigned public portal-images src unsigned', () => {
+    const src = 'https://feedback.example.com/api/storage/portal-images/2026/04/shot.png'
+    const rewritten = withCurrentStorageReadTokens(doc([{ type: 'image', attrs: { src } }]))
+    expect(rewritten.content?.[0]?.attrs?.src).toBe('/api/storage/portal-images/2026/04/shot.png')
+  })
 })

--- a/apps/web/src/lib/server/domains/changelog/changelog.public.ts
+++ b/apps/web/src/lib/server/domains/changelog/changelog.public.ts
@@ -22,6 +22,8 @@ import { computeStatus } from './changelog.service'
 import { getCategoriesForEntries, categoryGateAllows } from './changelog-category.service'
 import { ANONYMOUS_ACTOR, type Actor } from '@/lib/server/policy/types'
 import type { PublicChangelogEntry, PublicChangelogListResult } from './changelog.types'
+import { contentJsonForClient } from '@/lib/server/content/storage-read-urls'
+import { resignStoredAssetUrl } from '@/lib/server/storage/s3'
 
 const effectiveDisplayDate = sql<Date>`coalesce(${changelogEntries.displayDate}, ${changelogEntries.publishedAt})`
 
@@ -156,9 +158,11 @@ export async function getPublicChangelogById(
     id: entry.id,
     title: entry.title,
     content: entry.content,
-    contentJson: entry.contentJson,
+    contentJson: contentJsonForClient(entry.contentJson),
     publishedAt: entry.displayDate ?? entry.publishedAt,
-    featuredImageUrl: entry.featuredImageUrl,
+    featuredImageUrl: entry.featuredImageUrl
+      ? resignStoredAssetUrl(entry.featuredImageUrl)
+      : entry.featuredImageUrl,
     categories: categories.map((c) => ({ id: c.id, name: c.name, color: c.color })),
     linkedPosts: linkedPostRows.map((lp) => ({
       id: lp.postId,
@@ -296,9 +300,11 @@ export async function listPublicChangelogs(
         id: entry.id,
         title: entry.title,
         content: entry.content,
-        contentJson: entry.contentJson,
+        contentJson: contentJsonForClient(entry.contentJson),
         publishedAt: entry.displayDate ?? entry.publishedAt!,
-        featuredImageUrl: entry.featuredImageUrl,
+        featuredImageUrl: entry.featuredImageUrl
+          ? resignStoredAssetUrl(entry.featuredImageUrl)
+          : entry.featuredImageUrl,
         categories: entryCategories.map((c) => ({ id: c.id, name: c.name, color: c.color })),
         linkedPosts: entryLinkedPosts.map((lp) => ({
           id: lp.postId,

--- a/apps/web/src/lib/server/domains/changelog/changelog.query.ts
+++ b/apps/web/src/lib/server/domains/changelog/changelog.query.ts
@@ -22,6 +22,8 @@ import {
 import type { BoardId, ChangelogId, PrincipalId, PostId, PostStatusId } from '@quackback/ids'
 import { computeStatus } from './changelog.service'
 import { getCategoriesForEntries } from './changelog-category.service'
+import { contentJsonForClient } from '@/lib/server/content/storage-read-urls'
+import { resignStoredAssetUrl } from '@/lib/server/storage/s3'
 import type {
   ListChangelogParams,
   ChangelogEntryWithDetails,
@@ -158,11 +160,13 @@ export async function listChangelogs(params: ListChangelogParams): Promise<Chang
       id: entry.id,
       title: entry.title,
       content: entry.content,
-      contentJson: entry.contentJson,
+      contentJson: contentJsonForClient(entry.contentJson),
       principalId: entry.principalId,
       publishedAt: entry.publishedAt,
       displayDate: entry.displayDate,
-      featuredImageUrl: entry.featuredImageUrl,
+      featuredImageUrl: entry.featuredImageUrl
+        ? resignStoredAssetUrl(entry.featuredImageUrl)
+        : entry.featuredImageUrl,
       segmentIds: (entry.segmentIds ?? []) as ChangelogEntryWithDetails['segmentIds'],
       createdAt: entry.createdAt,
       updatedAt: entry.updatedAt,

--- a/apps/web/src/lib/server/domains/changelog/changelog.service.ts
+++ b/apps/web/src/lib/server/domains/changelog/changelog.service.ts
@@ -29,6 +29,8 @@ import type { ChangelogId, PrincipalId, PostId } from '@quackback/ids'
 import { NotFoundError, ValidationError } from '@/lib/shared/errors'
 import { markdownToTiptapJson, projectContentJsonToMarkdown } from '@/lib/server/markdown-tiptap'
 import { rehostExternalImages } from '@/lib/server/content/rehost-images'
+import { contentJsonForClient } from '@/lib/server/content/storage-read-urls'
+import { resignStoredAssetUrl } from '@/lib/server/storage/s3'
 import { changelogBodyHtml } from './changelog-email-body'
 import {
   buildEventActor,
@@ -412,11 +414,13 @@ export async function getChangelogById(id: ChangelogId): Promise<ChangelogEntryW
     id: entry.id,
     title: entry.title,
     content: entry.content,
-    contentJson: entry.contentJson,
+    contentJson: contentJsonForClient(entry.contentJson),
     principalId: entry.principalId,
     publishedAt: entry.publishedAt,
     displayDate: entry.displayDate,
-    featuredImageUrl: entry.featuredImageUrl,
+    featuredImageUrl: entry.featuredImageUrl
+      ? resignStoredAssetUrl(entry.featuredImageUrl)
+      : entry.featuredImageUrl,
     segmentIds: (entry.segmentIds ?? []) as ChangelogEntryWithDetails['segmentIds'],
     createdAt: entry.createdAt,
     updatedAt: entry.updatedAt,

--- a/apps/web/src/lib/server/domains/posts/post.public.detail.ts
+++ b/apps/web/src/lib/server/domains/posts/post.public.detail.ts
@@ -30,6 +30,7 @@ import {
 import { hydrateMentions } from './hydrate-mentions'
 import type { TiptapContent } from '@/lib/shared/db-types'
 import type { JSONContent } from '@tiptap/core'
+import { contentJsonForClient } from '@/lib/server/content/storage-read-urls'
 
 /**
  * Fetch the public-facing detail view for a post.
@@ -439,9 +440,11 @@ export async function getPublicPostDetail(
   // renamed users show up-to-date names. List views skip this; only the
   // detail read paths pay the extra round-trip.
   const hydratePublicCommentTree = async (node: PublicComment): Promise<PublicComment> => {
-    const hydratedContentJson = node.contentJson
-      ? ((await hydrateMentions(node.contentJson as JSONContent)) as PublicComment['contentJson'])
-      : node.contentJson
+    const hydratedContentJson = contentJsonForClient(
+      node.contentJson
+        ? ((await hydrateMentions(node.contentJson as JSONContent)) as PublicComment['contentJson'])
+        : node.contentJson
+    )
     const hydratedReplies = await Promise.all(node.replies.map(hydratePublicCommentTree))
     return { ...node, contentJson: hydratedContentJson, replies: hydratedReplies }
   }
@@ -461,11 +464,13 @@ export async function getPublicPostDetail(
     if (pinnedRow && !pinnedRow.deleted_at) {
       const pinnedContentJson =
         (pinnedRow.content_json as PinnedComment['contentJson'] | null | undefined) ?? null
-      const pinnedHydrated = pinnedContentJson
-        ? ((await hydrateMentions(
-            pinnedContentJson as JSONContent
-          )) as PinnedComment['contentJson'])
-        : null
+      const pinnedHydrated = contentJsonForClient(
+        pinnedContentJson
+          ? ((await hydrateMentions(
+              pinnedContentJson as JSONContent
+            )) as PinnedComment['contentJson'])
+          : null
+      )
       pinnedComment = {
         id: fromUuid('post_comment', pinnedRow.id) as PostCommentId,
         content: pinnedRow.content,
@@ -484,9 +489,11 @@ export async function getPublicPostDetail(
     }
   }
 
-  const hydratedPostContentJson = postResult.contentJson
-    ? ((await hydrateMentions(postResult.contentJson as JSONContent)) as TiptapContent | null)
-    : postResult.contentJson
+  const hydratedPostContentJson = contentJsonForClient(
+    postResult.contentJson
+      ? ((await hydrateMentions(postResult.contentJson as JSONContent)) as TiptapContent | null)
+      : postResult.contentJson
+  )
 
   return {
     id: postResult.id,

--- a/apps/web/src/lib/server/domains/posts/post.query.ts
+++ b/apps/web/src/lib/server/domains/posts/post.query.ts
@@ -32,6 +32,7 @@ import type { PostWithDetails, PinnedComment } from './post.types'
 import { hydrateMentions } from './hydrate-mentions'
 import type { JSONContent } from '@tiptap/core'
 import type { TiptapContent } from '@/lib/shared/db-types'
+import { contentJsonForClient } from '@/lib/server/content/storage-read-urls'
 
 /**
  * Get a post with full details including board, tags, and comment count.
@@ -127,9 +128,11 @@ export async function getPostWithDetails(postId: PostId): Promise<PostWithDetail
     const avatarUrl = author?.avatarUrl ?? null
 
     const pinnedRawContentJson = pinnedCommentData.contentJson ?? null
-    const pinnedHydratedContentJson = pinnedRawContentJson
-      ? ((await hydrateMentions(pinnedRawContentJson as JSONContent)) as TiptapContent | null)
-      : null
+    const pinnedHydratedContentJson = contentJsonForClient(
+      pinnedRawContentJson
+        ? ((await hydrateMentions(pinnedRawContentJson as JSONContent)) as TiptapContent | null)
+        : null
+    )
     pinnedComment = {
       id: pinnedCommentData.id,
       content: pinnedCommentData.content,
@@ -143,9 +146,13 @@ export async function getPostWithDetails(postId: PostId): Promise<PostWithDetail
   }
 
   // Hydrate mention labels on the post body so renamed users render correctly.
-  const hydratedPostContentJson = post.contentJson
-    ? ((await hydrateMentions(post.contentJson as JSONContent)) as TiptapContent | null)
-    : post.contentJson
+  // Remint storage read tokens after that: persist stays unsigned, and posts
+  // created before private-object tokens existed still have to render.
+  const hydratedPostContentJson = contentJsonForClient(
+    post.contentJson
+      ? ((await hydrateMentions(post.contentJson as JSONContent)) as TiptapContent | null)
+      : post.contentJson
+  )
 
   // Cast needed: columns selection omits heavy internal fields (embedding, searchVector,
   // etc.) that no caller reads, but PostWithDetails extends the full Post type.

--- a/apps/web/src/lib/server/storage/__tests__/generate-storage-key.test.ts
+++ b/apps/web/src/lib/server/storage/__tests__/generate-storage-key.test.ts
@@ -8,7 +8,7 @@ vi.mock('@/lib/server/config', () => ({
   config: { baseUrl: 'https://app.example.com' },
 }))
 
-const { generateStorageKey } = await import('@/lib/server/storage/s3')
+const { generateStorageKey, isPublicStorageKey } = await import('@/lib/server/storage/s3')
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 
@@ -24,5 +24,31 @@ describe('generateStorageKey', () => {
   it('keeps the prefix/year/month layout and sanitizes the filename', () => {
     const key = generateStorageKey('portal-images', 'My File (1).PNG')
     expect(key).toMatch(/^portal-images\/\d{4}\/\d{2}\/[0-9a-f-]{36}-my_file__1_.png$/)
+  })
+})
+
+describe('isPublicStorageKey', () => {
+  it('treats portal, changelog, and OG prefixes as public', () => {
+    // These prefixes appear in public portal/changelog content. Objects written
+    // before read tokens existed have unsigned /api/storage URLs; classifying
+    // them private 403s every historical image.
+    for (const key of [
+      'portal-images/2026/04/4eea0db0-screenshot.png',
+      'changelog/2026/04/shot.png',
+      'changelog-images/2026/04/shot.png',
+      'comment-images/2026/04/shot.png',
+      'portal-og/og.png',
+      'portal-welcome/hero.png',
+      'post-images/2026/04/shot.png',
+      'logos/brand.png',
+    ]) {
+      expect(isPublicStorageKey(key), key).toBe(true)
+    }
+  })
+
+  it('keeps unknown and conversation prefixes private', () => {
+    for (const key of ['uploads/2026/04/file.png', 'chat-images/shot.png', 'exports/run.zip']) {
+      expect(isPublicStorageKey(key), key).toBe(false)
+    }
   })
 })

--- a/apps/web/src/lib/server/storage/__tests__/s3-tenant-placement.test.ts
+++ b/apps/web/src/lib/server/storage/__tests__/s3-tenant-placement.test.ts
@@ -222,6 +222,12 @@ describe('public URLs', () => {
     )
   })
 
+  it('keeps an unsigned portal-images src unsigned', () => {
+    const src = '/api/storage/portal-images/2026/04/4eea0db0-screenshot.png'
+    expect(resignStoredAssetUrl(src)).toBe(src)
+    expect(resignStoredAssetUrl(`https://old.example.com${src}`)).toBe(src)
+  })
+
   it('leaves the unscoped read signature byte-identical to the historical one', () => {
     // HMAC-SHA256('env-secret-key', 'read|<key>') truncated to 32 hex chars —
     // the message as it stood before workspaces. These signatures are embedded in

--- a/apps/web/src/lib/server/storage/s3.ts
+++ b/apps/web/src/lib/server/storage/s3.ts
@@ -625,12 +625,18 @@ export async function currentWorkspaceStorage(): Promise<WorkspaceStorage> {
 const PUBLIC_STORAGE_PREFIXES = new Set([
   'assistant-avatars',
   'avatars',
+  // Admin changelog editor writes `changelog/`; rehost writes `changelog-images/`.
+  'changelog',
   'changelog-images',
+  'comment-images',
   'favicons',
   'header-logos',
   'help-center',
   'link-previews',
   'logos',
+  'portal-images',
+  'portal-og',
+  'portal-welcome',
   'post-images',
   'widget-hero',
 ])


### PR DESCRIPTION
## Why

https://feedback.quackback.io/api/storage/portal-images/2026/04/4eea0db0-screenshot_2026-04-07_at_11.58.16.png answers `{"error":"Invalid storage read token"}`.

Read tokens made unknown prefixes private. Portal uploads, the changelog editor prefix (`changelog/` vs `changelog-images/`), comment rehosts, welcome-card images, and OG images were never added to the public allow-list. Content written before that change stores unsigned `/api/storage/…` URLs, so every historical image 403s.

This is not a per-object rewrite. Persist stays host-independent and unsigned for public keys. The objects are already in the fleet buckets (`portal-images`, `changelog`, `portal-og`, plus private `uploads`).

## What

- Classify those public-facing prefixes as public so unsigned legacy URLs work without a token.
- Remint `?read=` on post and changelog `contentJson` (and changelog featured images) at read time, matching comments/messages/welcome cards, so remaining private prefixes (`uploads/`, `chat-images/`) still render.

Verified against Railway buckets: Cloud `storage` / `storage-ams`, plus the dedicated feedback.quackback.io bucket (9 `portal-images` objects including the reported screenshot).

## Test plan

- [x] `generate-storage-key`, `s3-tenant-placement`, `storage-read-urls` unit tests
- [x] changelog / comments / storage GET suites
- [ ] After deploy: the reported URL returns the image (302/200), not 403
- [ ] The post at `/b/feature-requests/posts/post_01knkpjcc6faha6bc1sg4jgqw9` shows the screenshot