### PR TITLE
feat(gitlab): self-hosted instance URL for issue sync

### DIFF
--- a/apps/web/src/components/admin/settings/integrations/integration-settings-registry.tsx
+++ b/apps/web/src/components/admin/settings/integrations/integration-settings-registry.tsx
@@ -496,16 +496,19 @@ export const INTEGRATION_SETTINGS: Record<string, IntegrationSettingsEntry> = {
     setup: {
       title: 'Connect GitLab',
       description:
-        'Connect GitLab to automatically create issues from feedback and sync statuses between platforms.',
+        'Connect GitLab.com or a self-hosted GitLab instance to create issues from feedback and sync statuses.',
       steps: [
         <p key="1">
           Configure your GitLab{' '}
-          <span className="font-medium text-foreground">OAuth application credentials</span> in the
-          platform settings.
+          <span className="font-medium text-foreground">Application ID and Secret</span>. For a
+          self-hosted instance, also set the{' '}
+          <span className="font-medium text-foreground">GitLab instance URL</span>. Register the
+          redirect URI shown in the credentials form on your GitLab OAuth application.
         </p>,
         <p key="2">
           Click <span className="font-medium text-foreground">Connect</span> to authorize Quackback
-          with your GitLab account.
+          with your GitLab account. You will be sent to GitLab.com or your instance, depending on
+          the URL you configured.
         </p>,
         <p key="3">
           Select a project to create issues in, then choose which events should trigger new issues.

--- a/apps/web/src/components/admin/settings/integrations/platform-credentials-form.tsx
+++ b/apps/web/src/components/admin/settings/integrations/platform-credentials-form.tsx
@@ -7,6 +7,7 @@ import { useSavePlatformCredentials, useDeletePlatformCredentials } from '@/lib/
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { CopyButton } from '@/components/shared/copy-button'
 import type { PlatformCredentialField } from '@/lib/shared/integration-types'
 
 interface PlatformCredentialsFormProps {
@@ -65,7 +66,28 @@ export function PlatformCredentialsForm({
     )
   }
 
-  const allFieldsFilled = fields.every((f) => values[f.key]?.trim())
+  const requiredFilled = fields
+    .filter((f) => f.required !== false)
+    .every((f) => values[f.key]?.trim())
+
+  const redirectUri =
+    typeof window !== 'undefined'
+      ? `${window.location.origin}/oauth/${integrationType}/callback`
+      : `/oauth/${integrationType}/callback`
+
+  const redirectCallout = (
+    <div className="rounded-lg border border-border/50 bg-muted/20 p-3 space-y-1.5">
+      <Label className="text-xs font-medium text-muted-foreground">
+        Redirect URI to register in your OAuth application
+      </Label>
+      <div className="flex items-center gap-2">
+        <code className="flex-1 rounded bg-muted px-3 py-2 text-xs font-mono break-all">
+          {redirectUri}
+        </code>
+        <CopyButton value={redirectUri} variant="outline" size="sm" />
+      </div>
+    </div>
+  )
 
   // Managed cloud: credentials are platform-provided and not editable per-workspace.
   if (isManaged) {
@@ -94,6 +116,7 @@ export function PlatformCredentialsForm({
   if (isConfigured && !isEditing) {
     return (
       <div className="space-y-4">
+        {redirectCallout}
         <div className="space-y-3">
           {fields.map((field) => (
             <div key={field.key}>
@@ -125,15 +148,19 @@ export function PlatformCredentialsForm({
   // Show input form when not configured or editing
   return (
     <div className="space-y-4">
+      {redirectCallout}
       <div className="space-y-3">
         {fields.map((field) => (
           <div key={field.key}>
             <Label htmlFor={`cred-${field.key}`} className="text-sm font-medium">
               {field.label}
+              {field.required === false ? (
+                <span className="ml-1 font-normal text-muted-foreground">(optional)</span>
+              ) : null}
             </Label>
             <Input
               id={`cred-${field.key}`}
-              type={field.sensitive ? 'password' : 'text'}
+              type={field.sensitive ? 'password' : field.url ? 'url' : 'text'}
               placeholder={field.placeholder ?? ''}
               value={values[field.key] ?? ''}
               onChange={(e) => setValues((prev) => ({ ...prev, [field.key]: e.target.value }))}
@@ -156,11 +183,7 @@ export function PlatformCredentialsForm({
         ))}
       </div>
       <div className="flex gap-2">
-        <Button
-          size="sm"
-          onClick={handleSave}
-          disabled={!allFieldsFilled || saveMutation.isPending}
-        >
+        <Button size="sm" onClick={handleSave} disabled={!requiredFilled || saveMutation.isPending}>
           {saveMutation.isPending ? 'Saving...' : 'Save'}
         </Button>
         {isEditing && (

--- a/apps/web/src/integrations/gitlab/server/__tests__/definition.test.ts
+++ b/apps/web/src/integrations/gitlab/server/__tests__/definition.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { gitlabIntegration } from '@/integrations/gitlab/server'
+
+describe('gitlabIntegration platform credentials', () => {
+  it('declares an optional SSRF-checked instance URL plus Application ID and Secret', () => {
+    const keys = gitlabIntegration.platformCredentials.map((f) => f.key)
+    expect(keys).toEqual(['instanceUrl', 'clientId', 'clientSecret'])
+
+    const instanceUrl = gitlabIntegration.platformCredentials.find((f) => f.key === 'instanceUrl')
+    expect(instanceUrl).toMatchObject({
+      required: false,
+      url: true,
+      sensitive: false,
+    })
+  })
+})

--- a/apps/web/src/integrations/gitlab/server/__tests__/fetch.test.ts
+++ b/apps/web/src/integrations/gitlab/server/__tests__/fetch.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest'
+
+const { safeFetch } = vi.hoisted(() => ({ safeFetch: vi.fn(async () => new Response('{}')) }))
+vi.mock('@/lib/server/content/ssrf-guard', () => ({ safeFetch }))
+
+import {
+  gitlabFetch,
+  GITLAB_MAX_RESPONSE_BYTES,
+  GITLAB_REQUEST_TIMEOUT_MS,
+} from '@/integrations/gitlab/server/fetch'
+
+describe('gitlabFetch', () => {
+  it('pins every request through the SSRF guard with GitLab-sized limits', async () => {
+    await gitlabFetch('https://gitlab.example.com/api/v4/user', {
+      headers: { Authorization: 'Bearer tok' },
+    })
+
+    expect(safeFetch).toHaveBeenCalledWith('https://gitlab.example.com/api/v4/user', {
+      headers: { Authorization: 'Bearer tok' },
+      timeoutMs: GITLAB_REQUEST_TIMEOUT_MS,
+      maxResponseBytes: GITLAB_MAX_RESPONSE_BYTES,
+      onOverflow: 'error',
+    })
+  })
+
+  it('lets a caller shorten the timeout but never lift the body cap', async () => {
+    await gitlabFetch('https://gitlab.com/api/v4/user', { timeoutMs: 1000 })
+
+    expect(safeFetch).toHaveBeenLastCalledWith(
+      'https://gitlab.com/api/v4/user',
+      expect.objectContaining({ timeoutMs: 1000, maxResponseBytes: GITLAB_MAX_RESPONSE_BYTES })
+    )
+  })
+})

--- a/apps/web/src/integrations/gitlab/server/__tests__/hook.test.ts
+++ b/apps/web/src/integrations/gitlab/server/__tests__/hook.test.ts
@@ -2,6 +2,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { EventData, PostCreatedEvent } from '@/lib/server/events/types'
 import { gitlabHook } from '@/integrations/gitlab/server/hook'
 
+// GitLab requests go through the SSRF guard; route them to the stubbed global
+// fetch so the assertions below see the same calls.
+vi.mock('@/lib/server/content/ssrf-guard', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/server/content/ssrf-guard')>()),
+  safeFetch: (url: string, init?: RequestInit) => globalThis.fetch(url, init),
+}))
+
 function mockFetch(status: number, body: unknown = {}) {
   return vi.fn().mockResolvedValue({
     ok: status >= 200 && status < 300,
@@ -81,6 +88,7 @@ describe('gitlabHook', () => {
     const fetchMock = mockFetch(200, { username: 'ada' })
     vi.stubGlobal('fetch', fetchMock)
 
+    if (!gitlabHook.testConnection) throw new Error('gitlabHook.testConnection missing')
     const result = await gitlabHook.testConnection({
       accessToken: 'tok',
       rootUrl: 'https://app.example.com',

--- a/apps/web/src/integrations/gitlab/server/__tests__/hook.test.ts
+++ b/apps/web/src/integrations/gitlab/server/__tests__/hook.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { EventData, PostCreatedEvent } from '@/lib/server/events/types'
+import { gitlabHook } from '@/integrations/gitlab/server/hook'
+
+function mockFetch(status: number, body: unknown = {}) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  })
+}
+
+function makePostCreatedEvent(): PostCreatedEvent {
+  return {
+    id: 'evt-1',
+    type: 'post.created',
+    timestamp: '2025-01-01T00:00:00Z',
+    actor: { type: 'user', userId: 'user_1', email: 'test@test.com' },
+    data: {
+      post: {
+        id: 'post_1',
+        title: 'Bug report',
+        content: '<p>Something broke</p>',
+        boardId: 'board_1',
+        boardSlug: 'bugs',
+        voteCount: 3,
+      },
+    },
+  }
+}
+
+const target = { channelId: '42' }
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('gitlabHook', () => {
+  it('creates issues on gitlab.com when instanceUrl is omitted', async () => {
+    const fetchMock = mockFetch(201, { iid: 9, web_url: 'https://gitlab.com/acme/app/-/issues/9' })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await gitlabHook.run(makePostCreatedEvent(), target, {
+      accessToken: 'tok',
+      rootUrl: 'https://app.example.com',
+    })
+
+    expect(result).toEqual({
+      success: true,
+      externalId: '9',
+      externalUrl: 'https://gitlab.com/acme/app/-/issues/9',
+    })
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://gitlab.com/api/v4/projects/42/issues',
+      expect.objectContaining({ method: 'POST' })
+    )
+  })
+
+  it('creates issues on a custom HTTPS instance', async () => {
+    const fetchMock = mockFetch(201, {
+      iid: 3,
+      web_url: 'https://gitlab.example.com/acme/app/-/issues/3',
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await gitlabHook.run(makePostCreatedEvent(), target, {
+      accessToken: 'tok',
+      rootUrl: 'https://app.example.com',
+      instanceUrl: 'https://gitlab.example.com/',
+    })
+
+    expect(result.success).toBe(true)
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://gitlab.example.com/api/v4/projects/42/issues',
+      expect.objectContaining({ method: 'POST' })
+    )
+  })
+
+  it('tests the connection against the configured instance', async () => {
+    const fetchMock = mockFetch(200, { username: 'ada' })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await gitlabHook.testConnection({
+      accessToken: 'tok',
+      rootUrl: 'https://app.example.com',
+      instanceUrl: 'https://gitlab.example.com',
+    })
+
+    expect(result).toEqual({ ok: true, error: undefined })
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://gitlab.example.com/api/v4/user',
+      expect.any(Object)
+    )
+  })
+
+  it('skips non post.created events', async () => {
+    const result = await gitlabHook.run(
+      { type: 'post.status_changed' } as unknown as EventData,
+      target,
+      { accessToken: 'tok', rootUrl: 'https://app.example.com' }
+    )
+    expect(result).toEqual({ success: true })
+  })
+})

--- a/apps/web/src/integrations/gitlab/server/__tests__/oauth.test.ts
+++ b/apps/web/src/integrations/gitlab/server/__tests__/oauth.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { exchangeGitLabCode, getGitLabOAuthUrl } from '@/integrations/gitlab/server/oauth'
+
+const creds = { clientId: 'app-id', clientSecret: 'app-secret' }
+
+function mockFetch(handlers: Array<{ url: string | RegExp; status: number; body: unknown }>) {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input)
+    const handler = handlers.find((h) =>
+      typeof h.url === 'string' ? url === h.url || url.startsWith(h.url) : h.url.test(url)
+    )
+    if (!handler) throw new Error(`unexpected fetch: ${url}`)
+    return {
+      ok: handler.status >= 200 && handler.status < 300,
+      status: handler.status,
+      json: async () => handler.body,
+      text: async () => JSON.stringify(handler.body),
+    }
+  })
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('getGitLabOAuthUrl', () => {
+  it('authorizes against gitlab.com when instanceUrl is omitted', () => {
+    const url = getGitLabOAuthUrl(
+      'state-1',
+      'https://app.example.com/oauth/gitlab/callback',
+      {},
+      creds
+    )
+    const parsed = new URL(url)
+    expect(parsed.origin).toBe('https://gitlab.com')
+    expect(parsed.pathname).toBe('/oauth/authorize')
+    expect(parsed.searchParams.get('client_id')).toBe('app-id')
+    expect(parsed.searchParams.get('redirect_uri')).toBe(
+      'https://app.example.com/oauth/gitlab/callback'
+    )
+    expect(parsed.searchParams.get('scope')).toBe('api')
+  })
+
+  it('authorizes against a custom HTTPS instance', () => {
+    const url = getGitLabOAuthUrl(
+      'state-1',
+      'https://app.example.com/oauth/gitlab/callback',
+      {},
+      {
+        ...creds,
+        instanceUrl: 'https://gitlab.example.com/',
+      }
+    )
+    expect(new URL(url).origin).toBe('https://gitlab.example.com')
+    expect(url).toContain('/oauth/authorize?')
+  })
+
+  it('throws when the client ID is missing', () => {
+    expect(() => getGitLabOAuthUrl('s', 'https://app.example.com/cb')).toThrow(/client ID/)
+  })
+})
+
+describe('exchangeGitLabCode', () => {
+  it('exchanges against gitlab.com and omits instanceUrl from config', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch([
+        {
+          url: 'https://gitlab.com/oauth/token',
+          status: 200,
+          body: { access_token: 'tok', refresh_token: 'ref', expires_in: 7200 },
+        },
+        {
+          url: 'https://gitlab.com/api/v4/user',
+          status: 200,
+          body: { name: 'Ada', username: 'ada' },
+        },
+      ])
+    )
+
+    const result = await exchangeGitLabCode(
+      'code-1',
+      'https://app.example.com/oauth/gitlab/callback',
+      {},
+      creds
+    )
+
+    expect(result.accessToken).toBe('tok')
+    expect(result.config).toEqual({ workspaceName: 'Ada' })
+    expect(result.config).not.toHaveProperty('instanceUrl')
+  })
+
+  it('exchanges against a custom instance and persists the origin', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch([
+        {
+          url: 'https://gitlab.example.com/oauth/token',
+          status: 200,
+          body: { access_token: 'tok', refresh_token: 'ref', expires_in: 7200 },
+        },
+        {
+          url: 'https://gitlab.example.com/api/v4/user',
+          status: 200,
+          body: { username: 'ada' },
+        },
+      ])
+    )
+
+    const result = await exchangeGitLabCode(
+      'code-1',
+      'https://app.example.com/oauth/gitlab/callback',
+      {},
+      { ...creds, instanceUrl: 'https://gitlab.example.com/' }
+    )
+
+    expect(result.accessToken).toBe('tok')
+    expect(result.config).toEqual({
+      workspaceName: 'ada',
+      instanceUrl: 'https://gitlab.example.com',
+    })
+  })
+})

--- a/apps/web/src/integrations/gitlab/server/__tests__/oauth.test.ts
+++ b/apps/web/src/integrations/gitlab/server/__tests__/oauth.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { exchangeGitLabCode, getGitLabOAuthUrl } from '@/integrations/gitlab/server/oauth'
 
+// GitLab requests go through the SSRF guard; route them to the stubbed global
+// fetch so the assertions below see the same calls.
+vi.mock('@/lib/server/content/ssrf-guard', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/server/content/ssrf-guard')>()),
+  safeFetch: (url: string, init?: RequestInit) => globalThis.fetch(url, init),
+}))
+
 const creds = { clientId: 'app-id', clientSecret: 'app-secret' }
 
 function mockFetch(handlers: Array<{ url: string | RegExp; status: number; body: unknown }>) {

--- a/apps/web/src/integrations/gitlab/server/__tests__/projects.test.ts
+++ b/apps/web/src/integrations/gitlab/server/__tests__/projects.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { listGitLabProjects } from '@/integrations/gitlab/server/projects'
+
+function mockFetch(status: number, body: unknown = []) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  })
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('listGitLabProjects', () => {
+  const projects = [{ id: 7, name_with_namespace: 'Acme / Widgets' }]
+
+  it('lists projects from gitlab.com by default', async () => {
+    const fetchMock = mockFetch(200, projects)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await listGitLabProjects('tok')
+
+    expect(result).toEqual([{ id: '7', name: 'Acme / Widgets' }])
+    expect(String(fetchMock.mock.calls[0][0])).toMatch(/^https:\/\/gitlab\.com\/api\/v4\/projects/)
+  })
+
+  it('lists projects from a custom HTTPS instance', async () => {
+    const fetchMock = mockFetch(200, projects)
+    vi.stubGlobal('fetch', fetchMock)
+
+    await listGitLabProjects('tok', 'https://gitlab.example.com/')
+
+    expect(String(fetchMock.mock.calls[0][0])).toMatch(
+      /^https:\/\/gitlab\.example\.com\/api\/v4\/projects/
+    )
+  })
+})

--- a/apps/web/src/integrations/gitlab/server/__tests__/projects.test.ts
+++ b/apps/web/src/integrations/gitlab/server/__tests__/projects.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { listGitLabProjects } from '@/integrations/gitlab/server/projects'
 
+// GitLab requests go through the SSRF guard; route them to the stubbed global
+// fetch so the assertions below see the same calls.
+vi.mock('@/lib/server/content/ssrf-guard', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/server/content/ssrf-guard')>()),
+  safeFetch: (url: string, init?: RequestInit) => globalThis.fetch(url, init),
+}))
+
 function mockFetch(status: number, body: unknown = []) {
   return vi.fn().mockResolvedValue({
     ok: status >= 200 && status < 300,

--- a/apps/web/src/integrations/gitlab/server/__tests__/url.test.ts
+++ b/apps/web/src/integrations/gitlab/server/__tests__/url.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest'
+import {
+  GITLAB_COM_ORIGIN,
+  GitLabInstanceUrlError,
+  extractGitLabProjectPath,
+  gitlabApiBase,
+  normalizeGitLabInstanceUrl,
+} from '@/integrations/gitlab/server/url'
+
+describe('normalizeGitLabInstanceUrl', () => {
+  it('defaults to gitlab.com when the URL is omitted', () => {
+    expect(normalizeGitLabInstanceUrl(undefined)).toBe(GITLAB_COM_ORIGIN)
+    expect(normalizeGitLabInstanceUrl(null)).toBe(GITLAB_COM_ORIGIN)
+    expect(normalizeGitLabInstanceUrl('')).toBe(GITLAB_COM_ORIGIN)
+    expect(normalizeGitLabInstanceUrl('   ')).toBe(GITLAB_COM_ORIGIN)
+  })
+
+  it('reduces a custom HTTPS instance to its origin', () => {
+    expect(normalizeGitLabInstanceUrl('https://gitlab.example.com')).toBe(
+      'https://gitlab.example.com'
+    )
+    expect(normalizeGitLabInstanceUrl('https://gitlab.example.com/')).toBe(
+      'https://gitlab.example.com'
+    )
+    expect(normalizeGitLabInstanceUrl('https://gitlab.example.com/foo')).toBe(
+      'https://gitlab.example.com'
+    )
+    expect(normalizeGitLabInstanceUrl('https://gitlab.example.com:8443')).toBe(
+      'https://gitlab.example.com:8443'
+    )
+  })
+
+  it('rejects non-http(s) schemes', () => {
+    expect(() => normalizeGitLabInstanceUrl('javascript:alert(1)')).toThrow(GitLabInstanceUrlError)
+    expect(() => normalizeGitLabInstanceUrl('file:///etc/passwd')).toThrow(GitLabInstanceUrlError)
+  })
+
+  it('rejects URLs that embed credentials', () => {
+    expect(() => normalizeGitLabInstanceUrl('https://user:pass@gitlab.example.com')).toThrow(
+      GitLabInstanceUrlError
+    )
+  })
+
+  it('rejects unparseable strings', () => {
+    expect(() => normalizeGitLabInstanceUrl('not a url')).toThrow(GitLabInstanceUrlError)
+  })
+})
+
+describe('gitlabApiBase', () => {
+  it('appends /api/v4 to gitlab.com by default', () => {
+    expect(gitlabApiBase()).toBe('https://gitlab.com/api/v4')
+  })
+
+  it('appends /api/v4 to a custom instance origin', () => {
+    expect(gitlabApiBase('https://gitlab.example.com/')).toBe('https://gitlab.example.com/api/v4')
+  })
+})
+
+describe('extractGitLabProjectPath', () => {
+  it('extracts the project path from a gitlab.com issue URL', () => {
+    expect(extractGitLabProjectPath('https://gitlab.com/my-org/my-project/-/issues/7')).toBe(
+      'my-org/my-project'
+    )
+  })
+
+  it('extracts the project path from a self-hosted issue URL', () => {
+    expect(
+      extractGitLabProjectPath('https://gitlab.example.com/group/sub/project/-/issues/42')
+    ).toBe('group/sub/project')
+  })
+
+  it('accepts the older /issues/ form', () => {
+    expect(extractGitLabProjectPath('https://gitlab.com/acme/widgets/issues/142')).toBe(
+      'acme/widgets'
+    )
+  })
+
+  it('returns null when the URL is missing or not an issue URL', () => {
+    expect(extractGitLabProjectPath(null)).toBeNull()
+    expect(extractGitLabProjectPath('https://gitlab.com/my-org/my-project')).toBeNull()
+  })
+})

--- a/apps/web/src/integrations/gitlab/server/archive.ts
+++ b/apps/web/src/integrations/gitlab/server/archive.ts
@@ -4,16 +4,19 @@ import {
   type ArchiveContext,
   type ArchiveResult,
 } from '@/lib/server/integrations/archive'
-
-const GITLAB_API = 'https://gitlab.com/api/v4'
+import {
+  extractGitLabProjectPath,
+  gitlabApiBase,
+  normalizeGitLabInstanceUrl,
+} from '@/integrations/gitlab/server/url'
 
 /** Close the linked GitLab issue on cascading post delete. */
 export async function closeGitLabIssue(ctx: ArchiveContext): Promise<ArchiveResult> {
-  const projectId = extractGitLabProjectId(ctx.externalUrl)
+  const projectId = extractGitLabProjectPath(ctx.externalUrl)
   if (!projectId) return { success: false, error: 'Cannot determine project from external URL' }
 
   const response = await fetch(
-    `${GITLAB_API}/projects/${encodeURIComponent(projectId)}/issues/${ctx.externalId}`,
+    `${gitlabApiBase(instanceUrlFrom(ctx))}/projects/${encodeURIComponent(projectId)}/issues/${ctx.externalId}`,
     {
       method: 'PUT',
       headers: {
@@ -30,8 +33,17 @@ export async function closeGitLabIssue(ctx: ArchiveContext): Promise<ArchiveResu
   return { success: true, action: 'closed' }
 }
 
-function extractGitLabProjectId(url?: string | null): string | null {
-  if (!url) return null
-  const match = url.match(/gitlab\.com\/(.+?)\/-\/issues/)
-  return match?.[1] ?? null
+function instanceUrlFrom(ctx: ArchiveContext): string {
+  const stored = ctx.integrationConfig.instanceUrl
+  if (typeof stored === 'string' && stored.trim()) {
+    return normalizeGitLabInstanceUrl(stored)
+  }
+  if (ctx.externalUrl) {
+    try {
+      return new URL(ctx.externalUrl).origin
+    } catch {
+      // fall through to gitlab.com default
+    }
+  }
+  return normalizeGitLabInstanceUrl(null)
 }

--- a/apps/web/src/integrations/gitlab/server/archive.ts
+++ b/apps/web/src/integrations/gitlab/server/archive.ts
@@ -9,13 +9,14 @@ import {
   gitlabApiBase,
   normalizeGitLabInstanceUrl,
 } from '@/integrations/gitlab/server/url'
+import { gitlabFetch } from '@/integrations/gitlab/server/fetch'
 
 /** Close the linked GitLab issue on cascading post delete. */
 export async function closeGitLabIssue(ctx: ArchiveContext): Promise<ArchiveResult> {
   const projectId = extractGitLabProjectPath(ctx.externalUrl)
   if (!projectId) return { success: false, error: 'Cannot determine project from external URL' }
 
-  const response = await fetch(
+  const response = await gitlabFetch(
     `${gitlabApiBase(instanceUrlFrom(ctx))}/projects/${encodeURIComponent(projectId)}/issues/${ctx.externalId}`,
     {
       method: 'PUT',
@@ -24,7 +25,7 @@ export async function closeGitLabIssue(ctx: ArchiveContext): Promise<ArchiveResu
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({ state_event: 'close' }),
-      signal: AbortSignal.timeout(ARCHIVE_TIMEOUT_MS),
+      timeoutMs: ARCHIVE_TIMEOUT_MS,
     }
   )
 

--- a/apps/web/src/integrations/gitlab/server/catalog.ts
+++ b/apps/web/src/integrations/gitlab/server/catalog.ts
@@ -3,7 +3,8 @@ import type { IntegrationCatalogEntry } from '@/lib/server/integrations/types'
 export const gitlabCatalog: IntegrationCatalogEntry = {
   id: 'gitlab',
   name: 'GitLab',
-  description: 'Create issues in GitLab from feedback and sync statuses.',
+  description:
+    'Create issues in GitLab (GitLab.com or self-hosted) from feedback and sync statuses.',
   category: 'issue_tracking',
   iconBg: 'bg-[#FC6D26]',
   settingsPath: '/admin/settings/integrations/gitlab',

--- a/apps/web/src/integrations/gitlab/server/fetch.ts
+++ b/apps/web/src/integrations/gitlab/server/fetch.ts
@@ -1,0 +1,27 @@
+/**
+ * Every outbound GitLab request goes through the SSRF guard.
+ *
+ * The instance URL is admin-supplied and only validated at save time; DNS
+ * can change (or start redirecting to a private address) afterwards.
+ * `safeFetch` re-validates on each call, connects to the validated IP
+ * rather than re-resolving the hostname, and never follows redirects, so
+ * the save-time check cannot be bypassed later.
+ */
+
+import { safeFetch, type SafeFetchInit } from '@/lib/server/content/ssrf-guard'
+
+export const GITLAB_REQUEST_TIMEOUT_MS = 15_000
+/** Project listings (100 per page) run well past the guard's 64 KiB default. */
+export const GITLAB_MAX_RESPONSE_BYTES = 4 * 1024 * 1024
+
+export function gitlabFetch(
+  url: string,
+  init: Pick<SafeFetchInit, 'method' | 'headers' | 'body' | 'timeoutMs'> = {}
+): Promise<Response> {
+  return safeFetch(url, {
+    ...init,
+    timeoutMs: init.timeoutMs ?? GITLAB_REQUEST_TIMEOUT_MS,
+    maxResponseBytes: GITLAB_MAX_RESPONSE_BYTES,
+    onOverflow: 'error',
+  })
+}

--- a/apps/web/src/integrations/gitlab/server/functions.ts
+++ b/apps/web/src/integrations/gitlab/server/functions.ts
@@ -81,7 +81,8 @@ export const fetchGitLabProjectsFn = createServerFn({ method: 'GET' }).handler(
       throw new Error('GitLab access token missing')
     }
 
-    const projects = await listGitLabProjects(secrets.accessToken)
+    const instanceUrl = (integration.config as { instanceUrl?: string } | null)?.instanceUrl
+    const projects = await listGitLabProjects(secrets.accessToken, instanceUrl)
     return projects
   }
 )

--- a/apps/web/src/integrations/gitlab/server/hook.ts
+++ b/apps/web/src/integrations/gitlab/server/hook.ts
@@ -7,11 +7,10 @@ import type { HookHandler, HookResult } from '@/lib/server/events/hook-types'
 import type { EventData } from '@/lib/server/events/types'
 import { isRetryableError } from '@/lib/server/events/hook-utils'
 import { buildGitLabIssue } from '@/integrations/gitlab/server/message'
+import { gitlabApiBase } from '@/integrations/gitlab/server/url'
 import { logger } from '@/lib/server/logger'
 
 const log = logger.child({ component: 'gitlab' })
-
-const GITLAB_API = 'https://gitlab.com/api/v4'
 
 export interface GitLabTarget {
   channelId: string // projectId stored as channelId for consistency
@@ -20,6 +19,8 @@ export interface GitLabTarget {
 export interface GitLabConfig {
   accessToken: string
   rootUrl: string
+  /** Origin of a self-hosted GitLab instance; omitted for gitlab.com. */
+  instanceUrl?: string
 }
 
 export const gitlabHook: HookHandler = {
@@ -29,24 +30,22 @@ export const gitlabHook: HookHandler = {
     }
 
     const { channelId: projectId } = target as GitLabTarget
-    const { accessToken, rootUrl } = config as GitLabConfig
+    const { accessToken, rootUrl, instanceUrl } = config as GitLabConfig
+    const api = gitlabApiBase(instanceUrl)
 
     log.debug({ event_type: event.type, project_id: projectId }, 'processing event')
 
     const { title, description } = buildGitLabIssue(event, rootUrl)
 
     try {
-      const response = await fetch(
-        `${GITLAB_API}/projects/${encodeURIComponent(projectId)}/issues`,
-        {
-          method: 'POST',
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ title, description }),
-        }
-      )
+      const response = await fetch(`${api}/projects/${encodeURIComponent(projectId)}/issues`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ title, description }),
+      })
 
       if (!response.ok) {
         const errorBody = await response.text()
@@ -91,9 +90,9 @@ export const gitlabHook: HookHandler = {
   },
 
   async testConnection(config: unknown): Promise<{ ok: boolean; error?: string }> {
-    const { accessToken } = config as GitLabConfig
+    const { accessToken, instanceUrl } = config as GitLabConfig
     try {
-      const response = await fetch(`${GITLAB_API}/user`, {
+      const response = await fetch(`${gitlabApiBase(instanceUrl)}/user`, {
         headers: { Authorization: `Bearer ${accessToken}` },
       })
       return { ok: response.ok, error: response.ok ? undefined : `HTTP ${response.status}` }

--- a/apps/web/src/integrations/gitlab/server/hook.ts
+++ b/apps/web/src/integrations/gitlab/server/hook.ts
@@ -8,6 +8,7 @@ import type { EventData } from '@/lib/server/events/types'
 import { isRetryableError } from '@/lib/server/events/hook-utils'
 import { buildGitLabIssue } from '@/integrations/gitlab/server/message'
 import { gitlabApiBase } from '@/integrations/gitlab/server/url'
+import { gitlabFetch } from '@/integrations/gitlab/server/fetch'
 import { logger } from '@/lib/server/logger'
 
 const log = logger.child({ component: 'gitlab' })
@@ -38,14 +39,17 @@ export const gitlabHook: HookHandler = {
     const { title, description } = buildGitLabIssue(event, rootUrl)
 
     try {
-      const response = await fetch(`${api}/projects/${encodeURIComponent(projectId)}/issues`, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ title, description }),
-      })
+      const response = await gitlabFetch(
+        `${api}/projects/${encodeURIComponent(projectId)}/issues`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ title, description }),
+        }
+      )
 
       if (!response.ok) {
         const errorBody = await response.text()
@@ -92,7 +96,7 @@ export const gitlabHook: HookHandler = {
   async testConnection(config: unknown): Promise<{ ok: boolean; error?: string }> {
     const { accessToken, instanceUrl } = config as GitLabConfig
     try {
-      const response = await fetch(`${gitlabApiBase(instanceUrl)}/user`, {
+      const response = await gitlabFetch(`${gitlabApiBase(instanceUrl)}/user`, {
         headers: { Authorization: `Bearer ${accessToken}` },
       })
       return { ok: response.ok, error: response.ok ? undefined : `HTTP ${response.status}` }

--- a/apps/web/src/integrations/gitlab/server/index.ts
+++ b/apps/web/src/integrations/gitlab/server/index.ts
@@ -7,6 +7,8 @@ import { gitlabCatalog } from '@/integrations/gitlab/server/catalog'
 import { gitlabInboundHandler } from '@/integrations/gitlab/server/inbound'
 import { listGitLabProjects } from '@/integrations/gitlab/server/projects'
 
+const GITLAB_APP_DOCS = 'https://docs.gitlab.com/integration/oauth_provider.html'
+
 export const gitlabIntegration: IntegrationDefinition = {
   id: 'gitlab',
   catalog: gitlabCatalog,
@@ -18,8 +20,11 @@ export const gitlabIntegration: IntegrationDefinition = {
   destinations: {
     project: {
       label: 'Project',
-      list: async ({ accessToken }) => {
-        const projects = await listGitLabProjects(accessToken)
+      list: async ({ accessToken, config }) => {
+        const projects = await listGitLabProjects(
+          accessToken,
+          config.instanceUrl as string | undefined
+        )
         return projects.map((p) => ({ id: String(p.id), name: p.name }))
       },
     },
@@ -31,16 +36,28 @@ export const gitlabIntegration: IntegrationDefinition = {
   listExternalStatuses: fetchGitLabStatuses,
   platformCredentials: [
     {
+      key: 'instanceUrl',
+      label: 'GitLab instance URL',
+      placeholder: 'https://gitlab.com',
+      sensitive: false,
+      required: false,
+      url: true,
+      helpText:
+        'Leave blank to use GitLab.com. For a self-hosted instance, enter the base URL (https://gitlab.example.com).',
+    },
+    {
       key: 'clientId',
       label: 'Application ID',
       sensitive: false,
-      helpUrl: 'https://gitlab.com/-/user_settings/applications',
+      helpUrl: GITLAB_APP_DOCS,
+      helpText:
+        'Create an OAuth application on your GitLab instance and register the redirect URI shown above.',
     },
     {
       key: 'clientSecret',
       label: 'Secret',
       sensitive: true,
-      helpUrl: 'https://gitlab.com/-/user_settings/applications',
+      helpUrl: GITLAB_APP_DOCS,
     },
   ],
 }

--- a/apps/web/src/integrations/gitlab/server/oauth.ts
+++ b/apps/web/src/integrations/gitlab/server/oauth.ts
@@ -2,6 +2,12 @@
  * GitLab OAuth utilities.
  */
 
+import { GITLAB_COM_ORIGIN, normalizeGitLabInstanceUrl } from '@/integrations/gitlab/server/url'
+
+function instanceOrigin(credentials?: Record<string, string>): string {
+  return normalizeGitLabInstanceUrl(credentials?.instanceUrl)
+}
+
 /**
  * Generate the GitLab OAuth authorization URL.
  */
@@ -24,7 +30,7 @@ export function getGitLabOAuthUrl(
     scope: 'api',
   })
 
-  return `https://gitlab.com/oauth/authorize?${params}`
+  return `${instanceOrigin(credentials)}/oauth/authorize?${params}`
 }
 
 /**
@@ -48,7 +54,9 @@ export async function exchangeGitLabCode(
     throw new Error('GitLab credentials not configured')
   }
 
-  const response = await fetch('https://gitlab.com/oauth/token', {
+  const origin = instanceOrigin(credentials)
+
+  const response = await fetch(`${origin}/oauth/token`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -72,7 +80,7 @@ export async function exchangeGitLabCode(
   }
 
   // Fetch user info for workspace name
-  const userResponse = await fetch('https://gitlab.com/api/v4/user', {
+  const userResponse = await fetch(`${origin}/api/v4/user`, {
     headers: { Authorization: `Bearer ${data.access_token}` },
   })
 
@@ -86,6 +94,10 @@ export async function exchangeGitLabCode(
     expiresIn: data.expires_in,
     config: {
       workspaceName: user?.name || user?.username || 'GitLab',
+      // Persist the origin so hook / archive / project listing talk to the
+      // same instance without a credentials lookup. Omit when defaulting
+      // to gitlab.com so existing connections stay unchanged.
+      ...(origin !== GITLAB_COM_ORIGIN ? { instanceUrl: origin } : {}),
     },
   }
 }

--- a/apps/web/src/integrations/gitlab/server/oauth.ts
+++ b/apps/web/src/integrations/gitlab/server/oauth.ts
@@ -3,6 +3,7 @@
  */
 
 import { GITLAB_COM_ORIGIN, normalizeGitLabInstanceUrl } from '@/integrations/gitlab/server/url'
+import { gitlabFetch } from '@/integrations/gitlab/server/fetch'
 
 function instanceOrigin(credentials?: Record<string, string>): string {
   return normalizeGitLabInstanceUrl(credentials?.instanceUrl)
@@ -56,7 +57,7 @@ export async function exchangeGitLabCode(
 
   const origin = instanceOrigin(credentials)
 
-  const response = await fetch(`${origin}/oauth/token`, {
+  const response = await gitlabFetch(`${origin}/oauth/token`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -80,7 +81,7 @@ export async function exchangeGitLabCode(
   }
 
   // Fetch user info for workspace name
-  const userResponse = await fetch(`${origin}/api/v4/user`, {
+  const userResponse = await gitlabFetch(`${origin}/api/v4/user`, {
     headers: { Authorization: `Bearer ${data.access_token}` },
   })
 

--- a/apps/web/src/integrations/gitlab/server/projects.ts
+++ b/apps/web/src/integrations/gitlab/server/projects.ts
@@ -3,6 +3,7 @@
  */
 
 import { gitlabApiBase } from '@/integrations/gitlab/server/url'
+import { gitlabFetch } from '@/integrations/gitlab/server/fetch'
 
 /**
  * List projects accessible to the authenticated user.
@@ -11,7 +12,7 @@ export async function listGitLabProjects(
   accessToken: string,
   instanceUrl?: string | null
 ): Promise<Array<{ id: string; name: string }>> {
-  const response = await fetch(
+  const response = await gitlabFetch(
     `${gitlabApiBase(instanceUrl)}/projects?membership=true&order_by=last_activity_at&sort=desc&per_page=100`,
     {
       headers: { Authorization: `Bearer ${accessToken}` },

--- a/apps/web/src/integrations/gitlab/server/projects.ts
+++ b/apps/web/src/integrations/gitlab/server/projects.ts
@@ -2,16 +2,17 @@
  * GitLab project listing.
  */
 
-const GITLAB_API = 'https://gitlab.com/api/v4'
+import { gitlabApiBase } from '@/integrations/gitlab/server/url'
 
 /**
  * List projects accessible to the authenticated user.
  */
 export async function listGitLabProjects(
-  accessToken: string
+  accessToken: string,
+  instanceUrl?: string | null
 ): Promise<Array<{ id: string; name: string }>> {
   const response = await fetch(
-    `${GITLAB_API}/projects?membership=true&order_by=last_activity_at&sort=desc&per_page=100`,
+    `${gitlabApiBase(instanceUrl)}/projects?membership=true&order_by=last_activity_at&sort=desc&per_page=100`,
     {
       headers: { Authorization: `Bearer ${accessToken}` },
     }

--- a/apps/web/src/integrations/gitlab/server/url.ts
+++ b/apps/web/src/integrations/gitlab/server/url.ts
@@ -1,0 +1,59 @@
+/**
+ * GitLab instance URL helpers.
+ *
+ * Platform credentials may include an optional `instanceUrl`. When it is
+ * omitted, every GitLab call site uses gitlab.com — the historical default.
+ * A provided value is reduced to its origin so a trailing slash or path
+ * cannot change which host we talk to.
+ */
+
+export const GITLAB_COM_ORIGIN = 'https://gitlab.com'
+
+export class GitLabInstanceUrlError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'GitLabInstanceUrlError'
+  }
+}
+
+/**
+ * Normalize a GitLab instance URL to its origin.
+ * Empty / missing values resolve to gitlab.com so existing connections
+ * keep working. Rejects credentials, non-http(s) schemes, and unparseable
+ * strings — the same class of unsafe URLs sibling integrations refuse.
+ */
+export function normalizeGitLabInstanceUrl(raw?: string | null): string {
+  const trimmed = raw?.trim()
+  if (!trimmed) return GITLAB_COM_ORIGIN
+
+  let parsed: URL
+  try {
+    parsed = new URL(trimmed)
+  } catch {
+    throw new GitLabInstanceUrlError('GitLab instance URL must be a valid URL')
+  }
+
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    throw new GitLabInstanceUrlError('GitLab instance URL must be an http(s) URL')
+  }
+  if (parsed.username || parsed.password) {
+    throw new GitLabInstanceUrlError('GitLab instance URL must not include credentials')
+  }
+
+  return parsed.origin
+}
+
+/** REST API root for the given instance (`{origin}/api/v4`). */
+export function gitlabApiBase(instanceUrl?: string | null): string {
+  return `${normalizeGitLabInstanceUrl(instanceUrl)}/api/v4`
+}
+
+/**
+ * Project path from a GitLab issue web URL.
+ * Accepts both `/{path}/-/issues/{iid}` (current) and `/{path}/issues/{iid}`.
+ */
+export function extractGitLabProjectPath(url?: string | null): string | null {
+  if (!url) return null
+  const match = url.match(/https?:\/\/[^/]+\/(.+?)\/(?:-\/)?issues(?:\/|$|\?)/)
+  return match?.[1] ?? null
+}

--- a/apps/web/src/integrations/gitlab/ui/gitlab-config.tsx
+++ b/apps/web/src/integrations/gitlab/ui/gitlab-config.tsx
@@ -221,6 +221,7 @@ export function GitLabConfig({
         config={initialConfig}
         enabled={integrationEnabled}
         externalStatuses={externalStatuses}
+        isManual
       />
 
       <TicketStatusSyncConfig

--- a/apps/web/src/lib/server/domains/platform-credentials/__tests__/credential-source.test.ts
+++ b/apps/web/src/lib/server/domains/platform-credentials/__tests__/credential-source.test.ts
@@ -3,9 +3,10 @@
  *
  * EnvCredentialSource is the cloud path: shared OAuth-app credentials arrive as
  * INTEGRATION_<PROVIDER>_<FIELD> env (projected from OpenBao via ESO). It reports an
- * integration as configured only when EVERY field the provider declares is present
- * (fail closed), matching the DB write validation. Pure (env in, record out), so it
- * is tested with real code and injected env / known types / required fields.
+ * integration as configured only when every *required* field the provider declares
+ * is present (fail closed), matching the DB write validation. Optional fields may
+ * be absent. Pure (env in, record out), so it is tested with real code and injected
+ * env / known types / required / declared fields.
  */
 
 import { describe, it, expect } from 'vitest'
@@ -112,6 +113,43 @@ describe('EnvCredentialSource', () => {
         INTEGRATION_SLACK_SIGNING_SECRET: 'sig',
       }).get('slack')
     ).toBeNull()
+  })
+
+  it('get() includes an optional field when present and stays configured without it', async () => {
+    const required = async () => ['clientId', 'clientSecret']
+    const declared = async () => ['clientId', 'clientSecret', 'instanceUrl']
+    const known = async () => ['gitlab']
+
+    const withUrl = new EnvCredentialSource(
+      {
+        INTEGRATION_GITLAB_CLIENT_ID: 'id',
+        INTEGRATION_GITLAB_CLIENT_SECRET: 'sec',
+        INTEGRATION_GITLAB_INSTANCE_URL: 'https://gitlab.example.com',
+      },
+      known,
+      required,
+      declared
+    )
+    expect(await withUrl.get('gitlab')).toEqual({
+      clientId: 'id',
+      clientSecret: 'sec',
+      instanceUrl: 'https://gitlab.example.com',
+    })
+
+    const withoutUrl = new EnvCredentialSource(
+      {
+        INTEGRATION_GITLAB_CLIENT_ID: 'id',
+        INTEGRATION_GITLAB_CLIENT_SECRET: 'sec',
+      },
+      known,
+      required,
+      declared
+    )
+    expect(await withoutUrl.get('gitlab')).toEqual({
+      clientId: 'id',
+      clientSecret: 'sec',
+    })
+    expect(await withoutUrl.has('gitlab')).toBe(true)
   })
 
   it('get() returns only declared fields, dropping undeclared INTEGRATION_ vars', async () => {

--- a/apps/web/src/lib/server/domains/platform-credentials/credential-source.ts
+++ b/apps/web/src/lib/server/domains/platform-credentials/credential-source.ts
@@ -82,8 +82,19 @@ async function defaultKnownTypes(): Promise<string[]> {
   return listIntegrationTypes()
 }
 
-/** The platform-credential field keys a provider declares (all are required). */
+/** Declared field keys that must be present for the provider to count as configured. */
 async function defaultRequiredFields(integrationType: string): Promise<string[]> {
+  const mod = await import('@/lib/server/integrations')
+  return (
+    mod
+      .getIntegration?.(integrationType)
+      ?.platformCredentials?.filter((f) => f.required !== false)
+      .map((f) => f.key) ?? []
+  )
+}
+
+/** Every declared field key, including optional ones (e.g. GitLab instanceUrl). */
+async function defaultDeclaredFields(integrationType: string): Promise<string[]> {
   const mod = await import('@/lib/server/integrations')
   return mod.getIntegration?.(integrationType)?.platformCredentials?.map((f) => f.key) ?? []
 }
@@ -92,21 +103,35 @@ async function defaultRequiredFields(integrationType: string): Promise<string[]>
  * Managed-cloud source: shared OAuth-app credentials from
  * INTEGRATION_<PROVIDER>_<FIELD> env (projected from OpenBao via ESO).
  *
- * Reports an integration as configured only when EVERY field the provider declares
- * in `platformCredentials` is present (fail closed) — matching the DB write
- * validation in functions/platform-credentials.ts. This prevents a partially
- * populated OpenBao path from looking configured and then failing mid-OAuth (e.g.
- * clientId present but clientSecret/signingSecret missing).
+ * Reports an integration as configured only when every *required* field the
+ * provider declares in `platformCredentials` is present (fail closed) —
+ * matching the DB write validation in functions/platform-credentials.ts.
+ * Optional fields (required: false) may be absent; when present they are
+ * returned. This prevents a partially populated OpenBao path from looking
+ * configured and then failing mid-OAuth (e.g. clientId present but
+ * clientSecret/signingSecret missing), without forcing optional instance
+ * URLs to be set for gitlab.com.
  *
- * `env`, `knownTypes` and `requiredFields` are injectable for testing; in production
- * they default to process.env and the integration registry.
+ * `env`, `knownTypes`, `requiredFields`, and `declaredFields` are injectable
+ * for testing; in production they default to process.env and the registry.
  */
 export class EnvCredentialSource implements CredentialSource {
+  private readonly declaredFields: (type: string) => Promise<string[]>
+
   constructor(
     private readonly env: Record<string, string | undefined> = process.env,
     private readonly knownTypes: () => Promise<string[]> = defaultKnownTypes,
-    private readonly requiredFields: (type: string) => Promise<string[]> = defaultRequiredFields
-  ) {}
+    private readonly requiredFields: (type: string) => Promise<string[]> = defaultRequiredFields,
+    declaredFields?: (type: string) => Promise<string[]>
+  ) {
+    // Tests that only inject requiredFields keep the previous "required ===
+    // declared" behaviour. Production (`new EnvCredentialSource()`) uses
+    // both registry defaults so optional fields are returned when present
+    // without being demanded.
+    this.declaredFields =
+      declaredFields ??
+      (requiredFields === defaultRequiredFields ? defaultDeclaredFields : requiredFields)
+  }
 
   private read(integrationType: string): Record<string, string> {
     const prefix = envPrefix(integrationType)
@@ -122,19 +147,25 @@ export class EnvCredentialSource implements CredentialSource {
     return out
   }
 
-  /** The creds for a type, or null unless every declared field is present (fail closed). */
+  /** The creds for a type, or null unless every required field is present (fail closed). */
   private async complete(integrationType: string): Promise<Record<string, string> | null> {
     const required = await this.requiredFields(integrationType)
+    const declared = await this.declaredFields(integrationType)
     // A provider that declares no platform-credential fields is not configurable via
     // env — return null rather than reporting it configured off a stray INTEGRATION_* var.
+    if (declared.length === 0 && required.length === 0) return null
+    // Configurable providers must have at least one required field; an all-optional
+    // declaration would otherwise look configured with an empty object.
     if (required.length === 0) return null
     const creds = this.read(integrationType)
     // Return ONLY the declared fields (like the DB save path, which strips extras), so
     // an undeclared INTEGRATION_<TYPE>_* var can never leak through the masked admin API.
     const out: Record<string, string> = {}
+    for (const key of declared) {
+      if (creds[key]) out[key] = creds[key]
+    }
     for (const key of required) {
-      if (!creds[key]) return null
-      out[key] = creds[key]
+      if (!out[key]) return null
     }
     return out
   }

--- a/apps/web/src/lib/server/domains/platform-credentials/platform-schema.ts
+++ b/apps/web/src/lib/server/domains/platform-credentials/platform-schema.ts
@@ -8,10 +8,11 @@
  *    is `env`, `EnvCredentialSource` reads those fields from
  *    `INTEGRATION_<TYPE>_<FIELD>` variables instead of the database, so whatever
  *    populates that environment needs the field list and the exact variable
- *    names, and needs them without importing this code. Every declared field is
- *    required: `EnvCredentialSource` reports a provider as configured only when
- *    all of them are present, so a partial population reads as unconfigured and
+ *    names, and needs them without importing this code. Required fields must
+ *    all be present: `EnvCredentialSource` reports a provider as configured
+ *    only when they are, so a partial population reads as unconfigured and
  *    the provider disappears from the catalog rather than half working.
+ *    Optional fields (`required: false`) may be absent.
  * 2. AI configuration keys, taken from the explicit env mapping in
  *    `src/lib/server/config.ts`.
  *
@@ -89,6 +90,10 @@ export interface PlatformFieldSchema {
   placeholder?: string
   helpText?: string
   helpUrl?: string
+  /** false when the field may be omitted. Omitted means required. */
+  required?: boolean
+  /** true when the value is a URL the server will fetch (SSRF-checked at save). */
+  url?: boolean
 }
 
 export interface PlatformProviderSchema {
@@ -271,6 +276,8 @@ function toFieldSchema(id: string, field: PlatformCredentialField): PlatformFiel
     ...(field.placeholder === undefined ? {} : { placeholder: field.placeholder }),
     ...(field.helpText === undefined ? {} : { helpText: field.helpText }),
     ...(field.helpUrl === undefined ? {} : { helpUrl: field.helpUrl }),
+    ...(field.required === false ? { required: false } : {}),
+    ...(field.url ? { url: true } : {}),
   }
 }
 

--- a/apps/web/src/lib/server/functions/__tests__/platform-credentials-ssrf.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/platform-credentials-ssrf.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const hoisted = vi.hoisted(() => ({
+  mockSavePlatformCredentials: vi.fn(async () => undefined),
+  mockGetTierLimits: vi.fn(),
+  mockCheckUrlSafety: vi.fn(),
+  mockGetIntegration: vi.fn(),
+}))
+
+vi.mock('../auth-helpers', () => ({
+  requireAuth: vi.fn(async () => ({ principal: { id: 'principal_admin' } })),
+}))
+vi.mock('@/lib/server/domains/platform-credentials/platform-credential.service', () => ({
+  savePlatformCredentials: hoisted.mockSavePlatformCredentials,
+  deletePlatformCredentials: vi.fn(),
+  getPlatformCredentials: vi.fn(),
+  arePlatformCredentialsManaged: vi.fn(() => false),
+}))
+vi.mock('@/lib/server/domains/settings/tier-limits.service', () => ({
+  getTierLimits: hoisted.mockGetTierLimits,
+}))
+vi.mock('@/lib/server/integrations', () => ({
+  getIntegration: (...args: unknown[]) => hoisted.mockGetIntegration(...args),
+}))
+vi.mock('@/lib/server/content/ssrf-guard', () => ({
+  checkUrlSafety: (...args: unknown[]) => hoisted.mockCheckUrlSafety(...args),
+}))
+
+import { OSS_TIER_LIMITS } from '@/lib/server/domains/settings/tier-limits.types'
+import { savePlatformCredentialsFn } from '../platform-credentials'
+
+const gitlabFields = [
+  {
+    key: 'instanceUrl',
+    label: 'GitLab instance URL',
+    sensitive: false,
+    required: false,
+    url: true,
+  },
+  { key: 'clientId', label: 'Application ID', sensitive: false },
+  { key: 'clientSecret', label: 'Secret', sensitive: true },
+]
+
+describe('savePlatformCredentialsFn — SSRF URL guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    hoisted.mockGetTierLimits.mockResolvedValue(OSS_TIER_LIMITS)
+    hoisted.mockGetIntegration.mockReturnValue({ platformCredentials: gitlabFields })
+  })
+
+  it('rejects an instance URL that fails the SSRF guard, before storing', async () => {
+    hoisted.mockCheckUrlSafety.mockResolvedValue({ safe: false, reason: 'ssrf-rejected' })
+
+    await expect(
+      savePlatformCredentialsFn({
+        data: {
+          integrationType: 'gitlab',
+          credentials: {
+            clientId: 'id',
+            clientSecret: 'secret',
+            instanceUrl: 'http://169.254.169.254',
+          },
+        },
+      })
+    ).rejects.toThrow(/valid public URL/i)
+
+    expect(hoisted.mockCheckUrlSafety).toHaveBeenCalledWith('http://169.254.169.254')
+    expect(hoisted.mockSavePlatformCredentials).not.toHaveBeenCalled()
+  })
+
+  it('rejects a non-http(s) instance URL', async () => {
+    hoisted.mockCheckUrlSafety.mockResolvedValue({ safe: false, reason: 'scheme-rejected' })
+
+    await expect(
+      savePlatformCredentialsFn({
+        data: {
+          integrationType: 'gitlab',
+          credentials: {
+            clientId: 'id',
+            clientSecret: 'secret',
+            instanceUrl: 'javascript:alert(1)',
+          },
+        },
+      })
+    ).rejects.toThrow(/valid public URL/i)
+
+    expect(hoisted.mockSavePlatformCredentials).not.toHaveBeenCalled()
+  })
+
+  it('stores a custom HTTPS instance URL when the guard passes', async () => {
+    hoisted.mockCheckUrlSafety.mockResolvedValue({ safe: true, address: '203.0.113.7', family: 4 })
+
+    await savePlatformCredentialsFn({
+      data: {
+        integrationType: 'gitlab',
+        credentials: {
+          clientId: 'id',
+          clientSecret: 'secret',
+          instanceUrl: 'https://gitlab.example.com/',
+        },
+      },
+    })
+
+    expect(hoisted.mockCheckUrlSafety).toHaveBeenCalledWith('https://gitlab.example.com/')
+    expect(hoisted.mockSavePlatformCredentials).toHaveBeenCalledWith(
+      expect.objectContaining({
+        credentials: {
+          clientId: 'id',
+          clientSecret: 'secret',
+          instanceUrl: 'https://gitlab.example.com/',
+        },
+      })
+    )
+  })
+
+  it('allows omitting the optional instance URL and skips the guard', async () => {
+    await savePlatformCredentialsFn({
+      data: {
+        integrationType: 'gitlab',
+        credentials: { clientId: 'id', clientSecret: 'secret' },
+      },
+    })
+
+    expect(hoisted.mockCheckUrlSafety).not.toHaveBeenCalled()
+    expect(hoisted.mockSavePlatformCredentials).toHaveBeenCalledWith(
+      expect.objectContaining({
+        credentials: { clientId: 'id', clientSecret: 'secret' },
+      })
+    )
+  })
+
+  it('skips the guard for integrations with no URL fields', async () => {
+    hoisted.mockGetIntegration.mockReturnValue({
+      platformCredentials: [
+        { key: 'clientId', label: 'Client ID', sensitive: false },
+        { key: 'clientSecret', label: 'Client Secret', sensitive: true },
+      ],
+    })
+
+    await savePlatformCredentialsFn({
+      data: {
+        integrationType: 'github',
+        credentials: { clientId: 'g', clientSecret: 'g' },
+      },
+    })
+
+    expect(hoisted.mockCheckUrlSafety).not.toHaveBeenCalled()
+    expect(hoisted.mockSavePlatformCredentials).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/src/lib/server/functions/__tests__/platform-credentials-tier-gate.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/platform-credentials-tier-gate.test.ts
@@ -30,6 +30,12 @@ vi.mock('@/lib/server/domains/settings/tier-limits.service', () => ({
   getTierLimits: hoisted.mockGetTierLimits,
 }))
 
+// The save path SSRF-validates url:true fields; this suite has none, but
+// keep it off real DNS the same way the auth-provider tier gate does.
+vi.mock('@/lib/server/content/ssrf-guard', () => ({
+  checkUrlSafety: vi.fn(async () => ({ safe: true, address: '93.184.216.34', family: 4 })),
+}))
+
 import { OSS_TIER_LIMITS } from '@/lib/server/domains/settings/tier-limits.types'
 import { savePlatformCredentialsFn } from '../platform-credentials'
 

--- a/apps/web/src/lib/server/functions/platform-credentials.ts
+++ b/apps/web/src/lib/server/functions/platform-credentials.ts
@@ -50,19 +50,37 @@ export const savePlatformCredentialsFn = createServerFn({ method: 'POST' })
       throw new Error(`Unknown integration type: ${data.integrationType}`)
     }
 
-    const requiredFields = definition.platformCredentials
-    for (const field of requiredFields) {
+    for (const field of definition.platformCredentials) {
+      if (field.required === false) continue
       if (!data.credentials[field.key]?.trim()) {
         throw new Error(`${field.label} is required`)
       }
     }
 
-    // Strip any extra keys not defined in platformCredentials
+    // Strip any extra keys not defined in platformCredentials. Optional
+    // fields that are blank are dropped so an omitted instance URL keeps
+    // the gitlab.com default rather than storing an empty string.
     const allowedKeys = new Set(definition.platformCredentials.map((f) => f.key))
     const cleaned: Record<string, string> = {}
     for (const [key, value] of Object.entries(data.credentials)) {
-      if (allowedKeys.has(key)) {
-        cleaned[key] = value.trim()
+      if (!allowedKeys.has(key)) continue
+      const trimmed = value.trim()
+      if (!trimmed) continue
+      cleaned[key] = trimmed
+    }
+
+    // SSRF defense: any URL the server will later fetch (e.g. a self-hosted
+    // GitLab instance) must not resolve to internal infrastructure. Validate
+    // at save so a poisoned URL is never stored — same guard as auth-provider
+    // URL fields.
+    const { checkUrlSafety } = await import('@/lib/server/content/ssrf-guard')
+    for (const field of definition.platformCredentials) {
+      if (!field.url) continue
+      const value = cleaned[field.key]
+      if (!value) continue
+      const verdict = await checkUrlSafety(value)
+      if (!verdict.safe) {
+        throw new Error(`${field.label} must be a valid public URL`)
       }
     }
 

--- a/apps/web/src/lib/server/integrations/__tests__/archive.test.ts
+++ b/apps/web/src/lib/server/integrations/__tests__/archive.test.ts
@@ -196,6 +196,24 @@ describe('gitlab close', () => {
     expect(result.success).toBe(false)
     expect(result.error).toContain('Cannot determine project')
   })
+
+  it('closes the issue on a custom HTTPS instance', async () => {
+    const fetchMock = mockFetch(200)
+    vi.stubGlobal('fetch', fetchMock)
+
+    await archiveExternalIssue(
+      'gitlab',
+      glCtx({
+        externalUrl: 'https://gitlab.example.com/my-org/my-project/-/issues/7',
+        integrationConfig: { instanceUrl: 'https://gitlab.example.com' },
+      })
+    )
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://gitlab.example.com/api/v4/projects/my-org%2Fmy-project/issues/7',
+      expect.objectContaining({ method: 'PUT' })
+    )
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/lib/server/integrations/__tests__/archive.test.ts
+++ b/apps/web/src/lib/server/integrations/__tests__/archive.test.ts
@@ -5,6 +5,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { archiveExternalIssue, type ArchiveContext } from '../archive'
 
+// GitLab requests go through the SSRF guard; route them to the stubbed global
+// fetch so the assertions below see the same calls.
+vi.mock('@/lib/server/content/ssrf-guard', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/server/content/ssrf-guard')>()),
+  safeFetch: (url: string, init?: RequestInit) => globalThis.fetch(url, init),
+}))
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------

--- a/apps/web/src/lib/server/integrations/types.ts
+++ b/apps/web/src/lib/server/integrations/types.ts
@@ -38,6 +38,8 @@ export interface PlatformCredentialField {
   /** true → the value is a URL the server will fetch; validated against the
    *  SSRF guard at save so an admin can't point it at internal infrastructure. */
   url?: boolean
+  /** false → the field may be omitted (empty). Defaults to required. */
+  required?: boolean
 }
 
 export interface IntegrationOAuthConfig {

--- a/apps/web/src/lib/shared/platform-schema.generated.json
+++ b/apps/web/src/lib/shared/platform-schema.generated.json
@@ -250,18 +250,29 @@
       "envPrefix": "INTEGRATION_GITLAB_",
       "fields": [
         {
+          "key": "instanceUrl",
+          "envKey": "INTEGRATION_GITLAB_INSTANCE_URL",
+          "label": "GitLab instance URL",
+          "sensitive": false,
+          "placeholder": "https://gitlab.com",
+          "helpText": "Leave blank to use GitLab.com. For a self-hosted instance, enter the base URL (https://gitlab.example.com).",
+          "required": false,
+          "url": true
+        },
+        {
           "key": "clientId",
           "envKey": "INTEGRATION_GITLAB_CLIENT_ID",
           "label": "Application ID",
           "sensitive": false,
-          "helpUrl": "https://gitlab.com/-/user_settings/applications"
+          "helpText": "Create an OAuth application on your GitLab instance and register the redirect URI shown above.",
+          "helpUrl": "https://docs.gitlab.com/integration/oauth_provider.html"
         },
         {
           "key": "clientSecret",
           "envKey": "INTEGRATION_GITLAB_CLIENT_SECRET",
           "label": "Secret",
           "sensitive": true,
-          "helpUrl": "https://gitlab.com/-/user_settings/applications"
+          "helpUrl": "https://docs.gitlab.com/integration/oauth_provider.html"
         }
       ]
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/QuackbackIO/quackback/issues/349

## Problem

The GitLab **issue-sync** integration (not GitLab sign-in/SSO) always sent OAuth and API traffic to `gitlab.com`. Admins could only enter Application ID and Secret — there was no instance URL — so self-hosted two-way issue/status sync was unusable.

## Solution

Admins set an optional **GitLab instance URL** using the same platform-credential pattern as other integrations (`url: true`, SSRF-checked at save, and every GitLab request — OAuth, project listing, issue create/close, connection test — goes through `safeFetch`, which revalidates per call, connects to the validated IP and never follows redirects). When the field is omitted, behaviour stays on gitlab.com so existing connections keep working.

That origin is used for:

- OAuth authorize and token exchange
- REST API (project listing, issue create, connection test)
- Archive/close of linked issues
- Persist-on-connect so hooks keep talking to the same instance

Redirect/callback copy in Connect UI now tells admins to register `{Quackback}/oauth/gitlab/callback` on their GitLab OAuth application (GitLab.com or self-hosted). Application ID and Secret remain required.

[GitLab credentials dialog with optional instance URL](https://cursor.com/agents/bc-559c427e-3af0-4828-9bbb-4e9055dd8706/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgitlab_credentials_dialog_custom_url.webp)

[gitlab_credentials_dialog_self_hosted.mp4](https://cursor.com/agents/bc-559c427e-3af0-4828-9bbb-4e9055dd8706/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgitlab_credentials_dialog_self_hosted.mp4)

## Tests

- Default gitlab.com when the URL is omitted
- Custom HTTPS instance origin for OAuth, API, hook, archive, and project listing
- Rejection of unsafe URLs (non-http(s), credentials, SSRF-blocked addresses), consistent with other `url: true` credential fields
- Optional env-sourced `INTEGRATION_GITLAB_INSTANCE_URL` does not unconfigure gitlab.com

78 related unit tests passed locally.

## Out of scope

GitLab sign-in/SSO already has an Issuer URL and is unchanged. No billing, production, or unrelated feature changes.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-559c427e-3af0-4828-9bbb-4e9055dd8706?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-559c427e-3af0-4828-9bbb-4e9055dd8706&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


