### PR TITLE
fix(widget): make the shell's tab bar, Escape key and view focus accessible

### DIFF
--- a/apps/web/src/components/ui/mention-extension.ts
+++ b/apps/web/src/components/ui/mention-extension.ts
@@ -5,6 +5,7 @@ import { ReactRenderer } from '@tiptap/react'
 import tippy, { type Instance } from 'tippy.js'
 import 'tippy.js/dist/tippy.css'
 import { MentionPicker, type MentionItem, type MentionPickerHandle } from './mention-picker'
+import { markSuggestionPopup } from './suggestion-popup'
 
 const DEBOUNCE_MS = 200
 
@@ -47,7 +48,7 @@ const renderSuggestion: SuggestionOptions<MentionItem>['render'] = () => {
       popup = tippy(document.body, {
         getReferenceClientRect: () => props.clientRect?.() ?? new DOMRect(),
         appendTo: () => document.body,
-        content: component.element,
+        content: markSuggestionPopup(component.element),
         showOnCreate: true,
         interactive: true,
         trigger: 'manual',

--- a/apps/web/src/components/ui/rich-text-editor.tsx
+++ b/apps/web/src/components/ui/rich-text-editor.tsx
@@ -22,6 +22,7 @@ import TableHeader from '@tiptap/extension-table-header'
 import Youtube from '@tiptap/extension-youtube'
 import { Emoji } from '@tiptap/extension-emoji'
 import { MentionExtension } from './mention-extension'
+import { createSuggestionPopup } from './suggestion-popup'
 import { QuackbackEmbed } from './quackback-embed-extension'
 import { ConversationImage } from './conversation-image-node'
 import { Markdown } from '@tiptap/markdown'
@@ -882,10 +883,7 @@ function createSlashCommands(
                 })
 
                 // Create container element
-                floatingEl = document.createElement('div')
-                floatingEl.style.position = 'fixed'
-                floatingEl.style.zIndex = '50'
-                floatingEl.style.pointerEvents = 'auto'
+                floatingEl = createSuggestionPopup()
                 floatingEl.appendChild(component.element)
                 document.body.appendChild(floatingEl)
 
@@ -1100,10 +1098,7 @@ export function createEmojiExtension() {
               },
               editor: props.editor,
             })
-            floatingEl = document.createElement('div')
-            floatingEl.style.position = 'fixed'
-            floatingEl.style.zIndex = '50'
-            floatingEl.style.pointerEvents = 'auto'
+            floatingEl = createSuggestionPopup()
             floatingEl.appendChild(component.element)
             document.body.appendChild(floatingEl)
             updatePosition(props.clientRect ?? null)
@@ -1128,10 +1123,7 @@ export function createEmojiExtension() {
                 },
                 editor: props.editor,
               })
-              floatingEl = document.createElement('div')
-              floatingEl.style.position = 'fixed'
-              floatingEl.style.zIndex = '50'
-              floatingEl.style.pointerEvents = 'auto'
+              floatingEl = createSuggestionPopup()
               floatingEl.appendChild(component.element)
               document.body.appendChild(floatingEl)
             } else {

--- a/apps/web/src/components/ui/suggestion-popup.ts
+++ b/apps/web/src/components/ui/suggestion-popup.ts
@@ -1,0 +1,23 @@
+// Editor suggestion popups (slash menu, emoji, mention) are portalled to
+// <body>, outside the editor DOM. They carry this attribute so code that
+// only sees the document — e.g. a global Escape handler — can tell whether
+// a keypress was spent dismissing one.
+export const SUGGESTION_POPUP_ATTR = 'data-editor-suggestion'
+
+export function markSuggestionPopup<T extends Element>(el: T): T {
+  el.setAttribute(SUGGESTION_POPUP_ATTR, '')
+  return el
+}
+
+/** Fixed, body-level container for a suggestion list positioned by clientRect. */
+export function createSuggestionPopup(): HTMLDivElement {
+  const el = document.createElement('div')
+  el.style.position = 'fixed'
+  el.style.zIndex = '50'
+  el.style.pointerEvents = 'auto'
+  return markSuggestionPopup(el)
+}
+
+export function hasOpenSuggestionPopup(): boolean {
+  return document.querySelector(`[${SUGGESTION_POPUP_ATTR}]`) !== null
+}

--- a/apps/web/src/components/ui/suggestion-popup.ts
+++ b/apps/web/src/components/ui/suggestion-popup.ts
@@ -18,6 +18,18 @@ export function createSuggestionPopup(): HTMLDivElement {
   return markSuggestionPopup(el)
 }
 
+/**
+ * True when a suggestion popup is actually showing. Presence in the DOM is
+ * not enough: the mention popup is a tippy instance whose `hide()` can leave
+ * the marked element mounted (hidden) for a beat, and any renderer may keep
+ * a hidden element around — a stale marker would make every Escape look like
+ * a dismissal and trap focus in the composer.
+ */
 export function hasOpenSuggestionPopup(): boolean {
-  return document.querySelector(`[${SUGGESTION_POPUP_ATTR}]`) !== null
+  const popups = document.querySelectorAll<HTMLElement>(`[${SUGGESTION_POPUP_ATTR}]`)
+  return Array.from(popups).some((el) =>
+    typeof el.checkVisibility === 'function'
+      ? el.checkVisibility({ visibilityProperty: true, opacityProperty: true })
+      : el.getClientRects().length > 0
+  )
 }

--- a/apps/web/src/components/widget/widget-overview.tsx
+++ b/apps/web/src/components/widget/widget-overview.tsx
@@ -249,7 +249,14 @@ export function WidgetOverview({
               </span>
               <MagnifyingGlassIcon className="w-4 h-4 text-muted-foreground" />
             </button>
-            <ul className="mt-1">
+            {/* Eyebrow so the list reads as content, not as part of the search control. */}
+            <p className="mt-2 px-3 text-[11px] font-medium uppercase tracking-wide text-muted-foreground/60">
+              <FormattedMessage
+                id="widget.launcher.popularArticles"
+                defaultMessage="Popular articles"
+              />
+            </p>
+            <ul className="mt-0.5">
               {topArticles.map((a) => (
                 <li key={a.slug}>
                   <button

--- a/apps/web/src/components/widget/widget-shell.tsx
+++ b/apps/web/src/components/widget/widget-shell.tsx
@@ -23,6 +23,7 @@ import { useWidgetAuth } from './widget-auth-provider'
 import { useMessengerUnread } from './use-messenger-unread'
 import { useChangelogUnread } from './use-changelog-unread'
 import { useTicketStageBadge } from './use-ticket-stage-badge'
+import { hasOpenSuggestionPopup } from '@/components/ui/suggestion-popup'
 
 import { type WidgetTab, type EnabledTabs, visibleTabsForVisitor } from './widget-nav'
 export type { WidgetTab }
@@ -194,18 +195,23 @@ export function WidgetShell({
   // key. A focused field (search box, composer) gets the first press: it
   // either handles it itself (and preventDefaults) or is blurred, so a second
   // press closes. Popovers (Radix Select, menus) preventDefault on dismiss;
-  // that runs in a listener registered after ours, so the check is deferred
-  // to a microtask, after the whole dispatch has finished.
+  // that runs in the target phase, after this capture listener, so the check
+  // is deferred to a microtask, after the whole dispatch has finished.
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       if (e.key !== 'Escape') return
+      // Captured before the editor runs: dismissing a slash / emoji / mention
+      // popup removes it from the DOM synchronously, so by the microtask it
+      // is already gone.
+      const suggestionWasOpen = hasOpenSuggestionPopup()
       queueMicrotask(() => {
         const target = e.target instanceof HTMLElement ? e.target : null
-        // ProseMirror swallows Escape (preventDefault) without doing anything
-        // visible outside a suggestion popup, so the composer would otherwise
-        // trap the key: blur it regardless, and let the next press close.
         if (target?.isContentEditable) {
-          target.blur()
+          // The press was spent closing a suggestion popup: keep the draft
+          // focused. Otherwise ProseMirror swallows Escape (preventDefault)
+          // without doing anything visible, so the composer would trap the
+          // key: blur it and let the next press close.
+          if (!suggestionWasOpen) target.blur()
           return
         }
         if (e.defaultPrevented) return
@@ -216,8 +222,8 @@ export function WidgetShell({
         closeWidget()
       })
     }
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
+    document.addEventListener('keydown', handleKeyDown, true)
+    return () => document.removeEventListener('keydown', handleKeyDown, true)
   }, [closeWidget])
 
   // "Go to portal" CTA — shown only when ALL three conditions hold:

--- a/apps/web/src/components/widget/widget-shell.tsx
+++ b/apps/web/src/components/widget/widget-shell.tsx
@@ -190,12 +190,31 @@ export function WidgetShell({
 
   const onHome = activeTab === 'home' && !onBack
 
-  // Global Escape key handler — close widget from anywhere
+  // Global Escape closes the widget — but only when nothing closer owns the
+  // key. A focused field (search box, composer) gets the first press: it
+  // either handles it itself (and preventDefaults) or is blurred, so a second
+  // press closes. Popovers (Radix Select, menus) preventDefault on dismiss;
+  // that runs in a listener registered after ours, so the check is deferred
+  // to a microtask, after the whole dispatch has finished.
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === 'Escape') {
+      if (e.key !== 'Escape') return
+      queueMicrotask(() => {
+        const target = e.target instanceof HTMLElement ? e.target : null
+        // ProseMirror swallows Escape (preventDefault) without doing anything
+        // visible outside a suggestion popup, so the composer would otherwise
+        // trap the key: blur it regardless, and let the next press close.
+        if (target?.isContentEditable) {
+          target.blur()
+          return
+        }
+        if (e.defaultPrevented) return
+        if (target?.closest('input, textarea, select, [role="dialog"]')) {
+          target.blur()
+          return
+        }
         closeWidget()
-      }
+      })
     }
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
@@ -376,20 +395,39 @@ export function WidgetShell({
                   const cfg = TAB_CONFIG.find((c) => c.tab === tab)
                   if (!cfg) return null
                   const Icon = cfg.icon
+                  const active = activeTab === tab
                   return (
+                    // The label stays foreground-coloured when active: `primary`
+                    // is the workspace brand colour, and a light brand (yellow,
+                    // lime) on the panel background fails text contrast. The
+                    // icon carries the tint; aria-current carries the state.
                     <button
                       key={tab}
                       type="button"
                       onClick={() => onTabChange(tab)}
+                      aria-current={active ? 'page' : undefined}
                       className={cn(
                         'flex-1 flex flex-col items-center gap-0.5 py-2 transition-colors',
-                        activeTab === tab
-                          ? 'text-primary'
+                        active
+                          ? 'text-foreground'
                           : 'text-muted-foreground/60 hover:text-muted-foreground'
                       )}
                     >
                       <div className="relative">
-                        <Icon className="w-5 h-5" />
+                        <Icon className={cn('w-5 h-5', active && 'text-primary')} />
+                        {tab === 'changelog' && changelogUnread > 0 && (
+                          <span
+                            className="absolute -top-0.5 -end-1 size-2 rounded-full bg-primary ring-2 ring-background"
+                            aria-label={intl.formatMessage(
+                              {
+                                id: 'widget.shell.tab.changelog.unread',
+                                defaultMessage:
+                                  '{count, plural, one {# new update} other {# new updates}}',
+                              },
+                              { count: changelogUnread }
+                            )}
+                          />
+                        )}
                         {tab === 'messages' && messengerUnread > 0 && (
                           <span
                             className="absolute -top-1 -end-1.5 flex h-[15px] min-w-[15px] items-center justify-center rounded-full bg-primary px-1 text-xs font-semibold leading-none text-primary-foreground"

--- a/apps/web/src/locales/ar.json
+++ b/apps/web/src/locales/ar.json
@@ -1162,5 +1162,7 @@
   "automation.builtinTools.default": "افتراضي",
   "automation.builtinTools.saving": "جارٍ الحفظ…",
   "automation.builtinTools.saveError": "تعذّر تحديث أذونات الأدوات.",
-  "automation.builtinTools.loadError": "تعذّر تحميل قائمة الأدوات."
+  "automation.builtinTools.loadError": "تعذّر تحميل قائمة الأدوات.",
+  "widget.shell.tab.changelog.unread": "{count, plural, one {تحديث جديد واحد} other {# تحديثات جديدة}}",
+  "widget.launcher.popularArticles": "مقالات شائعة"
 }

--- a/apps/web/src/locales/de.json
+++ b/apps/web/src/locales/de.json
@@ -1162,5 +1162,7 @@
   "automation.builtinTools.default": "Standard",
   "automation.builtinTools.saving": "Wird gespeichert…",
   "automation.builtinTools.saveError": "Werkzeugberechtigungen konnten nicht aktualisiert werden.",
-  "automation.builtinTools.loadError": "Werkzeugkatalog konnte nicht geladen werden."
+  "automation.builtinTools.loadError": "Werkzeugkatalog konnte nicht geladen werden.",
+  "widget.shell.tab.changelog.unread": "{count, plural, one {# neue Aktualisierung} other {# neue Aktualisierungen}}",
+  "widget.launcher.popularArticles": "Beliebte Artikel"
 }

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -1162,5 +1162,7 @@
   "automation.builtinTools.default": "Default",
   "automation.builtinTools.saving": "Saving…",
   "automation.builtinTools.saveError": "Tool permissions could not be updated.",
-  "automation.builtinTools.loadError": "Could not load the tool catalogue."
+  "automation.builtinTools.loadError": "Could not load the tool catalogue.",
+  "widget.shell.tab.changelog.unread": "{count, plural, one {# new update} other {# new updates}}",
+  "widget.launcher.popularArticles": "Popular articles"
 }

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -1162,5 +1162,7 @@
   "automation.builtinTools.default": "Predeterminado",
   "automation.builtinTools.saving": "Guardando…",
   "automation.builtinTools.saveError": "No se pudieron actualizar los permisos de la herramienta.",
-  "automation.builtinTools.loadError": "No se pudo cargar el catálogo de herramientas."
+  "automation.builtinTools.loadError": "No se pudo cargar el catálogo de herramientas.",
+  "widget.shell.tab.changelog.unread": "{count, plural, one {# novedad} other {# novedades}}",
+  "widget.launcher.popularArticles": "Artículos populares"
 }

--- a/apps/web/src/locales/fr.json
+++ b/apps/web/src/locales/fr.json
@@ -1162,5 +1162,7 @@
   "automation.builtinTools.default": "Par défaut",
   "automation.builtinTools.saving": "Enregistrement…",
   "automation.builtinTools.saveError": "Impossible de mettre à jour les autorisations de l’outil.",
-  "automation.builtinTools.loadError": "Impossible de charger le catalogue d’outils."
+  "automation.builtinTools.loadError": "Impossible de charger le catalogue d’outils.",
+  "widget.shell.tab.changelog.unread": "{count, plural, one {# nouvelle mise à jour} other {# nouvelles mises à jour}}",
+  "widget.launcher.popularArticles": "Articles populaires"
 }

--- a/apps/web/src/locales/pt-br.json
+++ b/apps/web/src/locales/pt-br.json
@@ -1162,5 +1162,7 @@
   "automation.builtinTools.default": "Padrão",
   "automation.builtinTools.saving": "Salvando…",
   "automation.builtinTools.saveError": "Não foi possível atualizar as permissões da ferramenta.",
-  "automation.builtinTools.loadError": "Não foi possível carregar o catálogo de ferramentas."
+  "automation.builtinTools.loadError": "Não foi possível carregar o catálogo de ferramentas.",
+  "widget.shell.tab.changelog.unread": "{count, plural, one {# nova atualização} other {# novas atualizações}}",
+  "widget.launcher.popularArticles": "Artigos populares"
 }

--- a/apps/web/src/locales/ru.json
+++ b/apps/web/src/locales/ru.json
@@ -1162,5 +1162,7 @@
   "automation.builtinTools.default": "По умолчанию",
   "automation.builtinTools.saving": "Сохранение…",
   "automation.builtinTools.saveError": "Не удалось обновить разрешения инструментов.",
-  "automation.builtinTools.loadError": "Не удалось загрузить каталог инструментов."
+  "automation.builtinTools.loadError": "Не удалось загрузить каталог инструментов.",
+  "widget.shell.tab.changelog.unread": "{count, plural, one {# новое обновление} few {# новых обновления} other {# новых обновлений}}",
+  "widget.launcher.popularArticles": "Популярные статьи"
 }

--- a/apps/web/src/locales/zh-cn.json
+++ b/apps/web/src/locales/zh-cn.json
@@ -1162,5 +1162,7 @@
   "automation.builtinTools.default": "默认",
   "automation.builtinTools.saving": "保存中…",
   "automation.builtinTools.saveError": "无法更新工具权限。",
-  "automation.builtinTools.loadError": "无法加载工具目录。"
+  "automation.builtinTools.loadError": "无法加载工具目录。",
+  "widget.shell.tab.changelog.unread": "{count, plural, other {# 条新动态}}",
+  "widget.launcher.popularArticles": "热门文章"
 }

--- a/apps/web/src/locales/zh-tw.json
+++ b/apps/web/src/locales/zh-tw.json
@@ -1162,5 +1162,7 @@
   "automation.builtinTools.default": "預設",
   "automation.builtinTools.saving": "儲存中…",
   "automation.builtinTools.saveError": "無法更新工具權限。",
-  "automation.builtinTools.loadError": "無法載入工具目錄。"
+  "automation.builtinTools.loadError": "無法載入工具目錄。",
+  "widget.shell.tab.changelog.unread": "{count, plural, other {# 則新動態}}",
+  "widget.launcher.popularArticles": "熱門文章"
 }

--- a/apps/web/src/routes/widget/index.tsx
+++ b/apps/web/src/routes/widget/index.tsx
@@ -1,7 +1,16 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { useQuery, keepPreviousData } from '@tanstack/react-query'
 import { z } from 'zod'
-import { lazy, Suspense, useState, useCallback, useEffect, useMemo, type ReactNode } from 'react'
+import {
+  lazy,
+  Suspense,
+  useState,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  type ReactNode,
+} from 'react'
 import { motion, useReducedMotion } from 'framer-motion'
 import { FormattedMessage } from 'react-intl'
 import { CheckCircleIcon } from '@heroicons/react/24/solid'
@@ -323,28 +332,44 @@ interface SuccessPost {
  * while its data loads, so a cold-cache tab click paints one continuous
  * placeholder from chunk fetch through data fetch — no spinner → skeleton →
  * content hop. The idle-time prefetch makes the chunk phase a rare sight.
+ *
+ * `focusOnMount` moves keyboard/screen-reader focus into the new view. Push
+ * navigations and back navigations both leave focus on an element that has
+ * just unmounted (the tapped row, the back chevron), which would otherwise
+ * drop it to <body>. Tab-bar switches keep focus on the tab.
  */
 function ViewTransition({
   id,
   kind,
   fallback,
+  focusOnMount = false,
   children,
 }: {
   id: string
   kind: 'root' | 'push'
   fallback: ReactNode
+  focusOnMount?: boolean
   children: ReactNode
 }) {
   const reduceMotion = useReducedMotion()
+  const ref = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (focusOnMount) ref.current?.focus({ preventScroll: true })
+    // Mount-only by design: refocusing on every prop change would yank focus
+    // out of whatever the visitor moved to inside the view.
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
   return (
     <motion.div
       key={id}
+      ref={ref}
+      tabIndex={-1}
       initial={
         reduceMotion ? false : kind === 'push' ? { x: 28, opacity: 0 } : { y: 10, opacity: 0 }
       }
       animate={{ x: 0, y: 0, opacity: 1 }}
       transition={{ duration: 0.22, ease: [0.32, 0.72, 0, 1] }}
-      className="h-full"
+      className="h-full outline-none"
     >
       <Suspense fallback={fallback}>{children}</Suspense>
     </motion.div>
@@ -459,6 +484,12 @@ function WidgetPage() {
   // returns here. Cleared by any tab-bar click — tabs never show a back arrow.
   const [backTarget, setBackTarget] = useState<{ tab: WidgetTab; view: WidgetView } | null>(null)
 
+  // How the current view was reached. Tab-bar landings keep focus on the tab
+  // button; every other navigation ('move': push, back, cross-jump) unmounts
+  // the element that had focus, so the incoming view takes it instead.
+  const lastNavRef = useRef<'tab' | 'move'>('tab')
+  const focusIncoming = lastNavRef.current === 'move'
+
   const [successPost, setSuccessPost] = useState<SuccessPost | null>(null)
   const [selectedPostId, setSelectedPostId] = useState<string | null>(null)
   const [selectedChangelogId, setSelectedChangelogId] = useState<string | null>(null)
@@ -477,6 +508,7 @@ function WidgetPage() {
 
   const openMessenger = useCallback(
     (target?: ConversationId | 'new', from: WidgetTab = 'messages') => {
+      lastNavRef.current = 'move'
       setConversationTarget(target ?? null)
       setActiveTab(from === 'tickets' ? 'tickets' : 'messages')
       setView('messenger')
@@ -498,6 +530,7 @@ function WidgetPage() {
     if (shown.length === 0) return
     if (shown.includes(activeTab)) return
     const next = shown[0]
+    lastNavRef.current = 'tab'
     setActiveTab(next)
     setView(next === 'home' ? 'overview' : next)
   }, [tabs, hasTickets, activeTab, view])
@@ -527,6 +560,7 @@ function WidgetPage() {
       const opts = msg.data as { view?: string }
       // SDK-driven opens are tab-level landings: no back-chevron origin.
       setBackTarget(null)
+      lastNavRef.current = 'tab'
       if (opts.view === 'changelog' && tabs.changelog) {
         setActiveTab('changelog')
         setView('changelog')
@@ -558,6 +592,7 @@ function WidgetPage() {
   }, [tabs, openMessenger])
 
   const handlePostCreated = useCallback((post: SuccessPost) => {
+    lastNavRef.current = 'move'
     setCreatedPosts((prev) => [
       {
         id: post.id as (typeof prev)[number]['id'],
@@ -574,11 +609,13 @@ function WidgetPage() {
   }, [])
 
   const handlePostSelect = useCallback((postId: string) => {
+    lastNavRef.current = 'move'
     setSelectedPostId(postId)
     setView('post-detail')
   }, [])
 
   const handleBack = useCallback(() => {
+    lastNavRef.current = 'move'
     if (view === 'changelog-detail') {
       setSelectedChangelogId(null)
       setView('changelog')
@@ -650,6 +687,7 @@ function WidgetPage() {
   // arrow — any pending cross-navigation origin is dropped.
   const handleTabChange = useCallback(
     (tab: WidgetTab) => {
+      lastNavRef.current = 'tab'
       setBackTarget(null)
       navigateToTab(tab)
     },
@@ -660,6 +698,7 @@ function WidgetPage() {
   // the origin so the destination shows a back chevron returning here.
   const crossNavigate = useCallback(
     (tab: WidgetTab) => {
+      lastNavRef.current = 'move'
       setBackTarget({ tab: activeTab, view })
       navigateToTab(tab)
     },
@@ -667,17 +706,20 @@ function WidgetPage() {
   )
 
   const handleChangelogEntrySelect = useCallback((entryId: string) => {
+    lastNavRef.current = 'move'
     setSelectedChangelogId(entryId)
     setView('changelog-detail')
   }, [])
 
   const handleHelpArticleSelect = useCallback((articleSlug: string) => {
+    lastNavRef.current = 'move'
     setSelectedHelpSlug(articleSlug)
     setView('help-detail')
   }, [])
 
   const handleHelpCategorySelect = useCallback(
     (categoryId: string, categoryName: string, categoryIcon: string | null) => {
+      lastNavRef.current = 'move'
       setSelectedCategory({ id: categoryId, name: categoryName, icon: categoryIcon })
       setView('help-category')
     },
@@ -685,9 +727,20 @@ function WidgetPage() {
   )
 
   const handleHelpCategoryArticleSelect = useCallback((articleSlug: string) => {
+    lastNavRef.current = 'move'
     setSelectedHelpSlug(articleSlug)
     setView('help-detail')
   }, [])
+
+  // The feedback view stays mounted (form state survives a detail round-trip),
+  // so it can't take focus via ViewTransition's mount hook; do it when it
+  // becomes visible again after a back/cross navigation.
+  const feedbackViewRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (view === 'feedback' && lastNavRef.current === 'move') {
+      feedbackViewRef.current?.focus({ preventScroll: true })
+    }
+  }, [view])
 
   // Detail views always get a back arrow; root views only when a
   // cross-navigation origin is pending (tab-bar landings never show one).
@@ -757,7 +810,7 @@ function WidgetPage() {
     >
       {view === 'overview' && (
         // Overview is statically imported (SSR-complete Home) — never suspends.
-        <ViewTransition id="overview" kind="root" fallback={null}>
+        <ViewTransition id="overview" kind="root" focusOnMount={focusIncoming} fallback={null}>
           <WidgetOverview
             tabs={tabs}
             home={home}
@@ -795,7 +848,12 @@ function WidgetPage() {
       )}
 
       {view === 'changelog' && (
-        <ViewTransition id="changelog" kind="root" fallback={<WidgetChangelogListSkeleton />}>
+        <ViewTransition
+          id="changelog"
+          kind="root"
+          focusOnMount={focusIncoming}
+          fallback={<WidgetChangelogListSkeleton />}
+        >
           <WidgetChangelog teamName={teamName} onEntrySelect={handleChangelogEntrySelect} />
         </ViewTransition>
       )}
@@ -804,6 +862,7 @@ function WidgetPage() {
         <ViewTransition
           id={`messenger-${conversationTarget ?? 'active'}`}
           kind="push"
+          focusOnMount={focusIncoming}
           fallback={<WidgetMessengerViewSkeleton isNew={conversationTarget === 'new'} />}
         >
           <WidgetMessenger
@@ -817,7 +876,12 @@ function WidgetPage() {
       )}
 
       {view === 'messages' && (
-        <ViewTransition id="messages" kind="root" fallback={<WidgetConversationListSkeleton />}>
+        <ViewTransition
+          id="messages"
+          kind="root"
+          focusOnMount={focusIncoming}
+          fallback={<WidgetConversationListSkeleton />}
+        >
           <WidgetMessages
             teamName={teamName}
             assistant={assistant}
@@ -828,7 +892,12 @@ function WidgetPage() {
       )}
 
       {view === 'tickets' && (
-        <ViewTransition id="tickets" kind="root" fallback={<WidgetTicketListSkeleton />}>
+        <ViewTransition
+          id="tickets"
+          kind="root"
+          focusOnMount={focusIncoming}
+          fallback={<WidgetTicketListSkeleton />}
+        >
           <WidgetTickets onOpenTicket={(id) => openMessenger(id, 'tickets')} />
         </ViewTransition>
       )}
@@ -837,6 +906,7 @@ function WidgetPage() {
         <ViewTransition
           id={`changelog-${selectedChangelogId}`}
           kind="push"
+          focusOnMount={focusIncoming}
           fallback={<WidgetArticleSkeleton />}
         >
           <WidgetChangelogDetail entryId={selectedChangelogId} />
@@ -844,7 +914,12 @@ function WidgetPage() {
       )}
 
       {view === 'help' && (
-        <ViewTransition id="help" kind="root" fallback={<WidgetHelpViewSkeleton />}>
+        <ViewTransition
+          id="help"
+          kind="root"
+          focusOnMount={focusIncoming}
+          fallback={<WidgetHelpViewSkeleton />}
+        >
           <WidgetHelp
             onArticleSelect={handleHelpArticleSelect}
             onCategorySelect={handleHelpCategorySelect}
@@ -856,6 +931,7 @@ function WidgetPage() {
         <ViewTransition
           id={`help-category-${selectedCategory.id}`}
           kind="push"
+          focusOnMount={focusIncoming}
           fallback={
             <WidgetHelpCategoryViewSkeleton
               categoryName={selectedCategory.name}
@@ -876,6 +952,7 @@ function WidgetPage() {
         <ViewTransition
           id={`help-detail-${selectedHelpSlug}`}
           kind="push"
+          focusOnMount={focusIncoming}
           fallback={<WidgetArticleSkeleton />}
         >
           <WidgetHelpDetail articleSlug={selectedHelpSlug} />
@@ -884,10 +961,12 @@ function WidgetPage() {
 
       {/* Keep home mounted (hidden) when viewing post detail so form state is preserved */}
       <div
+        ref={feedbackViewRef}
+        tabIndex={-1}
         className={
           view === 'feedback' || view === 'post-detail'
             ? view === 'feedback'
-              ? 'flex flex-col h-full'
+              ? 'flex flex-col h-full outline-none'
               : 'hidden'
             : 'hidden'
         }
@@ -917,6 +996,7 @@ function WidgetPage() {
         <ViewTransition
           id={`post-${selectedPostId}`}
           kind="push"
+          focusOnMount={focusIncoming}
           fallback={<WidgetPostDetailSkeleton />}
         >
           <WidgetPostDetail postId={selectedPostId} statuses={statuses} />
@@ -925,7 +1005,12 @@ function WidgetPage() {
 
       {view === 'success' && successPost && (
         // SuccessView is defined in this module — never suspends.
-        <ViewTransition id={`success-${successPost.id}`} kind="push" fallback={null}>
+        <ViewTransition
+          id={`success-${successPost.id}`}
+          kind="push"
+          focusOnMount={focusIncoming}
+          fallback={null}
+        >
           <SuccessView
             post={successPost}
             status={


### PR DESCRIPTION
Part of the widget UX stack on top of #468 (loading skeletons). Each PR in the stack is a small, independently reviewable slice of the page-by-page UX review.

## Summary
- **Tab bar contrast.** The active tab label was `text-primary` — the workspace brand colour. With a light brand (the default yellow) that sits at roughly 1.4:1 against the panel. The label now stays `text-foreground`, only the icon takes the brand tint, and the active tab exposes `aria-current="page"` so the state is not colour-only.
- **Changelog unread on the tab.** The launcher already badged unread changelog entries; the Changelog tab itself did not. A small primary dot (with an sr-only count) now appears on the tab while `changelogUnread > 0`.
- **Scoped Escape.** Escape closed the whole widget from anywhere — mid-draft in the composer, inside an open Select. Now: a focused field gets the first press (its own handler, or a blur), popovers keep their own dismiss (checked after the dispatch completes via a microtask, since Radix registers its listener after ours), and only a second / unowned Escape closes the panel. ProseMirror swallows Escape, so the composer is blurred — otherwise it would trap the key — except when the press was spent dismissing a slash / emoji / mention popup (the shell listens in the capture phase and checks for the popup's marker), so keyboard users keep their draft focused.
- **Focus on navigation.** Push and back navigations unmounted the element that had focus (the tapped row, the back chevron) and dropped it to `<body>`. `ViewTransition` now focuses its container on mount for those navigations; tab-bar switches keep focus on the tab. The kept-mounted feedback view does the same when it becomes visible again.
- **Home.** A `Popular articles` eyebrow above the search card's article list, so it reads as content rather than as part of the search control.

## Test plan
- [x] `tsc --noEmit`, `oxlint`, locale parity tests (2 new keys × 9 locales)
- [x] Playwright: focus lands in the composer after a push; first Escape in the composer blurs it, second Escape posts `quackback:close`
- [ ] Manual: tab through the tab bar with a screen reader and confirm the active tab announces "current page"

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
