### PR TITLE
fix(admin): ignore stored trial notices on cloud workspaces

### DIFF
--- a/apps/web/src/components/admin/__tests__/plan-notice-banner.test.tsx
+++ b/apps/web/src/components/admin/__tests__/plan-notice-banner.test.tsx
@@ -1,16 +1,16 @@
 // @vitest-environment happy-dom
 import '@testing-library/jest-dom/vitest'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 import { PlanNoticeBanner } from '../plan-notice-banner'
 
 const ENDED = {
-  label: 'Pro trial',
-  message: "You're on the Free plan. Nothing was deleted.",
+  label: 'Growth trial ended',
+  message: 'Your trial has come to an end.',
   expiresAt: '2026-08-18T00:00:00.000Z',
-  actionLabel: 'Continue with Pro',
+  actionLabel: 'Update billing',
   actionUrl: '/admin/settings/billing',
-  dismissible: true,
+  ended: true,
 }
 
 const OPERATOR = {
@@ -23,13 +23,18 @@ describe('PlanNoticeBanner', () => {
     cleanup()
   })
 
-  it('still shows an operator notice after an ended-trial dismiss', async () => {
-    const { rerender } = render(<PlanNoticeBanner notice={ENDED} />)
-    expect(await screen.findByText('Pro trial')).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }))
-    expect(screen.queryByText('Pro trial')).not.toBeInTheDocument()
+  it('renders an ended-trial strip with no dismiss control', () => {
+    render(<PlanNoticeBanner notice={ENDED} />)
+    expect(screen.getByText('Growth trial ended')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Update billing/ })).toHaveAttribute(
+      'href',
+      '/admin/settings/billing'
+    )
+    expect(screen.queryByRole('button', { name: 'Dismiss' })).not.toBeInTheDocument()
+  })
 
-    rerender(<PlanNoticeBanner notice={OPERATOR} />)
-    expect(await screen.findByText('Scheduled maintenance')).toBeInTheDocument()
+  it('renders a self-host operator notice', () => {
+    render(<PlanNoticeBanner notice={OPERATOR} />)
+    expect(screen.getByText('Scheduled maintenance')).toBeInTheDocument()
   })
 })

--- a/apps/web/src/components/admin/plan-notice-banner.tsx
+++ b/apps/web/src/components/admin/plan-notice-banner.tsx
@@ -1,42 +1,19 @@
-import { useEffect, useState } from 'react'
-import { ArrowTopRightOnSquareIcon, XMarkIcon } from '@heroicons/react/24/solid'
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/solid'
 import type { PlanNotice } from '@/lib/server/domains/settings/tier-limits.types'
 import { presentPlanNotice } from '@/lib/shared/plan-notice'
-import { trialEndedStorageKey } from '@/lib/shared/billing/trial-state'
 
 interface PlanNoticeBannerProps {
   notice: PlanNotice | null
 }
 
-function readDismissed(expiresAt: string | undefined): boolean {
-  if (typeof window === 'undefined' || !expiresAt) return false
-  try {
-    return window.localStorage.getItem(trialEndedStorageKey(expiresAt)) === '1'
-  } catch {
-    return false
-  }
-}
-
 /**
- * Operator-set or trial notice strip. Driven by settings.tier_limits.notice
- * or a derived trial countdown. Operator notices are not dismissible.
- * An expired product trial is a persistent red strip, not dismissible.
+ * Self-host operator strip, or a cloud trial countdown derived from the
+ * billing projection. Not dismissible: an ended product trial stays until
+ * they pick a plan.
  */
 export function PlanNoticeBanner({ notice }: PlanNoticeBannerProps) {
   const view = presentPlanNotice(notice)
-  const dismissible = Boolean(notice?.dismissible)
-  const [ready, setReady] = useState(!dismissible)
-  const [dismissed, setDismissed] = useState(false)
-  useEffect(() => {
-    if (!dismissible) {
-      setDismissed(false)
-      setReady(true)
-      return
-    }
-    setDismissed(readDismissed(notice?.expiresAt))
-    setReady(true)
-  }, [dismissible, notice?.expiresAt])
-  if (!view || !ready || (dismissible && dismissed)) return null
+  if (!view) return null
 
   const ended = view.ended
   const tone = ended
@@ -48,17 +25,6 @@ export function PlanNoticeBanner({ notice }: PlanNoticeBannerProps) {
   const actionClass = ended
     ? 'inline-flex items-center gap-1 font-medium text-white underline underline-offset-2 hover:text-white'
     : 'inline-flex items-center gap-1 text-primary font-medium hover:underline'
-
-  function dismiss() {
-    if (notice?.expiresAt) {
-      try {
-        window.localStorage.setItem(trialEndedStorageKey(notice.expiresAt), '1')
-      } catch {
-        /* private mode */
-      }
-    }
-    setDismissed(true)
-  }
 
   return (
     <div className={`flex items-center justify-between gap-3 px-4 py-2.5 text-sm border-b ${tone}`}>
@@ -86,30 +52,18 @@ export function PlanNoticeBanner({ notice }: PlanNoticeBannerProps) {
           <span className={`${muted} hidden sm:inline truncate`}>{view.message}</span>
         )}
       </div>
-      <div className="flex items-center gap-2 shrink-0">
-        {view.actionUrl && (
-          <a
-            href={view.actionUrl}
-            {...(view.actionUrl.startsWith('/')
-              ? {}
-              : { target: '_blank', rel: 'noopener noreferrer' })}
-            className={actionClass}
-          >
-            {view.actionLabel ?? 'Manage'}
-            {!view.actionUrl.startsWith('/') && <ArrowTopRightOnSquareIcon className="h-3 w-3" />}
-          </a>
-        )}
-        {view.dismissible ? (
-          <button
-            type="button"
-            onClick={dismiss}
-            className="text-muted-foreground hover:text-foreground"
-            aria-label="Dismiss"
-          >
-            <XMarkIcon className="size-4" />
-          </button>
-        ) : null}
-      </div>
+      {view.actionUrl && (
+        <a
+          href={view.actionUrl}
+          {...(view.actionUrl.startsWith('/')
+            ? {}
+            : { target: '_blank', rel: 'noopener noreferrer' })}
+          className={`${actionClass} shrink-0`}
+        >
+          {view.actionLabel ?? 'Manage'}
+          {!view.actionUrl.startsWith('/') && <ArrowTopRightOnSquareIcon className="h-3 w-3" />}
+        </a>
+      )}
     </div>
   )
 }

--- a/apps/web/src/lib/server/control-plane/__tests__/starter-trial.test.ts
+++ b/apps/web/src/lib/server/control-plane/__tests__/starter-trial.test.ts
@@ -103,8 +103,34 @@ describe('reportStarterTrialIfDue', () => {
     expect(hoisted.reportTrialActivation).not.toHaveBeenCalled()
   })
 
+  it('skips complimentary grants and paid plans that omit trial timestamps', async () => {
+    hoisted.getCloudConfig.mockResolvedValueOnce({
+      enabled: true,
+      plan: 'scale',
+      trialStartedAt: null,
+      trialActive: false,
+      subscriptionStatus: null,
+    })
+    await expect(reportStarterTrialIfDue()).resolves.toBe('skipped')
+    hoisted.getCloudConfig.mockResolvedValueOnce({
+      enabled: true,
+      plan: 'pro',
+      trialStartedAt: null,
+      trialActive: false,
+      subscriptionStatus: 'active',
+    })
+    await expect(reportStarterTrialIfDue()).resolves.toBe('skipped')
+    expect(hoisted.reportTrialActivation).not.toHaveBeenCalled()
+  })
+
   it('reports the stamped evidence when Cloud is on and no trial has landed', async () => {
-    hoisted.getCloudConfig.mockResolvedValue({ enabled: true, trialStartedAt: null })
+    hoisted.getCloudConfig.mockResolvedValue({
+      enabled: true,
+      plan: 'free',
+      trialStartedAt: null,
+      trialActive: false,
+      subscriptionStatus: null,
+    })
     hoisted.getWorkspaceSettings.mockResolvedValue({
       settings: { id: 'ws_1', setupState: JSON.stringify(setup()) },
     })
@@ -124,7 +150,13 @@ describe('reportStarterTrialIfDue', () => {
   })
 
   it('does not block the admin surface when the control plane is down', async () => {
-    hoisted.getCloudConfig.mockResolvedValue({ enabled: true, trialStartedAt: null })
+    hoisted.getCloudConfig.mockResolvedValue({
+      enabled: true,
+      plan: 'free',
+      trialStartedAt: null,
+      trialActive: false,
+      subscriptionStatus: null,
+    })
     hoisted.getWorkspaceSettings.mockResolvedValue({
       settings: { id: 'ws_1', setupState: JSON.stringify(setup()) },
     })

--- a/apps/web/src/lib/server/control-plane/__tests__/starter-trial.test.ts
+++ b/apps/web/src/lib/server/control-plane/__tests__/starter-trial.test.ts
@@ -123,6 +123,22 @@ describe('reportStarterTrialIfDue', () => {
     expect(hoisted.reportTrialActivation).not.toHaveBeenCalled()
   })
 
+  it('still reports after a canceled subscription on Free', async () => {
+    hoisted.getCloudConfig.mockResolvedValue({
+      enabled: true,
+      plan: 'free',
+      trialStartedAt: null,
+      trialActive: false,
+      subscriptionStatus: 'canceled',
+    })
+    hoisted.getWorkspaceSettings.mockResolvedValue({
+      settings: { id: 'ws_1', setupState: JSON.stringify(setup()) },
+    })
+    hoisted.reportTrialActivation.mockResolvedValue('started')
+    await expect(reportStarterTrialIfDue()).resolves.toBe('started')
+    expect(hoisted.reportTrialActivation).toHaveBeenCalled()
+  })
+
   it('reports the stamped evidence when Cloud is on and no trial has landed', async () => {
     hoisted.getCloudConfig.mockResolvedValue({
       enabled: true,

--- a/apps/web/src/lib/server/control-plane/starter-trial.ts
+++ b/apps/web/src/lib/server/control-plane/starter-trial.ts
@@ -32,6 +32,12 @@ export function starterTrialEvidence(state: SetupState): StarterTrialEvidence | 
  * Re-report stamped starter evidence when Cloud is on and no trial has landed
  * locally. A control-plane outage at wizard completion must not permanently
  * skip the starter Pro trial.
+ *
+ * Complimentary grants and paid plans omit trial timestamps by design, so
+ * `trialStartedAt` being null is not "starter still due". Retrying
+ * `/billing/activate-trial` on every admin refresh would stall the page if
+ * the control plane is down, and `already_started` never stamps dates onto
+ * a grant so later calls would never suppress.
  */
 export async function reportStarterTrialIfDue(identity?: {
   principalId: string
@@ -39,6 +45,8 @@ export async function reportStarterTrialIfDue(identity?: {
   const { getCloudConfig } = await import('@/lib/server/domains/settings/cloud/cloud.service')
   const cloud = await getCloudConfig()
   if (!cloud.enabled || cloud.trialStartedAt) return 'skipped'
+  if (cloud.subscriptionStatus) return 'skipped'
+  if (cloud.plan && cloud.plan !== 'free' && !cloud.trialActive) return 'skipped'
 
   const { getWorkspaceSettings } = await import('@/lib/server/domains/settings/settings.service')
   const workspace = await getWorkspaceSettings()

--- a/apps/web/src/lib/server/control-plane/starter-trial.ts
+++ b/apps/web/src/lib/server/control-plane/starter-trial.ts
@@ -1,5 +1,6 @@
 import type { SetupState } from '@/lib/shared/db-types'
 import { getSetupState } from '@/lib/shared/db-types'
+import { hasLivePaidSub } from '@/lib/shared/billing/trial-state'
 import { logger } from '@/lib/server/logger'
 import { emitPlgEvent } from '@/lib/server/plg-events'
 
@@ -45,7 +46,8 @@ export async function reportStarterTrialIfDue(identity?: {
   const { getCloudConfig } = await import('@/lib/server/domains/settings/cloud/cloud.service')
   const cloud = await getCloudConfig()
   if (!cloud.enabled || cloud.trialStartedAt) return 'skipped'
-  if (cloud.subscriptionStatus) return 'skipped'
+  // Canceled is not live: upgradeContextFor still offers a trial on Free.
+  if (hasLivePaidSub(cloud.subscriptionStatus)) return 'skipped'
   if (cloud.plan && cloud.plan !== 'free' && !cloud.trialActive) return 'skipped'
 
   const { getWorkspaceSettings } = await import('@/lib/server/domains/settings/settings.service')

--- a/apps/web/src/lib/server/domains/settings/cloud/__tests__/commercial-notice.test.ts
+++ b/apps/web/src/lib/server/domains/settings/cloud/__tests__/commercial-notice.test.ts
@@ -51,7 +51,6 @@ describe('trialEndedNotice', () => {
       label: 'Growth trial ended',
       actionLabel: 'Update billing',
     })
-    expect(notice?.dismissible).toBeUndefined()
     expect(notice?.message).toMatch(/trial has come to an end/)
   })
 })

--- a/apps/web/src/lib/server/domains/settings/cloud/commercial-notice.ts
+++ b/apps/web/src/lib/server/domains/settings/cloud/commercial-notice.ts
@@ -2,10 +2,8 @@ import type { PlanNotice } from '../tier-limits.types'
 import { PLAN_CATALOGUE, type CloudConfig } from './cloud.types'
 import { daysUntil, isTrialEnded } from '@/lib/shared/billing/trial-state'
 
-export const IN_APP_PLANS_PATH = '/admin/settings/billing'
-
 export function plansActionUrl(config: Pick<CloudConfig, 'enabled' | 'canUpgrade'>): string | null {
-  return config.enabled && config.canUpgrade ? IN_APP_PLANS_PATH : null
+  return config.enabled && config.canUpgrade ? '/admin/settings/billing' : null
 }
 
 function planLabel(config: CloudConfig, trialPlanName?: string | null): string {

--- a/apps/web/src/lib/server/domains/settings/tier-limits.types.ts
+++ b/apps/web/src/lib/server/domains/settings/tier-limits.types.ts
@@ -43,8 +43,6 @@ export interface PlanNotice {
   /** When set the banner renders an action button linking here. */
   actionUrl?: string
   actionLabel?: string
-  /** Ended-trial banner only: per-admin localStorage dismiss. */
-  dismissible?: boolean
   /** Expired-trial strip: persistent red, no countdown. */
   ended?: boolean
 }

--- a/apps/web/src/lib/server/functions/__tests__/plan-notice-auth.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/plan-notice-auth.test.ts
@@ -174,6 +174,24 @@ describe('getPlanNotice — the trial countdown', () => {
     )
   })
 
+  it('re-reads cloud config after reporting a starter trial', async () => {
+    const preTrial = {
+      ...trialing,
+      projection: {
+        ...trialing.projection,
+        trialStartedAt: null,
+        trialExpiresAt: null,
+        planLimitsExpireAt: null,
+      },
+    }
+    hoisted.mockGetWorkspaceSettings
+      .mockResolvedValueOnce({ settings: { cloud: preTrial } })
+      .mockResolvedValueOnce({ settings: { cloud: trialing } })
+    await expect(getPlanNoticeHandler()).resolves.toEqual(
+      expect.objectContaining({ label: 'Pro trial', expiresAt: ENDS })
+    )
+  })
+
   it('keeps a persistent ended banner after expiry', async () => {
     vi.setSystemTime(AFTER)
     hoisted.mockFetchCatalogue.mockResolvedValue({ lastTrialPlanId: 'pro' })

--- a/apps/web/src/lib/server/functions/__tests__/plan-notice-auth.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/plan-notice-auth.test.ts
@@ -200,11 +200,47 @@ describe('getPlanNotice — the trial countdown', () => {
     )
   })
 
-  it('never talks over a notice the operator set', async () => {
+  it('never talks over a self-host operator notice', async () => {
     const notice = { label: 'Scheduled maintenance', message: 'Back at 09:00 UTC' }
     hoisted.mockGetTierLimits.mockResolvedValue({ notice })
-    hoisted.mockGetWorkspaceSettings.mockResolvedValue({ settings: { cloud: trialing } })
+    hoisted.mockGetWorkspaceSettings.mockResolvedValue({
+      settings: { cloud: { ...trialing, enabled: false } },
+    })
     await expect(getPlanNoticeHandler()).resolves.toEqual(notice)
+  })
+
+  it('does not let a leftover Free trial strip talk over a complimentary grant', async () => {
+    hoisted.mockGetTierLimits.mockResolvedValue({
+      notice: {
+        label: 'Free trial',
+        expiresAt: '2026-08-30T09:36:53.964Z',
+        actionUrl: 'https://app.quackback.io/dashboard/org_x/choose-plan',
+        actionLabel: 'Choose your plan',
+      },
+    })
+    hoisted.mockGetWorkspaceSettings.mockResolvedValue({
+      settings: {
+        cloud: {
+          enabled: true,
+          projection: {
+            version: 7,
+            effectivePlan: 'scale',
+            trialStartedAt: null,
+            trialExpiresAt: null,
+            subscriptionStatus: null,
+            entitlements: { customDomain: true },
+            freeLimits: limits,
+            planLimits: limits,
+            planLimitsExpireAt: '2026-09-30T23:33:31.110Z',
+            canUpgrade: true,
+            canManageBilling: true,
+            renewalAt: null,
+            cancellationAt: '2026-09-30T23:33:31.110Z',
+          },
+        },
+      },
+    })
+    await expect(getPlanNoticeHandler()).resolves.toBeNull()
   })
 
   it('says nothing on an install with no cloud config', async () => {

--- a/apps/web/src/lib/server/functions/plan-notice.ts
+++ b/apps/web/src/lib/server/functions/plan-notice.ts
@@ -17,11 +17,14 @@ export const getPlanNotice = createServerFn({ method: 'GET' }).handler(
     const auth = await requireAuth({ permission: PERMISSIONS.MEMBER_VIEW })
     const { getTierLimits } = await import('@/lib/server/domains/settings/tier-limits.service')
     const { getCloudConfig } = await import('@/lib/server/domains/settings/cloud/cloud.service')
-    const [limits, cloud] = await Promise.all([getTierLimits(), getCloudConfig()])
-    if (!cloud.enabled && limits.notice) return limits.notice
+    const [limits, initial] = await Promise.all([getTierLimits(), getCloudConfig()])
+    if (!initial.enabled && limits.notice) return limits.notice
 
     const { reportStarterTrialIfDue } = await import('@/lib/server/control-plane/starter-trial')
     await reportStarterTrialIfDue({ principalId: auth.principal.id })
+    // Re-read after reporting: a starter retry can land the signed trial
+    // projection before this returns, and the admin layout caches the result.
+    const cloud = initial.enabled ? await getCloudConfig() : initial
 
     const { trialNotice, trialEndedNotice } =
       await import('@/lib/server/domains/settings/cloud/commercial-notice')

--- a/apps/web/src/lib/server/functions/plan-notice.ts
+++ b/apps/web/src/lib/server/functions/plan-notice.ts
@@ -7,29 +7,24 @@ import { PERMISSIONS } from '@/lib/shared/permissions'
  *  banner. Team-only: the notice can carry billing or maintenance details, so
  *  the RPC endpoint must not leak it to portal users or anonymous callers.
  *
- *  Two sources, in order. An operator-set notice wins outright: someone chose
- *  those words for this workspace and a derived one must not talk over them.
- *  Otherwise a workspace running a trial gets its countdown here, derived from
- *  the trial rather than stored anywhere, so it appears and disappears with
- *  the trial itself and there is nothing left behind to clear.
- *
- *  Both reads are of already-cached workspace state, and on an install with no
- *  cloud config the second one resolves to "disabled" and returns null without
- *  looking at anything else. */
+ *  Two sources, in order. Self-host operator notices (config-file) win.
+ *  Cloud workspaces ignore stored `tier_limits.notice`: commercial banners
+ *  are derived from the signed billing projection so a leftover Free-trial
+ *  strip cannot outrank a grant or paid plan. On an install with no cloud
+ *  config the second source is disabled and returns null. */
 export const getPlanNotice = createServerFn({ method: 'GET' }).handler(
   async (): Promise<PlanNotice | null> => {
     const auth = await requireAuth({ permission: PERMISSIONS.MEMBER_VIEW })
     const { getTierLimits } = await import('@/lib/server/domains/settings/tier-limits.service')
-    const limits = await getTierLimits()
-    if (limits.notice) return limits.notice
+    const { getCloudConfig } = await import('@/lib/server/domains/settings/cloud/cloud.service')
+    const [limits, cloud] = await Promise.all([getTierLimits(), getCloudConfig()])
+    if (!cloud.enabled && limits.notice) return limits.notice
 
     const { reportStarterTrialIfDue } = await import('@/lib/server/control-plane/starter-trial')
     await reportStarterTrialIfDue({ principalId: auth.principal.id })
 
-    const { getCloudConfig } = await import('@/lib/server/domains/settings/cloud/cloud.service')
     const { trialNotice, trialEndedNotice } =
       await import('@/lib/server/domains/settings/cloud/commercial-notice')
-    const cloud = await getCloudConfig()
     const running = trialNotice(cloud)
     if (running) return running
 

--- a/apps/web/src/lib/shared/__tests__/plan-notice.test.ts
+++ b/apps/web/src/lib/shared/__tests__/plan-notice.test.ts
@@ -25,6 +25,12 @@ describe('presentPlanNotice', () => {
     ).toBeNull()
   })
 
+  it('hides a notice that expired less than a day ago, not "ends today"', () => {
+    expect(
+      presentPlanNotice({ label: 'Free trial', expiresAt: '2026-06-15T11:00:00.000Z' }, NOW)
+    ).toBeNull()
+  })
+
   it('keeps rendering a persistent ended strip after expiry', () => {
     const v = presentPlanNotice(
       { label: 'Pro trial ended', expiresAt: '2026-06-01T00:00:00.000Z', ended: true },

--- a/apps/web/src/lib/shared/__tests__/plan-notice.test.ts
+++ b/apps/web/src/lib/shared/__tests__/plan-notice.test.ts
@@ -19,9 +19,18 @@ describe('presentPlanNotice', () => {
     expect(v).toMatchObject({ daysLeft: 2, urgent: true })
   })
 
-  it('clamps an already-expired notice to 0 days, urgent', () => {
-    const v = presentPlanNotice({ label: 'Free trial', expiresAt: '2026-06-01T00:00:00.000Z' }, NOW)
-    expect(v).toMatchObject({ daysLeft: 0, urgent: true })
+  it('hides an already-expired dated notice instead of clamping to "ends today"', () => {
+    expect(
+      presentPlanNotice({ label: 'Free trial', expiresAt: '2026-06-01T00:00:00.000Z' }, NOW)
+    ).toBeNull()
+  })
+
+  it('keeps rendering a persistent ended strip after expiry', () => {
+    const v = presentPlanNotice(
+      { label: 'Pro trial ended', expiresAt: '2026-06-01T00:00:00.000Z', ended: true },
+      NOW
+    )
+    expect(v).toMatchObject({ label: 'Pro trial ended', ended: true, daysLeft: 0 })
   })
 
   it('passes through label-only notices with no countdown', () => {

--- a/apps/web/src/lib/shared/billing/trial-state.ts
+++ b/apps/web/src/lib/shared/billing/trial-state.ts
@@ -27,7 +27,3 @@ export function isTrialEnded(input: {
   const now = (input.now ?? new Date()).getTime()
   return now >= expires
 }
-
-export function trialEndedStorageKey(expiresAt: string): string {
-  return `qb.trial-ended:${expiresAt}`
-}

--- a/apps/web/src/lib/shared/plan-notice.ts
+++ b/apps/web/src/lib/shared/plan-notice.ts
@@ -13,7 +13,6 @@ export interface PlanNoticeView {
   urgent: boolean
   actionUrl?: string
   actionLabel?: string
-  dismissible: boolean
   ended: boolean
 }
 
@@ -28,7 +27,14 @@ export function presentPlanNotice(
   if (notice.expiresAt) {
     const expires = Date.parse(notice.expiresAt)
     if (!Number.isNaN(expires)) {
-      daysLeft = Math.max(0, Math.ceil((expires - now.getTime()) / DAY_MS))
+      const remaining = Math.ceil((expires - now.getTime()) / DAY_MS)
+      // A dated operator notice (legacy CP "Free trial" strips, maintenance
+      // windows) must disappear once the timestamp passes. Clamping to 0 made
+      // every expired leftover read as "ends today" forever, including on
+      // workspaces that now have a paid plan or complimentary grant.
+      // Persistent trial-ended strips set `ended` and keep rendering.
+      if (remaining < 0 && !notice.ended) return null
+      daysLeft = Math.max(0, remaining)
     }
   }
   return {
@@ -38,7 +44,6 @@ export function presentPlanNotice(
     urgent: daysLeft !== null && daysLeft <= 3,
     actionUrl: notice.actionUrl,
     actionLabel: notice.actionLabel,
-    dismissible: Boolean(notice.dismissible),
     ended: Boolean(notice.ended),
   }
 }

--- a/apps/web/src/lib/shared/plan-notice.ts
+++ b/apps/web/src/lib/shared/plan-notice.ts
@@ -27,14 +27,11 @@ export function presentPlanNotice(
   if (notice.expiresAt) {
     const expires = Date.parse(notice.expiresAt)
     if (!Number.isNaN(expires)) {
-      const remaining = Math.ceil((expires - now.getTime()) / DAY_MS)
-      // A dated operator notice (legacy CP "Free trial" strips, maintenance
-      // windows) must disappear once the timestamp passes. Clamping to 0 made
-      // every expired leftover read as "ends today" forever, including on
-      // workspaces that now have a paid plan or complimentary grant.
-      // Persistent trial-ended strips set `ended` and keep rendering.
-      if (remaining < 0 && !notice.ended) return null
-      daysLeft = Math.max(0, remaining)
+      // Compare the raw instant first. Math.ceil of a negative fraction
+      // (expired less than a day ago) rounds to 0, which used to keep the
+      // banner as "ends today". Persistent trial-ended strips set `ended`.
+      if (expires <= now.getTime() && !notice.ended) return null
+      daysLeft = Math.max(0, Math.ceil((expires - now.getTime()) / DAY_MS))
     }
   }
   return {


### PR DESCRIPTION
## Summary
- Cloud admin banners now come only from the signed billing projection, so leftover `tier_limits.notice` Free-trial strips (old CP `choose-plan` URLs) cannot outrank a complimentary grant or paid plan.
- Dated operator notices hide after `expiresAt` instead of clamping to "ends today".
- Unused dismissible/localStorage banner plumbing is gone.

## Why
Nexus Mods had Scale complimentary access through 1 Oct 2026 but still showed **Free trial · ends today** because a stored notice from the old control plane won over the live projection.

## Test plan
- [x] `plan-notice`, `plan-notice-auth`, `commercial-notice`, `trial-state`, `plan-notice-banner` unit tests
- [ ] Hard-refresh admin on a granted workspace that still has a leftover `tier_limits.notice` and confirm the strip is gone
- [ ] Confirm a live product trial still shows the derived countdown
- [ ] Confirm a self-host config-file operator notice still renders

Companion CP change: omit trial timestamps from grant projections (`fix/grant-omit-trial-window`).