### PR TITLE
fix(widget): mint a session before first-visit image uploads and reactions

### DIFF
--- a/apps/web/src/components/widget/__tests__/use-widget-image-upload.test.tsx
+++ b/apps/web/src/components/widget/__tests__/use-widget-image-upload.test.tsx
@@ -102,6 +102,24 @@ describe('useWidgetImageUpload — session guard (GH #464)', () => {
     expect(onError.mock.calls[0][0]).toBeInstanceOf(WidgetSessionError)
   })
 
+  it('rejects an unusable file before minting anything', async () => {
+    mintSucceedsWith('anon-should-not-exist')
+    const fetchMock = vi.fn().mockResolvedValue(uploadOk)
+    vi.stubGlobal('fetch', fetchMock)
+    const onError = vi.fn()
+
+    const { result } = renderHook(() => useWidgetImageUpload({ onError }), { wrapper })
+    const pdf = new File([new Uint8Array([1])], 'doc.pdf', { type: 'application/pdf' })
+
+    await expect(result.current.upload(pdf)).rejects.toThrow(/Invalid file type/)
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(onError.mock.calls[0][0]).not.toBeInstanceOf(WidgetSessionError)
+    expect(mintAnon).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(getWidgetToken()).toBeNull()
+    expect(readPersistedToken()).toBeNull()
+  })
+
   it('skips the mint when a session already exists', async () => {
     mintSucceedsWith('anon-first')
     const fetchMock = vi.fn().mockResolvedValue(uploadOk)

--- a/apps/web/src/components/widget/__tests__/use-widget-image-upload.test.tsx
+++ b/apps/web/src/components/widget/__tests__/use-widget-image-upload.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment happy-dom
+/**
+ * GH #464 regression pin: attaching/pasting an image can be a first-time
+ * visitor's very first session-requiring action, and anonymous widget sessions
+ * are lazily minted. The widget upload hook must establish a session before
+ * POSTing to /api/widget/upload, or the request goes out with no Bearer and
+ * 401s silently.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ReactNode } from 'react'
+import { renderHook } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { installInMemoryLocalStorage } from '@/test/local-storage'
+import { clearWidgetToken, getWidgetToken, readPersistedToken } from '@/lib/client/widget-auth'
+
+installInMemoryLocalStorage()
+
+vi.mock('@/lib/client/widget-bridge', () => ({ sendToHost: vi.fn() }))
+vi.mock('@/lib/client/auth-client', () => ({
+  authClient: { signIn: { anonymous: vi.fn() } },
+}))
+vi.mock('@/lib/shared/i18n', async (orig) => ({
+  ...(await orig<typeof import('@/lib/shared/i18n')>()),
+  loadMessages: vi.fn().mockResolvedValue({}),
+}))
+
+import { WidgetAuthProvider } from '../widget-auth-provider'
+import { useWidgetImageUpload, WidgetSessionError } from '../use-widget-image-upload'
+import { authClient } from '@/lib/client/auth-client'
+
+const mintAnon = vi.mocked(authClient.signIn.anonymous)
+
+/** Mimic better-auth's bearer flow: the token arrives via `set-auth-token`. */
+function mintSucceedsWith(token: string) {
+  mintAnon.mockImplementation(async (opts?: unknown) => {
+    const { fetchOptions } = (opts ?? {}) as {
+      fetchOptions?: { onSuccess?: (ctx: { response: Response }) => void }
+    }
+    fetchOptions?.onSuccess?.({
+      response: new Response(null, { headers: { 'set-auth-token': token } }),
+    })
+    return { data: { user: { id: 'anon' } }, error: null } as never
+  })
+}
+
+function mintFails() {
+  mintAnon.mockResolvedValue({ data: null, error: { message: 'nope' } } as never)
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient()
+  return (
+    <QueryClientProvider client={qc}>
+      <WidgetAuthProvider portalSessionToken={null}>{children}</WidgetAuthProvider>
+    </QueryClientProvider>
+  )
+}
+
+const pngFile = () => new File([new Uint8Array([1, 2, 3])], 'shot.png', { type: 'image/png' })
+
+const uploadOk = { ok: true, json: async () => ({ publicUrl: '/api/storage/shot.png' }) }
+
+describe('useWidgetImageUpload — session guard (GH #464)', () => {
+  beforeEach(() => {
+    clearWidgetToken()
+    window.localStorage.clear()
+    mintAnon.mockReset()
+    vi.unstubAllGlobals()
+  })
+
+  it('mints an anonymous session before uploading and sends the Bearer', async () => {
+    mintSucceedsWith('anon-fresh')
+    const fetchMock = vi.fn().mockResolvedValue(uploadOk)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useWidgetImageUpload(), { wrapper })
+    expect(getWidgetToken()).toBeNull()
+
+    const url = await result.current.upload(pngFile())
+
+    expect(url).toBe('/api/storage/shot.png')
+    expect(mintAnon).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [endpoint, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(endpoint).toBe('/api/widget/upload')
+    expect(init.headers).toEqual({ Authorization: 'Bearer anon-fresh' })
+    // The minted token is persisted so the next visit on this origin reuses it.
+    expect(readPersistedToken()).toBe('anon-fresh')
+  })
+
+  it('does not upload when no session can be established; surfaces onError and rejects', async () => {
+    mintFails()
+    const fetchMock = vi.fn().mockResolvedValue(uploadOk)
+    vi.stubGlobal('fetch', fetchMock)
+    const onError = vi.fn()
+
+    const { result } = renderHook(() => useWidgetImageUpload({ onError }), { wrapper })
+
+    await expect(result.current.upload(pngFile())).rejects.toBeInstanceOf(WidgetSessionError)
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(WidgetSessionError)
+  })
+
+  it('skips the mint when a session already exists', async () => {
+    mintSucceedsWith('anon-first')
+    const fetchMock = vi.fn().mockResolvedValue(uploadOk)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useWidgetImageUpload(), { wrapper })
+    await result.current.upload(pngFile())
+    await result.current.upload(pngFile())
+
+    expect(mintAnon).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    for (const call of fetchMock.mock.calls as [string, RequestInit][]) {
+      expect(call[1].headers).toEqual({ Authorization: 'Bearer anon-first' })
+    }
+  })
+
+  it('coalesces concurrent first uploads (multi-file paste) onto one mint', async () => {
+    mintSucceedsWith('anon-shared')
+    const fetchMock = vi.fn().mockResolvedValue(uploadOk)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useWidgetImageUpload(), { wrapper })
+    await Promise.all([result.current.upload(pngFile()), result.current.upload(pngFile())])
+
+    expect(mintAnon).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/web/src/components/widget/__tests__/widget-comment-list-reaction.test.tsx
+++ b/apps/web/src/components/widget/__tests__/widget-comment-list-reaction.test.tsx
@@ -8,21 +8,25 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { ReactNode } from 'react'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { IntlProvider } from 'react-intl'
 import type { PostCommentId } from '@quackback/ids'
 import type { PublicCommentView } from '@/lib/client/queries/portal-detail'
 
-const session = { token: null as string | null }
+const session = { token: null as string | null, version: 0 }
 const calls: string[] = []
 
 const ensureSessionThen = vi.fn(async (cb: () => void | Promise<void>) => {
   calls.push('ensureSession')
-  session.token = 'anon-minted'
+  if (!session.token) {
+    session.token = 'anon-minted'
+    session.version += 1
+  }
   await cb()
 })
 
 vi.mock('../widget-auth-provider', () => ({
-  useWidgetAuth: () => ({ ensureSessionThen }),
+  useWidgetAuth: () => ({ ensureSessionThen, getSessionVersion: () => session.version }),
 }))
 vi.mock('@/lib/client/widget-auth', () => ({
   getWidgetAuthHeaders: () => (session.token ? { Authorization: `Bearer ${session.token}` } : {}),
@@ -43,11 +47,14 @@ vi.mock('@/components/public/comment-content', () => ({
 
 import { WidgetCommentList } from '../widget-comment-list'
 
+let queryClient: QueryClient
 function wrapper({ children }: { children: ReactNode }) {
   return (
-    <IntlProvider locale="en" messages={{}}>
-      {children}
-    </IntlProvider>
+    <QueryClientProvider client={queryClient}>
+      <IntlProvider locale="en" messages={{}}>
+        {children}
+      </IntlProvider>
+    </QueryClientProvider>
   )
 }
 
@@ -71,9 +78,11 @@ const comment: PublicCommentView = {
 describe('WidgetCommentList — reaction session guard (GH #464)', () => {
   beforeEach(() => {
     session.token = null
+    session.version = 0
     calls.length = 0
     ensureSessionThen.mockClear()
     addReactionFn.mockClear()
+    queryClient = new QueryClient()
   })
 
   it('mints a session before firing the reaction and sends the Bearer', async () => {
@@ -89,5 +98,30 @@ describe('WidgetCommentList — reaction session guard (GH #464)', () => {
     })
     // Server result replaces the optimistic state.
     await waitFor(() => expect(screen.getByTestId('reaction-badge').textContent).toContain('2'))
+  })
+
+  it('refetches the post detail when the reaction minted the session (re-key race)', async () => {
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
+    render(<WidgetCommentList comments={[comment]} pinnedCommentId={null} />, { wrapper })
+
+    fireEvent.click(screen.getByTestId('reaction-badge'))
+
+    await waitFor(() => expect(invalidate).toHaveBeenCalledWith({ queryKey: ['widget', 'post'] }))
+  })
+
+  it('does not refetch the post detail when a session already existed', async () => {
+    session.token = 'anon-existing'
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
+    render(<WidgetCommentList comments={[comment]} pinnedCommentId={null} />, { wrapper })
+
+    fireEvent.click(screen.getByTestId('reaction-badge'))
+
+    await waitFor(() => expect(addReactionFn).toHaveBeenCalledTimes(1))
+    expect(addReactionFn).toHaveBeenCalledWith({
+      data: { commentId: 'pcm_1', emoji: '👍' },
+      headers: { Authorization: 'Bearer anon-existing' },
+    })
+    await waitFor(() => expect(screen.getByTestId('reaction-badge').textContent).toContain('2'))
+    expect(invalidate).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/components/widget/__tests__/widget-comment-list-reaction.test.tsx
+++ b/apps/web/src/components/widget/__tests__/widget-comment-list-reaction.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment happy-dom
+/**
+ * GH #464 (same class): toggling a comment reaction can be a first-time
+ * visitor's first write, so the widget must establish a session before
+ * calling the reaction server fn — which requireAuth()s — or the request goes
+ * out with no Bearer and is rejected silently.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ReactNode } from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { IntlProvider } from 'react-intl'
+import type { PostCommentId } from '@quackback/ids'
+import type { PublicCommentView } from '@/lib/client/queries/portal-detail'
+
+const session = { token: null as string | null }
+const calls: string[] = []
+
+const ensureSessionThen = vi.fn(async (cb: () => void | Promise<void>) => {
+  calls.push('ensureSession')
+  session.token = 'anon-minted'
+  await cb()
+})
+
+vi.mock('../widget-auth-provider', () => ({
+  useWidgetAuth: () => ({ ensureSessionThen }),
+}))
+vi.mock('@/lib/client/widget-auth', () => ({
+  getWidgetAuthHeaders: () => (session.token ? { Authorization: `Bearer ${session.token}` } : {}),
+}))
+
+const addReactionFn = vi.fn(async () => {
+  calls.push('addReaction')
+  return { added: true, reactions: [{ emoji: '👍', count: 2, hasReacted: true, reactors: [] }] }
+})
+vi.mock('@/lib/server/functions/comments', () => ({
+  addReactionFn: (...args: unknown[]) => addReactionFn(...(args as [])),
+  removeReactionFn: vi.fn(),
+}))
+vi.mock('@/components/ui/rich-text-editor', () => ({ RichTextEditor: () => null }))
+vi.mock('@/components/public/comment-content', () => ({
+  CommentContent: ({ content }: { content: string }) => <p>{content}</p>,
+}))
+
+import { WidgetCommentList } from '../widget-comment-list'
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <IntlProvider locale="en" messages={{}}>
+      {children}
+    </IntlProvider>
+  )
+}
+
+const comment: PublicCommentView = {
+  id: 'pcm_1' as PostCommentId,
+  content: 'Nice idea',
+  contentJson: null,
+  authorName: 'Ada',
+  principalId: 'prn_ada',
+  createdAt: '2026-07-30T10:00:00Z',
+  deletedAt: null,
+  isRemovedByTeam: false,
+  parentId: null,
+  isTeamMember: false,
+  isEdited: false,
+  avatarUrl: null,
+  replies: [],
+  reactions: [{ emoji: '👍', count: 1, hasReacted: false, reactors: [] }],
+}
+
+describe('WidgetCommentList — reaction session guard (GH #464)', () => {
+  beforeEach(() => {
+    session.token = null
+    calls.length = 0
+    ensureSessionThen.mockClear()
+    addReactionFn.mockClear()
+  })
+
+  it('mints a session before firing the reaction and sends the Bearer', async () => {
+    render(<WidgetCommentList comments={[comment]} pinnedCommentId={null} />, { wrapper })
+
+    fireEvent.click(screen.getByTestId('reaction-badge'))
+
+    await waitFor(() => expect(addReactionFn).toHaveBeenCalledTimes(1))
+    expect(calls).toEqual(['ensureSession', 'addReaction'])
+    expect(addReactionFn).toHaveBeenCalledWith({
+      data: { commentId: 'pcm_1', emoji: '👍' },
+      headers: { Authorization: 'Bearer anon-minted' },
+    })
+    // Server result replaces the optimistic state.
+    await waitFor(() => expect(screen.getByTestId('reaction-badge').textContent).toContain('2'))
+  })
+})

--- a/apps/web/src/components/widget/__tests__/widget-post-detail-session-rekey.test.tsx
+++ b/apps/web/src/components/widget/__tests__/widget-post-detail-session-rekey.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment happy-dom
+/**
+ * GH #464 follow-up: a first-visit upload/reaction/comment mints the anonymous
+ * session mid-action, which bumps sessionVersion and re-keys the post-detail
+ * query. The detail view must keep the current post (and so the comment
+ * editors and reaction chips) mounted while the Bearer refetch runs; a
+ * skeleton here would unmount the editor the in-flight upload inserts into.
+ * Switching to a different post still shows the skeleton.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ReactNode } from 'react'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { IntlProvider } from 'react-intl'
+
+const auth = { sessionVersion: 0 }
+vi.mock('../widget-auth-provider', () => ({
+  useWidgetAuth: () => ({
+    isIdentified: false,
+    hmacRequired: false,
+    user: null,
+    ensureSessionThen: async (cb: () => void | Promise<void>) => cb(),
+    emitEvent: vi.fn(),
+    sessionVersion: auth.sessionVersion,
+  }),
+}))
+vi.mock('@/lib/client/widget-auth', () => ({
+  getWidgetAuthHeaders: () => ({}),
+  generateOneTimeToken: async () => null,
+}))
+vi.mock('@/lib/client/widget-bridge', () => ({ sendToHost: vi.fn() }))
+vi.mock('../use-widget-image-upload', () => ({
+  useWidgetImageUpload: () => ({ upload: vi.fn() }),
+}))
+vi.mock('../widget-vote-button', () => ({ WidgetVoteButton: () => null }))
+vi.mock('../widget-comment-list', () => ({ WidgetCommentList: () => null }))
+vi.mock('../widget-comment-form', () => ({
+  WidgetCommentForm: () => <div data-testid="comment-form" />,
+}))
+vi.mock('../widget-skeletons', () => ({
+  WidgetPostDetailSkeleton: () => <div data-testid="skeleton" />,
+}))
+vi.mock('@/components/public/post-content', () => ({ PostContent: () => null }))
+vi.mock('@/lib/client/mutations/load-more-comments', () => ({
+  useLoadMoreWidgetComments: () => ({ loadMore: vi.fn(), isLoading: false, hasMore: false }),
+}))
+
+type Deferred = { resolve: (v: unknown) => void }
+const pending: Deferred[] = []
+const fetchPublicPostDetail = vi.fn(() => new Promise((resolve) => pending.push({ resolve })))
+vi.mock('@/lib/server/functions/portal', () => ({
+  fetchPublicPostDetail: (...args: unknown[]) => fetchPublicPostDetail(...(args as [])),
+}))
+vi.mock('@/lib/server/functions/comments', () => ({ createCommentFn: vi.fn() }))
+
+import { WidgetPostDetail } from '../widget-post-detail'
+
+const detail = (id: string, title: string) => ({
+  id,
+  title,
+  content: '',
+  contentJson: null,
+  authorName: 'Ada',
+  createdAt: '2026-07-30T10:00:00Z',
+  voteCount: 1,
+  statusId: null,
+  board: { slug: 'ideas', name: 'Ideas' },
+  comments: [],
+  pinnedComment: null,
+  pinnedCommentId: null,
+  isCommentsLocked: false,
+  canVote: true,
+  canComment: true,
+})
+
+let queryClient: QueryClient
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <IntlProvider locale="en" messages={{}}>
+        {children}
+      </IntlProvider>
+    </QueryClientProvider>
+  )
+}
+
+describe('WidgetPostDetail — session re-key keeps the view mounted', () => {
+  beforeEach(() => {
+    auth.sessionVersion = 0
+    pending.length = 0
+    fetchPublicPostDetail.mockClear()
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  })
+
+  it('keeps the current post and comment form while the Bearer refetch is in flight', async () => {
+    const { rerender } = render(<WidgetPostDetail postId="post_1" statuses={[]} />, { wrapper })
+    expect(screen.getByTestId('skeleton')).toBeTruthy()
+    await act(async () => pending[0].resolve(detail('post_1', 'First title')))
+    await screen.findByText('First title')
+    expect(screen.getByTestId('comment-form')).toBeTruthy()
+
+    // A mid-action mint bumps sessionVersion → new query key, no cached data.
+    auth.sessionVersion = 1
+    rerender(<WidgetPostDetail postId="post_1" statuses={[]} />)
+    await waitFor(() => expect(fetchPublicPostDetail).toHaveBeenCalledTimes(2))
+
+    expect(screen.queryByTestId('skeleton')).toBeNull()
+    expect(screen.getByText('First title')).toBeTruthy()
+    expect(screen.getByTestId('comment-form')).toBeTruthy()
+
+    await act(async () => pending[1].resolve(detail('post_1', 'Refetched title')))
+    await screen.findByText('Refetched title')
+  })
+
+  it('still shows the skeleton when navigating to a different post', async () => {
+    const { rerender } = render(<WidgetPostDetail postId="post_1" statuses={[]} />, { wrapper })
+    await act(async () => pending[0].resolve(detail('post_1', 'First title')))
+    await screen.findByText('First title')
+
+    rerender(<WidgetPostDetail postId="post_2" statuses={[]} />)
+    await waitFor(() => expect(fetchPublicPostDetail).toHaveBeenCalledTimes(2))
+
+    expect(screen.getByTestId('skeleton')).toBeTruthy()
+    expect(screen.queryByText('First title')).toBeNull()
+  })
+})

--- a/apps/web/src/components/widget/use-widget-image-upload.ts
+++ b/apps/web/src/components/widget/use-widget-image-upload.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react'
-import { useImageUpload } from '@/lib/client/hooks/use-image-upload'
+import { useImageUpload, validateImageFile } from '@/lib/client/hooks/use-image-upload'
 import { getWidgetAuthHeaders } from '@/lib/client/widget-auth'
 import { useWidgetAuth } from './widget-auth-provider'
 
@@ -38,6 +38,13 @@ export function useWidgetImageUpload(options: UseWidgetImageUploadOptions = {}) 
 
   const upload = useCallback(
     async (file: File): Promise<string> => {
+      // Reject unusable files before touching the session: an invalid pick
+      // must not mint/persist an anonymous session or bump sessionVersion.
+      const invalid = validateImageFile(file)
+      if (invalid) {
+        onError?.(invalid)
+        throw invalid
+      }
       const ready = await ensureSession()
       if (!ready) {
         const error = new WidgetSessionError()

--- a/apps/web/src/components/widget/use-widget-image-upload.ts
+++ b/apps/web/src/components/widget/use-widget-image-upload.ts
@@ -1,0 +1,53 @@
+import { useCallback } from 'react'
+import { useImageUpload } from '@/lib/client/hooks/use-image-upload'
+import { getWidgetAuthHeaders } from '@/lib/client/widget-auth'
+import { useWidgetAuth } from './widget-auth-provider'
+
+interface UseWidgetImageUploadOptions {
+  onStart?: () => void
+  onSuccess?: (url: string) => void
+  onError?: (error: Error) => void
+}
+
+/** Thrown when no widget session could be established before the upload. */
+export class WidgetSessionError extends Error {
+  constructor() {
+    super('Could not create session')
+    this.name = 'WidgetSessionError'
+  }
+}
+
+/**
+ * Image upload for widget surfaces (post composer, comment forms, messenger).
+ *
+ * Anonymous widget sessions are lazily minted on the visitor's first write, and
+ * attaching/pasting an image can be that first write — so there may be no
+ * session yet. Mint one first (anonymous is fine) or the upload goes out with
+ * no Bearer and `/api/widget/upload` 401s silently (GH #464).
+ */
+export function useWidgetImageUpload(options: UseWidgetImageUploadOptions = {}) {
+  const { onStart, onSuccess, onError } = options
+  const { ensureSession } = useWidgetAuth()
+  const { upload: rawUpload } = useImageUpload({
+    endpoint: '/api/widget/upload',
+    extraHeaders: getWidgetAuthHeaders,
+    onStart,
+    onSuccess,
+    onError,
+  })
+
+  const upload = useCallback(
+    async (file: File): Promise<string> => {
+      const ready = await ensureSession()
+      if (!ready) {
+        const error = new WidgetSessionError()
+        onError?.(error)
+        throw error
+      }
+      return rawUpload(file)
+    },
+    [ensureSession, rawUpload, onError]
+  )
+
+  return { upload }
+}

--- a/apps/web/src/components/widget/widget-comment-list.tsx
+++ b/apps/web/src/components/widget/widget-comment-list.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import {
   ArrowUturnLeftIcon,
   ChevronDownIcon,
@@ -14,6 +15,7 @@ import { REACTION_EMOJIS } from '@/lib/shared/db-types'
 import { ReactionChip } from '@/components/shared/reaction-chip'
 import { addReactionFn, removeReactionFn } from '@/lib/server/functions/comments'
 import { getWidgetAuthHeaders } from '@/lib/client/widget-auth'
+import { widgetQueryKeys } from '@/lib/client/hooks/use-widget-vote'
 import { useWidgetAuth } from './widget-auth-provider'
 import { cn } from '@/lib/shared/utils'
 import { CommentContent } from '@/components/public/comment-content'
@@ -102,7 +104,8 @@ function WidgetCommentItem({
   onImageUpload,
 }: WidgetCommentItemProps) {
   const intl = useIntl()
-  const { ensureSessionThen } = useWidgetAuth()
+  const { ensureSessionThen, getSessionVersion } = useWidgetAuth()
+  const queryClient = useQueryClient()
   const [isCollapsed, setIsCollapsed] = useState(false)
   const [showReplyForm, setShowReplyForm] = useState(false)
   const [replyText, setReplyText] = useState('')
@@ -140,6 +143,7 @@ function WidgetCommentItem({
       // Reacting may be the visitor's first write, so there may be no session
       // yet — mint one (anonymous is fine) or the request goes out with no
       // Bearer and requireAuth() rejects it silently (GH #464).
+      const versionBefore = getSessionVersion()
       await ensureSessionThen(async () => {
         const result = await fn({
           data: { commentId: comment.id, emoji },
@@ -147,6 +151,13 @@ function WidgetCommentItem({
         })
         setReactions(result.reactions)
       })
+      // Minting re-keyed the post-detail query, and that refetch raced this
+      // mutation: if it read before the reaction committed, the sync effect
+      // above would overwrite the result with stale server state. Refetch so
+      // the detail cache reflects the committed reaction.
+      if (getSessionVersion() !== versionBefore) {
+        void queryClient.invalidateQueries({ queryKey: widgetQueryKeys.postDetail.all })
+      }
     } catch (error) {
       console.error('Failed to update reaction:', error)
     } finally {

--- a/apps/web/src/components/widget/widget-comment-list.tsx
+++ b/apps/web/src/components/widget/widget-comment-list.tsx
@@ -14,6 +14,7 @@ import { REACTION_EMOJIS } from '@/lib/shared/db-types'
 import { ReactionChip } from '@/components/shared/reaction-chip'
 import { addReactionFn, removeReactionFn } from '@/lib/server/functions/comments'
 import { getWidgetAuthHeaders } from '@/lib/client/widget-auth'
+import { useWidgetAuth } from './widget-auth-provider'
 import { cn } from '@/lib/shared/utils'
 import { CommentContent } from '@/components/public/comment-content'
 import { RichTextEditor } from '@/components/ui/rich-text-editor'
@@ -101,6 +102,7 @@ function WidgetCommentItem({
   onImageUpload,
 }: WidgetCommentItemProps) {
   const intl = useIntl()
+  const { ensureSessionThen } = useWidgetAuth()
   const [isCollapsed, setIsCollapsed] = useState(false)
   const [showReplyForm, setShowReplyForm] = useState(false)
   const [replyText, setReplyText] = useState('')
@@ -135,11 +137,16 @@ function WidgetCommentItem({
     try {
       const hasReacted = reactions.some((r) => r.emoji === emoji && r.hasReacted)
       const fn = hasReacted ? removeReactionFn : addReactionFn
-      const result = await fn({
-        data: { commentId: comment.id, emoji },
-        headers: getWidgetAuthHeaders(),
+      // Reacting may be the visitor's first write, so there may be no session
+      // yet — mint one (anonymous is fine) or the request goes out with no
+      // Bearer and requireAuth() rejects it silently (GH #464).
+      await ensureSessionThen(async () => {
+        const result = await fn({
+          data: { commentId: comment.id, emoji },
+          headers: getWidgetAuthHeaders(),
+        })
+        setReactions(result.reactions)
       })
-      setReactions(result.reactions)
     } catch (error) {
       console.error('Failed to update reaction:', error)
     } finally {

--- a/apps/web/src/components/widget/widget-home-animated.tsx
+++ b/apps/web/src/components/widget/widget-home-animated.tsx
@@ -28,7 +28,7 @@ import { useWidgetAuth } from './widget-auth-provider'
 import { sendToHost } from '@/lib/client/widget-bridge'
 import type { PostId } from '@quackback/ids'
 import { RichTextEditor } from '@/components/ui/rich-text-editor'
-import { useWidgetImageUpload } from '@/lib/client/hooks/use-image-upload'
+import { useWidgetImageUpload, WidgetSessionError } from './use-widget-image-upload'
 import type { JSONContent } from '@tiptap/react'
 import type { TiptapContent } from '@/lib/shared/schemas/posts'
 
@@ -232,7 +232,6 @@ export function WidgetHomeAnimated({
     metadata,
     getSessionVersion,
   } = useWidgetAuth()
-  const { upload: uploadImage } = useWidgetImageUpload()
   const queryClient = useQueryClient()
   const inputRef = useRef<HTMLInputElement>(null)
 
@@ -275,6 +274,27 @@ export function WidgetHomeAnimated({
   const signInRequired = !isIdentified && !!selectedBoardId && !canPost
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  // The editor swallows onImageUpload rejections, so a failed session mint
+  // would otherwise look like the attach did nothing (GH #464). Other upload
+  // failures (type/size/server) keep their existing behaviour.
+  const handleUploadStart = useCallback(() => setError(null), [])
+  const handleUploadError = useCallback(
+    (err: Error) => {
+      if (!(err instanceof WidgetSessionError)) return
+      setError(
+        intl.formatMessage({
+          id: 'widget.home.form.errorSession',
+          defaultMessage: 'Could not create session. Please try again.',
+        })
+      )
+    },
+    [intl]
+  )
+  const { upload: uploadImage } = useWidgetImageUpload({
+    onStart: handleUploadStart,
+    onError: handleUploadError,
+  })
 
   const [similarPostResults, setSimilarPostResults] = useState<SearchResult | null>(null)
   const [isSimilarSearching, setIsSimilarSearching] = useState(false)

--- a/apps/web/src/components/widget/widget-messenger.tsx
+++ b/apps/web/src/components/widget/widget-messenger.tsx
@@ -5,7 +5,7 @@ import { VisitorConversationThread } from '@/components/shared/conversation/visi
 import { useWidgetAuth } from './widget-auth-provider'
 import { getWidgetAuthHeaders } from '@/lib/client/widget-auth'
 import { useConversationPresence, markAgentPresentInCache } from './use-messenger-presence'
-import { useWidgetImageUpload } from '@/lib/client/hooks/use-image-upload'
+import { useWidgetImageUpload } from './use-widget-image-upload'
 
 interface WidgetMessengerProps {
   /** Whether the help center is available (gates in-conversation article suggestions). */

--- a/apps/web/src/components/widget/widget-post-detail.tsx
+++ b/apps/web/src/components/widget/widget-post-detail.tsx
@@ -24,7 +24,7 @@ import { WidgetPortalTitle } from './widget-portal-title'
 import { WidgetPostDetailSkeleton } from './widget-skeletons'
 import type { TiptapContent } from '@/lib/shared/db-types'
 import type { PostId } from '@quackback/ids'
-import { useWidgetImageUpload } from '@/lib/client/hooks/use-image-upload'
+import { useWidgetImageUpload } from './use-widget-image-upload'
 
 interface StatusInfo {
   id: string

--- a/apps/web/src/components/widget/widget-post-detail.tsx
+++ b/apps/web/src/components/widget/widget-post-detail.tsx
@@ -64,6 +64,13 @@ export function WidgetPostDetail({ postId, statuses }: WidgetPostDetailProps) {
       if (!result) throw new Error('Post not found')
       return result as PublicPostDetailView
     },
+    // Minting/identifying bumps sessionVersion mid-action (first-visit upload,
+    // reaction, comment), which re-keys this query. Keep showing the same
+    // post while the Bearer refetch runs so the comment editors and reaction
+    // chips stay mounted for the in-flight request to land in — a skeleton
+    // here would tear them down. Only for the same post: switching posts
+    // still shows the skeleton rather than the previous post.
+    placeholderData: (prev, prevQuery) => (prevQuery?.queryKey[2] === postId ? prev : undefined),
     staleTime: 30 * 1000,
   })
 

--- a/apps/web/src/lib/client/hooks/use-image-upload.ts
+++ b/apps/web/src/lib/client/hooks/use-image-upload.ts
@@ -1,5 +1,4 @@
 import { useCallback } from 'react'
-import { getWidgetAuthHeaders } from '@/lib/client/widget-auth'
 import { MAX_FILE_SIZE, isAllowedImageType } from '@/lib/shared/storage-config'
 
 interface UseImageUploadOptions {
@@ -93,12 +92,5 @@ export function usePortalImageUpload(
   return useImageUpload({ ...options, endpoint: '/api/portal/upload' })
 }
 
-export function useWidgetImageUpload(
-  options: Omit<UseImageUploadOptions, 'prefix' | 'endpoint' | 'extraHeaders'> = {}
-) {
-  return useImageUpload({
-    ...options,
-    endpoint: '/api/widget/upload',
-    extraHeaders: getWidgetAuthHeaders,
-  })
-}
+// The widget flavour lives in `@/components/widget/use-widget-image-upload`:
+// it needs the widget auth context to mint a session before uploading.

--- a/apps/web/src/lib/client/hooks/use-image-upload.ts
+++ b/apps/web/src/lib/client/hooks/use-image-upload.ts
@@ -10,6 +10,17 @@ interface UseImageUploadOptions {
   onError?: (error: Error) => void
 }
 
+/** Client-side type/size check shared by every upload flavour; null when uploadable. */
+export function validateImageFile(file: File): Error | null {
+  if (!isAllowedImageType(file.type)) {
+    return new Error(`Invalid file type: ${file.type}. Allowed types: JPEG, PNG, GIF, WebP.`)
+  }
+  if (file.size > MAX_FILE_SIZE) {
+    return new Error(`File too large. Maximum size is ${MAX_FILE_SIZE / 1024 / 1024}MB.`)
+  }
+  return null
+}
+
 export function useImageUpload(options: UseImageUploadOptions = {}) {
   const {
     prefix = 'uploads',
@@ -22,18 +33,10 @@ export function useImageUpload(options: UseImageUploadOptions = {}) {
 
   const upload = useCallback(
     async (file: File): Promise<string> => {
-      if (!isAllowedImageType(file.type)) {
-        const error = new Error(
-          `Invalid file type: ${file.type}. Allowed types: JPEG, PNG, GIF, WebP.`
-        )
-        onError?.(error)
-        throw error
-      }
-
-      if (file.size > MAX_FILE_SIZE) {
-        const error = new Error(`File too large. Maximum size is ${MAX_FILE_SIZE / 1024 / 1024}MB.`)
-        onError?.(error)
-        throw error
+      const invalid = validateImageFile(file)
+      if (invalid) {
+        onError?.(invalid)
+        throw invalid
       }
 
       onStart?.()


### PR DESCRIPTION
## Summary

Fixes #464.

Anonymous widget sessions are lazily minted on the visitor's first write. Several widget write paths skipped `ensureSession()`, so for a visitor with no persisted `quackback:anon-token:<origin>` the request went out with no `Authorization` header and was rejected silently:

- Post composer image upload (`widget-home-animated.tsx`) — the case in #464
- Root comment and reply form image uploads (`widget-post-detail.tsx` → `WidgetCommentForm` / `WidgetCommentList`)
- Comment reactions (`widget-comment-list.tsx` → `addReactionFn` / `removeReactionFn`, which `requireAuth()`) — same class, not in the issue

Changes:

- `useWidgetImageUpload` moves from `lib/client/hooks` to `components/widget/use-widget-image-upload.ts` (it now needs `useWidgetAuth`, and `lib/client` doesn't import from `components/`). It calls `ensureSession()` before uploading and throws a `WidgetSessionError` when no session can be established, so every widget upload surface is guarded in one place. The messenger's existing call-site guard stays; `ensureSession` short-circuits and coalesces so the double call is free.
- `handleReaction` is wrapped in `ensureSessionThen`.
- The post composer surfaces a failed mint through its existing error slot using the existing `widget.home.form.errorSession` message (no new i18n keys). `RichTextEditor` swallows `onImageUpload` rejections, so without this the failure would still look like "nothing happened".

- `WidgetPostDetail` keeps the previous post as `placeholderData` while a `sessionVersion` re-key refetches (same `postId` only). Minting mid-action used to swap the view to its skeleton, unmounting the comment editor the upload was about to insert into (Codex P1). When a reaction minted the session, `handleReaction` also invalidates the detail so the racing refetch can't drop the committed reaction (Codex P2).

- The widget hook validates type/size (shared `validateImageFile`) before `ensureSession()`, so an invalid pick never mints or persists a session (Codex P2, second pass).

Not touched: `widget-changelog-detail.tsx` renders `EmbedHydration` without `getAuthHeaders`, so an embedded post card's vote box in a widget changelog entry relies on cookie auth a cross-origin iframe doesn't have. Different mechanism; worth its own issue.

## Test plan

- [x] `use-widget-image-upload.test.tsx` — against the real `WidgetAuthProvider`: mints before the upload and sends the Bearer; no upload + `onError` + rejection when the mint fails; no re-mint once a session exists; concurrent first uploads coalesce on one mint; an invalid file is rejected before any mint
- [x] `widget-comment-list-reaction.test.tsx` — reaction toggle goes through `ensureSessionThen` and carries the Bearer; invalidates the detail only when the session was minted mid-action
- [x] `widget-post-detail-session-rekey.test.tsx` — detail view and comment form stay mounted across a `sessionVersion` re-key; skeleton still shown when switching posts (fails without the `placeholderData` change)
- [x] `typecheck`, `lint`, widget + `lib/client` vitest suites green
- [ ] Manual: fresh private window on `/widget`, paste an image into the composer → `POST /api/widget/upload` 200 preceded by the anonymous sign-in, token persisted under `quackback:anon-token:<origin>` (my local dev DB is behind main's schema so I couldn't run this here; the reporter verified the equivalent call-site fix end to end)

Made with [Cursor](https://cursor.com)

