### PR TITLE
fix(billing): drop the 1,000-seat cap in the checkout configurator URL

### DIFF
--- a/apps/web/src/lib/shared/billing/__tests__/checkout-path.test.ts
+++ b/apps/web/src/lib/shared/billing/__tests__/checkout-path.test.ts
@@ -39,6 +39,7 @@ describe('parseCheckoutSearch', () => {
     expect(parseCheckoutSearch({ branding: 'yes' })).toEqual({})
     expect(parseCheckoutSearch({ plan: 'enterprise', seats: 'lots' })).toEqual({})
     expect(parseCheckoutSearch({ seats: 2.5 })).toEqual({})
+    expect(parseCheckoutSearch({ seats: '1001' })).toEqual({ seats: 1001 })
   })
 })
 

--- a/apps/web/src/lib/shared/billing/checkout-path.ts
+++ b/apps/web/src/lib/shared/billing/checkout-path.ts
@@ -25,7 +25,9 @@ export function parseCheckoutSearch(raw: Record<string, unknown>): CheckoutSearc
   if (isPaidPlanId(raw.plan)) search.plan = raw.plan
   if (raw.period === 'monthly' || raw.period === 'annual') search.period = raw.period
   const seats = typeof raw.seats === 'string' ? Number(raw.seats) : raw.seats
-  if (typeof seats === 'number' && Number.isInteger(seats) && seats >= 1 && seats <= 1000) {
+  // Same bound as the checkout API (any positive integer): a workspace already
+  // past an arbitrary cap must still be able to add seats.
+  if (typeof seats === 'number' && Number.isSafeInteger(seats) && seats >= 1) {
     search.seats = seats
   }
   if (raw.branding === true || raw.branding === 'true') search.branding = true


### PR DESCRIPTION
## Summary
Follow-up to #466 (P2). `parseCheckoutSearch` capped `seats` at 1,000 while `/api/billing/session` accepts any positive integer. For a workspace already past 1,000 seats, "More seats" wrote e.g. `seats=1001` to the URL, validation dropped it, and the page fell back to live usage, so seats could never be added. The parser now matches the API: any positive safe integer.

## Test plan
- [x] `checkout-path.test.ts` covers `seats=1001`
- [x] `tsc --noEmit`

Made with [Cursor](https://cursor.com)