### PR TITLE
fix(widget): localise the last hardcoded strings and date formats

### DIFF
--- a/apps/web/src/components/shared/conversation/visitor-conversation-thread.tsx
+++ b/apps/web/src/components/shared/conversation/visitor-conversation-thread.tsx
@@ -1083,7 +1083,13 @@ export function VisitorConversationThread({
                       type="button"
                       onClick={() => submitRating(n)}
                       className="text-lg leading-none text-muted-foreground/50 transition-colors hover:text-amber-500"
-                      aria-label={`Rate ${n} of 5`}
+                      aria-label={intl.formatMessage(
+                        {
+                          id: 'widget.messenger.csat.rateAria',
+                          defaultMessage: 'Rate {n} of 5',
+                        },
+                        { n }
+                      )}
                     >
                       ★
                     </button>

--- a/apps/web/src/components/widget/widget-changelog-detail.tsx
+++ b/apps/web/src/components/widget/widget-changelog-detail.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { FormattedMessage } from 'react-intl'
+import { FormattedDate, FormattedMessage } from 'react-intl'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { publicChangelogQueries } from '@/lib/client/queries/changelog'
 import { RichTextContent, isRichTextContent } from '@/components/ui/rich-text-content'
@@ -10,14 +10,6 @@ import type { JSONContent } from '@tiptap/react'
 import { WidgetPortalTitle } from './widget-portal-title'
 import { sendToHost } from '@/lib/client/widget-bridge'
 import { WidgetArticleSkeleton } from './widget-skeletons'
-
-function formatDate(iso: string) {
-  return new Date(iso).toLocaleDateString('en-US', {
-    month: 'long',
-    day: 'numeric',
-    year: 'numeric',
-  })
-}
 
 interface WidgetChangelogDetailProps {
   entryId: string
@@ -52,8 +44,11 @@ export function WidgetChangelogDetail({ entryId }: WidgetChangelogDetailProps) {
       <ScrollArea scrollBarClassName="w-1.5" className="flex-1 min-h-0">
         {/* Readable column when the host panel expands for long-form content. */}
         <div className="mx-auto w-full max-w-2xl px-4 py-3">
-          <time className="text-[11px] text-muted-foreground/60 uppercase tracking-wide">
-            {formatDate(entry.publishedAt)}
+          <time
+            dateTime={entry.publishedAt}
+            className="text-[11px] text-muted-foreground/60 uppercase tracking-wide"
+          >
+            <FormattedDate value={entry.publishedAt} month="long" day="numeric" year="numeric" />
           </time>
           {entry.categories.length > 0 && (
             <div className="mt-1.5 flex flex-wrap gap-1">

--- a/apps/web/src/components/widget/widget-changelog.tsx
+++ b/apps/web/src/components/widget/widget-changelog.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
-import { FormattedMessage } from 'react-intl'
+import { FormattedDate, FormattedMessage } from 'react-intl'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { contentPreview } from '@/lib/shared/utils/string'
 import { cn } from '@/lib/shared/utils'
@@ -10,14 +10,6 @@ import { markChangelogSeen } from './changelog-unread'
 import { NewspaperIcon } from '@heroicons/react/24/outline'
 import type { ChangelogCategoryId } from '@quackback/ids'
 import { WidgetChangelogListSkeleton, WidgetChangelogMoreSkeleton } from './widget-skeletons'
-
-function formatDate(iso: string) {
-  return new Date(iso).toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  })
-}
 
 interface WidgetChangelogProps {
   /** Team label for the "From {team}" subline; omitted when unknown. */
@@ -145,8 +137,16 @@ export function WidgetChangelog({ teamName, onEntrySelect }: WidgetChangelogProp
                 className="w-full text-start rounded-xl border border-border/50 bg-card hover:bg-muted/30 transition-colors px-3.5 py-3 cursor-pointer"
               >
                 <div className="flex items-center gap-2 mb-1">
-                  <time className="text-[11px] font-medium text-muted-foreground/60 uppercase tracking-wide">
-                    {formatDate(entry.publishedAt)}
+                  <time
+                    dateTime={entry.publishedAt}
+                    className="text-[11px] font-medium text-muted-foreground/60 uppercase tracking-wide"
+                  >
+                    <FormattedDate
+                      value={entry.publishedAt}
+                      month="short"
+                      day="numeric"
+                      year="numeric"
+                    />
                   </time>
                 </div>
                 <h3 className="text-sm font-semibold text-foreground line-clamp-2 leading-snug">

--- a/apps/web/src/locales/ar.json
+++ b/apps/web/src/locales/ar.json
@@ -1164,5 +1164,9 @@
   "automation.builtinTools.saveError": "تعذّر تحديث أذونات الأدوات.",
   "automation.builtinTools.loadError": "تعذّر تحميل قائمة الأدوات.",
   "widget.shell.tab.changelog.unread": "{count, plural, one {تحديث جديد واحد} other {# تحديثات جديدة}}",
-  "widget.launcher.popularArticles": "مقالات شائعة"
+  "widget.launcher.popularArticles": "مقالات شائعة",
+  "widget.success.title": "شكرًا على ملاحظاتك!",
+  "widget.success.subtitle": "تم إرسال فكرتك.",
+  "widget.success.backToIdeas": "الرجوع إلى الأفكار",
+  "widget.messenger.csat.rateAria": "تقييم {n} من 5"
 }

--- a/apps/web/src/locales/de.json
+++ b/apps/web/src/locales/de.json
@@ -1164,5 +1164,9 @@
   "automation.builtinTools.saveError": "Werkzeugberechtigungen konnten nicht aktualisiert werden.",
   "automation.builtinTools.loadError": "Werkzeugkatalog konnte nicht geladen werden.",
   "widget.shell.tab.changelog.unread": "{count, plural, one {# neue Aktualisierung} other {# neue Aktualisierungen}}",
-  "widget.launcher.popularArticles": "Beliebte Artikel"
+  "widget.launcher.popularArticles": "Beliebte Artikel",
+  "widget.success.title": "Danke für dein Feedback!",
+  "widget.success.subtitle": "Deine Idee wurde eingereicht.",
+  "widget.success.backToIdeas": "Zurück zu den Ideen",
+  "widget.messenger.csat.rateAria": "{n} von 5 bewerten"
 }

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -1164,5 +1164,9 @@
   "automation.builtinTools.saveError": "Tool permissions could not be updated.",
   "automation.builtinTools.loadError": "Could not load the tool catalogue.",
   "widget.shell.tab.changelog.unread": "{count, plural, one {# new update} other {# new updates}}",
-  "widget.launcher.popularArticles": "Popular articles"
+  "widget.launcher.popularArticles": "Popular articles",
+  "widget.success.title": "Thanks for your feedback!",
+  "widget.success.subtitle": "Your idea has been submitted.",
+  "widget.success.backToIdeas": "Back to ideas",
+  "widget.messenger.csat.rateAria": "Rate {n} of 5"
 }

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -1164,5 +1164,9 @@
   "automation.builtinTools.saveError": "No se pudieron actualizar los permisos de la herramienta.",
   "automation.builtinTools.loadError": "No se pudo cargar el catálogo de herramientas.",
   "widget.shell.tab.changelog.unread": "{count, plural, one {# novedad} other {# novedades}}",
-  "widget.launcher.popularArticles": "Artículos populares"
+  "widget.launcher.popularArticles": "Artículos populares",
+  "widget.success.title": "¡Gracias por tu comentario!",
+  "widget.success.subtitle": "Tu idea se ha enviado.",
+  "widget.success.backToIdeas": "Volver a las ideas",
+  "widget.messenger.csat.rateAria": "Puntuar {n} de 5"
 }

--- a/apps/web/src/locales/fr.json
+++ b/apps/web/src/locales/fr.json
@@ -1164,5 +1164,9 @@
   "automation.builtinTools.saveError": "Impossible de mettre à jour les autorisations de l’outil.",
   "automation.builtinTools.loadError": "Impossible de charger le catalogue d’outils.",
   "widget.shell.tab.changelog.unread": "{count, plural, one {# nouvelle mise à jour} other {# nouvelles mises à jour}}",
-  "widget.launcher.popularArticles": "Articles populaires"
+  "widget.launcher.popularArticles": "Articles populaires",
+  "widget.success.title": "Merci pour votre retour !",
+  "widget.success.subtitle": "Votre idée a été envoyée.",
+  "widget.success.backToIdeas": "Retour aux idées",
+  "widget.messenger.csat.rateAria": "Noter {n} sur 5"
 }

--- a/apps/web/src/locales/pt-br.json
+++ b/apps/web/src/locales/pt-br.json
@@ -1164,5 +1164,9 @@
   "automation.builtinTools.saveError": "Não foi possível atualizar as permissões da ferramenta.",
   "automation.builtinTools.loadError": "Não foi possível carregar o catálogo de ferramentas.",
   "widget.shell.tab.changelog.unread": "{count, plural, one {# nova atualização} other {# novas atualizações}}",
-  "widget.launcher.popularArticles": "Artigos populares"
+  "widget.launcher.popularArticles": "Artigos populares",
+  "widget.success.title": "Obrigado pelo seu feedback!",
+  "widget.success.subtitle": "Sua ideia foi enviada.",
+  "widget.success.backToIdeas": "Voltar às ideias",
+  "widget.messenger.csat.rateAria": "Avaliar {n} de 5"
 }

--- a/apps/web/src/locales/ru.json
+++ b/apps/web/src/locales/ru.json
@@ -1164,5 +1164,9 @@
   "automation.builtinTools.saveError": "Не удалось обновить разрешения инструментов.",
   "automation.builtinTools.loadError": "Не удалось загрузить каталог инструментов.",
   "widget.shell.tab.changelog.unread": "{count, plural, one {# новое обновление} few {# новых обновления} other {# новых обновлений}}",
-  "widget.launcher.popularArticles": "Популярные статьи"
+  "widget.launcher.popularArticles": "Популярные статьи",
+  "widget.success.title": "Спасибо за ваш отзыв!",
+  "widget.success.subtitle": "Ваша идея отправлена.",
+  "widget.success.backToIdeas": "Назад к идеям",
+  "widget.messenger.csat.rateAria": "Оценка {n} из 5"
 }

--- a/apps/web/src/locales/zh-cn.json
+++ b/apps/web/src/locales/zh-cn.json
@@ -1164,5 +1164,9 @@
   "automation.builtinTools.saveError": "无法更新工具权限。",
   "automation.builtinTools.loadError": "无法加载工具目录。",
   "widget.shell.tab.changelog.unread": "{count, plural, other {# 条新动态}}",
-  "widget.launcher.popularArticles": "热门文章"
+  "widget.launcher.popularArticles": "热门文章",
+  "widget.success.title": "感谢您的反馈！",
+  "widget.success.subtitle": "您的想法已提交。",
+  "widget.success.backToIdeas": "返回想法列表",
+  "widget.messenger.csat.rateAria": "评分 {n}/5"
 }

--- a/apps/web/src/locales/zh-tw.json
+++ b/apps/web/src/locales/zh-tw.json
@@ -1164,5 +1164,9 @@
   "automation.builtinTools.saveError": "無法更新工具權限。",
   "automation.builtinTools.loadError": "無法載入工具目錄。",
   "widget.shell.tab.changelog.unread": "{count, plural, other {# 則新動態}}",
-  "widget.launcher.popularArticles": "熱門文章"
+  "widget.launcher.popularArticles": "熱門文章",
+  "widget.success.title": "感謝您的回饋！",
+  "widget.success.subtitle": "您的想法已送出。",
+  "widget.success.backToIdeas": "返回想法列表",
+  "widget.messenger.csat.rateAria": "評分 {n}/5"
 }

--- a/apps/web/src/routes/widget/index.tsx
+++ b/apps/web/src/routes/widget/index.tsx
@@ -12,7 +12,7 @@ import {
   type ReactNode,
 } from 'react'
 import { motion, useReducedMotion } from 'framer-motion'
-import { FormattedMessage } from 'react-intl'
+import { FormattedMessage, useIntl } from 'react-intl'
 import { CheckCircleIcon } from '@heroicons/react/24/solid'
 import { ArrowLeftIcon } from '@heroicons/react/24/outline'
 import { WidgetVoteButton } from '@/components/widget/widget-vote-button'
@@ -1050,6 +1050,7 @@ function SuccessView({
   onOpenPost: () => void
   onBack: () => void
 }) {
+  const intl = useIntl()
   return (
     <div className="flex flex-col h-full">
       <div className="flex items-center gap-2.5 px-4 pt-5 pb-3">
@@ -1057,8 +1058,18 @@ function SuccessView({
           <CheckCircleIcon className="w-4.5 h-4.5 text-primary" />
         </div>
         <div>
-          <p className="text-sm font-semibold text-foreground">Thanks for your feedback!</p>
-          <p className="text-[11px] text-muted-foreground">Your idea has been submitted.</p>
+          <p className="text-sm font-semibold text-foreground">
+            <FormattedMessage
+              id="widget.success.title"
+              defaultMessage="Thanks for your feedback!"
+            />
+          </p>
+          <p className="text-[11px] text-muted-foreground">
+            <FormattedMessage
+              id="widget.success.subtitle"
+              defaultMessage="Your idea has been submitted."
+            />
+          </p>
         </div>
       </div>
 
@@ -1072,7 +1083,14 @@ function SuccessView({
               postId={post.id as PostId}
               voteCount={post.voteCount}
               onBeforeVote={canVote ? ensureSession : undefined}
-              noAccessReason={canVote ? undefined : "You don't have access to vote on this board"}
+              noAccessReason={
+                canVote
+                  ? undefined
+                  : intl.formatMessage({
+                      id: 'widget.vote.noAccess',
+                      defaultMessage: "You don't have access to vote on this board",
+                    })
+              }
             />
           </div>
           <div className="flex-1 min-w-0">
@@ -1099,8 +1117,8 @@ function SuccessView({
           onClick={onBack}
           className="w-full flex items-center justify-center gap-1.5 px-3 py-2 text-sm font-medium text-foreground bg-muted/30 hover:bg-muted/50 rounded-lg border border-border/50 transition-colors"
         >
-          <ArrowLeftIcon className="w-3.5 h-3.5" />
-          Back to ideas
+          <ArrowLeftIcon className="w-3.5 h-3.5 rtl:rotate-180" />
+          <FormattedMessage id="widget.success.backToIdeas" defaultMessage="Back to ideas" />
         </button>
       </div>
     </div>


### PR DESCRIPTION
Part of the widget UX stack on top of #468. Stacked on #471.

## Summary
- The post-submit success view (`Thanks for your feedback!`, `Your idea has been submitted.`, `Back to ideas`) and the vote no-access tooltip were literal English while every neighbouring string went through react-intl. All four now use `FormattedMessage` / `intl.formatMessage` (the tooltip reuses the existing `widget.vote.noAccess` key).
- CSAT star buttons had a hardcoded `Rate n of 5` `aria-label`; now `widget.messenger.csat.rateAria`.
- Both changelog views pinned dates to `en-US` via `toLocaleDateString`. They now render `<FormattedDate>` (short month on cards, long on the entry) and the `<time>` elements carry a machine-readable `dateTime`.

## Test plan
- [x] `tsc --noEmit`, `oxlint`, locale parity tests (4 new keys × 9 locales)
- [ ] Manual: load the widget with `?locale=de` and confirm the success view and changelog dates follow the locale

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>