### PR TITLE
fix(fleet): catch up workspace schema before the first settings read

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -60,6 +60,7 @@
         "**/src/lib/server/fleet/migrator.ts",
         "**/src/lib/server/fleet/schema-state.ts",
         "**/src/lib/server/fleet/schema-floor.ts",
+        "**/src/lib/server/fleet/ensure-schema-current.ts",
         "**/src/lib/server/fleet/__tests__/**",
         "**/src/lib/server/policy/migration-contract/__tests__/lineage-double-apply.db.test.ts"
       ],
@@ -77,6 +78,7 @@
         "**/src/lib/server/fleet/migrator.ts",
         "**/src/lib/server/fleet/schema-state.ts",
         "**/src/lib/server/fleet/schema-floor.ts",
+        "**/src/lib/server/fleet/ensure-schema-current.ts",
         "**/src/lib/server/fleet/__tests__/**",
         "**/src/lib/server/policy/migration-contract/__tests__/lineage-double-apply.db.test.ts"
       ],

--- a/apps/web/src/lib/server/fleet/__tests__/ensure-schema-current.test.ts
+++ b/apps/web/src/lib/server/fleet/__tests__/ensure-schema-current.test.ts
@@ -9,15 +9,15 @@ import { BUNDLED_MIGRATIONS, latestBundledVersion } from '@quackback/db/schema-v
 import { WorkspaceSchemaFloorRefusal } from '../schema-floor'
 
 const readAppliedLedger = vi.fn()
-const runMigrations = vi.fn()
+const migrateDirect = vi.fn()
 
 vi.mock('@quackback/db/schema-version', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@quackback/db/schema-version')>()
   return { ...actual, readAppliedLedger: (...args: unknown[]) => readAppliedLedger(...args) }
 })
 
-vi.mock('@quackback/db/migrate', () => ({
-  runMigrations: (...args: unknown[]) => runMigrations(...args),
+vi.mock('../migrator', () => ({
+  migrateDirect: (...args: unknown[]) => migrateDirect(...args),
 }))
 
 vi.mock('@/lib/server/logger', () => ({
@@ -37,25 +37,29 @@ function allBut(...omit: string[]) {
   return BUNDLED_MIGRATIONS.filter((e) => !omit.includes(e.tag)).map((e) => e.tag)
 }
 
+function completeLedger() {
+  return {
+    versions: new Set(BUNDLED_MIGRATIONS.map((e) => e.when)),
+    count: BUNDLED_MIGRATIONS.length,
+    max: latestBundledVersion(),
+  }
+}
+
 describe('ensureWorkspaceSchemaCurrent', () => {
   beforeEach(() => {
     readAppliedLedger.mockReset()
-    runMigrations.mockReset()
+    migrateDirect.mockReset()
   })
 
   it('does not migrate when the ledger already records every bundled migration', async () => {
     const { ensureWorkspaceSchemaCurrent } = await import('../ensure-schema-current')
-    readAppliedLedger.mockResolvedValue({
-      versions: new Set(BUNDLED_MIGRATIONS.map((e) => e.when)),
-      count: BUNDLED_MIGRATIONS.length,
-      max: latestBundledVersion(),
-    })
+    readAppliedLedger.mockResolvedValue(completeLedger())
     await ensureWorkspaceSchemaCurrent({
       workspaceKey: 'inst_x',
       sql: {} as never,
       directConnectionString: 'postgresql://role:pw@direct.example/db',
     })
-    expect(runMigrations).not.toHaveBeenCalled()
+    expect(migrateDirect).not.toHaveBeenCalled()
   })
 
   it('migrates a mint whose vendor snapshot stopped short of this build', async () => {
@@ -66,15 +70,13 @@ describe('ensureWorkspaceSchemaCurrent', () => {
       '0271_widget_installed_sdk_version',
       '0272_kb_url_id',
     ])
-    readAppliedLedger.mockResolvedValueOnce(behind).mockResolvedValueOnce({
-      versions: new Set(BUNDLED_MIGRATIONS.map((e) => e.when)),
-      count: BUNDLED_MIGRATIONS.length,
-      max: latestBundledVersion(),
-    })
-    runMigrations.mockResolvedValue({
-      healed: [],
-      unhealable: [],
-      postconditions: { ok: true, violations: [], covers: [], observed: {} },
+    readAppliedLedger.mockResolvedValue(behind)
+    migrateDirect.mockResolvedValue({
+      ok: true,
+      code: 'reconciled',
+      detail: 'applied 2',
+      after: completeLedger(),
+      gap: null,
     })
 
     await ensureWorkspaceSchemaCurrent({
@@ -82,26 +84,38 @@ describe('ensureWorkspaceSchemaCurrent', () => {
       sql: {} as never,
       directConnectionString: 'postgresql://role:pw@direct.example/db',
     })
-    expect(runMigrations).toHaveBeenCalledWith('postgresql://role:pw@direct.example/db')
+    expect(migrateDirect).toHaveBeenCalledWith('inst_new', 'postgresql://role:pw@direct.example/db')
   })
 
-  it('refuses to serve when migrate reports failing post-conditions', async () => {
+  it('uses migrateDirect so a gapped ledger can be healed rather than 503-looping', async () => {
+    const { ensureWorkspaceSchemaCurrent } = await import('../ensure-schema-current')
+    const gapped = ledger(allBut('0271_widget_installed_sdk_version'))
+    readAppliedLedger.mockResolvedValue(gapped)
+    migrateDirect.mockResolvedValue({
+      ok: true,
+      code: 'healed_ledger_gap',
+      detail: 'healed',
+      after: completeLedger(),
+      gap: { missing: ['0271_widget_installed_sdk_version'] },
+    })
+
+    await ensureWorkspaceSchemaCurrent({
+      workspaceKey: 'inst_gap',
+      sql: {} as never,
+      directConnectionString: 'postgresql://role:pw@direct.example/db',
+    })
+    expect(migrateDirect).toHaveBeenCalledOnce()
+  })
+
+  it('refuses to serve when migrateDirect does not succeed', async () => {
     const { ensureWorkspaceSchemaCurrent } = await import('../ensure-schema-current')
     readAppliedLedger.mockResolvedValue(ledger(allBut('0271_widget_installed_sdk_version')))
-    runMigrations.mockResolvedValue({
-      healed: [],
-      unhealable: [],
-      postconditions: {
-        ok: false,
-        violations: [
-          {
-            kind: 'missing_column',
-            detail: 'column public.settings.widget_installed_sdk_version is missing',
-          },
-        ],
-        covers: [],
-        observed: {},
-      },
+    migrateDirect.mockResolvedValue({
+      ok: false,
+      code: 'postconditions_violated',
+      detail: 'column public.settings.widget_installed_sdk_version is missing',
+      after: null,
+      gap: null,
     })
 
     await expect(

--- a/apps/web/src/lib/server/fleet/__tests__/ensure-schema-current.test.ts
+++ b/apps/web/src/lib/server/fleet/__tests__/ensure-schema-current.test.ts
@@ -1,0 +1,115 @@
+/**
+ * First-request catch-up when a workspace ledger is behind this build.
+ *
+ * The CP's vendored migrator can mint a database that the serving image cannot
+ * query (explicit column lists). This is the request-path backstop.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { BUNDLED_MIGRATIONS, latestBundledVersion } from '@quackback/db/schema-version'
+import { WorkspaceSchemaFloorRefusal } from '../schema-floor'
+
+const readAppliedLedger = vi.fn()
+const runMigrations = vi.fn()
+
+vi.mock('@quackback/db/schema-version', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@quackback/db/schema-version')>()
+  return { ...actual, readAppliedLedger: (...args: unknown[]) => readAppliedLedger(...args) }
+})
+
+vi.mock('@quackback/db/migrate', () => ({
+  runMigrations: (...args: unknown[]) => runMigrations(...args),
+}))
+
+vi.mock('@/lib/server/logger', () => ({
+  logger: { child: () => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn() }) },
+}))
+
+function ledger(tags: string[]) {
+  const when = new Set(BUNDLED_MIGRATIONS.filter((e) => tags.includes(e.tag)).map((e) => e.when))
+  return {
+    versions: when,
+    count: when.size,
+    max: when.size === 0 ? 0 : Math.max(...when),
+  }
+}
+
+function allBut(...omit: string[]) {
+  return BUNDLED_MIGRATIONS.filter((e) => !omit.includes(e.tag)).map((e) => e.tag)
+}
+
+describe('ensureWorkspaceSchemaCurrent', () => {
+  beforeEach(() => {
+    readAppliedLedger.mockReset()
+    runMigrations.mockReset()
+  })
+
+  it('does not migrate when the ledger already records every bundled migration', async () => {
+    const { ensureWorkspaceSchemaCurrent } = await import('../ensure-schema-current')
+    readAppliedLedger.mockResolvedValue({
+      versions: new Set(BUNDLED_MIGRATIONS.map((e) => e.when)),
+      count: BUNDLED_MIGRATIONS.length,
+      max: latestBundledVersion(),
+    })
+    await ensureWorkspaceSchemaCurrent({
+      workspaceKey: 'inst_x',
+      sql: {} as never,
+      directConnectionString: 'postgresql://role:pw@direct.example/db',
+    })
+    expect(runMigrations).not.toHaveBeenCalled()
+  })
+
+  it('migrates a mint whose vendor snapshot stopped short of this build', async () => {
+    const { ensureWorkspaceSchemaCurrent, missingBundledMigrations } =
+      await import('../ensure-schema-current')
+    const behind = ledger(allBut('0271_widget_installed_sdk_version', '0272_kb_url_id'))
+    expect(missingBundledMigrations(behind)).toEqual([
+      '0271_widget_installed_sdk_version',
+      '0272_kb_url_id',
+    ])
+    readAppliedLedger.mockResolvedValueOnce(behind).mockResolvedValueOnce({
+      versions: new Set(BUNDLED_MIGRATIONS.map((e) => e.when)),
+      count: BUNDLED_MIGRATIONS.length,
+      max: latestBundledVersion(),
+    })
+    runMigrations.mockResolvedValue({
+      healed: [],
+      unhealable: [],
+      postconditions: { ok: true, violations: [], covers: [], observed: {} },
+    })
+
+    await ensureWorkspaceSchemaCurrent({
+      workspaceKey: 'inst_new',
+      sql: {} as never,
+      directConnectionString: 'postgresql://role:pw@direct.example/db',
+    })
+    expect(runMigrations).toHaveBeenCalledWith('postgresql://role:pw@direct.example/db')
+  })
+
+  it('refuses to serve when migrate reports failing post-conditions', async () => {
+    const { ensureWorkspaceSchemaCurrent } = await import('../ensure-schema-current')
+    readAppliedLedger.mockResolvedValue(ledger(allBut('0271_widget_installed_sdk_version')))
+    runMigrations.mockResolvedValue({
+      healed: [],
+      unhealable: [],
+      postconditions: {
+        ok: false,
+        violations: [
+          {
+            kind: 'missing_column',
+            detail: 'column public.settings.widget_installed_sdk_version is missing',
+          },
+        ],
+        covers: [],
+        observed: {},
+      },
+    })
+
+    await expect(
+      ensureWorkspaceSchemaCurrent({
+        workspaceKey: 'inst_broken',
+        sql: {} as never,
+        directConnectionString: 'postgresql://role:pw@direct.example/db',
+      })
+    ).rejects.toBeInstanceOf(WorkspaceSchemaFloorRefusal)
+  })
+})

--- a/apps/web/src/lib/server/fleet/ensure-schema-current.ts
+++ b/apps/web/src/lib/server/fleet/ensure-schema-current.ts
@@ -1,0 +1,72 @@
+/**
+ * Bring a workspace database up to this build's bundled schema before serving it.
+ *
+ * New cloud workspaces are migrated by the control plane's vendored `migrate.mjs`.
+ * That snapshot lags the serving image (SAAS-HOSTING-STACK vendor-lag: "broken
+ * newborns"). Drizzle emits explicit column lists, so a build that postdates an
+ * additive migration throws on ordinary reads — the settings fetch that 500s
+ * every page when `widget_installed_sdk_version` is absent.
+ *
+ * The hourly fleet-migrator pass will catch these up, but a mint is Ready and
+ * routed immediately. This runs once per pool, after identity checks, and is a
+ * no-op when the ledger already records every bundled migration.
+ *
+ * Uses the session-mode DSN: `runMigrations` refuses a transaction-mode pooler
+ * because the advisory lock is session-scoped.
+ */
+import type { Sql } from 'postgres'
+import { runMigrations } from '@quackback/db/migrate'
+import {
+  BUNDLED_MIGRATIONS,
+  readAppliedLedger,
+  type AppliedLedger,
+} from '@quackback/db/schema-version'
+import { logger } from '@/lib/server/logger'
+import { WorkspaceSchemaFloorRefusal } from './schema-floor'
+
+const log = logger.child({ component: 'ensure-schema-current' })
+
+export function missingBundledMigrations(applied: AppliedLedger): string[] {
+  return BUNDLED_MIGRATIONS.filter((e) => !applied.versions.has(e.when)).map((e) => e.tag)
+}
+
+export async function ensureWorkspaceSchemaCurrent(opts: {
+  workspaceKey: string
+  sql: Sql
+  directConnectionString: string
+}): Promise<void> {
+  const applied = await readAppliedLedger(opts.sql)
+  const missing = missingBundledMigrations(applied)
+  if (missing.length === 0) return
+
+  log.warn(
+    { workspaceKey: opts.workspaceKey, missing: missing.slice(0, 8), missingCount: missing.length },
+    'workspace schema is behind this build — migrating before serving'
+  )
+
+  const result = await runMigrations(opts.directConnectionString)
+  if (result.postconditions && !result.postconditions.ok) {
+    log.error(
+      {
+        workspaceKey: opts.workspaceKey,
+        violations: result.postconditions.violations.map((v) => v.detail),
+      },
+      'workspace migrate completed but post-conditions failed'
+    )
+    throw new WorkspaceSchemaFloorRefusal(opts.workspaceKey, {
+      ok: false,
+      missing,
+      floorTag: missing[missing.length - 1] ?? 'bundled',
+    })
+  }
+
+  const after = await readAppliedLedger(opts.sql)
+  const stillMissing = missingBundledMigrations(after)
+  if (stillMissing.length > 0) {
+    throw new WorkspaceSchemaFloorRefusal(opts.workspaceKey, {
+      ok: false,
+      missing: stillMissing,
+      floorTag: stillMissing[stillMissing.length - 1] ?? 'bundled',
+    })
+  }
+}

--- a/apps/web/src/lib/server/fleet/ensure-schema-current.ts
+++ b/apps/web/src/lib/server/fleet/ensure-schema-current.ts
@@ -11,11 +11,14 @@
  * routed immediately. This runs once per pool, after identity checks, and is a
  * no-op when the ledger already records every bundled migration.
  *
- * Uses the session-mode DSN: `runMigrations` refuses a transaction-mode pooler
- * because the advisory lock is session-scoped.
+ * Catch-up goes through {@link migrateDirect}, not raw `runMigrations`. Drizzle
+ * only applies a suffix above the ledger high-water mark, so a hole below the
+ * tip would otherwise 503-loop on every checkout. `migrateDirect` is the
+ * gap-aware planner that can truncate and replay, or refuse a mutating replay.
+ *
+ * Uses the session-mode DSN: the advisory lock is session-scoped.
  */
 import type { Sql } from 'postgres'
-import { runMigrations } from '@quackback/db/migrate'
 import {
   BUNDLED_MIGRATIONS,
   readAppliedLedger,
@@ -44,23 +47,28 @@ export async function ensureWorkspaceSchemaCurrent(opts: {
     'workspace schema is behind this build — migrating before serving'
   )
 
-  const result = await runMigrations(opts.directConnectionString)
-  if (result.postconditions && !result.postconditions.ok) {
+  // Dynamic import: migrator.ts imports pool-cache for the registry-backed
+  // wrapper, and pool-cache calls this module on checkout.
+  const { migrateDirect } = await import('./migrator')
+  const outcome = await migrateDirect(opts.workspaceKey, opts.directConnectionString)
+  if (!outcome.ok) {
     log.error(
       {
         workspaceKey: opts.workspaceKey,
-        violations: result.postconditions.violations.map((v) => v.detail),
+        code: outcome.code,
+        detail: outcome.detail,
+        gap: outcome.gap?.missing,
       },
-      'workspace migrate completed but post-conditions failed'
+      'workspace catch-up migrate refused or failed'
     )
     throw new WorkspaceSchemaFloorRefusal(opts.workspaceKey, {
       ok: false,
-      missing,
+      missing: outcome.gap?.missing ?? missing,
       floorTag: missing[missing.length - 1] ?? 'bundled',
     })
   }
 
-  const after = await readAppliedLedger(opts.sql)
+  const after = outcome.after ?? (await readAppliedLedger(opts.sql))
   const stillMissing = missingBundledMigrations(after)
   if (stillMissing.length > 0) {
     throw new WorkspaceSchemaFloorRefusal(opts.workspaceKey, {

--- a/apps/web/src/lib/server/workspaces/__tests__/pool-cache.test.ts
+++ b/apps/web/src/lib/server/workspaces/__tests__/pool-cache.test.ts
@@ -61,6 +61,10 @@ vi.mock('@quackback/db/client', async (importOriginal) => {
   return { ...actual, createDbFromSql: vi.fn((sql: unknown) => ({ boundTo: sql })) }
 })
 
+vi.mock('@/lib/server/fleet/ensure-schema-current', () => ({
+  ensureWorkspaceSchemaCurrent: vi.fn(async () => {}),
+}))
+
 vi.mock('../fingerprint', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>()
   return {

--- a/apps/web/src/lib/server/workspaces/pool-cache.ts
+++ b/apps/web/src/lib/server/workspaces/pool-cache.ts
@@ -38,6 +38,7 @@ import { createDbFromSql, type Database } from '@quackback/db/client'
 import { config } from '@/lib/server/config'
 import { logger } from '@/lib/server/logger'
 import { runWithLogContext } from '@/lib/server/log-context'
+import { ensureWorkspaceSchemaCurrent } from '@/lib/server/fleet/ensure-schema-current'
 import { assertSchemaFloor } from '@/lib/server/fleet/schema-floor'
 import {
   evaluateSecretKeyCanary,
@@ -48,7 +49,7 @@ import {
 import { openWorkspaceSecret } from './vendor/fleet-secrets'
 import type { WorkspaceDescriptor } from './registry'
 import { clearWorkspaceSecretsCache, resolveWorkspaceSecrets } from './workspace-secrets'
-import { parseSecretRef, redactRef } from './vendor/secret-ref'
+import { parseSecretRef, redactRef, withPassword } from './vendor/secret-ref'
 import type { ResolvedWorkspaceSecrets } from './vendor/workspace-secret-resolution'
 
 const log = logger.child({ component: 'workspace-pool-cache' })
@@ -271,7 +272,7 @@ async function verifyWorkspaceDatabase(
   // for the error. A password provider that throws is swallowed by the driver
   // and reported as `CONNECT_TIMEOUT` fifteen seconds later, which is both slow
   // and names the wrong cause; a missing secret should say so immediately.
-  await resolvePassword(workspace)
+  const password = await resolvePassword(workspace)
 
   // Before the first query, and before the fingerprint. An unresolvable
   // `SECRET_KEY` is not a degraded workspace, it is a workspace this process must not
@@ -294,11 +295,16 @@ async function verifyWorkspaceDatabase(
       )
     : verdict
   if (keyVerdict.ok) {
-    // §10.5's compatibility gate, in the same pass and cached the same way: this
-    // database is the right one, but is its schema new enough for this build to
-    // read? Deliberately *after* the identity checks — asking a database we have
-    // not established the identity of what version it is at would be answering
-    // the second question before the first.
+    // Identity first, then schema. A mint migrated by a lagging CP vendor
+    // snapshot is otherwise Ready and 500s on `settings` (explicit column
+    // lists, missing column). Catch up to this build, then the MIN_SCHEMA_VERSION
+    // floor — asking a database we have not identified what version it is at
+    // would be answering the second question before the first.
+    await ensureWorkspaceSchemaCurrent({
+      workspaceKey: workspace.workspaceKey,
+      sql,
+      directConnectionString: withPassword(workspace.database.directUrl, password),
+    })
     await assertSchemaFloor(workspace.workspaceKey, sql)
     log.info(
       {

--- a/bun.lock
+++ b/bun.lock
@@ -298,7 +298,7 @@
     "axios": "1.19.0",
     "browserslist": "4.28.8",
     "dompurify": "3.4.13",
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.7",
     "fast-xml-builder": "1.1.7",
     "form-data": "4.0.6",
     "hono": "4.12.25",
@@ -1705,7 +1705,7 @@
 
     "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
 
-    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
+    "fast-uri": ["fast-uri@3.1.7", "", {}, "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg=="],
 
     "fast-xml-builder": ["fast-xml-builder@1.1.7", "", { "dependencies": { "path-expression-matcher": "^1.1.3" } }, "sha512-Yh7/7rQuMXICNr0oMYDR2yHP6oUvmQsTToFeOWj/kIDhAwQ+c4Ol/lbcwOmEM5OHYQmh6S6EQSQ1sljCKP36bQ=="],
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "js-yaml": "4.3.1",
     "kysely": "0.28.17",
     "nanoid": "3.3.18",
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.7",
     "postcss": "8.5.26",
     "fast-xml-builder": "1.1.7",
     "ws": "8.21.0",

--- a/packages/db/src/schema/__tests__/settings-columns.test.ts
+++ b/packages/db/src/schema/__tests__/settings-columns.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { getTableColumns } from 'drizzle-orm'
+import { settings } from '../auth'
+
+/**
+ * SQL names Drizzle emits on `settings` findFirst(). A missing column is a
+ * throw, not a null — that is the new-mint 500
+ * (`Failed to fetch settings with all configs`).
+ *
+ * When this list changes:
+ * 1. Add an expand-only migration in `packages/db/drizzle`.
+ * 2. Restage the control-plane vendor lineage
+ *    (`quackback-cp/scripts/vendor-migrator.sh` from the fleet image digest).
+ * 3. Update `REQUIRED_SETTINGS_COLUMNS` in
+ *    `quackback-cp/src/lib/server/tenancy/tenant-schema.ts` so provision
+ *    refuses a short schema instead of marking the workspace Ready.
+ *
+ * The serving image also migrates a behind-ledger workspace on first pool
+ * checkout (`ensureWorkspaceSchemaCurrent`). That is what stops vendor lag
+ * from 500ing a customer even if steps 2–3 are late.
+ */
+export const SETTINGS_SQL_COLUMNS = [
+  'id',
+  'name',
+  'slug',
+  'logo_key',
+  'favicon_key',
+  'header_logo_key',
+  'portal_og_image_key',
+  'created_at',
+  'metadata',
+  'auth_config',
+  'portal_config',
+  'branding_config',
+  'custom_css',
+  'developer_config',
+  'header_display_mode',
+  'header_display_name',
+  'setup_state',
+  'assistant_config',
+  'assistant_config_revision',
+  'widget_config',
+  'widget_secret',
+  'widget_installed_first_seen_at',
+  'widget_installed_last_seen_at',
+  'widget_installed_origin_host',
+  'widget_installed_sdk_version',
+  'feature_flags',
+  'spam_filter_config',
+  'help_center_config',
+  'tier_limits',
+  'cloud',
+  'cloud_revision',
+  'cloud_identity',
+  'cloud_identity_revision',
+  'managed_field_paths',
+  'state',
+  'auth_config_version',
+] as const
+
+describe('settings columns the serving image queries', () => {
+  it('matches the lock list (update this list AND re-vendor the CP when it fails)', () => {
+    const names = Object.values(getTableColumns(settings)).map((c) => c.name)
+    expect([...names].sort()).toEqual([...SETTINGS_SQL_COLUMNS].sort())
+  })
+})


### PR DESCRIPTION
## Why

New cloud workspaces 500 on every page with `Failed to fetch settings with all configs`. The SELECT names `widget_installed_sdk_version` (migration 0271). The control plane mints with a vendored migrator last staged at 0268, so that column does not exist. Drizzle emits explicit column lists — a missing column is a throw, not a null.

`MIN_SCHEMA_VERSION` is 0256, so the floor does not 503. The fleet migrator would apply 0269–0272, but only on the hourly pass, and the workspace is already Ready.

Companion: QuackbackIO/quackback-cp `fix/vendor-lineage-settings-columns` (restage vendor + refuse short schemas at mint).

## What

On first pool checkout, after identity checks, if this build's journal is not fully recorded, run migrations on the session-mode DSN before serving. No-op when the ledger is current.

Lock the `settings` SQL column list in `packages/db` so adding a column fails CI until the CP vendor lineage is restaged.

## How this does not happen again

The serving image is the source of truth. A new settings column that ships in this image cannot 500 due to vendor lag: first request applies the missing SQL, then queries.

Fail-closed at mint is the CP PR (column check + restaged vendor). This PR is what still saves a customer if that restage is late.

## Test plan

- [x] `ensure-schema-current` unit tests (no-op when current, migrates when 0271/0272 missing, refuses on failed post-conditions)
- [x] pool-cache still green with the catch-up mocked
- [x] settings column lock list matches drizzle `settings`
- [ ] After merge: a new mint's first request should not 500 even before the CP vendor PR lands; after the CP PR, provision itself should already have 0271