### PR TITLE
feat(widget): make feedback rows keyboardable and surface what the list already knows

### DIFF
--- a/apps/web/src/components/widget/widget-auth-provider.tsx
+++ b/apps/web/src/components/widget/widget-auth-provider.tsx
@@ -60,6 +60,9 @@ interface WidgetAuthContextValue {
   metadata: WidgetMetadata | null
   /** Increments when the session token changes — use in query keys to trigger refetch */
   sessionVersion: number
+  /** Latest sessionVersion, readable inside async handlers after ensureSession()
+   *  may have bumped it (the rendered `sessionVersion` closure would be stale). */
+  getSessionVersion: () => number
 }
 
 const WidgetAuthContext = createContext<WidgetAuthContextValue | null>(null)
@@ -143,6 +146,7 @@ export function WidgetAuthProvider({
   }, [locale])
 
   const sessionVersionRef = useRef(0)
+  const getSessionVersion = useCallback(() => sessionVersionRef.current, [])
   const storeToken = useCallback((token: string) => {
     setWidgetToken(token)
     sessionReadyRef.current = true
@@ -445,6 +449,7 @@ export function WidgetAuthProvider({
       emitEvent,
       metadata: widgetMetadata,
       sessionVersion,
+      getSessionVersion,
     }),
     [
       user,
@@ -456,6 +461,7 @@ export function WidgetAuthProvider({
       emitEvent,
       widgetMetadata,
       sessionVersion,
+      getSessionVersion,
     ]
   )
 

--- a/apps/web/src/components/widget/widget-home-animated.tsx
+++ b/apps/web/src/components/widget/widget-home-animated.tsx
@@ -122,31 +122,17 @@ const WidgetPostRow = memo(
   }) {
     const status = post.statusId ? (statusMap.get(post.statusId) ?? null) : null
     return (
-      // The whole row is the tap target (a nested <button> would forbid the
-      // vote button inside it), so it carries the button role and keyboard
-      // activation itself. The vote button stops propagation both ways.
+      // Two sibling controls, never nested: a button-role ancestor would make
+      // the vote button presentational to assistive tech. The open button's
+      // ::after is stretched over the row so the whole row stays the tap
+      // target; the vote button sits above it.
       <div
-        role="button"
-        tabIndex={0}
-        onClick={onSelect}
-        onKeyDown={(e) => {
-          if (e.target !== e.currentTarget) return
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault()
-            onSelect?.()
-          }
-        }}
         className={cn(
-          'w-full overflow-hidden flex items-center gap-2 rounded-lg hover:bg-muted/30 transition-colors cursor-pointer',
-          'outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
+          'relative w-full overflow-hidden flex items-center gap-2 rounded-lg hover:bg-muted/30 transition-colors',
           compact ? 'px-1.5 py-1' : 'px-2 py-1.5'
         )}
       >
-        <div
-          onClick={(e) => e.stopPropagation()}
-          onKeyDown={(e) => e.stopPropagation()}
-          className="shrink-0"
-        >
+        <div className="relative z-10 shrink-0">
           <WidgetVoteButton
             postId={post.id as PostId}
             voteCount={post.voteCount}
@@ -166,7 +152,15 @@ const WidgetPostRow = memo(
             onAuthRequired={!canVote ? onAuthRequired : undefined}
           />
         </div>
-        <div className="flex-1 min-w-0">
+        <button
+          type="button"
+          onClick={onSelect}
+          className={cn(
+            'flex-1 min-w-0 text-start cursor-pointer outline-none',
+            'after:absolute after:inset-0 after:rounded-lg',
+            'focus-visible:after:ring-2 focus-visible:after:ring-inset focus-visible:after:ring-ring/50'
+          )}
+        >
           <div className="flex items-center gap-1.5">
             {status && (
               <span className="inline-flex items-center gap-0.5 text-[11px] text-muted-foreground">
@@ -202,7 +196,7 @@ const WidgetPostRow = memo(
           >
             {post.title}
           </p>
-        </div>
+        </button>
       </div>
     )
   },
@@ -236,6 +230,7 @@ export function WidgetHomeAnimated({
     user,
     emitEvent,
     metadata,
+    getSessionVersion,
   } = useWidgetAuth()
   const { upload: uploadImage } = useWidgetImageUpload()
   const queryClient = useQueryClient()
@@ -515,12 +510,19 @@ export function WidgetHomeAnimated({
       })
 
       // The server auto-upvotes the author; reflect that immediately so the
-      // success card shows a cast vote instead of an inviting empty 0. Written
-      // across every session-version key: ensureSession() may have bumped it
-      // mid-submit.
-      queryClient.setQueriesData<Set<string>>(
-        { queryKey: widgetQueryKeys.votedPosts.all },
-        (old) => new Set([...(old ?? []), result.id])
+      // success card shows a cast vote instead of an inviting empty 0 — a
+      // click on that would silently remove the server's vote. A fetch that
+      // started before the post existed must not land over the seed.
+      await queryClient.cancelQueries({ queryKey: widgetQueryKeys.votedPosts.all })
+      const addVote = (old?: Set<string>) => new Set([...(old ?? []), result.id])
+      // Every already-instantiated version key (ensureSession() may have
+      // bumped it mid-submit) …
+      queryClient.setQueriesData<Set<string>>({ queryKey: widgetQueryKeys.votedPosts.all }, addVote)
+      // … and the live one explicitly: when this submit minted the first
+      // session there are no rows yet, so no query for it exists to update.
+      queryClient.setQueryData<Set<string>>(
+        widgetQueryKeys.votedPosts.bySession(getSessionVersion()),
+        addVote
       )
       onPostCreated?.({
         id: result.id,

--- a/apps/web/src/components/widget/widget-home-animated.tsx
+++ b/apps/web/src/components/widget/widget-home-animated.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, memo, useRef, useState } from 'react'
 import { usePillsScroll } from '@/lib/client/hooks/use-pills-scroll'
-import { Squares2X2Icon, PencilIcon } from '@heroicons/react/24/solid'
+import { Squares2X2Icon, PencilIcon, ChatBubbleLeftIcon } from '@heroicons/react/24/solid'
 import {
   LightBulbIcon,
   MagnifyingGlassIcon,
@@ -9,7 +9,7 @@ import {
   ChevronRightIcon,
 } from '@heroicons/react/24/outline'
 import { motion, AnimatePresence } from 'framer-motion'
-import { useInfiniteQuery, useQuery, keepPreviousData } from '@tanstack/react-query'
+import { useInfiniteQuery, useQuery, useQueryClient, keepPreviousData } from '@tanstack/react-query'
 import { useIntl, FormattedMessage } from 'react-intl'
 import {
   Select,
@@ -22,6 +22,7 @@ import { listPublicPostsFn } from '@/lib/server/functions/public-posts'
 import { useInfiniteScroll } from '@/lib/client/hooks/use-infinite-scroll'
 import { WidgetVoteButton } from './widget-vote-button'
 import { WidgetPostListSkeleton } from './widget-skeletons'
+import { widgetQueryKeys } from '@/lib/client/hooks/use-widget-vote'
 import { cn } from '@/lib/shared/utils'
 import { useWidgetAuth } from './widget-auth-provider'
 import { sendToHost } from '@/lib/client/widget-bridge'
@@ -121,11 +122,31 @@ const WidgetPostRow = memo(
   }) {
     const status = post.statusId ? (statusMap.get(post.statusId) ?? null) : null
     return (
+      // The whole row is the tap target (a nested <button> would forbid the
+      // vote button inside it), so it carries the button role and keyboard
+      // activation itself. The vote button stops propagation both ways.
       <div
-        className={`w-full overflow-hidden flex items-center gap-2 rounded-lg hover:bg-muted/30 transition-colors cursor-pointer ${compact ? 'px-1.5 py-1' : 'px-2 py-1.5'}`}
+        role="button"
+        tabIndex={0}
         onClick={onSelect}
+        onKeyDown={(e) => {
+          if (e.target !== e.currentTarget) return
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            onSelect?.()
+          }
+        }}
+        className={cn(
+          'w-full overflow-hidden flex items-center gap-2 rounded-lg hover:bg-muted/30 transition-colors cursor-pointer',
+          'outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
+          compact ? 'px-1.5 py-1' : 'px-2 py-1.5'
+        )}
       >
-        <div onClick={(e) => e.stopPropagation()} className="shrink-0">
+        <div
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
+          className="shrink-0"
+        >
           <WidgetVoteButton
             postId={post.id as PostId}
             voteCount={post.voteCount}
@@ -160,6 +181,19 @@ const WidgetPostRow = memo(
               <span className="inline-flex items-center gap-0.5 text-[11px] text-muted-foreground/60">
                 <Squares2X2Icon className="h-2.5 w-2.5 text-muted-foreground/40" />
                 {post.board.name}
+              </span>
+            )}
+            {post.commentCount > 0 && (
+              <span className="ms-auto inline-flex items-center gap-0.5 text-[11px] text-muted-foreground/60 tabular-nums">
+                <ChatBubbleLeftIcon className="h-2.5 w-2.5 text-muted-foreground/40" aria-hidden />
+                <span aria-hidden>{post.commentCount}</span>
+                <span className="sr-only">
+                  <FormattedMessage
+                    id="widget.home.row.comments"
+                    defaultMessage="{count, plural, one {# comment} other {# comments}}"
+                    values={{ count: post.commentCount }}
+                  />
+                </span>
               </span>
             )}
           </div>
@@ -204,6 +238,7 @@ export function WidgetHomeAnimated({
     metadata,
   } = useWidgetAuth()
   const { upload: uploadImage } = useWidgetImageUpload()
+  const queryClient = useQueryClient()
   const inputRef = useRef<HTMLInputElement>(null)
 
   const [title, setTitle] = useState('')
@@ -479,10 +514,18 @@ export function WidgetHomeAnimated({
         statusId: result.statusId ?? null,
       })
 
+      // The server auto-upvotes the author; reflect that immediately so the
+      // success card shows a cast vote instead of an inviting empty 0. Written
+      // across every session-version key: ensureSession() may have bumped it
+      // mid-submit.
+      queryClient.setQueriesData<Set<string>>(
+        { queryKey: widgetQueryKeys.votedPosts.all },
+        (old) => new Set([...(old ?? []), result.id])
+      )
       onPostCreated?.({
         id: result.id,
         title: result.title,
-        voteCount: 0,
+        voteCount: Math.max(result.voteCount ?? 0, 1),
         statusId: result.statusId ?? null,
         board: result.board,
       })
@@ -705,6 +748,13 @@ export function WidgetHomeAnimated({
                             id="widget.home.posting.noAccess"
                             defaultMessage="You don't have access to post on this board"
                           />
+                        ) : boards.length > 1 && !selectedBoardId ? (
+                          // Submit is disabled until a board is picked; say so
+                          // rather than leaving a dead button unexplained.
+                          <FormattedMessage
+                            id="widget.home.posting.chooseBoard"
+                            defaultMessage="Choose a board to post"
+                          />
                         ) : user ? (
                           <FormattedMessage
                             id="widget.home.posting.postingAs"
@@ -775,6 +825,13 @@ export function WidgetHomeAnimated({
                     onChange={(e) => setPopularSearch(e.target.value)}
                     onKeyDown={(e) => {
                       if (e.key === 'Enter') e.preventDefault()
+                      if (e.key === 'Escape') {
+                        // Own the first Escape (the shell closes the widget on
+                        // an unhandled one): clear or close the search instead.
+                        e.preventDefault()
+                        if (popularSearch) setPopularSearch('')
+                        else setPopularSearchOpen(false)
+                      }
                     }}
                     placeholder={intl.formatMessage({
                       id: 'widget.home.popular.search.placeholder',
@@ -809,7 +866,7 @@ export function WidgetHomeAnimated({
                   <button
                     type="button"
                     onClick={() => setPopularSearchOpen(true)}
-                    className="text-muted-foreground/40 hover:text-muted-foreground transition-colors"
+                    className="flex size-6 items-center justify-center rounded-md text-muted-foreground/70 hover:bg-muted/50 hover:text-foreground transition-colors"
                     aria-label={intl.formatMessage({
                       id: 'widget.home.popular.search.aria',
                       defaultMessage: 'Search ideas',
@@ -827,6 +884,20 @@ export function WidgetHomeAnimated({
                   ref={pills.ref}
                   className="flex gap-1 overflow-x-auto scrollbar-none px-1 pb-0.5"
                 >
+                  {/* Explicit "All" (matching the changelog filter) — re-tapping
+                      the active board to clear it was undiscoverable. */}
+                  <button
+                    type="button"
+                    onClick={() => setActiveBoardSlug(null)}
+                    aria-pressed={activeBoardSlug === null}
+                    className={`rounded-full text-xs px-2 py-0.5 whitespace-nowrap transition-colors shrink-0 ${
+                      activeBoardSlug === null
+                        ? 'bg-primary text-primary-foreground'
+                        : 'bg-muted/50 text-muted-foreground hover:bg-muted'
+                    }`}
+                  >
+                    <FormattedMessage id="widget.home.boards.all" defaultMessage="All" />
+                  </button>
                   {boards.map((board) => (
                     <button
                       key={board.id}
@@ -834,6 +905,7 @@ export function WidgetHomeAnimated({
                       onClick={() =>
                         setActiveBoardSlug(activeBoardSlug === board.slug ? null : board.slug)
                       }
+                      aria-pressed={activeBoardSlug === board.slug}
                       className={`rounded-full text-xs px-2 py-0.5 whitespace-nowrap transition-colors shrink-0 ${
                         activeBoardSlug === board.slug
                           ? 'bg-primary text-primary-foreground'

--- a/apps/web/src/components/widget/widget-home-animated.tsx
+++ b/apps/web/src/components/widget/widget-home-animated.tsx
@@ -491,6 +491,11 @@ export function WidgetHomeAnimated({
         import('@/lib/client/widget-auth'),
         import('@/lib/server/functions/public-posts'),
       ])
+      // Headers and session version are captured together: the vote the
+      // server casts belongs to whichever principal made this request, even
+      // if the host identifies or clears the visitor while it is in flight.
+      const headers = getWidgetAuthHeaders()
+      const votedPostsKey = widgetQueryKeys.votedPosts.bySession(getSessionVersion())
       const result = await createPublicPostFn({
         data: {
           boardId: selectedBoardId,
@@ -499,7 +504,7 @@ export function WidgetHomeAnimated({
           contentJson: (contentJson ?? undefined) as TiptapContent | undefined,
           metadata: metadata ?? undefined,
         },
-        headers: getWidgetAuthHeaders(),
+        headers,
       })
 
       emitEvent('post:created', {
@@ -511,19 +516,18 @@ export function WidgetHomeAnimated({
 
       // The server auto-upvotes the author; reflect that immediately so the
       // success card shows a cast vote instead of an inviting empty 0 — a
-      // click on that would silently remove the server's vote. A fetch that
-      // started before the post existed must not land over the seed.
-      await queryClient.cancelQueries({ queryKey: widgetQueryKeys.votedPosts.all })
-      const addVote = (old?: Set<string>) => new Set([...(old ?? []), result.id])
-      // Every already-instantiated version key (ensureSession() may have
-      // bumped it mid-submit) …
-      queryClient.setQueriesData<Set<string>>({ queryKey: widgetQueryKeys.votedPosts.all }, addVote)
-      // … and the live one explicitly: when this submit minted the first
-      // session there are no rows yet, so no query for it exists to update.
+      // click on that would silently remove the server's vote. The seed is
+      // written explicitly (when this submit minted the first session there
+      // are no rows yet, so no query for the key exists to update) and then
+      // invalidated: the refetch replaces it with the server's complete set,
+      // so a visitor whose earlier votes were not cached yet does not see
+      // them vanish for the stale window, and a fetch that started before
+      // the post existed is cancelled rather than landing over the seed.
       queryClient.setQueryData<Set<string>>(
-        widgetQueryKeys.votedPosts.bySession(getSessionVersion()),
-        addVote
+        votedPostsKey,
+        (old) => new Set([...(old ?? []), result.id])
       )
+      void queryClient.invalidateQueries({ queryKey: votedPostsKey })
       onPostCreated?.({
         id: result.id,
         title: result.title,

--- a/apps/web/src/components/widget/widget-portal-title.tsx
+++ b/apps/web/src/components/widget/widget-portal-title.tsx
@@ -1,18 +1,35 @@
 import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/solid'
+import { FormattedMessage } from 'react-intl'
 
 interface WidgetPortalTitleProps {
   title: string
   onClick: () => void
 }
 
-/** Clickable title that links to the portal. Shows an external link icon on hover. */
+/**
+ * Clickable title that opens the item on the portal. The external-link icon
+ * is always visible (faint, stronger on hover/focus): a hover-only reveal is
+ * invisible on touch, and nothing else tells a visitor the heading is a link.
+ */
 export function WidgetPortalTitle({ title, onClick }: WidgetPortalTitleProps) {
   return (
-    <button type="button" onClick={onClick} className="group text-left mt-0.5 block">
-      <h2 className="text-[15px] font-semibold text-foreground leading-snug group-hover:text-primary transition-colors inline">
+    <button
+      type="button"
+      onClick={onClick}
+      className="group text-left mt-0.5 block rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+    >
+      {/* Hover cue is an underline, not text-primary: a light brand colour on
+          the panel background would push the heading below text contrast. */}
+      <h2 className="text-[15px] font-semibold text-foreground leading-snug inline decoration-muted-foreground/40 underline-offset-2 group-hover:underline">
         {title}
       </h2>
-      <ArrowTopRightOnSquareIcon className="h-4 w-4 text-muted-foreground/40 inline ml-1.5 mb-0.5 opacity-0 group-hover:opacity-100 transition-opacity duration-200" />
+      <ArrowTopRightOnSquareIcon
+        aria-hidden
+        className="h-4 w-4 text-muted-foreground/40 group-hover:text-muted-foreground/70 group-focus-visible:text-muted-foreground/70 inline ml-1.5 mb-0.5 transition-colors duration-200"
+      />
+      <span className="sr-only">
+        <FormattedMessage id="widget.portalTitle.openInPortal" defaultMessage="Open in portal" />
+      </span>
     </button>
   )
 }

--- a/apps/web/src/components/widget/widget-post-detail.tsx
+++ b/apps/web/src/components/widget/widget-post-detail.tsx
@@ -147,6 +147,10 @@ export function WidgetPostDetail({ postId, statuses }: WidgetPostDetailProps) {
   }
 
   if (error || !post) {
+    // "Post not found" is the one error we raise ourselves and can name; any
+    // other message is a transport/stack string a visitor can't act on, so
+    // show the generic line and keep the raw text in a tooltip for support.
+    const notFound = error instanceof Error && error.message === 'Post not found'
     return (
       <div className="flex flex-col items-center justify-center h-full px-4 text-center">
         <p className="text-sm text-muted-foreground">
@@ -155,13 +159,21 @@ export function WidgetPostDetail({ postId, statuses }: WidgetPostDetailProps) {
             defaultMessage="Could not load post"
           />
         </p>
-        <p className="text-xs text-muted-foreground/60 mt-1">
-          {error instanceof Error
-            ? error.message
-            : intl.formatMessage({
-                id: 'widget.postDetail.error.somethingWrong',
-                defaultMessage: 'Something went wrong',
-              })}
+        <p
+          className="text-xs text-muted-foreground/60 mt-1"
+          title={!notFound && error instanceof Error ? error.message : undefined}
+        >
+          {notFound ? (
+            <FormattedMessage
+              id="widget.postDetail.error.notFound"
+              defaultMessage="This post may have been removed or made private."
+            />
+          ) : (
+            <FormattedMessage
+              id="widget.postDetail.error.somethingWrong"
+              defaultMessage="Something went wrong"
+            />
+          )}
         </p>
       </div>
     )

--- a/apps/web/src/locales/ar.json
+++ b/apps/web/src/locales/ar.json
@@ -1168,5 +1168,10 @@
   "widget.success.title": "شكرًا على ملاحظاتك!",
   "widget.success.subtitle": "تم إرسال فكرتك.",
   "widget.success.backToIdeas": "الرجوع إلى الأفكار",
-  "widget.messenger.csat.rateAria": "تقييم {n} من 5"
+  "widget.messenger.csat.rateAria": "تقييم {n} من 5",
+  "widget.home.row.comments": "{count, plural, one {تعليق واحد} other {# تعليقات}}",
+  "widget.home.posting.chooseBoard": "اختر لوحة للنشر",
+  "widget.home.boards.all": "الكل",
+  "widget.portalTitle.openInPortal": "فتح في البوابة",
+  "widget.postDetail.error.notFound": "ربما تمت إزالة هذه المشاركة أو جعلها خاصة."
 }

--- a/apps/web/src/locales/de.json
+++ b/apps/web/src/locales/de.json
@@ -1168,5 +1168,10 @@
   "widget.success.title": "Danke für dein Feedback!",
   "widget.success.subtitle": "Deine Idee wurde eingereicht.",
   "widget.success.backToIdeas": "Zurück zu den Ideen",
-  "widget.messenger.csat.rateAria": "{n} von 5 bewerten"
+  "widget.messenger.csat.rateAria": "{n} von 5 bewerten",
+  "widget.home.row.comments": "{count, plural, one {# Kommentar} other {# Kommentare}}",
+  "widget.home.posting.chooseBoard": "Wähle ein Board zum Posten",
+  "widget.home.boards.all": "Alle",
+  "widget.portalTitle.openInPortal": "Im Portal öffnen",
+  "widget.postDetail.error.notFound": "Dieser Beitrag wurde möglicherweise entfernt oder auf privat gesetzt."
 }

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -1168,5 +1168,10 @@
   "widget.success.title": "Thanks for your feedback!",
   "widget.success.subtitle": "Your idea has been submitted.",
   "widget.success.backToIdeas": "Back to ideas",
-  "widget.messenger.csat.rateAria": "Rate {n} of 5"
+  "widget.messenger.csat.rateAria": "Rate {n} of 5",
+  "widget.home.row.comments": "{count, plural, one {# comment} other {# comments}}",
+  "widget.home.posting.chooseBoard": "Choose a board to post",
+  "widget.home.boards.all": "All",
+  "widget.portalTitle.openInPortal": "Open in portal",
+  "widget.postDetail.error.notFound": "This post may have been removed or made private."
 }

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -1168,5 +1168,10 @@
   "widget.success.title": "¡Gracias por tu comentario!",
   "widget.success.subtitle": "Tu idea se ha enviado.",
   "widget.success.backToIdeas": "Volver a las ideas",
-  "widget.messenger.csat.rateAria": "Puntuar {n} de 5"
+  "widget.messenger.csat.rateAria": "Puntuar {n} de 5",
+  "widget.home.row.comments": "{count, plural, one {# comentario} other {# comentarios}}",
+  "widget.home.posting.chooseBoard": "Elige un tablero para publicar",
+  "widget.home.boards.all": "Todos",
+  "widget.portalTitle.openInPortal": "Abrir en el portal",
+  "widget.postDetail.error.notFound": "Es posible que esta publicación se haya eliminado o sea privada."
 }

--- a/apps/web/src/locales/fr.json
+++ b/apps/web/src/locales/fr.json
@@ -1168,5 +1168,10 @@
   "widget.success.title": "Merci pour votre retour !",
   "widget.success.subtitle": "Votre idée a été envoyée.",
   "widget.success.backToIdeas": "Retour aux idées",
-  "widget.messenger.csat.rateAria": "Noter {n} sur 5"
+  "widget.messenger.csat.rateAria": "Noter {n} sur 5",
+  "widget.home.row.comments": "{count, plural, one {# commentaire} other {# commentaires}}",
+  "widget.home.posting.chooseBoard": "Choisissez un tableau pour publier",
+  "widget.home.boards.all": "Tous",
+  "widget.portalTitle.openInPortal": "Ouvrir dans le portail",
+  "widget.postDetail.error.notFound": "Cette publication a peut-être été supprimée ou rendue privée."
 }

--- a/apps/web/src/locales/pt-br.json
+++ b/apps/web/src/locales/pt-br.json
@@ -1168,5 +1168,10 @@
   "widget.success.title": "Obrigado pelo seu feedback!",
   "widget.success.subtitle": "Sua ideia foi enviada.",
   "widget.success.backToIdeas": "Voltar às ideias",
-  "widget.messenger.csat.rateAria": "Avaliar {n} de 5"
+  "widget.messenger.csat.rateAria": "Avaliar {n} de 5",
+  "widget.home.row.comments": "{count, plural, one {# comentário} other {# comentários}}",
+  "widget.home.posting.chooseBoard": "Escolha um quadro para publicar",
+  "widget.home.boards.all": "Todos",
+  "widget.portalTitle.openInPortal": "Abrir no portal",
+  "widget.postDetail.error.notFound": "Esta publicação pode ter sido removida ou tornada privada."
 }

--- a/apps/web/src/locales/ru.json
+++ b/apps/web/src/locales/ru.json
@@ -1168,5 +1168,10 @@
   "widget.success.title": "Спасибо за ваш отзыв!",
   "widget.success.subtitle": "Ваша идея отправлена.",
   "widget.success.backToIdeas": "Назад к идеям",
-  "widget.messenger.csat.rateAria": "Оценка {n} из 5"
+  "widget.messenger.csat.rateAria": "Оценка {n} из 5",
+  "widget.home.row.comments": "{count, plural, one {# комментарий} few {# комментария} other {# комментариев}}",
+  "widget.home.posting.chooseBoard": "Выберите доску для публикации",
+  "widget.home.boards.all": "Все",
+  "widget.portalTitle.openInPortal": "Открыть на портале",
+  "widget.postDetail.error.notFound": "Возможно, этот пост был удалён или скрыт."
 }

--- a/apps/web/src/locales/zh-cn.json
+++ b/apps/web/src/locales/zh-cn.json
@@ -1168,5 +1168,10 @@
   "widget.success.title": "感谢您的反馈！",
   "widget.success.subtitle": "您的想法已提交。",
   "widget.success.backToIdeas": "返回想法列表",
-  "widget.messenger.csat.rateAria": "评分 {n}/5"
+  "widget.messenger.csat.rateAria": "评分 {n}/5",
+  "widget.home.row.comments": "{count, plural, other {# 条评论}}",
+  "widget.home.posting.chooseBoard": "选择要发布到的看板",
+  "widget.home.boards.all": "全部",
+  "widget.portalTitle.openInPortal": "在门户中打开",
+  "widget.postDetail.error.notFound": "此帖子可能已被删除或设为私密。"
 }

--- a/apps/web/src/locales/zh-tw.json
+++ b/apps/web/src/locales/zh-tw.json
@@ -1168,5 +1168,10 @@
   "widget.success.title": "感謝您的回饋！",
   "widget.success.subtitle": "您的想法已送出。",
   "widget.success.backToIdeas": "返回想法列表",
-  "widget.messenger.csat.rateAria": "評分 {n}/5"
+  "widget.messenger.csat.rateAria": "評分 {n}/5",
+  "widget.home.row.comments": "{count, plural, other {# 則留言}}",
+  "widget.home.posting.chooseBoard": "選擇要發布到的看板",
+  "widget.home.boards.all": "全部",
+  "widget.portalTitle.openInPortal": "在入口網站中開啟",
+  "widget.postDetail.error.notFound": "此貼文可能已被移除或設為私密。"
 }

--- a/apps/web/src/routes/widget/index.tsx
+++ b/apps/web/src/routes/widget/index.tsx
@@ -1075,10 +1075,23 @@ function SuccessView({
 
       <div className="px-3">
         <div
-          className="flex items-center gap-2 rounded-lg bg-muted/20 border border-border/50 px-2 py-2 cursor-pointer hover:bg-muted/30 transition-colors"
+          role="button"
+          tabIndex={0}
           onClick={onOpenPost}
+          onKeyDown={(e) => {
+            if (e.target !== e.currentTarget) return
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault()
+              onOpenPost()
+            }
+          }}
+          className="flex items-center gap-2 rounded-lg bg-muted/20 border border-border/50 px-2 py-2 cursor-pointer hover:bg-muted/30 transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
         >
-          <div onClick={(e) => e.stopPropagation()} className="shrink-0">
+          <div
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
+            className="shrink-0"
+          >
             <WidgetVoteButton
               postId={post.id as PostId}
               voteCount={post.voteCount}

--- a/apps/web/src/routes/widget/index.tsx
+++ b/apps/web/src/routes/widget/index.tsx
@@ -1074,24 +1074,11 @@ function SuccessView({
       </div>
 
       <div className="px-3">
-        <div
-          role="button"
-          tabIndex={0}
-          onClick={onOpenPost}
-          onKeyDown={(e) => {
-            if (e.target !== e.currentTarget) return
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault()
-              onOpenPost()
-            }
-          }}
-          className="flex items-center gap-2 rounded-lg bg-muted/20 border border-border/50 px-2 py-2 cursor-pointer hover:bg-muted/30 transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-        >
-          <div
-            onClick={(e) => e.stopPropagation()}
-            onKeyDown={(e) => e.stopPropagation()}
-            className="shrink-0"
-          >
+        {/* Vote and open are siblings (a button-role ancestor would hide the
+            vote button from assistive tech); the open button's ::after is
+            stretched over the card so the whole card stays tappable. */}
+        <div className="relative flex items-center gap-2 rounded-lg bg-muted/20 border border-border/50 px-2 py-2 hover:bg-muted/30 transition-colors">
+          <div className="relative z-10 shrink-0">
             <WidgetVoteButton
               postId={post.id as PostId}
               voteCount={post.voteCount}
@@ -1106,7 +1093,11 @@ function SuccessView({
               }
             />
           </div>
-          <div className="flex-1 min-w-0">
+          <button
+            type="button"
+            onClick={onOpenPost}
+            className="flex-1 min-w-0 text-start cursor-pointer outline-none after:absolute after:inset-0 after:rounded-lg focus-visible:after:ring-2 focus-visible:after:ring-inset focus-visible:after:ring-ring/50"
+          >
             <h3 className="text-sm font-medium text-foreground line-clamp-2">{post.title}</h3>
             <div className="flex items-center gap-1.5 mt-0.5">
               {status && (
@@ -1120,7 +1111,7 @@ function SuccessView({
               )}
               <span className="text-xs text-muted-foreground/60">{post.board.name}</span>
             </div>
-          </div>
+          </button>
         </div>
       </div>
 


### PR DESCRIPTION
Part of the widget UX stack on top of #468. Stacked on #472.

## Summary
- **Keyboardable rows.** Post rows (and the success card's post row) were `div onClick`: not focusable, not activatable from the keyboard, invisible to assistive tech as controls. The open control is now a real `<button>` that is a *sibling* of the vote button (never an ancestor — a button-role ancestor makes descendants presentational to assistive tech); its `::after` is stretched over the row so the whole row stays the tap target, with the vote button layered above it.
- **Comment counts.** `commentCount` was fetched for every row and never rendered. It now sits at the end of the meta line with a bubble icon (sr-only plural text for AT).
- **Explicit "All" pill** on the board filter, matching the changelog filter, instead of relying on re-tapping the active pill to clear it. Pills expose `aria-pressed`.
- **Search affordance.** The "Popular ideas" search trigger goes from a 14px glyph at 40% opacity to a 24px button target at 70%; Escape inside the search clears the query, then closes the search (instead of closing the widget).
- **Reflect the auto-vote.** The server auto-upvotes the author on create, but the success card showed `0` votes and an unvoted button. The post id is now added to the voted-posts cache — every already-instantiated session-version key plus the live one explicitly (when this submit minted the visitor's first session there is no query for it yet), with any in-flight voted-posts fetch cancelled first so it cannot land over the seed — and the count is seeded at 1.
- **Board hint.** With several boards and none chosen, Submit stays disabled with no explanation; the footer now says `Choose a board to post`.
- **Portal-link title.** The external-link icon was `opacity-0` until hover — absent on touch, unlabelled for AT. It is always faintly visible, with an sr-only `Open in portal`; the hover cue is an underline rather than `text-primary` (same contrast reasoning as #471).
- **Post detail error copy.** `Post not found` maps to a friendly line; any other error shows the generic line and keeps the raw message in a `title` tooltip.

## Test plan
- [x] `tsc --noEmit`, `oxlint`, locale parity tests (5 new keys × 9 locales)
- [x] Playwright screenshot of the Feedback tab: All pill, comment counts, search button, dark active-tab label
- [ ] Manual: submit a post and confirm the success card shows 1 vote in the voted state

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>