### PR TITLE
feat(widget): sharpen the Messages and Tickets lists

### DIFF
--- a/apps/web/src/components/widget/widget-messages.tsx
+++ b/apps/web/src/components/widget/widget-messages.tsx
@@ -78,16 +78,12 @@ export function WidgetMessages({
               const ticket = linkedTickets[c.id]
               return (
                 <li key={c.id} className="border-b border-border/40 last:border-b-0">
+                  {/* No aria-label override: the row's own content (name,
+                      time, preview, unread) is the accessible name, so AT
+                      users hear the same thing sighted users see. */}
                   <button
                     type="button"
                     onClick={() => onOpenMessenger(c.id)}
-                    aria-label={intl.formatMessage(
-                      {
-                        id: 'widget.messages.resumeAria',
-                        defaultMessage: 'Open conversation with {name}',
-                      },
-                      { name }
-                    )}
                     className="group flex w-full items-center gap-3 rounded-lg px-2 py-3 text-start transition-colors hover:bg-muted/40"
                   >
                     <Avatar
@@ -139,7 +135,14 @@ export function WidgetMessages({
                     </span>
                     {unread && (
                       <span className="inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-full bg-primary px-1.5 text-[11px] font-semibold text-primary-foreground">
-                        {c.unreadCount}
+                        <span aria-hidden>{c.unreadCount}</span>
+                        <span className="sr-only">
+                          <FormattedMessage
+                            id="widget.shell.tab.messages.unread"
+                            defaultMessage="{count} unread"
+                            values={{ count: c.unreadCount }}
+                          />
+                        </span>
                       </span>
                     )}
                   </button>
@@ -154,10 +157,19 @@ export function WidgetMessages({
               <FormattedMessage id="widget.messages.empty" defaultMessage="No conversations yet" />
             </p>
             <p className="mt-0.5 text-xs text-muted-foreground/50">
-              <FormattedMessage
-                id="widget.messages.emptyHint"
-                defaultMessage="Questions or feedback? We're here to help."
-              />
+              {canStartConversation ? (
+                <FormattedMessage
+                  id="widget.messages.emptyHint"
+                  defaultMessage="Questions or feedback? We're here to help."
+                />
+              ) : (
+                // Tickets-only workspace: no chat-start pill, so don't promise
+                // a path that isn't here — say what will show up instead.
+                <FormattedMessage
+                  id="widget.messages.emptyHint.ticketsOnly"
+                  defaultMessage="Replies from our team will show up here."
+                />
+              )}
             </p>
           </div>
         )}

--- a/apps/web/src/components/widget/widget-messages.tsx
+++ b/apps/web/src/components/widget/widget-messages.tsx
@@ -80,13 +80,16 @@ export function WidgetMessages({
                 <li key={c.id} className="border-b border-border/40 last:border-b-0">
                   {/* No aria-label override: the row's own content (name,
                       time, preview, unread) is the accessible name, so AT
-                      users hear the same thing sighted users see. */}
+                      users hear the same thing sighted users see. The avatar
+                      is decorative — its initials / alt would otherwise
+                      repeat the name ("S Support …"). */}
                   <button
                     type="button"
                     onClick={() => onOpenMessenger(c.id)}
                     className="group flex w-full items-center gap-3 rounded-lg px-2 py-3 text-start transition-colors hover:bg-muted/40"
                   >
                     <Avatar
+                      aria-hidden
                       src={c.assignedAgent?.avatarUrl ?? fallbackAvatar}
                       name={name}
                       className="size-9 shrink-0 text-xs"

--- a/apps/web/src/components/widget/widget-tickets.tsx
+++ b/apps/web/src/components/widget/widget-tickets.tsx
@@ -1,15 +1,21 @@
-import { useEffect } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { FormattedMessage } from 'react-intl'
 import { TicketIcon } from '@heroicons/react/24/solid'
+import { ChevronRightIcon } from '@heroicons/react/24/outline'
 import type { ConversationId } from '@quackback/ids'
 import { getMyTicketsFn } from '@/lib/server/functions/tickets'
 import { getWidgetAuthHeaders } from '@/lib/client/widget-auth'
 import { useWidgetAuth } from './widget-auth-provider'
-import { markTicketStagesSeen } from './ticket-stage-seen'
+import {
+  getTicketStagesSeen,
+  markTicketStagesSeen,
+  type TicketStageSeenMap,
+} from './ticket-stage-seen'
 import { TimeAgo } from '@/components/ui/time-ago'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { StageChip } from '@/components/shared/ticket-stage'
+import { cn } from '@/lib/shared/utils'
 import { WidgetTicketListSkeleton } from './widget-skeletons'
 
 /** The own-tickets list query key (shared with the Home recent-tickets card). */
@@ -43,6 +49,22 @@ export function WidgetTickets({
 
   const tickets = data?.tickets ?? []
 
+  // The launcher/tab badge counts tickets whose stage moved since the visitor
+  // last looked; the list should point at WHICH ones. Capture the seen map
+  // once, when the list first has data — before the effect below advances it
+  // — so the changed rows keep their marker for this visit.
+  const baselineRef = useRef<TicketStageSeenMap | null | undefined>(undefined)
+  if (data && baselineRef.current === undefined) baselineRef.current = getTicketStagesSeen()
+  const changedIds = useMemo(() => {
+    const seen = baselineRef.current
+    if (!seen) return new Set<string>()
+    return new Set(
+      tickets
+        .filter((t) => t.ticketId in seen && seen[t.ticketId] !== t.stage.slot)
+        .map((t) => t.ticketId)
+    )
+  }, [tickets])
+
   // The Tickets tab IS the stage-seen surface: having the list on screen
   // advances the visitor's stage markers, clearing the launcher badge.
   useEffect(() => {
@@ -55,43 +77,71 @@ export function WidgetTickets({
         {isLoading ? (
           <WidgetTicketListSkeleton />
         ) : tickets.length > 0 ? (
-          <ul className="px-3 pt-1 pb-24">
-            {tickets.map((t) => (
-              <li key={t.ticketId} className="border-b border-border/40 last:border-b-0">
-                <button
-                  type="button"
-                  disabled={!t.conversationId}
-                  onClick={() => t.conversationId && onOpenTicket(t.conversationId)}
-                  className="flex w-full items-center gap-3 rounded-lg px-2 py-3 text-start transition-colors hover:bg-muted/40 disabled:hover:bg-transparent"
-                >
-                  <span className="min-w-0 flex-1">
-                    <span className="flex items-center justify-between gap-2">
-                      <span className="truncate text-sm font-medium text-foreground">
-                        {t.title}
+          <ul className="px-3 pt-1 pb-3">
+            {tickets.map((t) => {
+              const openable = !!t.conversationId
+              const changed = changedIds.has(t.ticketId)
+              return (
+                <li key={t.ticketId} className="border-b border-border/40 last:border-b-0">
+                  <button
+                    type="button"
+                    disabled={!openable}
+                    onClick={() => t.conversationId && onOpenTicket(t.conversationId)}
+                    className={cn(
+                      'flex w-full items-center gap-3 rounded-lg px-2 py-3 text-start transition-colors',
+                      openable ? 'hover:bg-muted/40' : 'cursor-default'
+                    )}
+                  >
+                    <span className="min-w-0 flex-1">
+                      <span className="flex items-center justify-between gap-2">
+                        <span
+                          className={cn(
+                            'truncate text-sm text-foreground',
+                            changed ? 'font-semibold' : 'font-medium'
+                          )}
+                        >
+                          {t.title}
+                        </span>
+                        <TimeAgo
+                          date={t.updatedAt}
+                          className="shrink-0 text-[11px] text-muted-foreground/60"
+                        />
                       </span>
-                      <TimeAgo
-                        date={t.updatedAt}
-                        className="shrink-0 text-[11px] text-muted-foreground/60"
-                      />
-                    </span>
-                    <span className="mt-1 flex items-center gap-1.5">
-                      <StageChip
-                        slot={t.stage.slot}
-                        label={t.stage.label}
-                        closed={t.stage.closed}
-                        closedLabelId="portal.tickets.stage.closed"
-                      />
-                      <span className="font-mono text-[11px] text-muted-foreground/60">
-                        {t.reference}
+                      <span className="mt-1 flex items-center gap-1.5">
+                        {changed && (
+                          <span className="size-1.5 shrink-0 rounded-full bg-primary" aria-hidden />
+                        )}
+                        <StageChip
+                          slot={t.stage.slot}
+                          label={t.stage.label}
+                          closed={t.stage.closed}
+                          closedLabelId="portal.tickets.stage.closed"
+                        />
+                        <span className="font-mono text-[11px] text-muted-foreground/60">
+                          {t.reference}
+                        </span>
+                        {changed && (
+                          <span className="sr-only">
+                            <FormattedMessage
+                              id="widget.tickets.stageChanged"
+                              defaultMessage="Status changed since your last visit"
+                            />
+                          </span>
+                        )}
                       </span>
                     </span>
-                  </span>
-                </button>
-              </li>
-            ))}
+                    {/* Chevron only on rows that open something — the missing
+                        chevron is what tells a legacy, thread-less row apart. */}
+                    {openable && (
+                      <ChevronRightIcon className="w-4 h-4 shrink-0 text-muted-foreground/40 rtl:rotate-180" />
+                    )}
+                  </button>
+                </li>
+              )
+            })}
           </ul>
         ) : (
-          <div className="flex h-full flex-col items-center justify-center px-6 pt-16 pb-24 text-center animate-in fade-in duration-200 motion-reduce:animate-none">
+          <div className="flex h-full flex-col items-center justify-center px-6 pt-16 pb-16 text-center animate-in fade-in duration-200 motion-reduce:animate-none">
             <TicketIcon className="mb-2 w-8 h-8 text-muted-foreground/30" />
             <p className="text-sm font-medium text-muted-foreground/70">
               <FormattedMessage id="widget.tickets.empty" defaultMessage="No tickets yet" />

--- a/apps/web/src/locales/ar.json
+++ b/apps/web/src/locales/ar.json
@@ -116,7 +116,6 @@
   "widget.tickets.new.type": "النوع",
   "widget.tickets.recent": "التذاكر الأخيرة",
   "widget.messages.emptyHint": "أسئلة أو ملاحظات؟ نحن هنا للمساعدة.",
-  "widget.messages.resumeAria": "فتح المحادثة مع {name}",
   "widget.helpDetail.notFound": "المقالة غير موجودة",
   "widget.changelog.empty": "لا توجد تحديثات بعد",
   "widget.changelog.emptyHint": "عد قريبًا للاطلاع على آخر تحديثات المنتج.",
@@ -1173,5 +1172,7 @@
   "widget.home.posting.chooseBoard": "اختر لوحة للنشر",
   "widget.home.boards.all": "الكل",
   "widget.portalTitle.openInPortal": "فتح في البوابة",
-  "widget.postDetail.error.notFound": "ربما تمت إزالة هذه المشاركة أو جعلها خاصة."
+  "widget.postDetail.error.notFound": "ربما تمت إزالة هذه المشاركة أو جعلها خاصة.",
+  "widget.messages.emptyHint.ticketsOnly": "ستظهر ردود فريقنا هنا.",
+  "widget.tickets.stageChanged": "تغيّرت الحالة منذ زيارتك الأخيرة"
 }

--- a/apps/web/src/locales/ar.json
+++ b/apps/web/src/locales/ar.json
@@ -1174,5 +1174,6 @@
   "widget.portalTitle.openInPortal": "فتح في البوابة",
   "widget.postDetail.error.notFound": "ربما تمت إزالة هذه المشاركة أو جعلها خاصة.",
   "widget.messages.emptyHint.ticketsOnly": "ستظهر ردود فريقنا هنا.",
-  "widget.tickets.stageChanged": "تغيّرت الحالة منذ زيارتك الأخيرة"
+  "widget.tickets.stageChanged": "تغيّرت الحالة منذ زيارتك الأخيرة",
+  "widget.shell.tab.messages.unread": "{count} غير مقروءة"
 }

--- a/apps/web/src/locales/de.json
+++ b/apps/web/src/locales/de.json
@@ -1174,5 +1174,6 @@
   "widget.portalTitle.openInPortal": "Im Portal öffnen",
   "widget.postDetail.error.notFound": "Dieser Beitrag wurde möglicherweise entfernt oder auf privat gesetzt.",
   "widget.messages.emptyHint.ticketsOnly": "Antworten unseres Teams erscheinen hier.",
-  "widget.tickets.stageChanged": "Status hat sich seit deinem letzten Besuch geändert"
+  "widget.tickets.stageChanged": "Status hat sich seit deinem letzten Besuch geändert",
+  "widget.shell.tab.messages.unread": "{count} ungelesen"
 }

--- a/apps/web/src/locales/de.json
+++ b/apps/web/src/locales/de.json
@@ -116,7 +116,6 @@
   "widget.tickets.new.type": "Typ",
   "widget.tickets.recent": "Aktuelle Tickets",
   "widget.messages.emptyHint": "Fragen oder Feedback? Wir helfen gerne.",
-  "widget.messages.resumeAria": "Unterhaltung mit {name} öffnen",
   "widget.helpDetail.notFound": "Artikel nicht gefunden",
   "widget.changelog.empty": "Noch keine Neuigkeiten vorhanden",
   "widget.changelog.emptyHint": "Schauen Sie bald wieder vorbei für die neuesten Produkt-Updates.",
@@ -1173,5 +1172,7 @@
   "widget.home.posting.chooseBoard": "Wähle ein Board zum Posten",
   "widget.home.boards.all": "Alle",
   "widget.portalTitle.openInPortal": "Im Portal öffnen",
-  "widget.postDetail.error.notFound": "Dieser Beitrag wurde möglicherweise entfernt oder auf privat gesetzt."
+  "widget.postDetail.error.notFound": "Dieser Beitrag wurde möglicherweise entfernt oder auf privat gesetzt.",
+  "widget.messages.emptyHint.ticketsOnly": "Antworten unseres Teams erscheinen hier.",
+  "widget.tickets.stageChanged": "Status hat sich seit deinem letzten Besuch geändert"
 }

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -116,7 +116,6 @@
   "widget.tickets.new.type": "Type",
   "widget.tickets.recent": "Recent tickets",
   "widget.messages.emptyHint": "Questions or feedback? We're here to help.",
-  "widget.messages.resumeAria": "Open conversation with {name}",
   "widget.helpDetail.notFound": "Article not found",
   "widget.changelog.empty": "No updates yet",
   "widget.changelog.emptyHint": "Check back soon for the latest product updates.",
@@ -1173,5 +1172,7 @@
   "widget.home.posting.chooseBoard": "Choose a board to post",
   "widget.home.boards.all": "All",
   "widget.portalTitle.openInPortal": "Open in portal",
-  "widget.postDetail.error.notFound": "This post may have been removed or made private."
+  "widget.postDetail.error.notFound": "This post may have been removed or made private.",
+  "widget.messages.emptyHint.ticketsOnly": "Replies from our team will show up here.",
+  "widget.tickets.stageChanged": "Status changed since your last visit"
 }

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -1174,5 +1174,6 @@
   "widget.portalTitle.openInPortal": "Open in portal",
   "widget.postDetail.error.notFound": "This post may have been removed or made private.",
   "widget.messages.emptyHint.ticketsOnly": "Replies from our team will show up here.",
-  "widget.tickets.stageChanged": "Status changed since your last visit"
+  "widget.tickets.stageChanged": "Status changed since your last visit",
+  "widget.shell.tab.messages.unread": "{count} unread"
 }

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -1174,5 +1174,6 @@
   "widget.portalTitle.openInPortal": "Abrir en el portal",
   "widget.postDetail.error.notFound": "Es posible que esta publicación se haya eliminado o sea privada.",
   "widget.messages.emptyHint.ticketsOnly": "Las respuestas de nuestro equipo aparecerán aquí.",
-  "widget.tickets.stageChanged": "El estado cambió desde tu última visita"
+  "widget.tickets.stageChanged": "El estado cambió desde tu última visita",
+  "widget.shell.tab.messages.unread": "{count} sin leer"
 }

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -116,7 +116,6 @@
   "widget.tickets.new.type": "Tipo",
   "widget.tickets.recent": "Tickets recientes",
   "widget.messages.emptyHint": "¿Preguntas o comentarios? Estamos aquí para ayudarte.",
-  "widget.messages.resumeAria": "Abrir conversación con {name}",
   "widget.helpDetail.notFound": "Artículo no encontrado",
   "widget.changelog.empty": "Aún no hay novedades",
   "widget.changelog.emptyHint": "Vuelve pronto para ver las últimas actualizaciones del producto.",
@@ -1173,5 +1172,7 @@
   "widget.home.posting.chooseBoard": "Elige un tablero para publicar",
   "widget.home.boards.all": "Todos",
   "widget.portalTitle.openInPortal": "Abrir en el portal",
-  "widget.postDetail.error.notFound": "Es posible que esta publicación se haya eliminado o sea privada."
+  "widget.postDetail.error.notFound": "Es posible que esta publicación se haya eliminado o sea privada.",
+  "widget.messages.emptyHint.ticketsOnly": "Las respuestas de nuestro equipo aparecerán aquí.",
+  "widget.tickets.stageChanged": "El estado cambió desde tu última visita"
 }

--- a/apps/web/src/locales/fr.json
+++ b/apps/web/src/locales/fr.json
@@ -1174,5 +1174,6 @@
   "widget.portalTitle.openInPortal": "Ouvrir dans le portail",
   "widget.postDetail.error.notFound": "Cette publication a peut-être été supprimée ou rendue privée.",
   "widget.messages.emptyHint.ticketsOnly": "Les réponses de notre équipe apparaîtront ici.",
-  "widget.tickets.stageChanged": "Le statut a changé depuis votre dernière visite"
+  "widget.tickets.stageChanged": "Le statut a changé depuis votre dernière visite",
+  "widget.shell.tab.messages.unread": "{count} non lu(s)"
 }

--- a/apps/web/src/locales/fr.json
+++ b/apps/web/src/locales/fr.json
@@ -116,7 +116,6 @@
   "widget.tickets.new.type": "Type",
   "widget.tickets.recent": "Tickets récents",
   "widget.messages.emptyHint": "Des questions ou des retours ? Nous sommes là pour vous aider.",
-  "widget.messages.resumeAria": "Ouvrir la conversation avec {name}",
   "widget.helpDetail.notFound": "Article introuvable",
   "widget.changelog.empty": "Aucune mise à jour pour le moment",
   "widget.changelog.emptyHint": "Revenez bientôt pour les dernières mises à jour produit.",
@@ -1173,5 +1172,7 @@
   "widget.home.posting.chooseBoard": "Choisissez un tableau pour publier",
   "widget.home.boards.all": "Tous",
   "widget.portalTitle.openInPortal": "Ouvrir dans le portail",
-  "widget.postDetail.error.notFound": "Cette publication a peut-être été supprimée ou rendue privée."
+  "widget.postDetail.error.notFound": "Cette publication a peut-être été supprimée ou rendue privée.",
+  "widget.messages.emptyHint.ticketsOnly": "Les réponses de notre équipe apparaîtront ici.",
+  "widget.tickets.stageChanged": "Le statut a changé depuis votre dernière visite"
 }

--- a/apps/web/src/locales/pt-br.json
+++ b/apps/web/src/locales/pt-br.json
@@ -116,7 +116,6 @@
   "widget.tickets.new.type": "Tipo",
   "widget.tickets.recent": "Tickets recentes",
   "widget.messages.emptyHint": "Dúvidas ou feedback? Estamos aqui para ajudar.",
-  "widget.messages.resumeAria": "Abrir conversa com {name}",
   "widget.helpDetail.notFound": "Artigo não encontrado",
   "widget.changelog.empty": "Ainda não há atualizações",
   "widget.changelog.emptyHint": "Volte em breve para conferir as últimas atualizações do produto.",
@@ -1173,5 +1172,7 @@
   "widget.home.posting.chooseBoard": "Escolha um quadro para publicar",
   "widget.home.boards.all": "Todos",
   "widget.portalTitle.openInPortal": "Abrir no portal",
-  "widget.postDetail.error.notFound": "Esta publicação pode ter sido removida ou tornada privada."
+  "widget.postDetail.error.notFound": "Esta publicação pode ter sido removida ou tornada privada.",
+  "widget.messages.emptyHint.ticketsOnly": "As respostas da nossa equipe aparecerão aqui.",
+  "widget.tickets.stageChanged": "O status mudou desde sua última visita"
 }

--- a/apps/web/src/locales/pt-br.json
+++ b/apps/web/src/locales/pt-br.json
@@ -1174,5 +1174,6 @@
   "widget.portalTitle.openInPortal": "Abrir no portal",
   "widget.postDetail.error.notFound": "Esta publicação pode ter sido removida ou tornada privada.",
   "widget.messages.emptyHint.ticketsOnly": "As respostas da nossa equipe aparecerão aqui.",
-  "widget.tickets.stageChanged": "O status mudou desde sua última visita"
+  "widget.tickets.stageChanged": "O status mudou desde sua última visita",
+  "widget.shell.tab.messages.unread": "{count} não lida(s)"
 }

--- a/apps/web/src/locales/ru.json
+++ b/apps/web/src/locales/ru.json
@@ -1174,5 +1174,6 @@
   "widget.portalTitle.openInPortal": "Открыть на портале",
   "widget.postDetail.error.notFound": "Возможно, этот пост был удалён или скрыт.",
   "widget.messages.emptyHint.ticketsOnly": "Ответы нашей команды появятся здесь.",
-  "widget.tickets.stageChanged": "Статус изменился с вашего последнего визита"
+  "widget.tickets.stageChanged": "Статус изменился с вашего последнего визита",
+  "widget.shell.tab.messages.unread": "{count} непрочитанных"
 }

--- a/apps/web/src/locales/ru.json
+++ b/apps/web/src/locales/ru.json
@@ -116,7 +116,6 @@
   "widget.tickets.new.type": "Тип",
   "widget.tickets.recent": "Недавние тикеты",
   "widget.messages.emptyHint": "Вопросы или отзывы? Мы готовы помочь.",
-  "widget.messages.resumeAria": "Открыть разговор с {name}",
   "widget.helpDetail.notFound": "Статья не найдена",
   "widget.changelog.empty": "Пока нет обновлений",
   "widget.changelog.emptyHint": "Загляните позже, чтобы увидеть последние обновления продукта.",
@@ -1173,5 +1172,7 @@
   "widget.home.posting.chooseBoard": "Выберите доску для публикации",
   "widget.home.boards.all": "Все",
   "widget.portalTitle.openInPortal": "Открыть на портале",
-  "widget.postDetail.error.notFound": "Возможно, этот пост был удалён или скрыт."
+  "widget.postDetail.error.notFound": "Возможно, этот пост был удалён или скрыт.",
+  "widget.messages.emptyHint.ticketsOnly": "Ответы нашей команды появятся здесь.",
+  "widget.tickets.stageChanged": "Статус изменился с вашего последнего визита"
 }

--- a/apps/web/src/locales/zh-cn.json
+++ b/apps/web/src/locales/zh-cn.json
@@ -116,7 +116,6 @@
   "widget.tickets.new.type": "类型",
   "widget.tickets.recent": "最近的工单",
   "widget.messages.emptyHint": "有问题或反馈？我们随时为您服务。",
-  "widget.messages.resumeAria": "打开与 {name} 的对话",
   "widget.helpDetail.notFound": "未找到文章",
   "widget.changelog.empty": "暂无更新",
   "widget.changelog.emptyHint": "请稍后再来查看最新的产品更新。",
@@ -1173,5 +1172,7 @@
   "widget.home.posting.chooseBoard": "选择要发布到的看板",
   "widget.home.boards.all": "全部",
   "widget.portalTitle.openInPortal": "在门户中打开",
-  "widget.postDetail.error.notFound": "此帖子可能已被删除或设为私密。"
+  "widget.postDetail.error.notFound": "此帖子可能已被删除或设为私密。",
+  "widget.messages.emptyHint.ticketsOnly": "团队的回复将显示在这里。",
+  "widget.tickets.stageChanged": "自上次访问以来状态已更改"
 }

--- a/apps/web/src/locales/zh-cn.json
+++ b/apps/web/src/locales/zh-cn.json
@@ -1174,5 +1174,6 @@
   "widget.portalTitle.openInPortal": "在门户中打开",
   "widget.postDetail.error.notFound": "此帖子可能已被删除或设为私密。",
   "widget.messages.emptyHint.ticketsOnly": "团队的回复将显示在这里。",
-  "widget.tickets.stageChanged": "自上次访问以来状态已更改"
+  "widget.tickets.stageChanged": "自上次访问以来状态已更改",
+  "widget.shell.tab.messages.unread": "{count} 条未读"
 }

--- a/apps/web/src/locales/zh-tw.json
+++ b/apps/web/src/locales/zh-tw.json
@@ -116,7 +116,6 @@
   "widget.tickets.new.type": "類型",
   "widget.tickets.recent": "最近的工單",
   "widget.messages.emptyHint": "有問題或意見回饋？我們隨時為您服務。",
-  "widget.messages.resumeAria": "開啟與 {name} 的對話",
   "widget.helpDetail.notFound": "找不到文章",
   "widget.changelog.empty": "還沒有更新",
   "widget.changelog.emptyHint": "稍後再回來查看最新的產品更新。",
@@ -1173,5 +1172,7 @@
   "widget.home.posting.chooseBoard": "選擇要發布到的看板",
   "widget.home.boards.all": "全部",
   "widget.portalTitle.openInPortal": "在入口網站中開啟",
-  "widget.postDetail.error.notFound": "此貼文可能已被移除或設為私密。"
+  "widget.postDetail.error.notFound": "此貼文可能已被移除或設為私密。",
+  "widget.messages.emptyHint.ticketsOnly": "團隊的回覆將顯示在這裡。",
+  "widget.tickets.stageChanged": "自上次造訪以來狀態已變更"
 }

--- a/apps/web/src/locales/zh-tw.json
+++ b/apps/web/src/locales/zh-tw.json
@@ -1174,5 +1174,6 @@
   "widget.portalTitle.openInPortal": "在入口網站中開啟",
   "widget.postDetail.error.notFound": "此貼文可能已被移除或設為私密。",
   "widget.messages.emptyHint.ticketsOnly": "團隊的回覆將顯示在這裡。",
-  "widget.tickets.stageChanged": "自上次造訪以來狀態已變更"
+  "widget.tickets.stageChanged": "自上次造訪以來狀態已變更",
+  "widget.shell.tab.messages.unread": "{count} 則未讀"
 }


### PR DESCRIPTION
Part of the widget UX stack on top of #468. Stacked on #473.

## Summary
**Messages**
- The row's `aria-label` (`Open conversation with {name}`) replaced its whole accessible name, so screen-reader users lost the preview, the time and the unread count. The override is gone; the badge gets an sr-only `{n} unread`. The orphaned `widget.messages.resumeAria` key is pruned from all locales.
- The empty-state hint promised "we're here to help" even on tickets-only workspaces where the chat-start pill is hidden. It now says `Replies from our team will show up here.` in that mode.

**Tickets**
- Rows had no affordance, and a legacy thread-less row (disabled button) looked identical to an openable one. Openable rows now carry a trailing chevron — its absence marks the inert row.
- The tab badge counted stage changes without saying which ticket moved. Rows whose stage differs from the visitor's seen marker get a dot and a bold title for this visit; the baseline is captured on first data, before the list advances the markers.
- Drops the `pb-24` inherited from Messages — there is no floating pill here to clear.

**Not done here:** a `You:` prefix on the last-message preview needs the sender on the conversation DTO (a server change).

## Test plan
- [x] `tsc --noEmit`, `oxlint`, locale parity tests (2 new keys, 1 pruned × 9 locales)
- [x] Playwright screenshot of the Tickets tab as the demo user: chevrons on openable rows
- [ ] Manual: move a ticket's stage as an agent, reopen the widget, confirm the dot on that row and that it clears on the next visit

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>