### PR TITLE
feat(widget): give the help surface an exit ramp and a search that keeps its place

### DIFF
--- a/apps/web/src/components/widget/widget-article-footer.tsx
+++ b/apps/web/src/components/widget/widget-article-footer.tsx
@@ -5,6 +5,7 @@ import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/solid'
 import { recordArticleFeedbackFn } from '@/lib/server/functions/help-center'
 import { getWidgetAuthHeaders } from '@/lib/client/widget-auth'
 import { cn } from '@/lib/shared/utils'
+import { useWidgetAuth } from './widget-auth-provider'
 import type { KbArticleId } from '@quackback/ids'
 
 interface WidgetArticleFooterProps {
@@ -23,12 +24,18 @@ interface WidgetArticleFooterProps {
 export function WidgetArticleFooter({ articleId, onAskQuestion }: WidgetArticleFooterProps) {
   const [vote, setVote] = useState<'helpful' | 'not-helpful' | null>(null)
   const [pending, setPending] = useState(false)
+  const { ensureSession } = useWidgetAuth()
 
   const cast = async (helpful: boolean) => {
     const next = helpful ? 'helpful' : 'not-helpful'
     if (pending || vote === next) return
     setPending(true)
     try {
+      // A fresh anonymous visitor has no token until their first write. Mint
+      // it here (like a vote or a post would) so the feedback is attributed
+      // to a principal — otherwise the server can't find an existing vote to
+      // update and every tap inserts and counts another row.
+      if (!(await ensureSession())) return
       await recordArticleFeedbackFn({
         data: { articleId: articleId as KbArticleId, helpful },
         headers: getWidgetAuthHeaders(),

--- a/apps/web/src/components/widget/widget-article-footer.tsx
+++ b/apps/web/src/components/widget/widget-article-footer.tsx
@@ -1,0 +1,145 @@
+import { useState } from 'react'
+import { FormattedMessage } from 'react-intl'
+import { HandThumbUpIcon, HandThumbDownIcon } from '@heroicons/react/24/outline'
+import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/solid'
+import { recordArticleFeedbackFn } from '@/lib/server/functions/help-center'
+import { getWidgetAuthHeaders } from '@/lib/client/widget-auth'
+import { cn } from '@/lib/shared/utils'
+import type { KbArticleId } from '@quackback/ids'
+
+interface WidgetArticleFooterProps {
+  articleId: string
+  /** When set, offers "Still stuck? Ask a question" opening a new thread. */
+  onAskQuestion?: () => void
+}
+
+/**
+ * The exit ramp under a help article. An article either answered the question
+ * or it didn't; this gives both outcomes somewhere to go — a one-tap helpful
+ * vote (the same signal the portal collects) and a jump into the messenger
+ * for the visitor who is still stuck. Kept to a single compact row: the
+ * portal's reason textarea would crowd a 400px panel.
+ */
+export function WidgetArticleFooter({ articleId, onAskQuestion }: WidgetArticleFooterProps) {
+  const [vote, setVote] = useState<'helpful' | 'not-helpful' | null>(null)
+  const [pending, setPending] = useState(false)
+
+  const cast = async (helpful: boolean) => {
+    const next = helpful ? 'helpful' : 'not-helpful'
+    if (pending || vote === next) return
+    setPending(true)
+    try {
+      await recordArticleFeedbackFn({
+        data: { articleId: articleId as KbArticleId, helpful },
+        headers: getWidgetAuthHeaders(),
+      })
+      setVote(next)
+    } catch {
+      // Non-critical: the article is still readable, the CTA still works.
+    } finally {
+      setPending(false)
+    }
+  }
+
+  return (
+    <div className="mt-6 rounded-lg border border-border/50 bg-muted/20 px-3 py-2.5">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs text-muted-foreground">
+          {vote === null ? (
+            <FormattedMessage id="widget.help.article.helpful" defaultMessage="Was this helpful?" />
+          ) : vote === 'helpful' ? (
+            <FormattedMessage
+              id="widget.help.article.helpful.thanks"
+              defaultMessage="Thanks — glad it helped."
+            />
+          ) : (
+            <FormattedMessage
+              id="widget.help.article.helpful.sorry"
+              defaultMessage="Sorry about that."
+            />
+          )}
+        </p>
+        <div className="flex items-center gap-1 shrink-0" role="group">
+          <VoteButton
+            active={vote === 'helpful'}
+            disabled={pending}
+            onClick={() => cast(true)}
+            label={
+              <FormattedMessage
+                id="widget.help.article.helpful.yes"
+                defaultMessage="Yes, this helped"
+              />
+            }
+          >
+            <HandThumbUpIcon className="size-4" />
+          </VoteButton>
+          <VoteButton
+            active={vote === 'not-helpful'}
+            disabled={pending}
+            onClick={() => cast(false)}
+            label={
+              <FormattedMessage
+                id="widget.help.article.helpful.no"
+                defaultMessage="No, this didn't help"
+              />
+            }
+          >
+            <HandThumbDownIcon className="size-4" />
+          </VoteButton>
+        </div>
+      </div>
+      {onAskQuestion && (
+        <button
+          type="button"
+          onClick={onAskQuestion}
+          className="mt-2 flex w-full items-center gap-2 rounded-md border border-border/50 bg-background px-2.5 py-2 text-start text-xs transition-colors hover:bg-muted/40"
+        >
+          <ChatBubbleLeftRightIcon className="size-4 shrink-0 text-primary" />
+          <span className="min-w-0 flex-1">
+            <span className="text-muted-foreground">
+              <FormattedMessage id="widget.help.article.stillStuck" defaultMessage="Still stuck?" />
+            </span>{' '}
+            <span className="font-medium text-foreground">
+              <FormattedMessage
+                id="widget.help.article.askQuestion"
+                defaultMessage="Ask us a question"
+              />
+            </span>
+          </span>
+        </button>
+      )}
+    </div>
+  )
+}
+
+function VoteButton({
+  active,
+  disabled,
+  onClick,
+  label,
+  children,
+}: {
+  active: boolean
+  disabled: boolean
+  onClick: () => void
+  label: React.ReactNode
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-pressed={active}
+      className={cn(
+        'flex size-7 items-center justify-center rounded-md border transition-colors disabled:opacity-60',
+        active
+          ? 'border-primary/40 bg-primary/15 text-foreground'
+          : 'border-border/50 bg-background text-muted-foreground hover:bg-muted/40 hover:text-foreground'
+      )}
+    >
+      {children}
+      <span className="sr-only">{label}</span>
+    </button>
+  )
+}

--- a/apps/web/src/components/widget/widget-help-category.tsx
+++ b/apps/web/src/components/widget/widget-help-category.tsx
@@ -20,15 +20,38 @@ export function WidgetHelpCategory({
   onArticleSelect,
 }: WidgetHelpCategoryProps) {
   const articlesQuery = useQuery(publicHelpCenterQueries.articlesForCategory(categoryId))
+  // The collection list already has every category's description and icon;
+  // read them from that cache so the header carries context (and an icon even
+  // when we arrived from an article's eyebrow, which only knows id + name).
+  const categoriesQuery = useQuery(publicHelpCenterQueries.categories())
+  const category = categoriesQuery.data?.find((c) => c.id === categoryId)
+  const icon = categoryIcon ?? category?.icon ?? null
+  const articleCount = articlesQuery.data?.length ?? category?.articleCount
 
   return (
     <div className="flex flex-col h-full">
       {/* Category header */}
       <div className="px-3 pt-2 pb-2 shrink-0 border-b border-border/30">
         <div className="flex items-center gap-2">
-          {categoryIcon && <CategoryIcon icon={categoryIcon} className="w-5 h-5 shrink-0" />}
-          <h3 className="text-sm font-semibold text-foreground">{categoryName}</h3>
+          {icon && <CategoryIcon icon={icon} className="w-5 h-5 shrink-0" />}
+          <h3 className="text-sm font-semibold text-foreground min-w-0 flex-1 truncate">
+            {categoryName}
+          </h3>
+          {articleCount !== undefined && (
+            <span className="shrink-0 text-[11px] text-muted-foreground/60 tabular-nums">
+              <FormattedMessage
+                id="widget.help.articleCount"
+                defaultMessage="{count, plural, one {# article} other {# articles}}"
+                values={{ count: articleCount }}
+              />
+            </span>
+          )}
         </div>
+        {category?.description && (
+          <p className="mt-1 text-xs text-muted-foreground/70 line-clamp-2 leading-relaxed">
+            {category.description}
+          </p>
+        )}
       </div>
 
       <ScrollArea scrollBarClassName="w-1.5" className="flex-1 min-h-0 h-full">

--- a/apps/web/src/components/widget/widget-help-detail.tsx
+++ b/apps/web/src/components/widget/widget-help-detail.tsx
@@ -1,19 +1,30 @@
 import { useCallback } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { FormattedMessage } from 'react-intl'
+import { ChevronRightIcon } from '@heroicons/react/24/outline'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { publicHelpCenterQueries } from '@/lib/client/queries/help-center'
 import { RichTextContent, isRichTextContent } from '@/components/ui/rich-text-content'
 import type { JSONContent } from '@tiptap/react'
 import { WidgetPortalTitle } from './widget-portal-title'
+import { WidgetArticleFooter } from './widget-article-footer'
 import { sendToHost } from '@/lib/client/widget-bridge'
 import { WidgetArticleSkeleton } from './widget-skeletons'
 
 interface WidgetHelpDetailProps {
   articleSlug: string
+  /** Tapping the category eyebrow browses the rest of that collection. */
+  onCategorySelect?: (categoryId: string, categoryName: string) => void
+  /** "Still stuck?" exit ramp — opens a new conversation. Omitted when the
+   *  visitor can't start one (messenger off, or tickets-only). */
+  onAskQuestion?: () => void
 }
 
-export function WidgetHelpDetail({ articleSlug }: WidgetHelpDetailProps) {
+export function WidgetHelpDetail({
+  articleSlug,
+  onCategorySelect,
+  onAskQuestion,
+}: WidgetHelpDetailProps) {
   const { data: article, isLoading } = useQuery(publicHelpCenterQueries.articleBySlug(articleSlug))
 
   const handleViewOnPortal = useCallback(() => {
@@ -36,14 +47,31 @@ export function WidgetHelpDetail({ articleSlug }: WidgetHelpDetailProps) {
     )
   }
 
+  const eyebrowClass = 'text-[11px] text-muted-foreground/60 uppercase tracking-wide'
+
   return (
     <div className="flex flex-col h-full">
       <ScrollArea scrollBarClassName="w-1.5" className="flex-1 min-h-0">
         {/* Readable column when the host panel expands for long-form content. */}
         <div className="mx-auto w-full max-w-2xl px-4 py-3">
-          <span className="text-[11px] text-muted-foreground/60 uppercase tracking-wide">
-            {article.category.name}
-          </span>
+          {onCategorySelect ? (
+            <button
+              type="button"
+              onClick={() => onCategorySelect(article.category.id, article.category.name)}
+              className={`${eyebrowClass} -ms-1 inline-flex items-center gap-0.5 rounded px-1 py-0.5 transition-colors hover:bg-muted/40 hover:text-muted-foreground`}
+            >
+              {article.category.name}
+              <ChevronRightIcon className="size-3 rtl:rotate-180" aria-hidden />
+              <span className="sr-only">
+                <FormattedMessage
+                  id="widget.helpDetail.browseCategory"
+                  defaultMessage="Browse this collection"
+                />
+              </span>
+            </button>
+          ) : (
+            <span className={eyebrowClass}>{article.category.name}</span>
+          )}
           <WidgetPortalTitle title={article.title} onClick={handleViewOnPortal} />
 
           <div className="mt-3">
@@ -58,6 +86,8 @@ export function WidgetHelpDetail({ articleSlug }: WidgetHelpDetailProps) {
               </p>
             )}
           </div>
+
+          <WidgetArticleFooter articleId={article.id} onAskQuestion={onAskQuestion} />
         </div>
       </ScrollArea>
     </div>

--- a/apps/web/src/components/widget/widget-help.tsx
+++ b/apps/web/src/components/widget/widget-help.tsx
@@ -8,6 +8,7 @@ import {
   QuestionMarkCircleIcon,
   ArrowRightIcon,
   ChevronRightIcon,
+  XMarkIcon,
 } from '@heroicons/react/24/outline'
 import { publicHelpCenterQueries } from '@/lib/client/queries/help-center'
 import { getTopLevelCategories } from '@/components/help-center/help-center-utils'
@@ -27,11 +28,25 @@ import { WidgetHelpCollectionsSkeleton, WidgetHelpSearchSkeleton } from './widge
 interface WidgetHelpProps {
   onArticleSelect?: (articleSlug: string) => void
   onCategorySelect?: (categoryId: string, categoryName: string, categoryIcon: string | null) => void
+  /**
+   * Controlled search query. The page owner lifts it so a visitor who opens
+   * a result and comes back finds their query (and results) still there
+   * instead of the collection list; uncontrolled when omitted.
+   */
+  search?: string
+  onSearchChange?: (value: string) => void
 }
 
-export function WidgetHelp({ onArticleSelect, onCategorySelect }: WidgetHelpProps) {
+export function WidgetHelp({
+  onArticleSelect,
+  onCategorySelect,
+  search: controlledSearch,
+  onSearchChange,
+}: WidgetHelpProps) {
   const intl = useIntl()
-  const [search, setSearch] = useState('')
+  const [localSearch, setLocalSearch] = useState('')
+  const search = controlledSearch ?? localSearch
+  const setSearch = onSearchChange ?? setLocalSearch
 
   const categoriesQuery = useQuery(publicHelpCenterQueries.categories())
   const topLevelCategories = categoriesQuery.data ? getTopLevelCategories(categoriesQuery.data) : []
@@ -79,19 +94,44 @@ export function WidgetHelp({ onArticleSelect, onCategorySelect }: WidgetHelpProp
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             onKeyDown={handleKeyDown}
+            aria-label={intl.formatMessage({
+              id: 'widget.help.searchAria',
+              defaultMessage: 'Search help articles',
+            })}
+            // The portal's Ask-AI placeholder is a full sentence that truncates
+            // at the widget's width; the widget gets a shorter one.
             placeholder={
               askAiAvailable
                 ? intl.formatMessage({
-                    id: 'helpAskAi.searchPlaceholder',
-                    defaultMessage: 'Ask AI or search our help articles to find an answer',
+                    id: 'widget.help.askAiSearchPlaceholder',
+                    defaultMessage: 'Ask AI or search articles…',
                   })
                 : intl.formatMessage({
                     id: 'widget.help.searchPlaceholder',
                     defaultMessage: 'Search help articles...',
                   })
             }
-            className="w-full ps-8 pe-9 py-2 text-sm bg-muted/30 border border-border/50 rounded-lg placeholder:text-muted-foreground/40 focus:outline-none focus:ring-2 focus:ring-ring/50 focus:border-transparent"
+            className={cn(
+              'w-full ps-8 py-2 text-sm bg-muted/30 border border-border/50 rounded-lg placeholder:text-muted-foreground/40 focus:outline-none focus:ring-2 focus:ring-ring/50 focus:border-transparent',
+              hasAskRow ? 'pe-16' : 'pe-9'
+            )}
           />
+          {search && (
+            <button
+              type="button"
+              onClick={() => setSearch('')}
+              aria-label={intl.formatMessage({
+                id: 'widget.help.clearSearch',
+                defaultMessage: 'Clear search',
+              })}
+              className={cn(
+                'absolute top-1/2 -translate-y-1/2 flex size-6 items-center justify-center rounded-md text-muted-foreground/60 hover:text-foreground hover:bg-muted/50 transition-colors',
+                hasAskRow ? 'end-8' : 'end-1.5'
+              )}
+            >
+              <XMarkIcon className="w-3.5 h-3.5" />
+            </button>
+          )}
           {hasAskRow && (
             <button
               type="button"
@@ -135,12 +175,20 @@ export function WidgetHelp({ onArticleSelect, onCategorySelect }: WidgetHelpProp
 
               {!categoriesQuery.isLoading && topLevelCategories.length > 0 && (
                 <>
-                  <p className="px-1 pt-2 pb-1 text-sm font-semibold text-foreground">
-                    <FormattedMessage
-                      id="widget.help.collectionsCount"
-                      defaultMessage="{count, plural, one {# collection} other {# collections}}"
-                      values={{ count: topLevelCategories.length }}
-                    />
+                  <p className="flex items-baseline justify-between px-1 pt-2 pb-1">
+                    <span className="text-sm font-semibold text-foreground">
+                      <FormattedMessage
+                        id="widget.help.browseCollections"
+                        defaultMessage="Browse collections"
+                      />
+                    </span>
+                    <span className="text-[11px] text-muted-foreground/60 tabular-nums">
+                      <FormattedMessage
+                        id="widget.help.collectionsCount"
+                        defaultMessage="{count, plural, one {# collection} other {# collections}}"
+                        values={{ count: topLevelCategories.length }}
+                      />
+                    </span>
                   </p>
                   <ul>
                     {topLevelCategories.map((cat) => (
@@ -152,7 +200,7 @@ export function WidgetHelp({ onArticleSelect, onCategorySelect }: WidgetHelpProp
                         >
                           <CategoryIcon icon={cat.icon} className="w-6 h-6 shrink-0" />
                           <span className="min-w-0 flex-1">
-                            <span className="block text-sm font-semibold text-foreground group-hover:text-primary transition-colors line-clamp-1">
+                            <span className="block text-sm font-semibold text-foreground line-clamp-1">
                               {cat.name}
                             </span>
                             {cat.description && (

--- a/apps/web/src/locales/ar.json
+++ b/apps/web/src/locales/ar.json
@@ -1175,5 +1175,17 @@
   "widget.postDetail.error.notFound": "ربما تمت إزالة هذه المشاركة أو جعلها خاصة.",
   "widget.messages.emptyHint.ticketsOnly": "ستظهر ردود فريقنا هنا.",
   "widget.tickets.stageChanged": "تغيّرت الحالة منذ زيارتك الأخيرة",
+  "widget.help.searchAria": "البحث في مقالات المساعدة",
+  "widget.help.askAiSearchPlaceholder": "اسأل الذكاء الاصطناعي أو ابحث في المقالات…",
+  "widget.help.clearSearch": "مسح البحث",
+  "widget.help.browseCollections": "استعراض المجموعات",
+  "widget.helpDetail.browseCategory": "استعراض هذه المجموعة",
+  "widget.help.article.helpful": "هل كان هذا مفيدًا؟",
+  "widget.help.article.helpful.thanks": "شكرًا — يسعدنا أنه كان مفيدًا.",
+  "widget.help.article.helpful.sorry": "نعتذر عن ذلك.",
+  "widget.help.article.helpful.yes": "نعم، كان مفيدًا",
+  "widget.help.article.helpful.no": "لا، لم يكن مفيدًا",
+  "widget.help.article.stillStuck": "ما زلت بحاجة إلى مساعدة؟",
+  "widget.help.article.askQuestion": "اطرح علينا سؤالًا",
   "widget.shell.tab.messages.unread": "{count} غير مقروءة"
 }

--- a/apps/web/src/locales/de.json
+++ b/apps/web/src/locales/de.json
@@ -1175,5 +1175,17 @@
   "widget.postDetail.error.notFound": "Dieser Beitrag wurde möglicherweise entfernt oder auf privat gesetzt.",
   "widget.messages.emptyHint.ticketsOnly": "Antworten unseres Teams erscheinen hier.",
   "widget.tickets.stageChanged": "Status hat sich seit deinem letzten Besuch geändert",
+  "widget.help.searchAria": "Hilfeartikel durchsuchen",
+  "widget.help.askAiSearchPlaceholder": "KI fragen oder Artikel suchen…",
+  "widget.help.clearSearch": "Suche löschen",
+  "widget.help.browseCollections": "Sammlungen durchstöbern",
+  "widget.helpDetail.browseCategory": "Diese Sammlung durchstöbern",
+  "widget.help.article.helpful": "War das hilfreich?",
+  "widget.help.article.helpful.thanks": "Danke – schön, dass es geholfen hat.",
+  "widget.help.article.helpful.sorry": "Das tut uns leid.",
+  "widget.help.article.helpful.yes": "Ja, das hat geholfen",
+  "widget.help.article.helpful.no": "Nein, das hat nicht geholfen",
+  "widget.help.article.stillStuck": "Kommst du nicht weiter?",
+  "widget.help.article.askQuestion": "Stell uns eine Frage",
   "widget.shell.tab.messages.unread": "{count} ungelesen"
 }

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -1175,5 +1175,17 @@
   "widget.postDetail.error.notFound": "This post may have been removed or made private.",
   "widget.messages.emptyHint.ticketsOnly": "Replies from our team will show up here.",
   "widget.tickets.stageChanged": "Status changed since your last visit",
+  "widget.help.searchAria": "Search help articles",
+  "widget.help.askAiSearchPlaceholder": "Ask AI or search articles…",
+  "widget.help.clearSearch": "Clear search",
+  "widget.help.browseCollections": "Browse collections",
+  "widget.helpDetail.browseCategory": "Browse this collection",
+  "widget.help.article.helpful": "Was this helpful?",
+  "widget.help.article.helpful.thanks": "Thanks — glad it helped.",
+  "widget.help.article.helpful.sorry": "Sorry about that.",
+  "widget.help.article.helpful.yes": "Yes, this helped",
+  "widget.help.article.helpful.no": "No, this didn't help",
+  "widget.help.article.stillStuck": "Still stuck?",
+  "widget.help.article.askQuestion": "Ask us a question",
   "widget.shell.tab.messages.unread": "{count} unread"
 }

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -1175,5 +1175,17 @@
   "widget.postDetail.error.notFound": "Es posible que esta publicación se haya eliminado o sea privada.",
   "widget.messages.emptyHint.ticketsOnly": "Las respuestas de nuestro equipo aparecerán aquí.",
   "widget.tickets.stageChanged": "El estado cambió desde tu última visita",
+  "widget.help.searchAria": "Buscar artículos de ayuda",
+  "widget.help.askAiSearchPlaceholder": "Pregunta a la IA o busca artículos…",
+  "widget.help.clearSearch": "Borrar búsqueda",
+  "widget.help.browseCollections": "Explorar colecciones",
+  "widget.helpDetail.browseCategory": "Explorar esta colección",
+  "widget.help.article.helpful": "¿Te resultó útil?",
+  "widget.help.article.helpful.thanks": "Gracias. Nos alegra que te haya servido.",
+  "widget.help.article.helpful.sorry": "Lo sentimos.",
+  "widget.help.article.helpful.yes": "Sí, me ayudó",
+  "widget.help.article.helpful.no": "No, no me ayudó",
+  "widget.help.article.stillStuck": "¿Sigues atascado?",
+  "widget.help.article.askQuestion": "Haznos una pregunta",
   "widget.shell.tab.messages.unread": "{count} sin leer"
 }

--- a/apps/web/src/locales/fr.json
+++ b/apps/web/src/locales/fr.json
@@ -1175,5 +1175,17 @@
   "widget.postDetail.error.notFound": "Cette publication a peut-être été supprimée ou rendue privée.",
   "widget.messages.emptyHint.ticketsOnly": "Les réponses de notre équipe apparaîtront ici.",
   "widget.tickets.stageChanged": "Le statut a changé depuis votre dernière visite",
+  "widget.help.searchAria": "Rechercher dans les articles d'aide",
+  "widget.help.askAiSearchPlaceholder": "Demander à l'IA ou rechercher des articles…",
+  "widget.help.clearSearch": "Effacer la recherche",
+  "widget.help.browseCollections": "Parcourir les collections",
+  "widget.helpDetail.browseCategory": "Parcourir cette collection",
+  "widget.help.article.helpful": "Cela vous a-t-il aidé ?",
+  "widget.help.article.helpful.thanks": "Merci — ravi que cela ait aidé.",
+  "widget.help.article.helpful.sorry": "Désolé pour cela.",
+  "widget.help.article.helpful.yes": "Oui, cela m'a aidé",
+  "widget.help.article.helpful.no": "Non, cela ne m'a pas aidé",
+  "widget.help.article.stillStuck": "Toujours bloqué ?",
+  "widget.help.article.askQuestion": "Posez-nous une question",
   "widget.shell.tab.messages.unread": "{count} non lu(s)"
 }

--- a/apps/web/src/locales/pt-br.json
+++ b/apps/web/src/locales/pt-br.json
@@ -1175,5 +1175,17 @@
   "widget.postDetail.error.notFound": "Esta publicação pode ter sido removida ou tornada privada.",
   "widget.messages.emptyHint.ticketsOnly": "As respostas da nossa equipe aparecerão aqui.",
   "widget.tickets.stageChanged": "O status mudou desde sua última visita",
+  "widget.help.searchAria": "Pesquisar artigos de ajuda",
+  "widget.help.askAiSearchPlaceholder": "Pergunte à IA ou pesquise artigos…",
+  "widget.help.clearSearch": "Limpar pesquisa",
+  "widget.help.browseCollections": "Explorar coleções",
+  "widget.helpDetail.browseCategory": "Explorar esta coleção",
+  "widget.help.article.helpful": "Isso foi útil?",
+  "widget.help.article.helpful.thanks": "Obrigado! Que bom que ajudou.",
+  "widget.help.article.helpful.sorry": "Sentimos muito.",
+  "widget.help.article.helpful.yes": "Sim, ajudou",
+  "widget.help.article.helpful.no": "Não, não ajudou",
+  "widget.help.article.stillStuck": "Ainda com dúvidas?",
+  "widget.help.article.askQuestion": "Faça uma pergunta",
   "widget.shell.tab.messages.unread": "{count} não lida(s)"
 }

--- a/apps/web/src/locales/ru.json
+++ b/apps/web/src/locales/ru.json
@@ -1175,5 +1175,17 @@
   "widget.postDetail.error.notFound": "Возможно, этот пост был удалён или скрыт.",
   "widget.messages.emptyHint.ticketsOnly": "Ответы нашей команды появятся здесь.",
   "widget.tickets.stageChanged": "Статус изменился с вашего последнего визита",
+  "widget.help.searchAria": "Поиск по справочным статьям",
+  "widget.help.askAiSearchPlaceholder": "Спросите ИИ или найдите статью…",
+  "widget.help.clearSearch": "Очистить поиск",
+  "widget.help.browseCollections": "Обзор разделов",
+  "widget.helpDetail.browseCategory": "Открыть этот раздел",
+  "widget.help.article.helpful": "Это было полезно?",
+  "widget.help.article.helpful.thanks": "Спасибо — рады, что помогло.",
+  "widget.help.article.helpful.sorry": "Жаль, что не помогло.",
+  "widget.help.article.helpful.yes": "Да, помогло",
+  "widget.help.article.helpful.no": "Нет, не помогло",
+  "widget.help.article.stillStuck": "Не нашли ответ?",
+  "widget.help.article.askQuestion": "Задайте нам вопрос",
   "widget.shell.tab.messages.unread": "{count} непрочитанных"
 }

--- a/apps/web/src/locales/zh-cn.json
+++ b/apps/web/src/locales/zh-cn.json
@@ -1175,5 +1175,17 @@
   "widget.postDetail.error.notFound": "此帖子可能已被删除或设为私密。",
   "widget.messages.emptyHint.ticketsOnly": "团队的回复将显示在这里。",
   "widget.tickets.stageChanged": "自上次访问以来状态已更改",
+  "widget.help.searchAria": "搜索帮助文章",
+  "widget.help.askAiSearchPlaceholder": "询问 AI 或搜索文章…",
+  "widget.help.clearSearch": "清除搜索",
+  "widget.help.browseCollections": "浏览分类",
+  "widget.helpDetail.browseCategory": "浏览此分类",
+  "widget.help.article.helpful": "这篇文章有帮助吗？",
+  "widget.help.article.helpful.thanks": "谢谢，很高兴对您有帮助。",
+  "widget.help.article.helpful.sorry": "很抱歉。",
+  "widget.help.article.helpful.yes": "有帮助",
+  "widget.help.article.helpful.no": "没有帮助",
+  "widget.help.article.stillStuck": "仍有疑问？",
+  "widget.help.article.askQuestion": "向我们提问",
   "widget.shell.tab.messages.unread": "{count} 条未读"
 }

--- a/apps/web/src/locales/zh-tw.json
+++ b/apps/web/src/locales/zh-tw.json
@@ -1175,5 +1175,17 @@
   "widget.postDetail.error.notFound": "此貼文可能已被移除或設為私密。",
   "widget.messages.emptyHint.ticketsOnly": "團隊的回覆將顯示在這裡。",
   "widget.tickets.stageChanged": "自上次造訪以來狀態已變更",
+  "widget.help.searchAria": "搜尋說明文章",
+  "widget.help.askAiSearchPlaceholder": "詢問 AI 或搜尋文章…",
+  "widget.help.clearSearch": "清除搜尋",
+  "widget.help.browseCollections": "瀏覽分類",
+  "widget.helpDetail.browseCategory": "瀏覽此分類",
+  "widget.help.article.helpful": "這篇文章有幫助嗎？",
+  "widget.help.article.helpful.thanks": "謝謝，很高興對您有幫助。",
+  "widget.help.article.helpful.sorry": "很抱歉。",
+  "widget.help.article.helpful.yes": "有幫助",
+  "widget.help.article.helpful.no": "沒有幫助",
+  "widget.help.article.stillStuck": "仍有疑問？",
+  "widget.help.article.askQuestion": "向我們提問",
   "widget.shell.tab.messages.unread": "{count} 則未讀"
 }

--- a/apps/web/src/routes/widget/index.tsx
+++ b/apps/web/src/routes/widget/index.tsx
@@ -569,6 +569,11 @@ function WidgetPage() {
         setActiveTab('changelog')
         setView('changelog')
       } else if (opts.view === 'help' && tabs.help) {
+        // Same fresh start as navigateToTab('help'): the lifted search
+        // would otherwise resurface an old query on a programmatic open.
+        setSelectedHelpSlug(null)
+        setSelectedCategory(null)
+        setHelpSearch('')
         setActiveTab('help')
         setView('help')
       } else if (

--- a/apps/web/src/routes/widget/index.tsx
+++ b/apps/web/src/routes/widget/index.tsx
@@ -494,6 +494,10 @@ function WidgetPage() {
   const [selectedPostId, setSelectedPostId] = useState<string | null>(null)
   const [selectedChangelogId, setSelectedChangelogId] = useState<string | null>(null)
   const [selectedHelpSlug, setSelectedHelpSlug] = useState<string | null>(null)
+  // Help search lives here (not in the view) so it survives the article
+  // round-trip: back from a result lands on the same results, not the
+  // collection list.
+  const [helpSearch, setHelpSearch] = useState('')
   const [selectedCategory, setSelectedCategory] = useState<{
     id: string
     name: string
@@ -636,7 +640,14 @@ function WidgetPage() {
       return
     }
     if (view === 'messenger') {
-      // Return to the list we opened from (Messages or Tickets).
+      // Opened from an article's "Still stuck?" ramp: back resumes the read.
+      if (backTarget?.view === 'help-detail' && selectedHelpSlug) {
+        setActiveTab(backTarget.tab)
+        setView('help-detail')
+        setBackTarget(null)
+        return
+      }
+      // Otherwise return to the list we opened from (Messages or Tickets).
       setView(activeTab === 'tickets' ? 'tickets' : 'messages')
       return
     }
@@ -658,7 +669,7 @@ function WidgetPage() {
     }
     setSelectedPostId(null)
     setView('feedback')
-  }, [view, selectedCategory, backTarget, activeTab])
+  }, [view, selectedCategory, selectedHelpSlug, backTarget, activeTab])
 
   const navigateToTab = useCallback((tab: WidgetTab) => {
     setActiveTab(tab)
@@ -676,9 +687,11 @@ function WidgetPage() {
       setSelectedChangelogId(null)
       setView('changelog')
     } else {
-      // 'help' — the knowledge-base articles surface
+      // 'help' — the knowledge-base articles surface. A tab landing is a
+      // fresh start; only back navigations keep the query.
       setSelectedHelpSlug(null)
       setSelectedCategory(null)
+      setHelpSearch('')
       setView('help')
     }
   }, [])
@@ -923,6 +936,8 @@ function WidgetPage() {
           <WidgetHelp
             onArticleSelect={handleHelpArticleSelect}
             onCategorySelect={handleHelpCategorySelect}
+            search={helpSearch}
+            onSearchChange={setHelpSearch}
           />
         </ViewTransition>
       )}
@@ -955,7 +970,20 @@ function WidgetPage() {
           focusOnMount={focusIncoming}
           fallback={<WidgetArticleSkeleton />}
         >
-          <WidgetHelpDetail articleSlug={selectedHelpSlug} />
+          <WidgetHelpDetail
+            articleSlug={selectedHelpSlug}
+            onCategorySelect={(id, name) => handleHelpCategorySelect(id, name, null)}
+            onAskQuestion={
+              messengerEnabled
+                ? () => {
+                    // Back from the new thread returns to this article, not to
+                    // the Messages list — the visitor was mid-read.
+                    setBackTarget({ tab: 'help', view: 'help-detail' })
+                    openMessenger('new')
+                  }
+                : undefined
+            }
+          />
         </ViewTransition>
       )}
 

--- a/apps/web/src/routes/widget/index.tsx
+++ b/apps/web/src/routes/widget/index.tsx
@@ -510,9 +510,19 @@ function WidgetPage() {
     return [...createdPosts, ...posts.filter((p) => !createdIds.has(p.id))]
   }, [posts, createdPosts])
 
+  // Set when the messenger was opened from an article's "Still stuck?" ramp:
+  // back then resumes the read instead of landing on the Messages list. Kept
+  // apart from `backTarget`, which still holds where the *article* came from
+  // (e.g. a Home card), so that chevron survives the detour.
+  const messengerReturnRef = useRef<'help-detail' | null>(null)
   const openMessenger = useCallback(
-    (target?: ConversationId | 'new', from: WidgetTab = 'messages') => {
+    (
+      target?: ConversationId | 'new',
+      from: WidgetTab = 'messages',
+      opts?: { returnTo?: 'help-detail' }
+    ) => {
       lastNavRef.current = 'move'
+      messengerReturnRef.current = opts?.returnTo ?? null
       setConversationTarget(target ?? null)
       setActiveTab(from === 'tickets' ? 'tickets' : 'messages')
       setView('messenger')
@@ -646,10 +656,11 @@ function WidgetPage() {
     }
     if (view === 'messenger') {
       // Opened from an article's "Still stuck?" ramp: back resumes the read.
-      if (backTarget?.view === 'help-detail' && selectedHelpSlug) {
-        setActiveTab(backTarget.tab)
+      // `backTarget` is left alone — it still points at the article's origin.
+      if (messengerReturnRef.current === 'help-detail' && selectedHelpSlug) {
+        messengerReturnRef.current = null
+        setActiveTab('help')
         setView('help-detail')
-        setBackTarget(null)
         return
       }
       // Otherwise return to the list we opened from (Messages or Tickets).
@@ -983,8 +994,7 @@ function WidgetPage() {
                 ? () => {
                     // Back from the new thread returns to this article, not to
                     // the Messages list — the visitor was mid-read.
-                    setBackTarget({ tab: 'help', view: 'help-detail' })
-                    openMessenger('new')
+                    openMessenger('new', 'messages', { returnTo: 'help-detail' })
                   }
                 : undefined
             }


### PR DESCRIPTION
Part of the widget UX stack on top of #468. Stacked on #474.

## Summary
- **Article exit ramp.** Articles ended in whitespace: a visitor whose question wasn't answered had nowhere to go but the back chevron. New `WidgetArticleFooter`: a one-tap helpful / not-helpful vote (the same signal the portal records via `recordArticleFeedbackFn`, kept to a single compact row — the portal's reason textarea would crowd a 400px panel) and, when the messenger is enabled, `Still stuck? Ask us a question`, which opens a new thread. Back from that thread returns to the article, not the Messages list.
- **Category eyebrow is tappable.** The category name above the article title is now a button into that collection.
- **Search a11y.** The input had no accessible name and no way to clear it short of select-all-delete; the Ask-AI placeholder (a portal sentence) truncated at the widget's width. Adds `aria-label`, an × clear button, and a shorter widget-specific placeholder. Escape already clears the query inside the Ask-AI controller and `preventDefault`s, so it composes with #471's scoped Escape.
- **Search survives the round-trip.** The query is lifted to the page (`helpSearch`), so result → article → back lands on the same results instead of the collection list. A tab-bar landing on Help still starts fresh.
- **Collections list.** The heading was a bare count (`16 collections`); it's now `Browse collections` with the count as a secondary label. Category names no longer flip to `text-primary` on hover.
- **Category view header** shows the collection's description and article count, and picks up the icon from the categories cache when reached from an article (which only knows id + name).

## Test plan
- [x] `tsc --noEmit`, `oxlint`, locale parity tests (12 new keys × 9 locales)
- [x] Playwright: search `account` → open first result → back; input value is still `account` and the results are on screen
- [x] Playwright screenshot of an article's footer (vote buttons + Still stuck CTA)
- [ ] Manual: tap Still stuck → send a message → back returns to the article

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>