### PR TITLE
feat(billing): contextual upgrade prompts and a plan configurator before checkout

### DIFF
--- a/apps/web/src/components/admin/settings/billing/__tests__/billing-settings.test.tsx
+++ b/apps/web/src/components/admin/settings/billing/__tests__/billing-settings.test.tsx
@@ -131,11 +131,11 @@ describe('BillingPlansView', () => {
     expect(screen.getByRole('button', { name: 'Remove seats' })).toBeEnabled()
     expect(screen.getByRole('heading', { name: 'Plans' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Current plan' })).toBeDisabled()
-    const scaleField = document.querySelector('input[name="planId"][value="scale"]')
-    const form = scaleField?.closest('form')
-    expect(form).toHaveAttribute('action', '/api/billing/session')
-    expect(form?.querySelector('input[name="action"]')).toHaveValue('checkout')
-    expect(form?.querySelector('input[name="quantity"]')).toHaveValue('7')
+    const switchLinks = screen.getAllByRole('link', { name: 'Switch to this plan' })
+    expect(switchLinks.map((link) => link.getAttribute('href'))).toEqual([
+      '/admin/settings/billing/checkout?plan=growth&period=annual&seats=7',
+      '/admin/settings/billing/checkout?plan=scale&period=annual&seats=7',
+    ])
     expect(screen.getByText('INV-1001')).toBeInTheDocument()
   })
 

--- a/apps/web/src/components/admin/settings/billing/__tests__/checkout-builder.test.tsx
+++ b/apps/web/src/components/admin/settings/billing/__tests__/checkout-builder.test.tsx
@@ -1,0 +1,244 @@
+// @vitest-environment happy-dom
+import '@testing-library/jest-dom/vitest'
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { BillingCatalogue } from '@/lib/server/control-plane/client'
+import type { BillingProjectionOverview } from '@/lib/server/domains/billing/projection-overview'
+import { CheckoutBuilder, type CheckoutSelection } from '../checkout-builder'
+
+vi.mock('../free-downgrade-dialog', () => ({
+  FreeDowngradeDialog: () => <p>downgrade dialog</p>,
+}))
+
+const catalogue: BillingCatalogue = {
+  version: 1,
+  currency: 'usd',
+  annualDiscountMonths: 2,
+  recommendedPlanId: 'pro',
+  brandingRemoval: { monthlyCents: 5900, annualCents: 59000 },
+  trialDays: 14,
+  trialedPlanIds: [],
+  plans: [
+    {
+      id: 'free',
+      name: 'Free',
+      rank: 0,
+      priceMonthlyCents: 0,
+      priceYearlyCents: 0,
+      billedPer: 'workspace',
+      bestFor: 'For trying Quackback out',
+      highlights: ['1 seat'],
+      recommended: false,
+    },
+    {
+      id: 'growth',
+      name: 'Growth',
+      rank: 1,
+      priceMonthlyCents: 2900,
+      priceYearlyCents: 29000,
+      billedPer: 'seat',
+      bestFor: 'For small teams',
+      highlights: ['Custom domain'],
+      recommended: false,
+    },
+    {
+      id: 'pro',
+      name: 'Pro',
+      rank: 2,
+      priceMonthlyCents: 5900,
+      priceYearlyCents: 59000,
+      billedPer: 'seat',
+      bestFor: 'For inbox teams',
+      highlights: ['Workflows & SLAs', 'Moderation'],
+      recommended: true,
+    },
+    {
+      id: 'scale',
+      name: 'Scale',
+      rank: 3,
+      priceMonthlyCents: 11500,
+      priceYearlyCents: 106800,
+      billedPer: 'seat',
+      bestFor: 'For compliance needs',
+      highlights: ['SSO', 'Audit log'],
+      recommended: false,
+    },
+  ],
+}
+
+const freeOverview: BillingProjectionOverview = {
+  plan: 'free',
+  planName: 'Free',
+  status: null,
+  trialActive: false,
+  trialExpiresAt: null,
+  renewalAt: null,
+  cancellationAt: null,
+  canUpgrade: true,
+  canManageBilling: false,
+  purchasablePlans: [
+    { id: 'growth', name: 'Growth' },
+    { id: 'pro', name: 'Pro' },
+    { id: 'scale', name: 'Scale' },
+  ],
+  seats: { used: 3, pending: 1, members: 2, purchased: null },
+  ai: null,
+  hideBranding: false,
+}
+
+const proOverview: BillingProjectionOverview = {
+  ...freeOverview,
+  plan: 'pro',
+  planName: 'Pro',
+  status: 'active',
+  canManageBilling: true,
+  seats: { used: 7, pending: 1, members: 6, purchased: 10 },
+}
+
+function renderBuilder(
+  overview: BillingProjectionOverview,
+  selection: Partial<CheckoutSelection> = {}
+) {
+  const onChange = vi.fn()
+  render(
+    <CheckoutBuilder
+      overview={overview}
+      catalogue={catalogue}
+      selection={{ plan: 'pro', period: 'annual', seats: 3, branding: false, ...selection }}
+      onChange={onChange}
+    />
+  )
+  return { onChange }
+}
+
+function checkoutForm(): HTMLFormElement | null {
+  const marker = document.querySelector(
+    'form[action="/api/billing/session"] input[value="checkout"]'
+  )
+  return marker ? marker.closest('form') : null
+}
+
+describe('CheckoutBuilder', () => {
+  it('summarises the preselected plan, cycle and seats and hands off to checkout', () => {
+    renderBuilder(freeOverview)
+
+    expect(screen.getByRole('radio', { name: /Yearly/ })).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByRole('radio', { name: /Save 17%/ })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: /^Pro/ })).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByText('Workflows & SLAs')).toBeInTheDocument()
+
+    const summary = screen.getByRole('complementary')
+    expect(within(summary).getByText('Pro plan')).toBeInTheDocument()
+    expect(within(summary).getByText('3 seats × $590/year')).toBeInTheDocument()
+    expect(within(summary).getAllByText('$1,770/year')).toHaveLength(2)
+    expect(within(summary).getByText('$148/mo')).toBeInTheDocument()
+
+    const form = checkoutForm()
+    expect(form?.querySelector('input[name="planId"]')).toHaveValue('pro')
+    expect(form?.querySelector('input[name="billingPeriod"]')).toHaveValue('annual')
+    expect(form?.querySelector('input[name="quantity"]')).toHaveValue('3')
+    expect(within(summary).getByRole('button', { name: 'Continue to payment' })).toBeEnabled()
+  })
+
+  it('offers the trial as an alternative to a Free workspace that has not tried the plan', () => {
+    renderBuilder(freeOverview)
+    expect(screen.getByRole('button', { name: /Or try Pro free for 14 days/ })).toBeInTheDocument()
+  })
+
+  it('reports selection changes without clearing the plan', () => {
+    const { onChange } = renderBuilder(freeOverview)
+    fireEvent.click(screen.getByRole('radio', { name: /Monthly/ }))
+    expect(onChange).toHaveBeenCalledWith({ period: 'monthly' })
+    fireEvent.click(screen.getByRole('radio', { name: /^Scale/ }))
+    expect(onChange).toHaveBeenCalledWith({ plan: 'scale' })
+    fireEvent.click(screen.getByRole('button', { name: 'More seats' }))
+    expect(onChange).toHaveBeenCalledWith({ seats: 4 })
+  })
+
+  it('floors seats at live usage and says why', () => {
+    renderBuilder(freeOverview, { seats: 1 })
+    expect(screen.getByRole('button', { name: 'Fewer seats' })).toBeDisabled()
+    expect(screen.getByText(/min\. 3 — already in use/)).toBeInTheDocument()
+    expect(screen.getByText(/You have 2 members and 1 pending invite/)).toBeInTheDocument()
+    expect(checkoutForm()?.querySelector('input[name="quantity"]')).toHaveValue('3')
+  })
+
+  it('prices monthly without a monthly-equivalent line', () => {
+    renderBuilder(freeOverview, { period: 'monthly' })
+    const summary = screen.getByRole('complementary')
+    expect(within(summary).getByText('3 seats × $59/mo')).toBeInTheDocument()
+    expect(within(summary).getAllByText('$177/mo')).toHaveLength(2)
+    expect(within(summary).queryByText('Monthly equivalent')).not.toBeInTheDocument()
+  })
+
+  it('marks the current plan and disables checkout for it', () => {
+    renderBuilder(proOverview, { plan: 'pro', seats: 7 })
+    expect(screen.getAllByText('Current').length).toBeGreaterThan(0)
+    expect(screen.getByRole('button', { name: 'Current plan' })).toBeDisabled()
+    expect(checkoutForm()).toBeNull()
+    expect(screen.getByRole('button', { name: 'Switch to Free' })).toBeInTheDocument()
+  })
+
+  it('explains pro-rata and end-of-period timing when moving between paid plans', () => {
+    renderBuilder(proOverview, { plan: 'scale', seats: 7 })
+    expect(screen.getByText(/Moving up applies now, billed pro-rata/)).toBeInTheDocument()
+    renderBuilder(proOverview, { plan: 'growth', seats: 7 })
+    expect(screen.getByText(/takes effect at the end of the current period/)).toBeInTheDocument()
+  })
+
+  it('asks for a plan when none is selected', () => {
+    renderBuilder(freeOverview, { plan: null })
+    expect(screen.getByText('Pick a plan to see your total.')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Continue to payment' })).toBeDisabled()
+    expect(screen.queryByRole('heading', { name: 'Seats' })).not.toBeInTheDocument()
+  })
+
+  it('adds branding removal to the same checkout when ticked', () => {
+    const { onChange } = renderBuilder(freeOverview)
+    expect(screen.getByText('Remove Quackback branding')).toBeInTheDocument()
+    expect(screen.getByText('$590/yr')).toBeInTheDocument()
+    expect(checkoutForm()?.querySelector('input[name="brandingRemoval"]')).toBeNull()
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Add branding removal to the order' }))
+    expect(onChange).toHaveBeenCalledWith({ branding: true })
+  })
+
+  it('prices the bundled add-on into the total and posts it with the plan', () => {
+    renderBuilder(freeOverview, { branding: true })
+    const summary = screen.getByRole('complementary')
+    expect(within(summary).getByText('Remove branding')).toBeInTheDocument()
+    expect(within(summary).getByText('$590/year')).toBeInTheDocument()
+    expect(within(summary).getByText('$2,360/year')).toBeInTheDocument()
+    expect(within(summary).getByText('$197/mo')).toBeInTheDocument()
+    const form = checkoutForm()
+    expect(form?.querySelector('input[name="planId"]')).toHaveValue('pro')
+    expect(form?.querySelector('input[name="brandingRemoval"]')).toHaveValue('true')
+  })
+
+  it('sells the add-on on its own when the plan is the current one', () => {
+    renderBuilder(proOverview, { plan: 'pro', seats: 7, branding: true })
+    const summary = screen.getByRole('complementary')
+    expect(within(summary).queryByText(/7 seats ×/)).not.toBeInTheDocument()
+    expect(within(summary).getAllByText('$590/year')).toHaveLength(2)
+    expect(checkoutForm()).toBeNull()
+    const button = within(summary).getByRole('button', { name: 'Continue to payment' })
+    const form = button.closest('form')
+    expect(form?.querySelector('input[name="action"]')).toHaveValue('branding')
+    expect(form?.querySelector('input[name="billingPeriod"]')).toHaveValue('annual')
+    expect(screen.getByText(/only the add-on is charged/)).toBeInTheDocument()
+  })
+
+  it('shows branding removal as included and unselectable once owned', () => {
+    renderBuilder({ ...freeOverview, hideBranding: true }, { branding: true })
+    expect(screen.getByText('Included')).toBeInTheDocument()
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+    expect(screen.getByRole('complementary')).not.toHaveTextContent('Remove branding')
+    expect(checkoutForm()?.querySelector('input[name="brandingRemoval"]')).toBeNull()
+  })
+
+  it('blocks checkout for teammates who cannot change the plan', () => {
+    renderBuilder({ ...freeOverview, canUpgrade: false, canManageBilling: false })
+    expect(screen.getByRole('button', { name: 'Continue to payment' })).toBeDisabled()
+    expect(screen.getByText('Only workspace owners can change the plan.')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/admin/settings/billing/billing-settings.tsx
+++ b/apps/web/src/components/admin/settings/billing/billing-settings.tsx
@@ -20,6 +20,7 @@ import {
   type PaidPlanId,
 } from '@/lib/shared/billing/plan-action'
 import { daysUntil } from '@/lib/shared/billing/trial-state'
+import { checkoutPath } from '@/lib/shared/billing/checkout-path'
 import { AddSeatsDialog } from './add-seats-dialog'
 import { RemoveSeatsDialog } from './remove-seats-dialog'
 import { SubscribeDialog } from './subscribe-dialog'
@@ -704,15 +705,17 @@ function PlanActionButton(props: {
     )
   }
   return (
-    <form method="post" action="/api/billing/session">
-      <input type="hidden" name="action" value="checkout" />
-      <input type="hidden" name="planId" value={action.planId} />
-      <input type="hidden" name="billingPeriod" value={props.period} />
-      <input type="hidden" name="quantity" value={String(props.checkoutQuantity)} />
-      <Button size="sm" type="submit" className="w-full" variant="outline">
+    <Button size="sm" className="w-full" variant="outline" asChild>
+      <a
+        href={checkoutPath({
+          plan: action.planId,
+          period: props.period,
+          seats: props.checkoutQuantity,
+        })}
+      >
         Switch to this plan
-      </Button>
-    </form>
+      </a>
+    </Button>
   )
 }
 

--- a/apps/web/src/components/admin/settings/billing/checkout-builder.tsx
+++ b/apps/web/src/components/admin/settings/billing/checkout-builder.tsx
@@ -1,0 +1,586 @@
+import { useState } from 'react'
+import { ArrowTopRightOnSquareIcon, CheckIcon } from '@heroicons/react/24/solid'
+import type { BillingProjectionOverview } from '@/lib/server/domains/billing/projection-overview'
+import type { BillingCatalogue } from '@/lib/server/control-plane/client'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { ConfirmDialog } from '@/components/shared/confirm-dialog'
+import { cn } from '@/lib/shared/utils'
+import { formatUsd } from '@/lib/shared/format-usd'
+import {
+  billingPlanAction,
+  catalogueTrialDays,
+  catalogueTrialedPlanIds,
+  type BillingPlanAction,
+  type PaidPlanId,
+} from '@/lib/shared/billing/plan-action'
+import {
+  annualSavingsPercent,
+  checkoutSummary,
+  isPaidPlanId,
+  type BillingPeriod,
+} from '@/lib/shared/billing/checkout-path'
+import { QuantityStepper } from './quantity-stepper'
+import { FreeDowngradeDialog } from './free-downgrade-dialog'
+
+type CataloguePlan = BillingCatalogue['plans'][number]
+
+export type CheckoutSelection = {
+  plan: PaidPlanId | null
+  period: BillingPeriod
+  seats: number
+  /** Branding removal added to the order. */
+  branding: boolean
+}
+
+/** A change never clears the plan, so deep links stay meaningful across edits. */
+export type CheckoutSelectionChange = Partial<{
+  plan: PaidPlanId
+  period: BillingPeriod
+  seats: number
+  branding: boolean
+}>
+
+const PLANS_PATH = '/admin/settings/billing'
+
+/**
+ * The plan configurator: billing cycle, plan, seats and add-ons on the left,
+ * a live order summary on the right, then one hand-off to hosted checkout.
+ * Selection lives in the URL so an upgrade prompt can deep-link with the plan
+ * preselected and a refresh keeps the choice.
+ */
+export function CheckoutBuilder(props: {
+  overview: BillingProjectionOverview
+  catalogue: BillingCatalogue
+  selection: CheckoutSelection
+  onChange: (next: CheckoutSelectionChange) => void
+}) {
+  const { overview, catalogue, selection } = props
+  const paidPlans = catalogue.plans
+    .filter((plan) => isPaidPlanId(plan.id))
+    .sort((a, b) => a.rank - b.rank)
+  const freePlan = catalogue.plans.find((plan) => plan.id === 'free') ?? null
+  const selectedPlan = paidPlans.find((plan) => plan.id === selection.plan) ?? null
+  const minSeats = Math.max(overview.seats?.used ?? 1, 1)
+  const seats = Math.max(selection.seats, minSeats)
+  const trialedPlanIds = catalogueTrialedPlanIds(catalogue)
+  const trialDays = catalogueTrialDays(catalogue)
+  const savingsReference =
+    selectedPlan ?? paidPlans.find((plan) => plan.recommended) ?? paidPlans[0]
+  const savings = savingsReference ? annualSavingsPercent(savingsReference) : null
+  const freeAction = freePlan ? billingPlanAction('free', overview, trialedPlanIds) : null
+  const canPurchase = overview.canUpgrade || overview.canManageBilling
+  const branding = catalogue.brandingRemoval ?? null
+  const brandingInOrder = Boolean(
+    branding && selection.branding && !overview.hideBranding && canPurchase
+  )
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_20rem] lg:items-start">
+      <div className="space-y-8">
+        <section className="space-y-3">
+          <SectionTitle>Billing cycle</SectionTitle>
+          <CycleToggle
+            value={selection.period}
+            savingsPercent={savings}
+            discountMonths={catalogue.annualDiscountMonths}
+            onChange={(period) => props.onChange({ period })}
+          />
+        </section>
+
+        <section className="space-y-3">
+          <div className="flex items-end justify-between gap-3">
+            <SectionTitle>Plan</SectionTitle>
+            <a
+              href={PLANS_PATH}
+              className="inline-flex items-center gap-1 text-[13px] text-muted-foreground hover:text-foreground hover:underline"
+            >
+              Compare all plans
+              <ArrowTopRightOnSquareIcon className="size-3.5" />
+            </a>
+          </div>
+          <div
+            role="radiogroup"
+            aria-label="Plan"
+            className="divide-y divide-border/50 overflow-hidden rounded-xl border border-border/50 bg-card"
+          >
+            {freePlan && freeAction ? <FreePlanRow plan={freePlan} action={freeAction} /> : null}
+            {paidPlans.map((plan) => (
+              <PlanRow
+                key={plan.id}
+                plan={plan}
+                period={selection.period}
+                selected={plan.id === selection.plan}
+                action={billingPlanAction(plan.id, overview, trialedPlanIds)}
+                trialActive={overview.trialActive && overview.plan === plan.id}
+                onSelect={() => props.onChange({ plan: plan.id as PaidPlanId })}
+              />
+            ))}
+          </div>
+        </section>
+
+        {selectedPlan?.billedPer === 'seat' ? (
+          <section className="space-y-3">
+            <SectionTitle>Seats</SectionTitle>
+            <div className="rounded-xl border border-border/50 bg-card px-4 py-3">
+              <div className="flex flex-wrap items-center gap-3">
+                <QuantityStepper
+                  value={seats}
+                  min={minSeats}
+                  onChange={(next) => props.onChange({ seats: next })}
+                  decreaseLabel="Fewer seats"
+                  increaseLabel="More seats"
+                />
+                <span className="text-[13px] text-muted-foreground">
+                  {seats === 1 ? 'seat' : 'seats'} (min. {minSeats} — already in use)
+                </span>
+              </div>
+              <p className="mt-2 text-[12px] text-muted-foreground">
+                Each member or pending invite uses a seat. You have {overview.seats?.members ?? 0}{' '}
+                {(overview.seats?.members ?? 0) === 1 ? 'member' : 'members'} and{' '}
+                {overview.seats?.pending ?? 0} pending{' '}
+                {(overview.seats?.pending ?? 0) === 1 ? 'invite' : 'invites'}.
+              </p>
+            </div>
+          </section>
+        ) : null}
+
+        {branding ? (
+          <section className="space-y-3">
+            <SectionTitle>Add-ons</SectionTitle>
+            <BrandingAddOnRow
+              price={branding}
+              period={selection.period}
+              hideBranding={overview.hideBranding}
+              canPurchase={canPurchase}
+              checked={brandingInOrder}
+              onCheckedChange={(next) => props.onChange({ branding: next })}
+            />
+          </section>
+        ) : null}
+      </div>
+
+      <OrderSummary
+        overview={overview}
+        plan={selectedPlan}
+        period={selection.period}
+        seats={seats}
+        branding={brandingInOrder && branding ? branding : null}
+        trialDays={trialDays}
+        currentPlanRank={catalogue.plans.find((plan) => plan.id === overview.plan)?.rank ?? 0}
+        action={selectedPlan ? billingPlanAction(selectedPlan.id, overview, trialedPlanIds) : null}
+      />
+    </div>
+  )
+}
+
+function SectionTitle(props: { children: React.ReactNode }) {
+  return <h2 className="text-sm font-semibold">{props.children}</h2>
+}
+
+function CycleToggle(props: {
+  value: BillingPeriod
+  savingsPercent: number | null
+  discountMonths: number
+  onChange: (next: BillingPeriod) => void
+}) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Billing cycle"
+      className="inline-flex items-center rounded-lg border border-border/50 bg-muted/30 p-1"
+    >
+      {(['monthly', 'annual'] as const).map((option) => {
+        const active = props.value === option
+        return (
+          <button
+            key={option}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            onClick={() => props.onChange(option)}
+            className={cn(
+              'inline-flex h-8 items-center gap-2 rounded-md px-3 text-[13px] font-medium transition-colors',
+              active
+                ? 'bg-background text-foreground shadow-xs'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            {option === 'annual' ? 'Yearly' : 'Monthly'}
+            {option === 'annual' ? (
+              <Badge size="sm" shape="pill" variant={active ? 'default' : 'secondary'}>
+                {props.savingsPercent != null
+                  ? `Save ${props.savingsPercent}%`
+                  : `${props.discountMonths} mo free`}
+              </Badge>
+            ) : null}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+function PlanRow(props: {
+  plan: CataloguePlan
+  period: BillingPeriod
+  selected: boolean
+  action: BillingPlanAction
+  trialActive: boolean
+  onSelect: () => void
+}) {
+  const { plan, period } = props
+  const monthlyCents =
+    period === 'annual' ? Math.round(plan.priceYearlyCents / 12) : plan.priceMonthlyCents
+  const unit = plan.billedPer === 'seat' ? '/seat/mo' : '/mo'
+  const current = props.action.kind === 'current'
+  return (
+    <div
+      role="radio"
+      aria-checked={props.selected}
+      tabIndex={0}
+      onClick={props.onSelect}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault()
+          props.onSelect()
+        }
+      }}
+      className={cn(
+        'cursor-pointer px-5 py-4 outline-none transition-colors focus-visible:bg-muted/40',
+        props.selected ? 'bg-primary/5 ring-1 ring-inset ring-primary/40' : 'hover:bg-muted/30'
+      )}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <h3 className="text-sm font-semibold">{plan.name}</h3>
+            {current ? (
+              <Badge size="sm" shape="pill">
+                {props.trialActive ? 'Current · trial' : 'Current'}
+              </Badge>
+            ) : plan.recommended ? (
+              <Badge size="sm" shape="pill" variant="secondary">
+                Recommended
+              </Badge>
+            ) : null}
+          </div>
+          <p className="mt-1 text-[13px] text-muted-foreground">{plan.bestFor}</p>
+        </div>
+        <p className="shrink-0 text-right">
+          <span className="text-lg font-semibold tracking-tight tabular-nums">
+            {formatUsd(monthlyCents, 0)}
+          </span>
+          <span className="block text-[12px] text-muted-foreground">
+            {unit}
+            {period === 'annual' ? ', billed yearly' : ''}
+          </span>
+        </p>
+      </div>
+      {props.selected ? (
+        <ul className="mt-3 grid gap-x-6 gap-y-1.5 sm:grid-cols-2">
+          {plan.highlights.map((line) => (
+            <li key={line} className="flex items-start gap-2 text-[13px] leading-snug">
+              <CheckIcon className="mt-0.5 size-3.5 shrink-0 text-primary" />
+              <span>{line}</span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  )
+}
+
+function FreePlanRow(props: { plan: CataloguePlan; action: BillingPlanAction }) {
+  const [open, setOpen] = useState(false)
+  const current = props.action.kind === 'current'
+  return (
+    <div className="flex items-start justify-between gap-4 px-5 py-4">
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <h3 className="text-sm font-semibold">{props.plan.name}</h3>
+          {current ? (
+            <Badge size="sm" shape="pill">
+              Current
+            </Badge>
+          ) : null}
+        </div>
+        <p className="mt-1 text-[13px] text-muted-foreground">{props.plan.bestFor}</p>
+        {props.action.kind === 'downgrade' ? (
+          <div className="mt-3">
+            <Button type="button" size="sm" variant="outline" onClick={() => setOpen(true)}>
+              Switch to Free
+            </Button>
+            {open ? <FreeDowngradeDialog open onOpenChange={setOpen} /> : null}
+          </div>
+        ) : null}
+      </div>
+      <p className="shrink-0 text-right">
+        <span className="text-lg font-semibold tracking-tight tabular-nums">$0</span>
+        <span className="block text-[12px] text-muted-foreground">forever</span>
+      </p>
+    </div>
+  )
+}
+
+type BrandingPrice = NonNullable<BillingCatalogue['brandingRemoval']>
+
+function brandingCents(price: BrandingPrice, period: BillingPeriod): number {
+  return period === 'annual' ? price.annualCents : price.monthlyCents
+}
+
+function BrandingAddOnRow(props: {
+  price: BrandingPrice
+  period: BillingPeriod
+  hideBranding: boolean
+  canPurchase: boolean
+  checked: boolean
+  onCheckedChange: (next: boolean) => void
+}) {
+  const intervalLabel = props.period === 'annual' ? 'yr' : 'mo'
+  const price = `${formatUsd(brandingCents(props.price, props.period), 0)}/${intervalLabel}`
+  const selectable = !props.hideBranding && props.canPurchase
+  return (
+    <label
+      className={cn(
+        'flex items-center justify-between gap-3 rounded-xl border border-border/50 bg-card px-4 py-3',
+        selectable && 'cursor-pointer',
+        props.checked && 'bg-primary/5 ring-1 ring-inset ring-primary/40'
+      )}
+    >
+      <div className="flex min-w-0 items-start gap-3">
+        {selectable ? (
+          <Checkbox
+            className="mt-0.5"
+            checked={props.checked}
+            onCheckedChange={(value) => props.onCheckedChange(value === true)}
+            aria-label="Add branding removal to the order"
+          />
+        ) : null}
+        <div className="min-w-0">
+          <div className="text-[13px] font-medium">Remove Quackback branding</div>
+          <div className="text-[12px] text-muted-foreground">
+            Hide &quot;Powered by Quackback&quot; on the portal, widget, and emails. Billed with
+            your plan on the same {props.period === 'annual' ? 'yearly' : 'monthly'} cycle.
+          </div>
+        </div>
+      </div>
+      {props.hideBranding ? (
+        <Badge size="sm" shape="pill" variant="secondary">
+          Included
+        </Badge>
+      ) : (
+        <span className="shrink-0 text-[13px] font-medium tabular-nums">{price}</span>
+      )}
+    </label>
+  )
+}
+
+function OrderSummary(props: {
+  overview: BillingProjectionOverview
+  plan: CataloguePlan | null
+  period: BillingPeriod
+  seats: number
+  branding: BrandingPrice | null
+  trialDays: number
+  currentPlanRank: number
+  action: BillingPlanAction | null
+}) {
+  const { overview, plan, period } = props
+  const canAct = overview.canUpgrade || overview.canManageBilling
+  const summary = plan ? checkoutSummary(plan, period, props.seats) : null
+  const intervalLabel = period === 'annual' ? 'year' : 'mo'
+  const fromPaid = overview.plan !== 'free' && !overview.trialActive
+  const movingDown = plan != null && fromPaid && plan.rank < props.currentPlanRank
+  // A plan the workspace is already on (or none at all) is not charged, which
+  // leaves branding removal as the only purchasable line.
+  const planCharged = summary != null && props.action?.kind !== 'current'
+  const brandingOnly = props.branding != null && !planCharged
+  const addOnCents = props.branding ? brandingCents(props.branding, period) : 0
+  const totalCents = (planCharged ? summary.totalCents : 0) + addOnCents
+  const hasOrder = summary != null || props.branding != null
+
+  return (
+    <aside className="lg:sticky lg:top-6">
+      <div className="overflow-hidden rounded-xl border border-border/50 bg-card">
+        <div className="border-b border-border/50 px-5 py-4">
+          <h2 className="text-sm font-semibold">Order summary</h2>
+        </div>
+        {hasOrder ? (
+          <div className="space-y-4 px-5 py-4">
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-sm font-medium">
+                {plan ? `${plan.name} plan` : 'Add-ons only'}
+              </span>
+              <Badge size="sm" shape="pill" variant="secondary">
+                {period === 'annual' ? 'Yearly' : 'Monthly'}
+              </Badge>
+            </div>
+            <div className="space-y-2 text-[13px]">
+              {plan && summary && planCharged ? (
+                <div className="flex items-baseline justify-between gap-3">
+                  <span className="text-muted-foreground">
+                    {summary.billedPer === 'seat'
+                      ? `${summary.quantity} ${summary.quantity === 1 ? 'seat' : 'seats'} × ${formatUsd(summary.unitCents, 0)}/${intervalLabel}`
+                      : `Workspace × ${formatUsd(summary.unitCents, 0)}/${intervalLabel}`}
+                  </span>
+                  <span className="tabular-nums">
+                    {formatUsd(summary.totalCents, 0)}/{intervalLabel}
+                  </span>
+                </div>
+              ) : null}
+              {props.branding ? (
+                <div className="flex items-baseline justify-between gap-3">
+                  <span className="text-muted-foreground">Remove branding</span>
+                  <span className="tabular-nums">
+                    {formatUsd(addOnCents, 0)}/{intervalLabel}
+                  </span>
+                </div>
+              ) : null}
+            </div>
+            <div className="flex items-baseline justify-between gap-3 border-t border-border/50 pt-3">
+              <span className="text-sm font-medium">Total</span>
+              <span className="text-lg font-semibold tracking-tight tabular-nums">
+                {formatUsd(totalCents, 0)}/{intervalLabel}
+              </span>
+            </div>
+            {period === 'annual' ? (
+              <div className="flex items-baseline justify-between gap-3 text-[12px] text-muted-foreground">
+                <span>Monthly equivalent</span>
+                <span className="tabular-nums">{formatUsd(Math.round(totalCents / 12), 0)}/mo</span>
+              </div>
+            ) : null}
+          </div>
+        ) : (
+          <p className="px-5 py-4 text-[13px] text-muted-foreground">
+            Pick a plan to see your total.
+          </p>
+        )}
+        <div className="space-y-3 border-t border-border/50 px-5 py-4">
+          <SummaryAction
+            plan={plan}
+            period={period}
+            quantity={summary?.quantity ?? 1}
+            branding={props.branding != null}
+            brandingOnly={brandingOnly}
+            action={props.action}
+            canAct={canAct}
+            trialDays={props.trialDays}
+          />
+          <p className="text-[12px] leading-snug text-muted-foreground">
+            {!canAct
+              ? 'Only workspace owners can change the plan.'
+              : brandingOnly
+                ? plan
+                  ? 'You are already on this plan; only the add-on is charged, pro-rata on your current subscription.'
+                  : 'Payment is handled by Stripe. Branding removal renews on its own cycle until you cancel it.'
+                : props.action?.kind === 'current'
+                  ? 'You are already on this plan. Seats can be changed from Plans & billing.'
+                  : overview.trialActive
+                    ? 'Payment is handled by Stripe. Billing starts today and your trial ends when it goes through.'
+                    : movingDown
+                      ? 'Payment is handled by Stripe. Moving to a lower plan takes effect at the end of the current period.'
+                      : fromPaid
+                        ? 'Payment is handled by Stripe. Moving up applies now, billed pro-rata.'
+                        : 'Payment is handled by Stripe.'}
+          </p>
+        </div>
+      </div>
+    </aside>
+  )
+}
+
+function SummaryAction(props: {
+  plan: CataloguePlan | null
+  period: BillingPeriod
+  quantity: number
+  branding: boolean
+  brandingOnly: boolean
+  action: BillingPlanAction | null
+  canAct: boolean
+  trialDays: number
+}) {
+  const { plan, action } = props
+  if (props.brandingOnly && props.canAct) {
+    return (
+      <form method="post" action="/api/billing/session">
+        <input type="hidden" name="action" value="branding" />
+        <input type="hidden" name="billingPeriod" value={props.period} />
+        <Button type="submit" className="w-full">
+          Continue to payment
+        </Button>
+      </form>
+    )
+  }
+  if (!plan || !action || !isPaidPlanId(plan.id)) {
+    return (
+      <Button type="button" className="w-full" disabled>
+        Continue to payment
+      </Button>
+    )
+  }
+  if (action.kind === 'current') {
+    return (
+      <Button type="button" className="w-full" variant="outline" disabled>
+        Current plan
+      </Button>
+    )
+  }
+  if (!props.canAct || action.kind === 'unavailable' || action.kind === 'downgrade') {
+    return (
+      <Button type="button" className="w-full" disabled>
+        Continue to payment
+      </Button>
+    )
+  }
+  return (
+    <div className="space-y-2">
+      <form method="post" action="/api/billing/session">
+        <input type="hidden" name="action" value="checkout" />
+        <input type="hidden" name="planId" value={plan.id} />
+        <input type="hidden" name="billingPeriod" value={props.period} />
+        <input type="hidden" name="quantity" value={String(props.quantity)} />
+        {props.branding ? <input type="hidden" name="brandingRemoval" value="true" /> : null}
+        <Button type="submit" className="w-full">
+          Continue to payment
+        </Button>
+      </form>
+      {action.kind === 'trial' ? (
+        <TrialInstead planId={action.planId} planName={plan.name} trialDays={props.trialDays} />
+      ) : null}
+    </div>
+  )
+}
+
+function TrialInstead(props: { planId: PaidPlanId; planName: string; trialDays: number }) {
+  const [open, setOpen] = useState(false)
+  const formId = `checkout-trial-${props.planId}`
+  return (
+    <>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="w-full"
+        onClick={() => setOpen(true)}
+      >
+        Or try {props.planName} free for {props.trialDays} days
+      </Button>
+      <ConfirmDialog
+        open={open}
+        onOpenChange={setOpen}
+        title={`Try ${props.planName} for ${props.trialDays} days?`}
+        description={`You’ll have ${props.planName} for ${props.trialDays} days. When it ends you continue on Free with everything you have built. Each paid plan can be tried once.`}
+        confirmLabel={`Start ${props.planName} trial`}
+        onConfirm={() => {
+          const form = document.getElementById(formId) as HTMLFormElement | null
+          form?.requestSubmit()
+        }}
+      />
+      <form id={formId} method="post" action="/api/billing/trial" className="hidden">
+        <input type="hidden" name="planId" value={props.planId} />
+      </form>
+    </>
+  )
+}

--- a/apps/web/src/components/admin/upgrade/__tests__/upgrade-offer.test.tsx
+++ b/apps/web/src/components/admin/upgrade/__tests__/upgrade-offer.test.tsx
@@ -1,8 +1,9 @@
 // @vitest-environment happy-dom
-import { describe, expect, it, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { BillingCatalogue } from '@/lib/server/control-plane/client'
+import type { UpgradeContext } from '@/lib/server/domains/settings/cloud/upgrade-context'
 import { describeEntitlementUpgrade } from '@/lib/shared/describe-upgrade'
 
 const catalogue: BillingCatalogue = {
@@ -10,11 +11,43 @@ const catalogue: BillingCatalogue = {
   currency: 'usd',
   annualDiscountMonths: 2,
   recommendedPlanId: 'pro',
-  aiOutcomePriceCents: 29,
-  copilot: { freeConversationsPerSeat: 10, addonMonthlyCents: 1900, addonAnnualCents: 19000 },
   brandingRemoval: { monthlyCents: 5900, annualCents: 59000 },
-  liteSeatsIncluded: { free: 0, growth: 5, pro: 25, scale: null },
+  trialDays: 14,
+  trialedPlanIds: [],
   plans: [
+    {
+      id: 'free',
+      name: 'Free',
+      rank: 0,
+      priceMonthlyCents: 0,
+      priceYearlyCents: 0,
+      billedPer: 'workspace',
+      bestFor: 'Trying it out',
+      highlights: ['1 seat'],
+      recommended: false,
+    },
+    {
+      id: 'growth',
+      name: 'Growth',
+      rank: 1,
+      priceMonthlyCents: 2900,
+      priceYearlyCents: 29000,
+      billedPer: 'seat',
+      bestFor: 'Small teams',
+      highlights: ['Custom domain', 'API, MCP & webhooks'],
+      recommended: false,
+    },
+    {
+      id: 'pro',
+      name: 'Pro',
+      rank: 2,
+      priceMonthlyCents: 5900,
+      priceYearlyCents: 59000,
+      billedPer: 'seat',
+      bestFor: 'Inbox teams',
+      highlights: ['Workflows & SLAs', 'Moderation & private boards'],
+      recommended: true,
+    },
     {
       id: 'scale',
       name: 'Scale',
@@ -29,42 +62,166 @@ const catalogue: BillingCatalogue = {
   ],
 }
 
+const routerState = { billingEnabled: true }
+const permission = { canCheckout: true }
+
 vi.mock('@tanstack/react-router', () => ({
-  useRouteContext: () => ({ billingEnabled: true }),
+  useRouteContext: () => routerState,
+  useLocation: (opts: { select: (loc: { pathname: string; searchStr: string }) => string }) =>
+    opts.select({ pathname: '/admin/automation/workflows', searchStr: '' }),
 }))
 vi.mock('@/lib/client/hooks/use-permission', () => ({
-  usePermission: () => true,
+  usePermission: () => permission.canCheckout,
 }))
 
 const { UpgradeOffer } = await import('../upgrade-offer')
 
-function renderOffer() {
+function renderOffer(
+  context: UpgradeContext | null,
+  options: {
+    entitlement?: 'auditLog' | 'workflows' | 'webhooks'
+    catalogue?: BillingCatalogue
+  } = {}
+) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-  client.setQueryData(['billing', 'catalogue'], catalogue)
+  client.setQueryData(['billing', 'catalogue'], options.catalogue ?? catalogue)
+  client.setQueryData(['billing', 'upgrade-context'], context)
   return render(
     <QueryClientProvider client={client}>
-      <UpgradeOffer description={describeEntitlementUpgrade('auditLog')} />
+      <UpgradeOffer description={describeEntitlementUpgrade(options.entitlement ?? 'auditLog')} />
     </QueryClientProvider>
   )
 }
 
+const onPro: UpgradeContext = {
+  currentPlan: 'pro',
+  currentPlanName: 'Pro',
+  trialActive: false,
+  trialEligible: false,
+}
+const onFree: UpgradeContext = {
+  currentPlan: 'free',
+  currentPlanName: 'Free',
+  trialActive: false,
+  trialEligible: true,
+}
+
 describe('UpgradeOffer', () => {
-  it('renders catalogue price and highlights on the first paint', () => {
-    renderOffer()
-    expect(screen.getByRole('heading', { name: 'Upgrade to Scale' })).toBeTruthy()
-    expect(screen.getByText(/The audit log is a Scale feature/)).toBeTruthy()
-    expect(screen.getByText('SSO and audit log')).toBeTruthy()
+  afterEach(() => {
+    cleanup()
+    routerState.billingEnabled = true
+    permission.canCheckout = true
+  })
+
+  it('names the feature, both plans, the unlock list and the price on the first paint', () => {
+    renderOffer(onPro)
+    expect(
+      screen.getByRole('heading', { name: 'The audit log is available from the Scale plan' })
+    ).toBeTruthy()
+    expect(screen.getByText('Upgrade from Pro to Scale to unlock:')).toBeTruthy()
     expect(screen.getByText('Audit log')).toBeTruthy()
     expect(screen.getByText('SSO')).toBeTruthy()
+    expect(screen.queryByText(/Plus everything in/)).toBeNull()
     expect(screen.getByText('$89')).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Upgrade to Scale' })).toBeTruthy()
+    expect(screen.getByRole('link', { name: 'Upgrade to Scale' })).toHaveAttribute(
+      'href',
+      '/admin/settings/billing/checkout?plan=scale&period=annual'
+    )
+    expect(screen.getByRole('link', { name: /Compare all plans/ })).toHaveAttribute(
+      'href',
+      '/admin/settings/billing'
+    )
+    expect(document.querySelector('form')).toBeNull()
+  })
+
+  it('carries the chosen billing cycle into the configurator', () => {
+    renderOffer(onPro)
+    fireEvent.click(screen.getByRole('radio', { name: /Monthly/ }))
+    expect(screen.getByRole('link', { name: 'Upgrade to Scale' })).toHaveAttribute(
+      'href',
+      '/admin/settings/billing/checkout?plan=scale&period=monthly'
+    )
+  })
+
+  it('folds in the plans between the current one and the target', () => {
+    renderOffer({ ...onFree, trialEligible: false })
+    expect(screen.getByText('Upgrade from Free to Scale to unlock:')).toBeTruthy()
+    expect(screen.getByText('Plus everything in Growth:')).toBeTruthy()
+    expect(screen.getByText(/Custom domain · API, MCP & webhooks/)).toBeTruthy()
+    expect(screen.getByText('Plus everything in Pro:')).toBeTruthy()
+  })
+
+  it('offers a first-time trial that returns to the page that raised the prompt', () => {
+    renderOffer(onFree, { entitlement: 'workflows' })
+    expect(screen.getByRole('button', { name: 'Try Pro free for 14 days' })).toBeTruthy()
+    expect(screen.queryByRole('link', { name: 'Upgrade to Pro' })).toBeNull()
+    expect(screen.getByText(/Free for 14 days, then the price above/)).toBeTruthy()
     const form = document.querySelector('form')
-    expect(form?.getAttribute('action')).toBe('/api/billing/session')
-    expect((document.querySelector('input[name="planId"]') as HTMLInputElement)?.value).toBe(
-      'scale'
+    expect(form?.getAttribute('action')).toBe('/api/billing/trial')
+    expect((document.querySelector('input[name="planId"]') as HTMLInputElement)?.value).toBe('pro')
+    expect((document.querySelector('input[name="returnTo"]') as HTMLInputElement)?.value).toBe(
+      '/admin/automation/workflows'
     )
-    expect((document.querySelector('input[name="billingPeriod"]') as HTMLInputElement)?.value).toBe(
-      'annual'
+  })
+
+  it('falls back to checkout once that plan has been tried', () => {
+    renderOffer(onFree, {
+      entitlement: 'workflows',
+      catalogue: { ...catalogue, trialedPlanIds: ['pro'] },
+    })
+    expect(screen.getByRole('link', { name: 'Upgrade to Pro' })).toBeTruthy()
+    expect(screen.queryByText(/Free for 14 days/)).toBeNull()
+  })
+
+  it('acknowledges a running trial', () => {
+    renderOffer(
+      { currentPlan: 'growth', currentPlanName: 'Growth', trialActive: true, trialEligible: false },
+      { entitlement: 'workflows' }
     )
+    expect(screen.getByText("You're trialing Growth. Upgrade to Pro to unlock:")).toBeTruthy()
+    expect(screen.getByRole('link', { name: 'Upgrade to Pro' })).toBeTruthy()
+  })
+
+  it('uses plan-only copy when the current plan is unknown', () => {
+    renderOffer(null)
+    expect(screen.getByText('Upgrade to Scale to unlock:')).toBeTruthy()
+    expect(screen.getByRole('link', { name: 'Upgrade to Scale' })).toBeTruthy()
+  })
+
+  it('tells teammates without billing access who can act instead of linking to a page they cannot open', () => {
+    permission.canCheckout = false
+    renderOffer(onPro)
+    expect(screen.getByText('Only workspace owners can change the plan.')).toBeTruthy()
+    expect(screen.queryByRole('link', { name: /Upgrade to/ })).toBeNull()
+    expect(screen.queryByRole('link', { name: /Compare all plans/ })).toBeNull()
+    expect(screen.getByText('Audit log')).toBeTruthy()
+  })
+
+  it('still routes an owner to Plan & billing when the catalogue is unavailable', () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    client.setQueryData(['billing', 'catalogue'], null)
+    client.setQueryData(['billing', 'upgrade-context'], onPro)
+    render(
+      <QueryClientProvider client={client}>
+        <UpgradeOffer description={describeEntitlementUpgrade('auditLog')} />
+      </QueryClientProvider>
+    )
+    expect(screen.getByText(/The audit log is a Scale feature/)).toBeTruthy()
+    expect(screen.getByRole('link', { name: 'View & compare plans' })).toHaveAttribute(
+      'href',
+      '/admin/settings/billing'
+    )
+    expect(screen.queryByText('Only workspace owners can change the plan.')).toBeNull()
+  })
+
+  it('renders copy only when billing is off', () => {
+    routerState.billingEnabled = false
+    renderOffer(onPro)
+    expect(
+      screen.getByRole('heading', { name: 'The audit log is available from the Scale plan' })
+    ).toBeTruthy()
+    expect(screen.getByText(/The audit log is a Scale feature/)).toBeTruthy()
+    expect(document.querySelector('form')).toBeNull()
+    expect(screen.queryByRole('link')).toBeNull()
   })
 })

--- a/apps/web/src/components/admin/upgrade/upgrade-modal.tsx
+++ b/apps/web/src/components/admin/upgrade/upgrade-modal.tsx
@@ -19,7 +19,7 @@ export function UpgradeModal(props: {
   const description = props.description ?? describeEntitlementUpgrade(props.entitlement!)
   return (
     <Dialog open={props.open} onOpenChange={props.onOpenChange}>
-      <DialogContent className="max-w-md sm:max-w-md">
+      <DialogContent className="max-w-lg sm:max-w-lg">
         <DialogHeader className="sr-only">
           <DialogTitle>{description.headline}</DialogTitle>
           <DialogDescription>{description.body}</DialogDescription>
@@ -28,6 +28,7 @@ export function UpgradeModal(props: {
           description={description}
           onDismiss={() => props.onOpenChange(false)}
           dismissLabel="Maybe later"
+          className="[&>div:first-child]:pr-6"
         />
       </DialogContent>
     </Dialog>

--- a/apps/web/src/components/admin/upgrade/upgrade-notice.tsx
+++ b/apps/web/src/components/admin/upgrade/upgrade-notice.tsx
@@ -9,7 +9,7 @@ export function UpgradeNotice(props: {
 }) {
   const description = props.description ?? describeEntitlementUpgrade(props.entitlement!)
   return (
-    <div className="rounded-lg border border-dashed border-border/50 bg-muted/10 p-6">
+    <div className="rounded-lg border border-dashed border-border/50 bg-muted/10 p-5">
       <UpgradeOffer description={description} />
     </div>
   )

--- a/apps/web/src/components/admin/upgrade/upgrade-offer.tsx
+++ b/apps/web/src/components/admin/upgrade/upgrade-offer.tsx
@@ -1,17 +1,31 @@
 import { Suspense, useState } from 'react'
-import { CheckIcon } from '@heroicons/react/24/solid'
+import { ArrowTopRightOnSquareIcon, CheckIcon, LockClosedIcon } from '@heroicons/react/24/solid'
 import { useSuspenseQuery } from '@tanstack/react-query'
-import { useRouteContext } from '@tanstack/react-router'
+import { useLocation, useRouteContext } from '@tanstack/react-router'
 import { Button } from '@/components/ui/button'
 import { billingQueries } from '@/lib/client/queries/billing'
 import { usePermission } from '@/lib/client/hooks/use-permission'
 import { PERMISSIONS } from '@/lib/shared/permissions'
 import { formatUsd } from '@/lib/shared/format-usd'
-import { cataloguePlanFor, type UpgradeDescription } from '@/lib/shared/describe-upgrade'
+import {
+  catalogueTrialDays,
+  catalogueTrialedPlanIds,
+  type PaidPlanId,
+} from '@/lib/shared/billing/plan-action'
+import { checkoutPath, isPaidPlanId } from '@/lib/shared/billing/checkout-path'
+import {
+  cataloguePlanFor,
+  unlockedHighlights,
+  upgradeLead,
+  type UpgradeDescription,
+} from '@/lib/shared/describe-upgrade'
 import { cn } from '@/lib/shared/utils'
 import type { BillingCatalogue } from '@/lib/server/control-plane/client'
+import type { UpgradeContext } from '@/lib/server/domains/settings/cloud/upgrade-context'
 
 type BillingPeriod = 'monthly' | 'annual'
+
+const PLANS_PATH = '/admin/settings/billing'
 
 type UpgradeOfferProps = {
   description: UpgradeDescription
@@ -22,86 +36,196 @@ type UpgradeOfferProps = {
 
 /**
  * The one upgrade body. Card, in-route screen, and modal all render this.
- * Plan name, price, and highlights come from the same catalogue as Plan & billing.
- * The catalogue is prefetched in the route loader so the first paint is complete.
+ *
+ * It names the feature that was just attempted, the plan the workspace is on,
+ * the plan that includes the feature, and everything that move unlocks — the
+ * same catalogue Plan & billing renders. Both the catalogue and the upgrade
+ * context are prefetched in the route loader so the first paint is complete.
  */
 export function UpgradeOffer(props: UpgradeOfferProps) {
   const { billingEnabled } = useRouteContext({ from: '__root__' })
   const canCheckout = usePermission(PERMISSIONS.BILLING_MANAGE)
   if (!billingEnabled) {
-    return <OfferFrame {...props} catalogue={null} canCheckout={false} billingEnabled={false} />
+    return (
+      <OfferFrame
+        {...props}
+        catalogue={null}
+        context={null}
+        canCheckout={false}
+        billingEnabled={false}
+      />
+    )
   }
   return (
     <Suspense
-      fallback={<OfferFrame {...props} catalogue={null} canCheckout={canCheckout} billingEnabled />}
+      fallback={
+        <OfferFrame
+          {...props}
+          catalogue={null}
+          context={null}
+          canCheckout={canCheckout}
+          billingEnabled
+        />
+      }
     >
       <UpgradeOfferReady {...props} canCheckout={canCheckout} />
     </Suspense>
   )
 }
 
-function UpgradeOfferReady(
-  props: UpgradeOfferProps & {
-    canCheckout: boolean
-  }
-) {
+function UpgradeOfferReady(props: UpgradeOfferProps & { canCheckout: boolean }) {
   const { data: catalogue } = useSuspenseQuery(billingQueries.catalogue())
+  const { data: context } = useSuspenseQuery(billingQueries.upgradeContext())
   return (
     <OfferFrame
       {...props}
       catalogue={(catalogue ?? null) as BillingCatalogue | null}
+      context={(context ?? null) as UpgradeContext | null}
       billingEnabled
     />
   )
 }
 
-function OfferFrame(
-  props: UpgradeOfferProps & {
-    catalogue: BillingCatalogue | null
-    canCheckout: boolean
-    billingEnabled: boolean
-  }
-) {
-  const plan = cataloguePlanFor(props.catalogue, props.description.requiredPlan)
+type OfferFrameProps = UpgradeOfferProps & {
+  catalogue: BillingCatalogue | null
+  context: UpgradeContext | null
+  canCheckout: boolean
+  billingEnabled: boolean
+}
+
+function OfferFrame(props: OfferFrameProps) {
+  const { description, catalogue, context } = props
+  const plan = cataloguePlanFor(catalogue, description.requiredPlan)
   const [period, setPeriod] = useState<BillingPeriod>('annual')
+  const unlocked = unlockedHighlights(catalogue, context?.currentPlan, description.requiredPlan)
+  const trialDays = catalogueTrialDays(catalogue)
+  const trialPlanId = trialPlanIdFor(plan, context, catalogue)
+  const canManage = props.billingEnabled && props.canCheckout
+  const canAct = canManage && Boolean(plan)
+  const showFooter = props.billingEnabled || Boolean(props.onDismiss)
 
   return (
-    <div className={cn('mx-auto w-full max-w-md text-center', props.className)}>
-      <h2 className="text-lg font-semibold tracking-tight">{props.description.headline}</h2>
-      <p className="mt-2 text-[13px] leading-snug text-muted-foreground">
-        {props.description.body}
-      </p>
-      {plan ? (
-        <CatalogueDetails
+    <div className={cn('w-full text-left', props.className)}>
+      <div className="flex items-start gap-3">
+        <span
+          aria-hidden
+          className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary"
+        >
+          <LockClosedIcon className="size-4" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <h2 className="text-base font-semibold leading-snug tracking-tight">
+            {description.headline}
+          </h2>
+          <p className="mt-1 text-[13px] leading-snug text-muted-foreground">
+            {plan
+              ? upgradeLead(context?.currentPlanName, description.requiredPlanName, {
+                  trialActive: context?.trialActive,
+                })
+              : description.body}
+          </p>
+        </div>
+      </div>
+
+      {unlocked.target.length > 0 ? (
+        <ul className="mt-4 grid gap-x-6 gap-y-2 sm:grid-cols-2">
+          {unlocked.target.map((line) => (
+            <li key={line} className="flex items-start gap-2 text-[13px] leading-snug">
+              <span className="mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full bg-primary/15 text-primary">
+                <CheckIcon className="size-2.5" />
+              </span>
+              <span>{line}</span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {unlocked.included.map((group) => (
+        <p key={group.planName} className="mt-3 text-[12px] leading-snug text-muted-foreground">
+          <span className="font-medium text-foreground/80">
+            Plus everything in {group.planName}:
+          </span>{' '}
+          {group.highlights.join(' · ')}
+        </p>
+      ))}
+
+      {plan && props.billingEnabled ? (
+        <PriceRow
           plan={plan}
           period={period}
-          discountMonths={props.catalogue?.annualDiscountMonths ?? 2}
+          discountMonths={catalogue?.annualDiscountMonths ?? 2}
           onPeriodChange={setPeriod}
+          trialDays={trialPlanId ? trialDays : null}
         />
       ) : null}
-      <div className="mt-5 flex flex-col items-center gap-2">
-        {plan && props.canCheckout && props.billingEnabled ? (
-          <CheckoutButton planId={plan.id} period={period} label={`Upgrade to ${plan.name}`} />
-        ) : props.billingEnabled ? (
-          <Button asChild size="sm">
-            <a href="/admin/settings/billing">See plans</a>
-          </Button>
-        ) : null}
-        {props.onDismiss ? (
-          <Button type="button" variant="outline" size="sm" onClick={props.onDismiss}>
-            {props.dismissLabel ?? 'Maybe later'}
-          </Button>
-        ) : null}
-      </div>
+
+      {showFooter ? (
+        <div className="mt-5 flex flex-wrap items-center justify-between gap-3">
+          <div className="min-w-0 text-[13px] text-muted-foreground">
+            {canAct ? (
+              <a
+                href={PLANS_PATH}
+                className="inline-flex items-center gap-1 hover:text-foreground hover:underline"
+              >
+                Compare all plans
+                <ArrowTopRightOnSquareIcon className="size-3.5" />
+              </a>
+            ) : props.billingEnabled && !props.canCheckout ? (
+              <span>Only workspace owners can change the plan.</span>
+            ) : null}
+          </div>
+          <div className="flex items-center gap-2">
+            {props.onDismiss ? (
+              <Button type="button" variant="ghost" size="sm" onClick={props.onDismiss}>
+                {props.dismissLabel ?? 'Maybe later'}
+              </Button>
+            ) : null}
+            {canManage && plan ? (
+              trialPlanId ? (
+                <TrialButton
+                  planId={trialPlanId}
+                  label={`Try ${plan.name} free for ${trialDays} days`}
+                />
+              ) : (
+                <CheckoutButton
+                  planId={plan.id}
+                  period={period}
+                  label={`Upgrade to ${plan.name}`}
+                />
+              )
+            ) : canManage ? (
+              <Button asChild size="sm">
+                <a href={PLANS_PATH}>View & compare plans</a>
+              </Button>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
     </div>
   )
 }
 
-function CatalogueDetails(props: {
+/**
+ * The paid plan a first-time trial may be started for, or null when the
+ * workspace must convert through checkout instead. Mirrors `billingPlanAction`
+ * on Plan & billing so the two surfaces never disagree.
+ */
+function trialPlanIdFor(
+  plan: BillingCatalogue['plans'][number] | null,
+  context: UpgradeContext | null,
+  catalogue: BillingCatalogue | null
+): PaidPlanId | null {
+  if (!plan || !context?.trialEligible) return null
+  if (plan.id !== 'growth' && plan.id !== 'pro' && plan.id !== 'scale') return null
+  return catalogueTrialedPlanIds(catalogue).includes(plan.id) ? null : plan.id
+}
+
+function PriceRow(props: {
   plan: BillingCatalogue['plans'][number]
   period: BillingPeriod
   discountMonths: number
   onPeriodChange: (next: BillingPeriod) => void
+  trialDays: number | null
 }) {
   const isAnnual = props.period === 'annual'
   const monthlyCents = isAnnual
@@ -110,34 +234,31 @@ function CatalogueDetails(props: {
   const unit = props.plan.billedPer === 'seat' ? '/seat/mo' : '/mo'
 
   return (
-    <div className="mt-5 text-left">
-      <p className="text-[13px] text-muted-foreground">{props.plan.bestFor}</p>
-      <p className="mt-3 flex items-baseline justify-center gap-1">
-        <span className="text-[28px] font-semibold tracking-tight tabular-nums">
-          {formatUsd(monthlyCents, 0)}
-        </span>
-        <span className="text-[13px] text-muted-foreground">{unit}</span>
-      </p>
-      {props.plan.id !== 'free' ? (
-        <p className="mt-1 text-center text-[12px] text-muted-foreground">
-          {isAnnual
-            ? `${formatUsd(props.plan.priceYearlyCents, 0)} billed yearly`
-            : 'billed monthly'}
+    <div className="mt-4 rounded-lg border border-border/50 bg-muted/20 px-3 py-2.5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p className="flex items-baseline gap-1.5">
+          <span className="text-xl font-semibold tracking-tight tabular-nums">
+            {formatUsd(monthlyCents, 0)}
+          </span>
+          <span className="text-[12px] text-muted-foreground">
+            {unit}
+            {isAnnual
+              ? ` · ${formatUsd(props.plan.priceYearlyCents, 0)} billed yearly`
+              : ' · billed monthly'}
+          </span>
+        </p>
+        <PeriodToggle
+          value={props.period}
+          discountMonths={props.discountMonths}
+          onChange={props.onPeriodChange}
+        />
+      </div>
+      {props.trialDays ? (
+        <p className="mt-2 text-[12px] leading-snug text-muted-foreground">
+          Free for {props.trialDays} days, then the price above. Each paid plan can be tried once;
+          when the trial ends you continue on Free with everything you have built.
         </p>
       ) : null}
-      <PeriodToggle
-        value={props.period}
-        discountMonths={props.discountMonths}
-        onChange={props.onPeriodChange}
-      />
-      <ul className="mt-4 space-y-2">
-        {props.plan.highlights.map((line) => (
-          <li key={line} className="flex items-start gap-2 text-[13px] leading-snug">
-            <CheckIcon className="mt-0.5 size-3.5 shrink-0 text-primary" />
-            <span>{line}</span>
-          </li>
-        ))}
-      </ul>
     </div>
   )
 }
@@ -151,7 +272,7 @@ function PeriodToggle(props: {
     <div
       role="radiogroup"
       aria-label="Billing period"
-      className="mt-4 inline-flex w-full items-center justify-center rounded-full border border-border/50 bg-muted/30 p-0.5"
+      className="inline-flex items-center rounded-full border border-border/50 bg-background p-0.5"
     >
       {(['annual', 'monthly'] as const).map((option) => (
         <button
@@ -161,15 +282,15 @@ function PeriodToggle(props: {
           aria-checked={props.value === option}
           onClick={() => props.onChange(option)}
           className={cn(
-            'inline-flex h-8 flex-1 items-center justify-center rounded-full px-3 text-[13px] font-medium',
+            'inline-flex h-7 items-center justify-center rounded-full px-2.5 text-[12px] font-medium',
             props.value === option
-              ? 'bg-background text-foreground shadow-xs'
+              ? 'bg-muted text-foreground shadow-xs'
               : 'text-muted-foreground hover:text-foreground'
           )}
         >
           {option === 'annual' ? 'Annual' : 'Monthly'}
           {option === 'annual' ? (
-            <span className="ms-1.5 text-[11px] font-semibold text-primary">
+            <span className="ms-1 text-[11px] font-semibold text-primary">
               {props.discountMonths} mo free
             </span>
           ) : null}
@@ -179,13 +300,26 @@ function PeriodToggle(props: {
   )
 }
 
+/** Hands off to the plan configurator with this plan and cycle preselected; payment is the step after. */
 function CheckoutButton(props: { planId: string; period: BillingPeriod; label: string }) {
+  const href = isPaidPlanId(props.planId)
+    ? checkoutPath({ plan: props.planId, period: props.period })
+    : PLANS_PATH
   return (
-    <form method="post" action="/api/billing/session" className="w-full">
-      <input type="hidden" name="action" value="checkout" />
+    <Button asChild size="sm">
+      <a href={href}>{props.label}</a>
+    </Button>
+  )
+}
+
+/** Starts the trial and lands back on the page that raised the prompt, now unlocked. */
+function TrialButton(props: { planId: PaidPlanId; label: string }) {
+  const returnTo = useLocation({ select: (location) => location.pathname + location.searchStr })
+  return (
+    <form method="post" action="/api/billing/trial">
       <input type="hidden" name="planId" value={props.planId} />
-      <input type="hidden" name="billingPeriod" value={props.period} />
-      <Button size="sm" type="submit" className="w-full">
+      <input type="hidden" name="returnTo" value={returnTo} />
+      <Button size="sm" type="submit">
         {props.label}
       </Button>
     </form>

--- a/apps/web/src/components/admin/upgrade/upgrade-screen.tsx
+++ b/apps/web/src/components/admin/upgrade/upgrade-screen.tsx
@@ -11,11 +11,12 @@ export function UpgradeScreen(props: {
 }) {
   const description = props.description ?? describeEntitlementUpgrade(props.entitlement!)
   return (
-    <div className="rounded-xl border border-border/60 bg-card/30 px-6 py-10">
+    <div className="rounded-xl border border-border/60 bg-card/30 p-6 sm:p-8">
       <UpgradeOffer
         description={description}
         onDismiss={props.onDismiss}
         dismissLabel={props.dismissLabel}
+        className="mx-auto max-w-2xl"
       />
     </div>
   )

--- a/apps/web/src/components/shared/__tests__/error-page.test.tsx
+++ b/apps/web/src/components/shared/__tests__/error-page.test.tsx
@@ -73,7 +73,19 @@ describe('DefaultErrorPage', () => {
 
     expect(screen.queryByText(/Something went wrong/i)).toBeNull()
     expect(screen.queryByText(/Technical details/i)).toBeNull()
-    expect(screen.getByText(/This is a plan feature/i)).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'The audit log is available from the Scale plan' })
+    ).toBeInTheDocument()
     expect(screen.getByText(/The audit log is a Scale feature/)).toBeInTheDocument()
+  })
+
+  it('keeps the generic plan headline when the refusal names no plan', () => {
+    render(
+      <DefaultErrorPage
+        error={new Error('Workflows are not included in your plan. Contact us to enable it.')}
+      />
+    )
+
+    expect(screen.getByRole('heading', { name: 'This is a plan feature' })).toBeInTheDocument()
   })
 })

--- a/apps/web/src/components/shared/error-page.tsx
+++ b/apps/web/src/components/shared/error-page.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button'
+import { describePlanRefusal } from '@/lib/shared/describe-upgrade'
 import { cn } from '@/lib/shared/utils'
 
 interface ErrorPageProps {
@@ -92,15 +93,25 @@ export function EntitlementRequiredPage({
   fullPage?: boolean
 }) {
   const isAdminArea = typeof window !== 'undefined' && window.location.pathname.startsWith('/admin')
+  const refusal = describePlanRefusal(error, {
+    entitlement: null,
+    feature: 'This feature',
+    requiredPlan: null,
+    requiredPlanName: null,
+    headline: 'This is a plan feature',
+    body: error.message,
+  })
 
   return (
     <FriendlyShell fullPage={fullPage}>
-      <h1 className="text-2xl font-semibold tracking-tight">This is a plan feature</h1>
+      <h1 className="text-2xl font-semibold tracking-tight">{refusal.headline}</h1>
       <p className="mt-2 text-sm text-muted-foreground">{error.message}</p>
       <div className="mt-6 flex items-center justify-center gap-3">
         {isAdminArea ? (
           <Button asChild>
-            <a href="/admin/settings/billing">See plans</a>
+            <a href="/admin/settings/billing">
+              {refusal.requiredPlanName ? `Upgrade to ${refusal.requiredPlanName}` : 'See plans'}
+            </a>
           </Button>
         ) : null}
         <Button variant="outline" asChild>

--- a/apps/web/src/lib/client/queries/__tests__/ensure-billing-catalogue.test.ts
+++ b/apps/web/src/lib/client/queries/__tests__/ensure-billing-catalogue.test.ts
@@ -2,12 +2,15 @@ import { describe, expect, it, vi } from 'vitest'
 import { QueryClient } from '@tanstack/react-query'
 
 const fetchBillingCatalogueFn = vi.fn()
+const fetchUpgradeContextFn = vi.fn()
 vi.mock('@/lib/server/functions/billing', () => ({
   fetchBillingCatalogueFn: () => fetchBillingCatalogueFn(),
+  fetchUpgradeContextFn: () => fetchUpgradeContextFn(),
   fetchBillingInvoicesFn: vi.fn(),
   fetchBillingOverviewFn: vi.fn(),
   fetchPlanUsageFn: vi.fn(),
   fetchFreeDowngradePreviewFn: vi.fn(),
+  fetchSeatsPreviewFn: vi.fn(),
 }))
 
 const { billingQueries, ensureBillingCatalogue } = await import('../billing')
@@ -15,16 +18,33 @@ const { billingQueries, ensureBillingCatalogue } = await import('../billing')
 describe('ensureBillingCatalogue', () => {
   it('does not fetch when billing is off', async () => {
     fetchBillingCatalogueFn.mockClear()
+    fetchUpgradeContextFn.mockClear()
     const queryClient = new QueryClient()
     await expect(ensureBillingCatalogue(queryClient, false)).resolves.toBeNull()
     await expect(ensureBillingCatalogue(queryClient, undefined)).resolves.toBeNull()
     expect(fetchBillingCatalogueFn).not.toHaveBeenCalled()
+    expect(fetchUpgradeContextFn).not.toHaveBeenCalled()
   })
 
-  it('stores null when the catalogue fetch fails so the offer can still SSR', async () => {
+  it('warms the catalogue and the upgrade context together', async () => {
+    fetchBillingCatalogueFn.mockResolvedValueOnce({ version: 1, plans: [] })
+    fetchUpgradeContextFn.mockResolvedValueOnce({ currentPlan: 'free' })
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    await expect(ensureBillingCatalogue(queryClient, true)).resolves.toEqual({
+      version: 1,
+      plans: [],
+    })
+    expect(queryClient.getQueryData(billingQueries.upgradeContext().queryKey)).toEqual({
+      currentPlan: 'free',
+    })
+  })
+
+  it('stores null when either fetch fails so the offer can still SSR', async () => {
     fetchBillingCatalogueFn.mockRejectedValueOnce(new Error('control plane down'))
+    fetchUpgradeContextFn.mockRejectedValueOnce(new Error('settings read failed'))
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
     await expect(ensureBillingCatalogue(queryClient, true)).resolves.toBeNull()
     expect(queryClient.getQueryData(billingQueries.catalogue().queryKey)).toBeNull()
+    expect(queryClient.getQueryData(billingQueries.upgradeContext().queryKey)).toBeNull()
   })
 })

--- a/apps/web/src/lib/client/queries/billing.ts
+++ b/apps/web/src/lib/client/queries/billing.ts
@@ -6,6 +6,7 @@ import {
   fetchPlanUsageFn,
   fetchFreeDowngradePreviewFn,
   fetchSeatsPreviewFn,
+  fetchUpgradeContextFn,
 } from '@/lib/server/functions/billing'
 
 /** Billing state and catalogue from the control plane. */
@@ -21,6 +22,12 @@ export const billingQueries = {
     queryOptions({
       queryKey: ['billing', 'catalogue'] as const,
       queryFn: () => fetchBillingCatalogueFn(),
+      staleTime: 60_000,
+    }),
+  upgradeContext: () =>
+    queryOptions({
+      queryKey: ['billing', 'upgrade-context'] as const,
+      queryFn: () => fetchUpgradeContextFn(),
       staleTime: 60_000,
     }),
   invoices: () =>
@@ -50,18 +57,25 @@ export const billingQueries = {
 }
 
 /**
- * Warm the advertised-plan catalogue before an upgrade surface renders.
- * Fail-open: a control-plane miss stores null so the offer still SSRs.
+ * Warm everything an upgrade surface reads before it renders: the advertised
+ * plan catalogue and the workspace's upgrade context (current plan, trial
+ * eligibility). Fail-open: a miss on either stores null so the offer still SSRs
+ * with plan-only copy. Resolves to the catalogue, as before.
  */
 export async function ensureBillingCatalogue(
   queryClient: QueryClient,
   billingEnabled: boolean | undefined
 ) {
   if (!billingEnabled) return null
-  try {
-    return await queryClient.ensureQueryData(billingQueries.catalogue())
-  } catch {
-    queryClient.setQueryData(billingQueries.catalogue().queryKey, null)
-    return null
-  }
+  const [catalogue] = await Promise.all([
+    queryClient.ensureQueryData(billingQueries.catalogue()).catch(() => {
+      queryClient.setQueryData(billingQueries.catalogue().queryKey, null)
+      return null
+    }),
+    queryClient.ensureQueryData(billingQueries.upgradeContext()).catch(() => {
+      queryClient.setQueryData(billingQueries.upgradeContext().queryKey, null)
+      return null
+    }),
+  ])
+  return catalogue
 }

--- a/apps/web/src/lib/server/control-plane/client.ts
+++ b/apps/web/src/lib/server/control-plane/client.ts
@@ -193,6 +193,8 @@ export type HostedBillingSessionInput =
       planId: 'growth' | 'pro' | 'scale'
       billingPeriod: 'monthly' | 'annual'
       quantity?: number
+      /** Bundle branding removal into the same subscription and checkout. */
+      brandingRemoval?: boolean
     }
   | { action: 'downgrade'; planId: 'free' }
   | { action: 'seats'; quantity: number }

--- a/apps/web/src/lib/server/domains/settings/cloud/__tests__/upgrade-context.test.ts
+++ b/apps/web/src/lib/server/domains/settings/cloud/__tests__/upgrade-context.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { DISABLED_CLOUD_CONFIG, type CloudConfig } from '../cloud.types'
+import { upgradeContextFor } from '../upgrade-context'
+
+function cloud(overrides: Partial<CloudConfig> = {}): CloudConfig {
+  return {
+    ...DISABLED_CLOUD_CONFIG,
+    enabled: true,
+    plan: 'free',
+    entitlements: {},
+    canUpgrade: true,
+    ...overrides,
+  }
+}
+
+describe('upgradeContextFor', () => {
+  it('is null when cloud is off or no plan is in force', () => {
+    expect(upgradeContextFor(DISABLED_CLOUD_CONFIG)).toBeNull()
+    expect(upgradeContextFor(cloud({ plan: null }))).toBeNull()
+  })
+
+  it('names the current plan and offers a trial to a Free workspace that can upgrade', () => {
+    expect(upgradeContextFor(cloud())).toEqual({
+      currentPlan: 'free',
+      currentPlanName: 'Free',
+      trialActive: false,
+      trialEligible: true,
+    })
+  })
+
+  it('withholds the trial while one is running, on a paid plan, with a live sub, or without canUpgrade', () => {
+    expect(upgradeContextFor(cloud({ trialActive: true, plan: 'growth' }))).toMatchObject({
+      currentPlan: 'growth',
+      currentPlanName: 'Growth',
+      trialActive: true,
+      trialEligible: false,
+    })
+    expect(upgradeContextFor(cloud({ plan: 'pro' }))?.trialEligible).toBe(false)
+    expect(upgradeContextFor(cloud({ subscriptionStatus: 'active' }))?.trialEligible).toBe(false)
+    expect(upgradeContextFor(cloud({ subscriptionStatus: 'past_due' }))?.trialEligible).toBe(false)
+    expect(upgradeContextFor(cloud({ canUpgrade: false }))?.trialEligible).toBe(false)
+  })
+
+  it('still offers a trial after a canceled subscription on Free', () => {
+    expect(upgradeContextFor(cloud({ subscriptionStatus: 'canceled' }))?.trialEligible).toBe(true)
+  })
+})

--- a/apps/web/src/lib/server/domains/settings/cloud/upgrade-context.ts
+++ b/apps/web/src/lib/server/domains/settings/cloud/upgrade-context.ts
@@ -1,0 +1,43 @@
+import { hasLivePaidSub } from '@/lib/shared/billing/trial-state'
+import { PLAN_CATALOGUE, type CloudConfig, type PlanId } from './cloud.types'
+
+/**
+ * The commercial facts an upgrade prompt may name. Deliberately narrower than
+ * {@link CloudConfig}: no customer or subscription reference, no dates, no
+ * entitlement map. The plan name is already shown to every teammate by the
+ * trial banner, so naming it here leaks nothing new.
+ */
+export interface UpgradeContext {
+  currentPlan: PlanId
+  currentPlanName: string
+  trialActive: boolean
+  /**
+   * Whether this workspace may start a first-time product trial from a prompt.
+   * Plan-agnostic on purpose: which paid plans were already tried lives in the
+   * billing catalogue, and the client intersects the two.
+   */
+  trialEligible: boolean
+}
+
+/**
+ * Null when cloud is off or no plan is in force — the prompt then falls back to
+ * plan-only copy ("Upgrade to Pro to unlock") rather than guessing "Free".
+ *
+ * Trial eligibility mirrors `billingPlanAction`: only a Free workspace with no
+ * live subscription, not already trialing, and authorised to upgrade, is
+ * offered a trial. Everything else converts through checkout.
+ */
+export function upgradeContextFor(cloud: CloudConfig): UpgradeContext | null {
+  if (!cloud.enabled || !cloud.plan) return null
+  const trialEligible =
+    cloud.canUpgrade &&
+    !cloud.trialActive &&
+    cloud.plan === 'free' &&
+    !hasLivePaidSub(cloud.subscriptionStatus)
+  return {
+    currentPlan: cloud.plan,
+    currentPlanName: PLAN_CATALOGUE[cloud.plan].name,
+    trialActive: cloud.trialActive,
+    trialEligible,
+  }
+}

--- a/apps/web/src/lib/server/functions/billing.ts
+++ b/apps/web/src/lib/server/functions/billing.ts
@@ -27,6 +27,18 @@ export const fetchBillingCatalogueFn = createServerFn({ method: 'GET' }).handler
   return fetchBillingCatalogue()
 })
 
+/**
+ * What an upgrade prompt may say about the workspace it is shown in: the plan
+ * in force and whether a trial can be offered. Same audience as the catalogue.
+ * Null on self-hosted installs and whenever no plan is in force.
+ */
+export const fetchUpgradeContextFn = createServerFn({ method: 'GET' }).handler(async () => {
+  await requireAuth()
+  const { getCloudConfig } = await import('@/lib/server/domains/settings/cloud/cloud.service')
+  const { upgradeContextFor } = await import('@/lib/server/domains/settings/cloud/upgrade-context')
+  return upgradeContextFor(await getCloudConfig())
+})
+
 export const fetchBillingInvoicesFn = createServerFn({ method: 'GET' }).handler(async () => {
   await requireAuth({ permission: PERMISSIONS.BILLING_MANAGE })
   const { fetchBillingInvoices } = await import('@/lib/server/control-plane/client')

--- a/apps/web/src/lib/server/policy/authz-matrix/MATRIX.md
+++ b/apps/web/src/lib/server/policy/authz-matrix/MATRIX.md
@@ -100,7 +100,7 @@ Profiles: **Owner** = admin class + an admin-owned full API key (scoped keys hol
 
 ## 2. Surfaces and their enforced authorization
 
-### Server functions (`requireAuth`) — 671 surfaces
+### Server functions (`requireAuth`) — 672 surfaces
 
 | Surface | Enforces |
 | --- | --- |
@@ -261,6 +261,7 @@ Profiles: **Owner** = admin class + an admin-owned full API key (scoped keys hol
 | `lib/server/functions/auth-provider-credentials.ts`::fetchAuthProviderStatusFn | auth.manage |
 | `lib/server/functions/billing.ts`::fetchBillingOverviewFn | billing.manage |
 | `lib/server/functions/billing.ts`::fetchBillingCatalogueFn | END_USER (any authenticated) |
+| `lib/server/functions/billing.ts`::fetchUpgradeContextFn | END_USER (any authenticated) |
 | `lib/server/functions/billing.ts`::fetchBillingInvoicesFn | billing.manage |
 | `lib/server/functions/billing.ts`::fetchSeatsPreviewFn | billing.manage |
 | `lib/server/functions/billing.ts`::fetchPlanUsageFn | billing.manage |
@@ -982,7 +983,7 @@ Key scopes are enforced: an API key holds exactly its stored scopes (owner permi
 
 ## 4. Entry points without a requireAuth/key gate
 
-191 of 974 entry points hold no `requireAuth` / `withApiKeyAuth` / `requireTeamAuth` gate.
+191 of 975 entry points hold no `requireAuth` / `withApiKeyAuth` / `requireTeamAuth` gate.
 Each is expected to be intentionally public, a pre-auth flow, a signature-verified webhook, or a handler that delegates auth (e.g. the MCP route).
 **Adding a row here is an access-control change** — confirm the new entry point is meant to be reachable without a gate.
 

--- a/apps/web/src/lib/server/policy/authz-matrix/classifications.ts
+++ b/apps/web/src/lib/server/policy/authz-matrix/classifications.ts
@@ -360,6 +360,13 @@ export const BARE_GATE_CLASSIFICATIONS: Record<string, Classification> = {
     'advertised plan catalogue; null when cloud is off'
   ),
 
+  // Current plan name and trial eligibility for upgrade prompts. Same audience
+  // as the catalogue: the plan name already reaches every teammate through the
+  // trial banner, and nothing else (references, dates, entitlements) is exposed.
+  'lib/server/functions/billing.ts::fetchUpgradeContextFn': END_USER(
+    'current plan + trial eligibility; null when cloud is off'
+  ),
+
   // Cloud workspace ownership. The gate admits any authenticated principal and
   // the *handler* makes the access decision by comparing the caller's own
   // session address against the owner the control plane reports — there is no

--- a/apps/web/src/lib/shared/__tests__/describe-upgrade.test.ts
+++ b/apps/web/src/lib/shared/__tests__/describe-upgrade.test.ts
@@ -3,16 +3,20 @@ import type { BillingCatalogue } from '@/lib/server/control-plane/client'
 import {
   cataloguePlanFor,
   describeEntitlementUpgrade,
+  describePlanRefusal,
   describePlanUpgrade,
   isPlanRefusal,
   throwIfServerFnFailed,
+  unlockedHighlights,
+  upgradeLead,
 } from '../describe-upgrade'
 
 const catalogue = {
   plans: [
-    { id: 'growth', name: 'Growth', highlights: ['Custom domain'] },
-    { id: 'pro', name: 'Pro', highlights: ['Workflows'] },
-    { id: 'scale', name: 'Scale', highlights: ['Audit log', 'SSO'] },
+    { id: 'free', name: 'Free', rank: 0, highlights: ['1 seat'] },
+    { id: 'growth', name: 'Growth', rank: 1, highlights: ['Custom domain'] },
+    { id: 'pro', name: 'Pro', rank: 2, highlights: ['Workflows'] },
+    { id: 'scale', name: 'Scale', rank: 3, highlights: ['Audit log', 'SSO'] },
   ],
 } as BillingCatalogue
 
@@ -21,8 +25,12 @@ describe('describeEntitlementUpgrade', () => {
     expect(describeEntitlementUpgrade('auditLog')).toMatchObject({
       requiredPlan: 'scale',
       requiredPlanName: 'Scale',
-      headline: 'Upgrade to Scale',
+      headline: 'The audit log is available from the Scale plan',
       body: 'The audit log is a Scale feature. Upgrade to Scale to enable it.',
+    })
+    expect(describeEntitlementUpgrade('webhooks')).toMatchObject({
+      headline: 'Webhooks are available from the Growth plan',
+      body: 'Webhooks are a Growth feature. Upgrade to Growth to enable them.',
     })
     expect(describeEntitlementUpgrade('sso').requiredPlan).toBe('scale')
     expect(describeEntitlementUpgrade('customDomain').requiredPlan).toBe('growth')
@@ -74,16 +82,95 @@ describe('describePlanUpgrade', () => {
   it('builds the same sentence shape for a named feature', () => {
     expect(describePlanUpgrade('Data export', 'pro')).toMatchObject({
       requiredPlan: 'pro',
-      headline: 'Upgrade to Pro',
+      headline: 'Data export is available from the Pro plan',
       body: 'Data export is a Pro feature. Upgrade to Pro to enable it.',
     })
+  })
+
+  it('takes a plural verb when asked', () => {
+    expect(describePlanUpgrade('Integrations', 'pro', { plural: true })).toMatchObject({
+      headline: 'Integrations are available from the Pro plan',
+      body: 'Integrations are a Pro feature. Upgrade to Pro to enable them.',
+    })
+  })
+})
+
+describe('describePlanRefusal', () => {
+  const fallback = describePlanUpgrade('Custom colours', 'pro', { plural: true })
+
+  it('names the feature and plan from an entitlement refusal', () => {
+    expect(
+      describePlanRefusal(
+        new Error(
+          'Workflows are a Pro feature. Your workspace is on Growth. Upgrade to Pro to enable it.'
+        ),
+        fallback
+      )
+    ).toMatchObject({ feature: 'Workflows', requiredPlan: 'pro' })
+  })
+
+  it('names the feature from a tier refusal and keeps the fallback plan', () => {
+    expect(
+      describePlanRefusal(
+        new Error('Custom CSS is not available on your plan. Upgrade to enable it.'),
+        fallback
+      )
+    ).toMatchObject({
+      feature: 'Custom CSS',
+      requiredPlan: 'pro',
+      headline: 'Custom CSS is available from the Pro plan',
+    })
+  })
+
+  it('keeps the fallback for anything else', () => {
+    expect(describePlanRefusal(new Error('boom'), fallback)).toBe(fallback)
+    expect(describePlanRefusal(null, fallback)).toBe(fallback)
+  })
+})
+
+describe('upgradeLead', () => {
+  it('names both ends of the move when the current plan is known', () => {
+    expect(upgradeLead('Free', 'Pro')).toBe('Upgrade from Free to Pro to unlock:')
+    expect(upgradeLead(null, 'Pro')).toBe('Upgrade to Pro to unlock:')
+    expect(upgradeLead('Pro', 'Pro')).toBe('Upgrade to Pro to unlock:')
+    expect(upgradeLead('Free', null)).toBe('Upgrade your plan to unlock:')
+  })
+
+  it('acknowledges a running trial', () => {
+    expect(upgradeLead('Growth', 'Pro', { trialActive: true })).toBe(
+      "You're trialing Growth. Upgrade to Pro to unlock:"
+    )
+  })
+})
+
+describe('unlockedHighlights', () => {
+  it('lists the target plan and everything in between, cheapest first', () => {
+    expect(unlockedHighlights(catalogue, 'free', 'scale')).toEqual({
+      target: ['Audit log', 'SSO'],
+      included: [
+        { planName: 'Growth', highlights: ['Custom domain'] },
+        { planName: 'Pro', highlights: ['Workflows'] },
+      ],
+    })
+    expect(unlockedHighlights(catalogue, 'growth', 'pro')).toEqual({
+      target: ['Workflows'],
+      included: [],
+    })
+  })
+
+  it('shows only the target when the current plan is unknown or the catalogue is missing', () => {
+    expect(unlockedHighlights(catalogue, null, 'scale')).toEqual({
+      target: ['Audit log', 'SSO'],
+      included: [],
+    })
+    expect(unlockedHighlights(null, 'free', 'scale')).toEqual({ target: [], included: [] })
   })
 })
 
 describe('cataloguePlanFor', () => {
   it('returns the billing-page plan row', () => {
     expect(cataloguePlanFor(catalogue, 'scale')?.highlights).toEqual(['Audit log', 'SSO'])
-    expect(cataloguePlanFor(catalogue, 'free')).toBeNull()
+    expect(cataloguePlanFor(catalogue, 'free')?.id).toBe('free')
     expect(cataloguePlanFor(null, 'scale')).toBeNull()
   })
 })

--- a/apps/web/src/lib/shared/billing/__tests__/checkout-path.test.ts
+++ b/apps/web/src/lib/shared/billing/__tests__/checkout-path.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import {
+  annualSavingsPercent,
+  checkoutPath,
+  checkoutSummary,
+  parseCheckoutSearch,
+} from '../checkout-path'
+
+const pro = { priceMonthlyCents: 5900, priceYearlyCents: 59000, billedPer: 'seat' as const }
+
+describe('checkoutPath', () => {
+  it('encodes only what was given', () => {
+    expect(checkoutPath()).toBe('/admin/settings/billing/checkout')
+    expect(checkoutPath({ plan: 'pro' })).toBe('/admin/settings/billing/checkout?plan=pro')
+    expect(checkoutPath({ plan: 'pro', period: 'monthly', seats: 3 })).toBe(
+      '/admin/settings/billing/checkout?plan=pro&period=monthly&seats=3'
+    )
+    expect(checkoutPath({ plan: 'pro', branding: true })).toBe(
+      '/admin/settings/billing/checkout?plan=pro&branding=true'
+    )
+    expect(checkoutPath({ plan: 'pro', branding: false })).toBe(
+      '/admin/settings/billing/checkout?plan=pro'
+    )
+  })
+})
+
+describe('parseCheckoutSearch', () => {
+  it('keeps valid values and drops the rest', () => {
+    expect(
+      parseCheckoutSearch({ plan: 'scale', period: 'annual', seats: '4', branding: 'true' })
+    ).toEqual({
+      plan: 'scale',
+      period: 'annual',
+      seats: 4,
+      branding: true,
+    })
+    expect(parseCheckoutSearch({ plan: 'free', period: 'weekly', seats: '0' })).toEqual({})
+    expect(parseCheckoutSearch({ branding: 'false' })).toEqual({})
+    expect(parseCheckoutSearch({ branding: 'yes' })).toEqual({})
+    expect(parseCheckoutSearch({ plan: 'enterprise', seats: 'lots' })).toEqual({})
+    expect(parseCheckoutSearch({ seats: 2.5 })).toEqual({})
+  })
+})
+
+describe('checkoutSummary', () => {
+  it('prices seats per interval and shows a monthly equivalent for annual', () => {
+    expect(checkoutSummary(pro, 'annual', 3)).toEqual({
+      unitCents: 59000,
+      quantity: 3,
+      totalCents: 177000,
+      monthlyEquivalentCents: 14750,
+      interval: 'year',
+      billedPer: 'seat',
+    })
+    expect(checkoutSummary(pro, 'monthly', 3)).toMatchObject({
+      unitCents: 5900,
+      totalCents: 17700,
+      monthlyEquivalentCents: 17700,
+      interval: 'month',
+    })
+  })
+
+  it('ignores the seat count for workspace-priced plans', () => {
+    expect(checkoutSummary({ ...pro, billedPer: 'workspace' }, 'monthly', 12)).toMatchObject({
+      quantity: 1,
+      totalCents: 5900,
+    })
+  })
+})
+
+describe('annualSavingsPercent', () => {
+  it('rounds the saving of yearly over twelve monthly payments', () => {
+    expect(annualSavingsPercent(pro)).toBe(17)
+    expect(annualSavingsPercent({ priceMonthlyCents: 1000, priceYearlyCents: 12000 })).toBeNull()
+    expect(annualSavingsPercent({ priceMonthlyCents: 0, priceYearlyCents: 0 })).toBeNull()
+  })
+})

--- a/apps/web/src/lib/shared/billing/checkout-path.ts
+++ b/apps/web/src/lib/shared/billing/checkout-path.ts
@@ -1,0 +1,87 @@
+import type { BillingCatalogue } from '@/lib/server/control-plane/client'
+import type { PaidPlanId } from './plan-action'
+
+export const CHECKOUT_PATH = '/admin/settings/billing/checkout'
+
+export type BillingPeriod = 'monthly' | 'annual'
+
+export type CheckoutSearch = {
+  plan?: PaidPlanId
+  period?: BillingPeriod
+  seats?: number
+  /** Branding removal added to the order. */
+  branding?: boolean
+}
+
+const PAID_PLAN_IDS: readonly PaidPlanId[] = ['growth', 'pro', 'scale']
+
+export function isPaidPlanId(value: unknown): value is PaidPlanId {
+  return typeof value === 'string' && (PAID_PLAN_IDS as readonly string[]).includes(value)
+}
+
+/** Tolerant: an unknown or malformed value is dropped rather than failing the route. */
+export function parseCheckoutSearch(raw: Record<string, unknown>): CheckoutSearch {
+  const search: CheckoutSearch = {}
+  if (isPaidPlanId(raw.plan)) search.plan = raw.plan
+  if (raw.period === 'monthly' || raw.period === 'annual') search.period = raw.period
+  const seats = typeof raw.seats === 'string' ? Number(raw.seats) : raw.seats
+  if (typeof seats === 'number' && Number.isInteger(seats) && seats >= 1 && seats <= 1000) {
+    search.seats = seats
+  }
+  if (raw.branding === true || raw.branding === 'true') search.branding = true
+  return search
+}
+
+/** Deep link into the configurator with a plan (and optionally period / seats / add-on) preselected. */
+export function checkoutPath(search: CheckoutSearch = {}): string {
+  const params = new URLSearchParams()
+  if (search.plan) params.set('plan', search.plan)
+  if (search.period) params.set('period', search.period)
+  if (search.seats != null) params.set('seats', String(search.seats))
+  if (search.branding) params.set('branding', 'true')
+  const query = params.toString()
+  return query ? `${CHECKOUT_PATH}?${query}` : CHECKOUT_PATH
+}
+
+export type CheckoutSummary = {
+  /** Sticker for one billing unit over one interval (a seat-year on annual, a seat-month on monthly). */
+  unitCents: number
+  /** Seats billed; always 1 for workspace-priced plans. */
+  quantity: number
+  /** Recurring charge per interval. */
+  totalCents: number
+  /** Same total expressed per month, for comparing annual and monthly side by side. */
+  monthlyEquivalentCents: number
+  interval: 'year' | 'month'
+  billedPer: 'seat' | 'workspace'
+}
+
+export function checkoutSummary(
+  plan: Pick<
+    BillingCatalogue['plans'][number],
+    'priceMonthlyCents' | 'priceYearlyCents' | 'billedPer'
+  >,
+  period: BillingPeriod,
+  seats: number
+): CheckoutSummary {
+  const quantity = plan.billedPer === 'seat' ? Math.max(1, seats) : 1
+  const unitCents = period === 'annual' ? plan.priceYearlyCents : plan.priceMonthlyCents
+  const totalCents = unitCents * quantity
+  return {
+    unitCents,
+    quantity,
+    totalCents,
+    monthlyEquivalentCents: period === 'annual' ? Math.round(totalCents / 12) : totalCents,
+    interval: period === 'annual' ? 'year' : 'month',
+    billedPer: plan.billedPer,
+  }
+}
+
+/** Whole-percent saving of paying yearly over twelve monthly payments; null when there is none. */
+export function annualSavingsPercent(
+  plan: Pick<BillingCatalogue['plans'][number], 'priceMonthlyCents' | 'priceYearlyCents'>
+): number | null {
+  const yearOfMonthly = plan.priceMonthlyCents * 12
+  if (yearOfMonthly <= 0 || plan.priceYearlyCents >= yearOfMonthly) return null
+  return Math.round((1 - plan.priceYearlyCents / yearOfMonthly) * 100)
+}

--- a/apps/web/src/lib/shared/describe-upgrade.ts
+++ b/apps/web/src/lib/shared/describe-upgrade.ts
@@ -1,5 +1,6 @@
 import {
   ENTITLEMENTS,
+  PLAN_CATALOGUE,
   minimumPlanFor,
   type EntitlementKey,
   type PlanId,
@@ -11,7 +12,9 @@ export type UpgradeDescription = {
   feature: string
   requiredPlan: PlanId | null
   requiredPlanName: string | null
+  /** Feature-first: names what was just attempted and the plan that includes it. */
   headline: string
+  /** One plain sentence. Screen-reader description and the fallback when no plan is known. */
   body: string
 }
 
@@ -26,8 +29,8 @@ export function describeEntitlementUpgrade(key: EntitlementKey): UpgradeDescript
       feature: definition.friendly,
       requiredPlan: null,
       requiredPlanName: null,
-      headline: 'This is a plan feature',
-      body: `${definition.friendly} ${verb} not included in your plan.`,
+      headline: `${definition.friendly} ${verb} not included in your plan`,
+      body: `${definition.friendly} ${verb} not included in your plan. Contact us to add ${definition.plural ? 'them' : 'it'}.`,
     }
   }
   return {
@@ -35,22 +38,72 @@ export function describeEntitlementUpgrade(key: EntitlementKey): UpgradeDescript
     feature: definition.friendly,
     requiredPlan: plan.id,
     requiredPlanName: plan.name,
-    headline: `Upgrade to ${plan.name}`,
-    body: `${definition.friendly} ${verb} ${plan.article} ${plan.name} feature. Upgrade to ${plan.name} to enable it.`,
+    headline: `${definition.friendly} ${verb} available from the ${plan.name} plan`,
+    body: `${definition.friendly} ${verb} ${plan.article} ${plan.name} feature. Upgrade to ${plan.name} to enable ${definition.plural ? 'them' : 'it'}.`,
   }
 }
 
-/** Named feature that is not an entitlement key (e.g. data export). */
-export function describePlanUpgrade(feature: string, requiredPlan: PlanId): UpgradeDescription {
-  const name = requiredPlan.charAt(0).toUpperCase() + requiredPlan.slice(1)
+/**
+ * Named feature that is not an entitlement key (e.g. data export). Pass
+ * `plural` for names that take "are" ("Custom colours", "Integrations").
+ */
+export function describePlanUpgrade(
+  feature: string,
+  requiredPlan: PlanId,
+  options: { plural?: boolean } = {}
+): UpgradeDescription {
+  const plan = PLAN_CATALOGUE[requiredPlan]
+  const verb = options.plural ? 'are' : 'is'
   return {
     entitlement: null,
     feature,
     requiredPlan,
-    requiredPlanName: name,
-    headline: `Upgrade to ${name}`,
-    body: `${feature} is a ${name} feature. Upgrade to ${name} to enable it.`,
+    requiredPlanName: plan.name,
+    headline: `${feature} ${verb} available from the ${plan.name} plan`,
+    body: `${feature} ${verb} ${plan.article} ${plan.name} feature. Upgrade to ${plan.name} to enable ${options.plural ? 'them' : 'it'}.`,
   }
+}
+
+/** The sentence that introduces the unlock list, naming both ends of the move when known. */
+export function upgradeLead(
+  currentPlanName: string | null | undefined,
+  requiredPlanName: string | null | undefined,
+  options: { trialActive?: boolean } = {}
+): string {
+  if (!requiredPlanName) return 'Upgrade your plan to unlock:'
+  if (currentPlanName && currentPlanName !== requiredPlanName) {
+    return options.trialActive
+      ? `You're trialing ${currentPlanName}. Upgrade to ${requiredPlanName} to unlock:`
+      : `Upgrade from ${currentPlanName} to ${requiredPlanName} to unlock:`
+  }
+  return `Upgrade to ${requiredPlanName} to unlock:`
+}
+
+export type UnlockedHighlights = {
+  /** What the required plan itself adds. Shown as the checklist. */
+  target: string[]
+  /** Plans between the current one and the target, cheapest first, whose highlights come along. */
+  included: Array<{ planName: string; highlights: string[] }>
+}
+
+/**
+ * Everything the workspace gains by moving from `currentPlan` to `requiredPlan`.
+ * Catalogue highlights are incremental per plan, so a Free → Pro move also
+ * brings Growth's list. Unknown current plan means only the target's list.
+ */
+export function unlockedHighlights(
+  catalogue: BillingCatalogue | null | undefined,
+  currentPlan: PlanId | null | undefined,
+  requiredPlan: PlanId | null | undefined
+): UnlockedHighlights {
+  const target = cataloguePlanFor(catalogue, requiredPlan)
+  if (!catalogue || !target) return { target: [], included: [] }
+  const floor = currentPlan ? PLAN_CATALOGUE[currentPlan].rank : target.rank - 1
+  const included = catalogue.plans
+    .filter((plan) => plan.rank > floor && plan.rank < target.rank)
+    .sort((a, b) => a.rank - b.rank)
+    .map((plan) => ({ planName: plan.name, highlights: [...plan.highlights] }))
+  return { target: [...target.highlights], included }
 }
 
 /** The same plan object the billing cards render. */
@@ -62,25 +115,53 @@ export function cataloguePlanFor(
   return catalogue.plans.find((plan) => plan.id === planId) ?? null
 }
 
+function refusalMessage(error: unknown): string {
+  if (!error || typeof error !== 'object') return ''
+  if (error instanceof Error) return error.message
+  const record = error as { message?: unknown; error?: unknown }
+  return String(
+    record.message ?? (record.error as { message?: unknown } | undefined)?.message ?? ''
+  )
+}
+
 /** True for a 402 plan refusal from a server function or REST handler. */
 export function isPlanRefusal(error: unknown): boolean {
   if (!error || typeof error !== 'object') return false
   const record = error as {
     statusCode?: unknown
     error?: unknown
-    message?: unknown
-    result?: unknown
   }
   if (record.statusCode === 402) return true
   if (record.error === 'tier_limit_exceeded' || record.error === 'entitlement_required') return true
-  const message =
-    error instanceof Error
-      ? error.message
-      : String(record.message ?? (record.error as { message?: unknown } | undefined)?.message ?? '')
+  const message = refusalMessage(error)
   return (
     /upgrade to(?: \w+)? to enable it/i.test(message) ||
     /not (?:available|included) (?:in|on) your plan/i.test(message)
   )
+}
+
+/**
+ * Copy for the feature the server actually refused, so a save that trips on
+ * Custom CSS does not open a prompt about Custom colours. Reads the refusal
+ * sentence both gates produce; anything unrecognised keeps `fallback`.
+ */
+export function describePlanRefusal(
+  error: unknown,
+  fallback: UpgradeDescription
+): UpgradeDescription {
+  const message = refusalMessage(error)
+  const entitled = /^(.+?) (is|are) an? (\w+) feature\./.exec(message)
+  if (entitled) {
+    const [, feature, verb, planName] = entitled
+    const plan = Object.values(PLAN_CATALOGUE).find((candidate) => candidate.name === planName)
+    if (plan) return describePlanUpgrade(feature, plan.id, { plural: verb === 'are' })
+  }
+  const capped = /^(.+?) (is|are) not available (?:in|on) your plan\./.exec(message)
+  if (capped && fallback.requiredPlan) {
+    const [, feature, verb] = capped
+    return describePlanUpgrade(feature, fallback.requiredPlan, { plural: verb === 'are' })
+  }
+  return fallback
 }
 
 /**

--- a/apps/web/src/routes/admin/__tests__/settings.integrations.test.tsx
+++ b/apps/web/src/routes/admin/__tests__/settings.integrations.test.tsx
@@ -14,13 +14,13 @@ const { IntegrationsSettingsBody } = await import('../settings.integrations.inde
 describe('integrations settings page', () => {
   it('shows the in-route upgrade screen when integrations are off', () => {
     render(<IntegrationsSettingsBody enabled={false} catalog={[]} integrations={[]} />)
-    expect(screen.getByText(/Integrations is a Pro feature/)).toBeTruthy()
+    expect(screen.getByText(/Integrations are a Pro feature/)).toBeTruthy()
     expect(screen.queryByText('integration catalog')).toBeNull()
   })
 
   it('shows the catalog when integrations are on', () => {
     render(<IntegrationsSettingsBody enabled catalog={[]} integrations={[]} />)
     expect(screen.getByText('integration catalog')).toBeTruthy()
-    expect(screen.queryByText(/Integrations is a Pro feature/)).toBeNull()
+    expect(screen.queryByText(/Integrations are a Pro feature/)).toBeNull()
   })
 })

--- a/apps/web/src/routes/admin/settings.billing_.checkout.tsx
+++ b/apps/web/src/routes/admin/settings.billing_.checkout.tsx
@@ -1,0 +1,86 @@
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
+import { createFileRoute, useRouteContext } from '@tanstack/react-router'
+import { CreditCardIcon } from '@heroicons/react/24/solid'
+import { PERMISSIONS } from '@/lib/shared/permissions'
+import { assertRoutePermission } from '@/lib/shared/route-permission'
+import { BackLink } from '@/components/ui/back-link'
+import { PageHeader } from '@/components/shared/page-header'
+import { CheckoutBuilder } from '@/components/admin/settings/billing/checkout-builder'
+import { billingQueries } from '@/lib/client/queries/billing'
+import { parseCheckoutSearch, type CheckoutSearch } from '@/lib/shared/billing/checkout-path'
+import type { BillingCatalogue } from '@/lib/server/control-plane/client'
+
+// The trailing underscore on "billing_" keeps this a sibling of Plans &
+// billing rather than a child rendered inside it. The URL is still
+// /admin/settings/billing/checkout.
+export const Route = createFileRoute('/admin/settings/billing_/checkout')({
+  validateSearch: (search: Record<string, unknown>): CheckoutSearch => parseCheckoutSearch(search),
+  loader: async ({ context }) => {
+    assertRoutePermission(context.permissions, PERMISSIONS.BILLING_MANAGE)
+    await Promise.all([
+      context.queryClient.ensureQueryData(billingQueries.overview()),
+      context.queryClient.ensureQueryData(billingQueries.catalogue()).catch(() => null),
+    ])
+    return {}
+  },
+  component: CheckoutPage,
+})
+
+function CheckoutPage() {
+  const { billingEnabled } = useRouteContext({ from: '__root__' })
+  const search = Route.useSearch()
+  const navigate = Route.useNavigate()
+  const { data: overview } = useSuspenseQuery(billingQueries.overview())
+  const catalogue = useQuery(billingQueries.catalogue())
+  const catalogueData = (catalogue.data ?? null) as BillingCatalogue | null
+
+  const selection = {
+    plan: search.plan ?? null,
+    period: search.period ?? 'annual',
+    seats: search.seats ?? Math.max(overview?.seats?.used ?? 1, 1),
+    branding: search.branding ?? false,
+  }
+
+  return (
+    <div className="max-w-5xl space-y-6">
+      <BackLink
+        to="/admin/settings/billing"
+        search={{ checkout: undefined, billing_error: undefined }}
+      >
+        Plans &amp; billing
+      </BackLink>
+      <PageHeader
+        icon={CreditCardIcon}
+        title="Configure your plan"
+        description="Choose a plan, billing cycle, and seats. Payment happens on the next step."
+      />
+      {!billingEnabled || !overview ? (
+        <p className="text-sm text-muted-foreground">
+          Plan and billing is available only in a Quackback Cloud workspace.
+        </p>
+      ) : catalogue.isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading plans…</p>
+      ) : !catalogueData ? (
+        <p role="alert" className="text-[13px] text-destructive">
+          Couldn’t load plans. Try again in a moment.
+        </p>
+      ) : (
+        <CheckoutBuilder
+          overview={overview}
+          catalogue={catalogueData}
+          selection={selection}
+          onChange={(next) =>
+            navigate({
+              search: (previous) => {
+                const merged = { ...previous, ...next }
+                if (!merged.branding) delete merged.branding
+                return merged
+              },
+              replace: true,
+            })
+          }
+        />
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/routes/admin/settings.integrations.index.tsx
+++ b/apps/web/src/routes/admin/settings.integrations.index.tsx
@@ -66,6 +66,6 @@ export function IntegrationsSettingsBody(props: {
   return props.enabled ? (
     <IntegrationList catalog={props.catalog} integrations={props.integrations} />
   ) : (
-    <UpgradeScreen description={describePlanUpgrade('Integrations', 'pro')} />
+    <UpgradeScreen description={describePlanUpgrade('Integrations', 'pro', { plural: true })} />
   )
 }

--- a/apps/web/src/routes/admin/settings.portal.tsx
+++ b/apps/web/src/routes/admin/settings.portal.tsx
@@ -58,7 +58,12 @@ import {
 import { useUpdatePortalConfig } from '@/lib/client/mutations/settings'
 import { useImageUpload } from '@/lib/client/hooks/use-image-upload'
 import { UpgradeModal } from '@/components/admin/upgrade'
-import { describePlanUpgrade, isPlanRefusal } from '@/lib/shared/describe-upgrade'
+import {
+  describePlanRefusal,
+  describePlanUpgrade,
+  isPlanRefusal,
+  type UpgradeDescription,
+} from '@/lib/shared/describe-upgrade'
 import { DEFAULT_PORTAL_CONFIG, isProductEnabled } from '@/lib/shared/types/settings'
 import { isStatusPagePublished } from '@/lib/shared/status-settings'
 import { isPortalSupportSurfaceEnabled } from '@/lib/shared/support-surfaces'
@@ -155,7 +160,7 @@ function PortalPage() {
   const navBaseline = useRef(JSON.stringify(navItems))
 
   const [saving, setSaving] = useState(false)
-  const [upgradeOpen, setUpgradeOpen] = useState(false)
+  const [upgrade, setUpgrade] = useState<UpgradeDescription | null>(null)
 
   const themeDirty =
     state.cssText !== themeBaseline.current.css || state.themeMode !== themeBaseline.current.mode
@@ -204,7 +209,9 @@ function PortalPage() {
       startTransition(() => router.invalidate())
     } catch (error) {
       if (isPlanRefusal(error)) {
-        setUpgradeOpen(true)
+        setUpgrade(
+          describePlanRefusal(error, describePlanUpgrade('Custom colours', 'pro', { plural: true }))
+        )
       } else {
         toast.error(error instanceof Error ? error.message : "Couldn't save portal. Try again.")
       }
@@ -531,9 +538,11 @@ function PortalPage() {
         </div>
       </div>
       <UpgradeModal
-        open={upgradeOpen}
-        onOpenChange={setUpgradeOpen}
-        description={describePlanUpgrade('Custom colours', 'pro')}
+        open={upgrade !== null}
+        onOpenChange={(open) => {
+          if (!open) setUpgrade(null)
+        }}
+        description={upgrade ?? describePlanUpgrade('Custom colours', 'pro', { plural: true })}
       />
     </div>
   )

--- a/apps/web/src/routes/api/billing/__tests__/session.test.ts
+++ b/apps/web/src/routes/api/billing/__tests__/session.test.ts
@@ -228,6 +228,37 @@ describe('POST /api/billing/session checkout', () => {
     })
   })
 
+  it('bundles branding removal into the checkout only when the box was ticked', async () => {
+    await POST({
+      request: formRequest({
+        action: 'checkout',
+        planId: 'growth',
+        billingPeriod: 'annual',
+        quantity: '8',
+        brandingRemoval: 'true',
+      }),
+    })
+    expect(hoisted.createHostedBillingSession).toHaveBeenCalledWith({
+      action: 'checkout',
+      planId: 'growth',
+      billingPeriod: 'annual',
+      quantity: 8,
+      brandingRemoval: true,
+    })
+
+    hoisted.createHostedBillingSession.mockClear()
+    const res = await POST({
+      request: formRequest({
+        action: 'checkout',
+        planId: 'growth',
+        billingPeriod: 'annual',
+        brandingRemoval: 'yes',
+      }),
+    })
+    expect(res.headers.get('location')).toContain('billing_error=invalid')
+    expect(hoisted.createHostedBillingSession).not.toHaveBeenCalled()
+  })
+
   it('forwards branding-removal purchase to the control plane', async () => {
     hoisted.createHostedBillingSession.mockResolvedValue({ status: 'updated' })
     const res = await POST({

--- a/apps/web/src/routes/api/billing/__tests__/trial-return-path.test.ts
+++ b/apps/web/src/routes/api/billing/__tests__/trial-return-path.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { trialReturnPath } from '../trial'
+
+describe('trialReturnPath', () => {
+  it('returns to the admin page that raised the prompt', () => {
+    expect(trialReturnPath('/admin/automation/workflows')).toBe('/admin/automation/workflows')
+    expect(trialReturnPath('/admin/settings/developers?tab=webhooks')).toBe(
+      '/admin/settings/developers?tab=webhooks'
+    )
+    expect(trialReturnPath('/admin')).toBe('/admin')
+  })
+
+  it('falls back to Plan & billing when nothing was given', () => {
+    expect(trialReturnPath(undefined)).toBe('/admin/settings/billing')
+    expect(trialReturnPath('')).toBe('/admin/settings/billing')
+  })
+
+  it('never redirects off the admin area', () => {
+    for (const bad of [
+      'https://evil.example/admin',
+      '//evil.example/admin',
+      '/administrator',
+      '/portal',
+      '/admin\\@evil.example',
+      '/admin/x\r\nSet-Cookie: a=b',
+      '/admin/settings billing',
+    ]) {
+      expect(trialReturnPath(bad)).toBe('/admin/settings/billing')
+    }
+  })
+})

--- a/apps/web/src/routes/api/billing/session.ts
+++ b/apps/web/src/routes/api/billing/session.ts
@@ -45,6 +45,8 @@ const actionSchema = z.discriminatedUnion('action', [
     planId: z.enum(['growth', 'pro', 'scale']),
     billingPeriod: z.enum(['monthly', 'annual']),
     quantity: z.coerce.number().int().positive().optional(),
+    // A checked checkbox posts "true"; an unchecked one posts nothing.
+    brandingRemoval: z.enum(['true']).optional(),
   }),
   z.object({
     action: z.literal('downgrade'),
@@ -158,6 +160,7 @@ async function createCheckoutSession(input: {
   planId: 'growth' | 'pro' | 'scale'
   billingPeriod: 'monthly' | 'annual'
   quantity?: number
+  brandingRemoval?: 'true'
 }) {
   const { countSeatUsage } = await import('@/lib/server/domains/principals/seat-usage')
   const { createHostedBillingSession, fetchBillingCatalogue } =
@@ -175,6 +178,7 @@ async function createCheckoutSession(input: {
       planId: input.planId,
       billingPeriod: input.billingPeriod,
       quantity,
+      ...(input.brandingRemoval === 'true' ? { brandingRemoval: true } : {}),
     })
   })
 }

--- a/apps/web/src/routes/api/billing/trial.ts
+++ b/apps/web/src/routes/api/billing/trial.ts
@@ -6,7 +6,21 @@ import { billingFormErrorResponse, billingSessionErrorResponse } from './session
 
 const trialSchema = z.object({
   planId: z.enum(['growth', 'pro', 'scale']),
+  /** Admin page the prompt was raised on, so the trial lands back on the now-unlocked feature. */
+  returnTo: z.string().optional(),
 })
+
+/**
+ * Only a same-origin admin path may be returned to. Anything else — absolute
+ * or protocol-relative URLs, backslashes, control characters, non-admin paths —
+ * falls back to Plan & billing so the form can never be used as an open redirect.
+ */
+export function trialReturnPath(returnTo: string | undefined): string {
+  if (!returnTo) return '/admin/settings/billing'
+  if (!/^\/admin(?:[/?]|$)/.test(returnTo)) return '/admin/settings/billing'
+  if (/[\\\s]/.test(returnTo)) return '/admin/settings/billing'
+  return returnTo
+}
 
 export const Route = createFileRoute('/api/billing/trial')({
   server: {
@@ -33,7 +47,7 @@ export const Route = createFileRoute('/api/billing/trial')({
           await startWorkspaceTrial(parsed.data.planId)
           return new Response(null, {
             status: 303,
-            headers: { location: '/admin/settings/billing' },
+            headers: { location: trialReturnPath(parsed.data.returnTo) },
           })
         } catch (error) {
           return billingSessionErrorResponse(error)


### PR DESCRIPTION
## Summary

**Upgrade prompts** (`UpgradeModal` / `UpgradeScreen` / `UpgradeNotice`, seat gate, entitlement error page)
- Feature-first headline ("The audit log is available from the Scale plan"), a contextual lead ("You're on Growth. Upgrade to Scale to unlock:") and a two-column list of what the target plan adds over the *current* plan, sourced from the catalogue.
- New `UpgradeContext` (current plan, trial active/eligible) exposed via `fetchUpgradeContextFn` (classified `END_USER` in the authz matrix) and prefetched alongside the catalogue so prompts paint complete.
- First-time trialists get "Try X free for N days"; `/api/billing/trial` accepts a validated same-origin `returnTo` so the trial lands back on the feature that raised the prompt.
- `describePlanRefusal` turns server refusal messages into the same headline shape on the error page and portal save path.

**Plan configurator** — new route `/admin/settings/billing/checkout`
- Billing cycle toggle with a computed "Save N%", plan radio list with the selected plan's highlights inline, seat stepper floored at live usage, add-ons, and a sticky order summary with per-line pricing, total and monthly equivalent. Selection lives in the URL so prompts deep-link with the plan preselected (`checkoutPath()` / `parseCheckoutSearch()`).
- Contextual footnotes: pro-rata when moving up, end-of-period when moving down, trial-ends-on-payment during a trial, owner-only notice for teammates.
- Prompt CTAs and the billing page's "Switch to this plan" now link here instead of posting straight to hosted checkout.

**Branding removal bundled into checkout**
- The add-on is an "Add to order" checkbox; when ticked the checkout form carries `brandingRemoval=true` and the control plane adds it as a second item on the same subscription/cycle. With no plan change it falls back to the existing standalone `branding` action.

## Deploy order

Pairs with the control-plane PR that accepts `brandingRemoval` on `checkout` (strict schema). Ship that first; until then the field is only sent when the box is ticked and would surface as `unavailable`.

## Test plan

- [x] `vitest`: new suites for `CheckoutBuilder`, `checkout-path`, `upgrade-context`, `trial-return-path`; updated `upgrade-offer`, `billing-settings`, `session`, `describe-upgrade`, `error-page`, authz matrix snapshot — 3249 passing
- [x] `tsc`, `oxlint`, `prettier` clean
- [x] Verified against Stripe sandbox that a two-line-item subscription Checkout (plan seats + branding on the same interval) is accepted and totals match the configurator
- [ ] Manual: open a locked feature on Free → prompt → "Upgrade to Pro" lands on the configurator with Pro/yearly preselected → Continue to payment reaches Stripe with the right quantity

Made with [Cursor](https://cursor.com)