### PR TITLE
feat(widget): focus the composer for new threads and say when the team is back

### DIFF
--- a/apps/web/src/components/shared/conversation/conversation-presence-badge.tsx
+++ b/apps/web/src/components/shared/conversation/conversation-presence-badge.tsx
@@ -19,10 +19,14 @@ export function ConversationPresenceBadge({
   className?: string
 }) {
   return (
-    <span className={cn('flex items-center gap-1.5 text-xs text-muted-foreground', className)}>
+    // min-w-0 down the chain: a flex item defaults to min-width:auto and
+    // would grow past its container instead of letting `truncate` ellipsize.
+    <span
+      className={cn('flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground', className)}
+    >
       <span
         className={cn(
-          'size-2 rounded-full',
+          'size-2 shrink-0 rounded-full',
           available ? 'bg-emerald-500' : 'bg-muted-foreground/40'
         )}
         aria-hidden
@@ -30,7 +34,7 @@ export function ConversationPresenceBadge({
       {available ? (
         <FormattedMessage id="widget.messenger.online" defaultMessage="We're online" />
       ) : (
-        <span className="truncate">
+        <span className="min-w-0 truncate">
           <FormattedMessage id="widget.messenger.offline" defaultMessage="We'll reply by email" />
           {backAt && (
             <span className="text-muted-foreground/70">

--- a/apps/web/src/components/shared/conversation/conversation-presence-badge.tsx
+++ b/apps/web/src/components/shared/conversation/conversation-presence-badge.tsx
@@ -9,9 +9,13 @@ import { cn } from '@/lib/shared/utils'
  */
 export function ConversationPresenceBadge({
   available,
+  backAt,
   className,
 }: {
   available: boolean
+  /** Pre-formatted "when we're back" label, shown after the away copy when
+   *  office hours are configured — sets an honest expectation up front. */
+  backAt?: string | null
   className?: string
 }) {
   return (
@@ -26,7 +30,19 @@ export function ConversationPresenceBadge({
       {available ? (
         <FormattedMessage id="widget.messenger.online" defaultMessage="We're online" />
       ) : (
-        <FormattedMessage id="widget.messenger.offline" defaultMessage="We'll reply by email" />
+        <span className="truncate">
+          <FormattedMessage id="widget.messenger.offline" defaultMessage="We'll reply by email" />
+          {backAt && (
+            <span className="text-muted-foreground/70">
+              {' · '}
+              <FormattedMessage
+                id="widget.messenger.offline.backAt"
+                defaultMessage="Back {when}"
+                values={{ when: backAt }}
+              />
+            </span>
+          )}
+        </span>
       )}
     </span>
   )

--- a/apps/web/src/components/shared/conversation/visitor-conversation-thread.tsx
+++ b/apps/web/src/components/shared/conversation/visitor-conversation-thread.tsx
@@ -160,6 +160,13 @@ export interface VisitorConversationThreadProps {
   showHeader?: boolean
   /** Notified when the first send creates the conversation. */
   onConversationStarted?: (id: ConversationId) => void
+  /**
+   * Focus the composer as soon as it mounts. The surface decides: a "new
+   * conversation" landing on a desktop host wants the cursor in the box; a
+   * resumed thread (reading, not writing) or a mobile host (software keyboard
+   * would cover the thread) does not.
+   */
+  autofocusComposer?: boolean
 }
 
 /**
@@ -187,6 +194,7 @@ export function VisitorConversationThread({
   embedOpenMode = 'newTab',
   showHeader = true,
   onConversationStarted,
+  autofocusComposer = false,
 }: VisitorConversationThreadProps) {
   const intl = useIntl()
   const queryClient = useQueryClient()
@@ -1082,7 +1090,9 @@ export function VisitorConversationThread({
                       key={n}
                       type="button"
                       onClick={() => submitRating(n)}
-                      className="text-lg leading-none text-muted-foreground/50 transition-colors hover:text-amber-500"
+                      // Brand colour rather than a fixed amber: the stars are
+                      // the only element in the thread that ignored the theme.
+                      className="rounded text-lg leading-none text-muted-foreground/50 transition-colors hover:text-primary focus-visible:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
                       aria-label={intl.formatMessage(
                         {
                           id: 'widget.messenger.csat.rateAria',
@@ -1343,16 +1353,17 @@ export function VisitorConversationThread({
                 <LazyRichTextEditor
                   // Remounts the editor to clear it after a send (no imperative
                   // ref exists to call clearContent()) — resetSignal starts at 0
-                  // (no remount, no autofocus on first mount) and increments on
-                  // every successful send, at which point we DO want focus back
-                  // so the visitor can keep typing without re-clicking.
+                  // and increments on every successful send, at which point we
+                  // DO want focus back so the visitor can keep typing without
+                  // re-clicking. First mount focuses only when the surface asks
+                  // (a fresh "new conversation" landing).
                   key={composer.resetSignal}
                   borderless
                   minHeight="1.5rem"
                   disabled={sending}
                   placeholder={composerPlaceholder}
                   features={VISITOR_CONVERSATION_FEATURES}
-                  autofocus={composer.resetSignal > 0 ? 'end' : false}
+                  autofocus={composer.resetSignal > 0 || autofocusComposer ? 'end' : false}
                   onChange={handleEditorChange}
                   onSubmit={onComposerSubmit}
                 />

--- a/apps/web/src/components/widget/widget-messenger.tsx
+++ b/apps/web/src/components/widget/widget-messenger.tsx
@@ -17,6 +17,8 @@ interface WidgetMessengerProps {
   conversationTarget?: ConversationId | 'new'
   /** When true, render link preview cards below message bubbles. */
   linkPreviews?: boolean
+  /** Put the cursor in the composer on mount (new-thread landings on desktop). */
+  autofocusComposer?: boolean
 }
 
 /**
@@ -30,6 +32,7 @@ export function WidgetMessenger({
   onArticleSelect,
   conversationTarget,
   linkPreviews = false,
+  autofocusComposer = false,
 }: WidgetMessengerProps = {}) {
   const queryClient = useQueryClient()
   const { user, ensureSession, sessionVersion } = useWidgetAuth()
@@ -71,6 +74,7 @@ export function WidgetMessenger({
       helpSearch={helpSearch}
       embedOpenMode="newTab"
       showHeader={false}
+      autofocusComposer={autofocusComposer}
     />
   )
 }

--- a/apps/web/src/components/widget/widget-shell.tsx
+++ b/apps/web/src/components/widget/widget-shell.tsx
@@ -257,8 +257,10 @@ export function WidgetShell({
           body; the header/content render transparently over it. */}
       {backdrop}
       <div className="relative z-10 flex items-center justify-between gap-2 px-4 py-3 shrink-0">
-        {/* Left: back button on detail views; workspace logo on Home. */}
-        <div className="flex items-center gap-1">
+        {/* Left: back button on detail views; workspace logo on Home. min-w-0 so
+            header content (presence copy) truncates instead of pushing the
+            right-zone controls. */}
+        <div className="flex min-w-0 items-center gap-1">
           {onHome && logoUrl && (
             <img src={logoUrl} alt="" className="h-6 max-w-[120px] object-contain" />
           )}
@@ -266,7 +268,7 @@ export function WidgetShell({
             <button
               type="button"
               onClick={onBack}
-              className="flex h-8 w-8 items-center justify-center rounded-md hover:bg-muted transition-colors"
+              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md hover:bg-muted transition-colors"
               aria-label={intl.formatMessage({
                 id: 'widget.shell.aria.goBack',
                 defaultMessage: 'Go back',

--- a/apps/web/src/routes/widget/index.tsx
+++ b/apps/web/src/routes/widget/index.tsx
@@ -399,6 +399,7 @@ function WidgetPage() {
     showPoweredBy,
   } = Route.useLoaderData()
   const { ensureSession, sessionVersion } = useWidgetAuth()
+  const intl = useIntl()
 
   // The loader seeds boardPermissions for the anonymous SSR baseline (no Bearer
   // at loader time). Refetch it for the REAL actor with the widget's Bearer
@@ -786,6 +787,18 @@ function WidgetPage() {
   // the assistant identity when enabled — always available, no presence — or
   // the live presence badge for assistant-less workspaces.
   const presence = useConversationPresence(messengerEnabled && !assistant)
+  // When office hours are configured, tell the visitor up front when the team
+  // is back — the thread body only says so once they've typed.
+  const presenceBackAt = useMemo(() => {
+    if (!presence.nextOpenAt) return null
+    const at = new Date(presence.nextOpenAt)
+    if (Number.isNaN(at.getTime())) return null
+    return new Intl.DateTimeFormat(intl.locale, {
+      weekday: 'long',
+      hour: 'numeric',
+      minute: '2-digit',
+    }).format(at)
+  }, [presence.nextOpenAt, intl.locale])
   const messengerHeader =
     view === 'messenger' ? (
       assistant ? (
@@ -807,6 +820,7 @@ function WidgetPage() {
         <div className="ps-1">
           <ConversationPresenceBadge
             available={conversationAvailable(presence.agentsOnline, presence.withinOfficeHours)}
+            backAt={presenceBackAt}
           />
         </div>
       )
@@ -900,6 +914,9 @@ function WidgetPage() {
             onArticleSelect={handleHelpArticleSelect}
             conversationTarget={conversationTarget === null ? undefined : conversationTarget}
             linkPreviews={linkPreviews}
+            // A fresh thread exists to be typed into; a resumed one to be read.
+            // Mobile hosts skip it — the software keyboard would cover the thread.
+            autofocusComposer={conversationTarget === 'new' && !hostIsMobile}
           />
         </ViewTransition>
       )}

--- a/apps/web/src/routes/widget/index.tsx
+++ b/apps/web/src/routes/widget/index.tsx
@@ -817,7 +817,7 @@ function WidgetPage() {
           </div>
         </div>
       ) : (
-        <div className="ps-1">
+        <div className="min-w-0 ps-1">
           <ConversationPresenceBadge
             available={conversationAvailable(presence.agentsOnline, presence.withinOfficeHours)}
             backAt={presenceBackAt}


### PR DESCRIPTION
Part of the widget UX stack on top of #468. Stacked on #476 (top of the stack).

## Summary
- **Composer autofocus for new threads.** Landing on "Ask a question" left the visitor looking at an empty composer they still had to click — the one screen in the widget that exists to be typed into. New `autofocusComposer` prop on `VisitorConversationThread`, passed by the widget when `conversationTarget === 'new'` and the host is not mobile (the software keyboard would cover the thread). A resumed thread keeps its current behaviour.
- **Say when the team is back.** The header presence badge read `We'll reply by email` with no hint of when. When office hours are configured, `ConversationPresenceBadge` now appends `· Back Monday 9:00` (existing `widget.messenger.offline.backAt` key, formatted in the visitor's locale) — the same label the thread body only showed after typing.
- **CSAT stars** hovered a fixed amber, the one element in the thread that ignored the workspace theme, and had no focus ring. They now use the brand colour and a visible focus state.

## Test plan
- [x] `tsc --noEmit`, `oxlint`
- [x] Playwright: after clicking Ask a question, `document.activeElement` is the `.tiptap.ProseMirror` editor
- [ ] Manual: with office hours configured and the team away, confirm the header badge shows the return time

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>