### PR TITLE
feat(widget): let changelog cards say what kind of update they are, and what's new

### DIFF
--- a/apps/web/src/components/widget/widget-changelog-detail.tsx
+++ b/apps/web/src/components/widget/widget-changelog-detail.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { FormattedDate, FormattedMessage } from 'react-intl'
+import { FormattedMessage } from 'react-intl'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { publicChangelogQueries } from '@/lib/client/queries/changelog'
 import { RichTextContent, isRichTextContent } from '@/components/ui/rich-text-content'
@@ -10,6 +10,7 @@ import type { JSONContent } from '@tiptap/react'
 import { WidgetPortalTitle } from './widget-portal-title'
 import { sendToHost } from '@/lib/client/widget-bridge'
 import { WidgetArticleSkeleton } from './widget-skeletons'
+import { ChangelogMetaRow } from './widget-changelog-meta'
 
 interface WidgetChangelogDetailProps {
   entryId: string
@@ -44,25 +45,9 @@ export function WidgetChangelogDetail({ entryId }: WidgetChangelogDetailProps) {
       <ScrollArea scrollBarClassName="w-1.5" className="flex-1 min-h-0">
         {/* Readable column when the host panel expands for long-form content. */}
         <div className="mx-auto w-full max-w-2xl px-4 py-3">
-          <time
-            dateTime={entry.publishedAt}
-            className="text-[11px] text-muted-foreground/60 uppercase tracking-wide"
-          >
-            <FormattedDate value={entry.publishedAt} month="long" day="numeric" year="numeric" />
-          </time>
-          {entry.categories.length > 0 && (
-            <div className="mt-1.5 flex flex-wrap gap-1">
-              {entry.categories.map((category) => (
-                <span
-                  key={category.id}
-                  className="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium"
-                  style={{ backgroundColor: category.color + '1a', color: category.color }}
-                >
-                  {category.name}
-                </span>
-              ))}
-            </div>
-          )}
+          {/* Same meta strip as the list card, so the push doesn't reshuffle
+              date and chips around the title. */}
+          <ChangelogMetaRow publishedAt={entry.publishedAt} categories={entry.categories} long />
           <WidgetPortalTitle title={entry.title} onClick={handleViewOnPortal} />
 
           <div className="mt-3">

--- a/apps/web/src/components/widget/widget-changelog-meta.tsx
+++ b/apps/web/src/components/widget/widget-changelog-meta.tsx
@@ -1,0 +1,51 @@
+import { FormattedDate, FormattedMessage } from 'react-intl'
+import { cn } from '@/lib/shared/utils'
+
+/**
+ * The one-line "when / what kind / is it new" strip above a changelog title.
+ * Shared by the list card and the entry view so the two read identically.
+ */
+export function ChangelogMetaRow({
+  publishedAt,
+  categories,
+  isNew = false,
+  long = false,
+  className,
+}: {
+  publishedAt: string
+  categories: readonly { id: string; name: string; color: string }[]
+  isNew?: boolean
+  /** Long month name (entry view) vs. short (list card). */
+  long?: boolean
+  className?: string
+}) {
+  return (
+    <div className={cn('flex flex-wrap items-center gap-x-2 gap-y-1', className)}>
+      <time
+        dateTime={publishedAt}
+        className="text-[11px] font-medium text-muted-foreground/60 uppercase tracking-wide"
+      >
+        <FormattedDate
+          value={publishedAt}
+          month={long ? 'long' : 'short'}
+          day="numeric"
+          year="numeric"
+        />
+      </time>
+      {isNew && (
+        <span className="inline-flex items-center rounded-full bg-primary px-1.5 py-px text-[11px] font-semibold uppercase tracking-wide text-primary-foreground">
+          <FormattedMessage id="widget.changelog.new" defaultMessage="New" />
+        </span>
+      )}
+      {categories.map((category) => (
+        <span
+          key={category.id}
+          className="inline-flex items-center rounded-full px-1.5 py-px text-[11px] font-medium"
+          style={{ backgroundColor: category.color + '1a', color: category.color }}
+        >
+          {category.name}
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/apps/web/src/components/widget/widget-changelog.tsx
+++ b/apps/web/src/components/widget/widget-changelog.tsx
@@ -25,9 +25,17 @@ interface WidgetChangelogProps {
  * the same "pick up where you left off" the kept-mounted Feedback view gets
  * for free. Module state is per iframe, i.e. per widget session.
  */
-const lastVisit: { scrollTop: number; categoryId: ChangelogCategoryId | null } = {
+const lastVisit: {
+  scrollTop: number
+  categoryId: ChangelogCategoryId | null
+  /** Seen marker as it stood when the list first had data this session;
+   *  `undefined` until captured. Lives here, not in the component, because
+   *  opening an entry unmounts the list and the marker has advanced by then. */
+  seenBaseline: string | null | undefined
+} = {
   scrollTop: 0,
   categoryId: null,
+  seenBaseline: undefined,
 }
 
 /** Filtered pages to pull ahead before conceding "nothing in this category". */
@@ -48,21 +56,13 @@ export function WidgetChangelog({ teamName, onEntrySelect }: WidgetChangelogProp
   const allEntries = data?.pages.flatMap((page) => page.items) ?? []
 
   // The launcher badge counted unread entries; the list should show which.
-  // Capture the seen marker once, when the list first has data — before the
-  // effect below advances it — so "New" holds for this visit.
-  const baselineRef = useRef<string | null | undefined>(undefined)
-  if (data && baselineRef.current === undefined) baselineRef.current = getChangelogSeenAt()
-  const baseline = baselineRef.current ? new Date(baselineRef.current).getTime() : null
+  // Capture the seen marker once per session, when the list first has data —
+  // before the effect below advances it — so "New" holds across detail
+  // round-trips and not just this mount.
+  if (data && lastVisit.seenBaseline === undefined) lastVisit.seenBaseline = getChangelogSeenAt()
+  const baseline = lastVisit.seenBaseline ? new Date(lastVisit.seenBaseline).getTime() : null
   const isNew = (publishedAt: string) =>
     baseline !== null && new Date(publishedAt).getTime() > baseline
-
-  // Entries on screen are seen: advance the visitor's marker to the newest
-  // loaded entry so the launcher badge clears. The list is newest-first, so
-  // the first entry carries the max publishedAt.
-  useEffect(() => {
-    const newest = allEntries[0]?.publishedAt
-    if (newest) markChangelogSeen(newest)
-  }, [allEntries])
 
   const categoriesInUse = useMemo(() => {
     const usedIds = new Set(allEntries.flatMap((e) => e.categories.map((c) => c.id)))
@@ -72,6 +72,16 @@ export function WidgetChangelog({ teamName, onEntrySelect }: WidgetChangelogProp
   const entries = activeCategoryId
     ? allEntries.filter((e) => e.categories.some((c) => c.id === activeCategoryId))
     : allEntries
+
+  // Entries on screen are seen: advance the visitor's marker to the newest
+  // VISIBLE entry so the launcher badge clears. The list is newest-first, so
+  // the first entry carries the max publishedAt. Under a restored category
+  // filter a newer entry from another category is not on screen, so it must
+  // keep its badge (the marker only ever moves forward, so this is safe).
+  useEffect(() => {
+    const newest = entries[0]?.publishedAt
+    if (newest) markChangelogSeen(newest)
+  }, [entries])
 
   const sentinelRef = useInfiniteScroll({
     hasMore: hasNextPage ?? false,

--- a/apps/web/src/components/widget/widget-changelog.tsx
+++ b/apps/web/src/components/widget/widget-changelog.tsx
@@ -42,9 +42,8 @@ const lastVisit: {
 const FILTER_LOOKAHEAD_MIN_ROWS = 3
 
 export function WidgetChangelog({ teamName, onEntrySelect }: WidgetChangelogProps) {
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useInfiniteQuery(
-    publicChangelogQueries.list()
-  )
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isFetchNextPageError, isLoading } =
+    useInfiniteQuery(publicChangelogQueries.list())
   const { data: categories = [] } = useQuery(changelogCategoryQueries.list())
   const [activeCategoryId, setActiveCategoryId] = useState<ChangelogCategoryId | null>(
     lastVisit.categoryId
@@ -92,10 +91,14 @@ export function WidgetChangelog({ teamName, onEntrySelect }: WidgetChangelogProp
   // Filtering is client-side over the pages loaded so far, so a sparse
   // category could show "nothing yet" while later pages hold matches. Pull
   // pages ahead until the filtered list has a few rows (or pages run out).
+  // A failed page stops the automatic pull — otherwise a dead API would be
+  // re-requested in a tight loop — and the empty state shows; the scroll
+  // sentinel below it still retries on the visitor's own scrolling.
   const filteredLookahead =
     activeCategoryId !== null &&
     entries.length < FILTER_LOOKAHEAD_MIN_ROWS &&
-    (hasNextPage ?? false)
+    (hasNextPage ?? false) &&
+    !isFetchNextPageError
   useEffect(() => {
     if (filteredLookahead && !isFetchingNextPage) void fetchNextPage()
   }, [filteredLookahead, isFetchingNextPage, fetchNextPage])

--- a/apps/web/src/components/widget/widget-changelog.tsx
+++ b/apps/web/src/components/widget/widget-changelog.tsx
@@ -1,15 +1,16 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
-import { FormattedDate, FormattedMessage } from 'react-intl'
+import { FormattedMessage } from 'react-intl'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { contentPreview } from '@/lib/shared/utils/string'
 import { cn } from '@/lib/shared/utils'
 import { publicChangelogQueries, changelogCategoryQueries } from '@/lib/client/queries/changelog'
 import { useInfiniteScroll } from '@/lib/client/hooks/use-infinite-scroll'
-import { markChangelogSeen } from './changelog-unread'
+import { getChangelogSeenAt, markChangelogSeen } from './changelog-unread'
 import { NewspaperIcon } from '@heroicons/react/24/outline'
 import type { ChangelogCategoryId } from '@quackback/ids'
 import { WidgetChangelogListSkeleton, WidgetChangelogMoreSkeleton } from './widget-skeletons'
+import { ChangelogMetaRow } from './widget-changelog-meta'
 
 interface WidgetChangelogProps {
   /** Team label for the "From {team}" subline; omitted when unknown. */
@@ -17,14 +18,43 @@ interface WidgetChangelogProps {
   onEntrySelect?: (entryId: string) => void
 }
 
+/**
+ * Where the visitor was in the list when they left it. The view unmounts on
+ * every push into an entry (the transition remounts it), so the scroll offset
+ * and active filter live at module scope and are restored on the next mount —
+ * the same "pick up where you left off" the kept-mounted Feedback view gets
+ * for free. Module state is per iframe, i.e. per widget session.
+ */
+const lastVisit: { scrollTop: number; categoryId: ChangelogCategoryId | null } = {
+  scrollTop: 0,
+  categoryId: null,
+}
+
+/** Filtered pages to pull ahead before conceding "nothing in this category". */
+const FILTER_LOOKAHEAD_MIN_ROWS = 3
+
 export function WidgetChangelog({ teamName, onEntrySelect }: WidgetChangelogProps) {
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useInfiniteQuery(
     publicChangelogQueries.list()
   )
   const { data: categories = [] } = useQuery(changelogCategoryQueries.list())
-  const [activeCategoryId, setActiveCategoryId] = useState<ChangelogCategoryId | null>(null)
+  const [activeCategoryId, setActiveCategoryId] = useState<ChangelogCategoryId | null>(
+    lastVisit.categoryId
+  )
+  useEffect(() => {
+    lastVisit.categoryId = activeCategoryId
+  }, [activeCategoryId])
 
   const allEntries = data?.pages.flatMap((page) => page.items) ?? []
+
+  // The launcher badge counted unread entries; the list should show which.
+  // Capture the seen marker once, when the list first has data — before the
+  // effect below advances it — so "New" holds for this visit.
+  const baselineRef = useRef<string | null | undefined>(undefined)
+  if (data && baselineRef.current === undefined) baselineRef.current = getChangelogSeenAt()
+  const baseline = baselineRef.current ? new Date(baselineRef.current).getTime() : null
+  const isNew = (publishedAt: string) =>
+    baseline !== null && new Date(publishedAt).getTime() > baseline
 
   // Entries on screen are seen: advance the visitor's marker to the newest
   // loaded entry so the launcher badge clears. The list is newest-first, so
@@ -49,6 +79,31 @@ export function WidgetChangelog({ teamName, onEntrySelect }: WidgetChangelogProp
     onLoadMore: fetchNextPage,
   })
 
+  // Filtering is client-side over the pages loaded so far, so a sparse
+  // category could show "nothing yet" while later pages hold matches. Pull
+  // pages ahead until the filtered list has a few rows (or pages run out).
+  const filteredLookahead =
+    activeCategoryId !== null &&
+    entries.length < FILTER_LOOKAHEAD_MIN_ROWS &&
+    (hasNextPage ?? false)
+  useEffect(() => {
+    if (filteredLookahead && !isFetchingNextPage) void fetchNextPage()
+  }, [filteredLookahead, isFetchingNextPage, fetchNextPage])
+
+  // Scroll restore: put the viewport back where it was once the (cached) list
+  // has painted, then track every scroll so the next visit can do the same.
+  const viewportRef = useRef<HTMLDivElement>(null)
+  useLayoutEffect(() => {
+    const el = viewportRef.current
+    if (!el || isLoading) return
+    if (lastVisit.scrollTop > 0) el.scrollTop = lastVisit.scrollTop
+    const onScroll = () => {
+      lastVisit.scrollTop = el.scrollTop
+    }
+    el.addEventListener('scroll', onScroll, { passive: true })
+    return () => el.removeEventListener('scroll', onScroll)
+  }, [isLoading])
+
   if (isLoading) {
     return <WidgetChangelogListSkeleton />
   }
@@ -71,7 +126,11 @@ export function WidgetChangelog({ teamName, onEntrySelect }: WidgetChangelogProp
   }
 
   return (
-    <ScrollArea scrollBarClassName="w-1.5" className="flex-1 min-h-0 h-full">
+    <ScrollArea
+      scrollBarClassName="w-1.5"
+      className="flex-1 min-h-0 h-full"
+      viewportRef={viewportRef}
+    >
       <div className="px-3 pt-2 pb-3">
         <header className="px-1 pb-2">
           <h2 className="text-base font-semibold text-foreground">
@@ -93,6 +152,7 @@ export function WidgetChangelog({ teamName, onEntrySelect }: WidgetChangelogProp
             <button
               type="button"
               onClick={() => setActiveCategoryId(null)}
+              aria-pressed={activeCategoryId === null}
               className={cn(
                 'rounded-full px-2 py-0.5 text-[11px] font-medium transition-colors',
                 activeCategoryId === null
@@ -107,6 +167,7 @@ export function WidgetChangelog({ teamName, onEntrySelect }: WidgetChangelogProp
                 key={category.id}
                 type="button"
                 onClick={() => setActiveCategoryId(category.id)}
+                aria-pressed={activeCategoryId === category.id}
                 className="rounded-full px-2 py-0.5 text-[11px] font-medium transition-colors"
                 style={{
                   backgroundColor:
@@ -120,7 +181,7 @@ export function WidgetChangelog({ teamName, onEntrySelect }: WidgetChangelogProp
           </div>
         )}
 
-        {entries.length === 0 ? (
+        {entries.length === 0 && !filteredLookahead ? (
           <p className="px-1 py-6 text-center text-xs text-muted-foreground">
             <FormattedMessage
               id="widget.changelog.emptyFiltered"
@@ -136,19 +197,12 @@ export function WidgetChangelog({ teamName, onEntrySelect }: WidgetChangelogProp
                 onClick={() => onEntrySelect?.(entry.id)}
                 className="w-full text-start rounded-xl border border-border/50 bg-card hover:bg-muted/30 transition-colors px-3.5 py-3 cursor-pointer"
               >
-                <div className="flex items-center gap-2 mb-1">
-                  <time
-                    dateTime={entry.publishedAt}
-                    className="text-[11px] font-medium text-muted-foreground/60 uppercase tracking-wide"
-                  >
-                    <FormattedDate
-                      value={entry.publishedAt}
-                      month="short"
-                      day="numeric"
-                      year="numeric"
-                    />
-                  </time>
-                </div>
+                <ChangelogMetaRow
+                  publishedAt={entry.publishedAt}
+                  categories={entry.categories}
+                  isNew={isNew(entry.publishedAt)}
+                  className="mb-1"
+                />
                 <h3 className="text-sm font-semibold text-foreground line-clamp-2 leading-snug">
                   {entry.title}
                 </h3>

--- a/apps/web/src/locales/ar.json
+++ b/apps/web/src/locales/ar.json
@@ -1187,5 +1187,6 @@
   "widget.help.article.helpful.no": "لا، لم يكن مفيدًا",
   "widget.help.article.stillStuck": "ما زلت بحاجة إلى مساعدة؟",
   "widget.help.article.askQuestion": "اطرح علينا سؤالًا",
+  "widget.changelog.new": "جديد",
   "widget.shell.tab.messages.unread": "{count} غير مقروءة"
 }

--- a/apps/web/src/locales/de.json
+++ b/apps/web/src/locales/de.json
@@ -1187,5 +1187,6 @@
   "widget.help.article.helpful.no": "Nein, das hat nicht geholfen",
   "widget.help.article.stillStuck": "Kommst du nicht weiter?",
   "widget.help.article.askQuestion": "Stell uns eine Frage",
+  "widget.changelog.new": "Neu",
   "widget.shell.tab.messages.unread": "{count} ungelesen"
 }

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -1187,5 +1187,6 @@
   "widget.help.article.helpful.no": "No, this didn't help",
   "widget.help.article.stillStuck": "Still stuck?",
   "widget.help.article.askQuestion": "Ask us a question",
+  "widget.changelog.new": "New",
   "widget.shell.tab.messages.unread": "{count} unread"
 }

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -1187,5 +1187,6 @@
   "widget.help.article.helpful.no": "No, no me ayudó",
   "widget.help.article.stillStuck": "¿Sigues atascado?",
   "widget.help.article.askQuestion": "Haznos una pregunta",
+  "widget.changelog.new": "Nuevo",
   "widget.shell.tab.messages.unread": "{count} sin leer"
 }

--- a/apps/web/src/locales/fr.json
+++ b/apps/web/src/locales/fr.json
@@ -1187,5 +1187,6 @@
   "widget.help.article.helpful.no": "Non, cela ne m'a pas aidé",
   "widget.help.article.stillStuck": "Toujours bloqué ?",
   "widget.help.article.askQuestion": "Posez-nous une question",
+  "widget.changelog.new": "Nouveau",
   "widget.shell.tab.messages.unread": "{count} non lu(s)"
 }

--- a/apps/web/src/locales/pt-br.json
+++ b/apps/web/src/locales/pt-br.json
@@ -1187,5 +1187,6 @@
   "widget.help.article.helpful.no": "Não, não ajudou",
   "widget.help.article.stillStuck": "Ainda com dúvidas?",
   "widget.help.article.askQuestion": "Faça uma pergunta",
+  "widget.changelog.new": "Novo",
   "widget.shell.tab.messages.unread": "{count} não lida(s)"
 }

--- a/apps/web/src/locales/ru.json
+++ b/apps/web/src/locales/ru.json
@@ -1187,5 +1187,6 @@
   "widget.help.article.helpful.no": "Нет, не помогло",
   "widget.help.article.stillStuck": "Не нашли ответ?",
   "widget.help.article.askQuestion": "Задайте нам вопрос",
+  "widget.changelog.new": "Новое",
   "widget.shell.tab.messages.unread": "{count} непрочитанных"
 }

--- a/apps/web/src/locales/zh-cn.json
+++ b/apps/web/src/locales/zh-cn.json
@@ -1187,5 +1187,6 @@
   "widget.help.article.helpful.no": "没有帮助",
   "widget.help.article.stillStuck": "仍有疑问？",
   "widget.help.article.askQuestion": "向我们提问",
+  "widget.changelog.new": "新",
   "widget.shell.tab.messages.unread": "{count} 条未读"
 }

--- a/apps/web/src/locales/zh-tw.json
+++ b/apps/web/src/locales/zh-tw.json
@@ -1187,5 +1187,6 @@
   "widget.help.article.helpful.no": "沒有幫助",
   "widget.help.article.stillStuck": "仍有疑問？",
   "widget.help.article.askQuestion": "向我們提問",
+  "widget.changelog.new": "新",
   "widget.shell.tab.messages.unread": "{count} 則未讀"
 }


### PR DESCRIPTION
Part of the widget UX stack on top of #468. Stacked on #475.

## Summary
- **Shared meta strip.** Cards showed only a date while the entry view opened with category chips, so the one line that helps a visitor decide whether to tap was withheld from the list. Both surfaces now render the same `ChangelogMetaRow` (date · New · category chips) above the title, so the push no longer reshuffles the header. Lives in its own module so the detail chunk doesn't pull in the list.
- **New marker.** Entries published after the visitor's seen marker get a `New` chip for the visit. The marker is captured once per widget session on first data, before the list's effect advances it (kept in the same module state as the restored filter/scroll, so it survives the detail round-trip that unmounts the list). The seen marker advances to the newest *visible* entry, so an update hidden by a restored category filter keeps its badge.
- **Filtered paging.** Category filtering is client-side over loaded pages, so a sparse category could read `No updates in this category yet` with matches on unloaded pages. While a filter is active and the filtered list has fewer than three rows, the list pulls pages ahead until it has some (or pages run out) before conceding empty.
- **Pick up where you left off.** Opening an entry unmounts the list, resetting scroll and dropping the active filter on the way back. Scroll offset and filter are kept at module scope for the session and restored on mount, matching what the kept-mounted Feedback view already gets. Filter pills expose `aria-pressed`.

## Test plan
- [x] `tsc --noEmit`, `oxlint` (incl. the repo's ≥11px text rule), locale parity tests (1 new key × 9 locales)
- [x] Playwright screenshot of the Changelog tab (seed data has no categories, so no chips render there)
- [ ] Manual: assign a category to a few entries, filter, open one, back — filter and scroll position are preserved

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
