### PR TITLE
feat(auth): copy IdP claims into person attributes on sign-in

### DIFF
--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-detail-page.test.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-detail-page.test.tsx
@@ -71,6 +71,17 @@ const { state } = vi.hoisted(() => ({
     credentialStatus: { _emailConfigured: true } as Record<string, boolean>,
     accountCount: 0,
     navigate: vi.fn(async () => undefined),
+    userAttributes: [] as Array<{
+      id: string
+      key: string
+      label: string
+      type: 'string' | 'number' | 'boolean' | 'date' | 'currency'
+      description: string | null
+      currencyCode: string | null
+      externalKey: string | null
+      createdAt: Date
+      updatedAt: Date
+    }>,
   },
 }))
 
@@ -142,6 +153,11 @@ vi.mock('@/lib/client/queries/admin', () => ({
       queryFn: async () => state.credentialStatus,
       staleTime: Infinity,
     }),
+    userAttributes: () => ({
+      queryKey: ['admin', 'userAttributes'],
+      queryFn: async () => state.userAttributes,
+      staleTime: Infinity,
+    }),
   },
 }))
 
@@ -150,9 +166,15 @@ vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 // Stub the Test sign-in button so the page doesn't pull in the test-flow
 // server fns / context. Pass `disabled` through so tests can assert state.
 vi.mock('../../sso/test-sign-in-button', () => ({
-  TestSignInButton: ({ disabled }: { disabled?: boolean }) => (
+  TestSignInButton: ({
+    disabled,
+    children,
+  }: {
+    disabled?: boolean
+    children?: React.ReactNode
+  }) => (
     <button type="button" disabled={disabled}>
-      Test sign-in
+      {children ?? 'Test sign-in'}
     </button>
   ),
 }))
@@ -212,6 +234,7 @@ function renderPage(provider: IdentityProvider) {
   qc.setQueryData(['settings', 'identityProviders', provider.id, 'accountCount'], {
     count: state.accountCount,
   })
+  qc.setQueryData(['admin', 'userAttributes'], state.userAttributes)
   return render(
     <QueryClientProvider client={qc}>
       <ProviderDetailPage providerId={provider.id} />
@@ -232,6 +255,7 @@ beforeEach(() => {
   discoveryScopesSpy.mockClear()
   discoveryScopesSpy.mockResolvedValue({ scopesSupported: null })
   ssoTestRef.current = null
+  state.userAttributes = []
   state.authConfig = { oauth: { password: true } }
   state.credentialStatus = { _emailConfigured: true }
   state.accountCount = 0
@@ -767,6 +791,181 @@ describe('<ProviderDetailPage> identity fields', () => {
  * what it would cost before offering it — both refusals mirror server-side
  * invariants rather than being UI politeness.
  */
+const PEOPLE_ATTRS = [
+  {
+    id: 'ua_1',
+    key: 'department',
+    label: 'Department',
+    type: 'string' as const,
+    description: null,
+    currencyCode: null,
+    externalKey: null,
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+  },
+  {
+    id: 'ua_2',
+    key: 'plan',
+    label: 'Plan',
+    type: 'string' as const,
+    description: null,
+    currencyCode: null,
+    externalKey: null,
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+  },
+]
+
+const matchingCapture = {
+  registrationId: 'oidc_x',
+  capturedAt: '2026-09-01T00:00:00.000Z',
+  identity: { id: 'sub', email: 'alice@example.com', sources: { email: 'idToken' as const } },
+  claims: { department: 'Engineering' },
+}
+
+describe('<ProviderDetailPage> claim → person-attribute mapping', () => {
+  it('adds a row, picks a claim path and attribute, and saves without touching role/profile', async () => {
+    state.userAttributes = PEOPLE_ATTRS
+    renderPage(makeProvider({ claimMapping: null }))
+    fireEvent.click(screen.getByRole('button', { name: /Copy claims into person attributes/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Add mapping/ }))
+    fireEvent.click(screen.getByRole('combobox', { name: /Claim path \(mapping 1\)/ }))
+    fireEvent.change(screen.getByPlaceholderText('Search or type…'), {
+      target: { value: 'department' },
+    })
+    fireEvent.click(screen.getByText(/Use ["“]department["”]/))
+    fireEvent.click(screen.getByRole('combobox', { name: /Person attribute \(mapping 1\)/ }))
+    fireEvent.click(screen.getByRole('option', { name: /Department/ }))
+    saveMapping()
+    await waitFor(() => expect(upsertSpy).toHaveBeenCalled())
+    const sent = lastUpsert().claimMapping as {
+      attributes?: { map?: Array<{ claimPath: string; attributeKey: string }> }
+      role?: unknown
+      profile?: unknown
+    }
+    expect(sent.attributes?.map).toEqual([{ claimPath: 'department', attributeKey: 'department' }])
+    expect(sent).not.toHaveProperty('role')
+    expect(sent).not.toHaveProperty('profile')
+  })
+
+  it('removes the only row on save so attributes is absent from the payload', async () => {
+    state.userAttributes = PEOPLE_ATTRS
+    renderPage(
+      makeProvider({
+        claimMapping: {
+          attributes: { map: [{ claimPath: 'department', attributeKey: 'department' }] },
+        },
+      })
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Remove mapping 1/ }))
+    saveMapping()
+    await waitFor(() => expect(upsertSpy).toHaveBeenCalled())
+    expect(lastUpsert().claimMapping).toBeNull()
+  })
+
+  it('persists overrideExisting and syncOnSignIn independently', async () => {
+    state.userAttributes = PEOPLE_ATTRS
+    renderPage(
+      makeProvider({
+        claimMapping: {
+          attributes: { map: [{ claimPath: 'department', attributeKey: 'department' }] },
+        },
+      })
+    )
+    await userEvent.click(screen.getByLabelText('Overwrite values that are already set'))
+    saveMapping()
+    await waitFor(() => expect(upsertSpy).toHaveBeenCalled())
+    const first = lastUpsert().claimMapping as {
+      attributes?: { overrideExisting?: boolean; syncOnSignIn?: boolean }
+    }
+    expect(first.attributes?.overrideExisting).toBe(true)
+    expect(first.attributes?.syncOnSignIn).toBeUndefined()
+
+    upsertSpy.mockClear()
+    await userEvent.click(screen.getByLabelText('Clear an attribute when its claim is missing'))
+    saveMapping()
+    await waitFor(() => expect(upsertSpy).toHaveBeenCalled())
+    const second = lastUpsert().claimMapping as {
+      attributes?: { overrideExisting?: boolean; syncOnSignIn?: boolean }
+    }
+    expect(second.attributes?.overrideExisting).toBe(true)
+    expect(second.attributes?.syncOnSignIn).toBe(true)
+  })
+
+  it('shows the People empty state and no Add button when there are no definitions', () => {
+    state.userAttributes = []
+    renderPage(makeProvider({ claimMapping: null }))
+    fireEvent.click(screen.getByRole('button', { name: /Copy claims into person attributes/ }))
+    expect(screen.getByText(/No person attributes yet/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Open People settings' })).toHaveAttribute(
+      'href',
+      '/admin/settings/people'
+    )
+    expect(screen.queryByRole('button', { name: /Add mapping/ })).not.toBeInTheDocument()
+  })
+
+  it('renders an orphan-row warning when the attribute no longer exists', () => {
+    state.userAttributes = PEOPLE_ATTRS
+    renderPage(
+      makeProvider({
+        claimMapping: {
+          attributes: { map: [{ claimPath: 'cc', attributeKey: 'cost_center' }] },
+        },
+      })
+    )
+    expect(screen.getByText('attribute no longer exists')).toBeInTheDocument()
+    expect(screen.getByText('cost_center')).toBeInTheDocument()
+  })
+
+  it('previews a written value and a missing-claim skip from a matching capture', async () => {
+    state.userAttributes = PEOPLE_ATTRS
+    renderPage(
+      makeProvider({
+        lastTestCapture: matchingCapture,
+        claimMapping: {
+          attributes: {
+            map: [
+              { claimPath: 'department', attributeKey: 'department' },
+              { claimPath: 'plan', attributeKey: 'plan' },
+            ],
+          },
+        },
+      })
+    )
+    expect(screen.getByText('Attribute writes from your last test sign-in')).toBeInTheDocument()
+    expect(screen.getByText(/“Engineering”/)).toBeInTheDocument()
+    expect(screen.getByText(/skipped: missing claim/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('combobox', { name: /Claim path \(mapping 1\)/ }))
+    fireEvent.change(screen.getByPlaceholderText('Search or type…'), {
+      target: { value: 'nope' },
+    })
+    fireEvent.click(screen.getByText(/Use ["“]nope["”]/))
+    await waitFor(() => {
+      expect(screen.queryByText(/“Engineering”/)).not.toBeInTheDocument()
+    })
+    expect(screen.getAllByText(/skipped: missing claim/).length).toBeGreaterThan(0)
+  })
+
+  it('hides the capture preview when the capture is for a different registrationId', () => {
+    state.userAttributes = PEOPLE_ATTRS
+    renderPage(
+      makeProvider({
+        lastTestCapture: { ...matchingCapture, registrationId: 'oidc_other' },
+        claimMapping: {
+          attributes: { map: [{ claimPath: 'department', attributeKey: 'department' }] },
+        },
+      })
+    )
+    expect(
+      screen.queryByText('Attribute writes from your last test sign-in')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByText(/Run a test sign-in to preview what these mappings would write/)
+    ).toBeInTheDocument()
+  })
+})
+
 describe('<ProviderDetailPage> remove', () => {
   it('states that nobody is linked yet and allows removal', () => {
     state.accountCount = 0

--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-detail-page.test.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-detail-page.test.tsx
@@ -909,6 +909,26 @@ describe('<ProviderDetailPage> claim → person-attribute mapping', () => {
     expect(screen.queryByRole('button', { name: /Add mapping/ })).not.toBeInTheDocument()
   })
 
+  it('keeps an orphan row removable when the last definition is gone', async () => {
+    state.userAttributes = []
+    renderPage(
+      makeProvider({
+        claimMapping: {
+          attributes: { map: [{ claimPath: 'cc', attributeKey: 'cost_center' }] },
+        },
+      })
+    )
+    // The row, not the empty state: hiding it would leave the stale mapping
+    // unremovable and still forcing a userinfo fetch on every sign-in.
+    expect(screen.queryByText(/No person attributes yet/)).not.toBeInTheDocument()
+    expect(screen.getByText('attribute no longer exists')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Add mapping/ })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /Remove mapping 1/ }))
+    saveMapping()
+    await waitFor(() => expect(upsertSpy).toHaveBeenCalled())
+    expect(lastUpsert().claimMapping).toBeNull()
+  })
+
   it('renders an orphan-row warning when the attribute no longer exists', () => {
     state.userAttributes = PEOPLE_ATTRS
     renderPage(

--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-detail-page.test.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-detail-page.test.tsx
@@ -58,7 +58,12 @@ const { discoveryScopesSpy } = vi.hoisted(() => ({
 
 const { ssoTestRef } = vi.hoisted(() => ({
   ssoTestRef: {
-    current: null as null | { registrationId: string; claims: Record<string, unknown> },
+    current: null as null | {
+      registrationId: string
+      claims: Record<string, unknown>
+      capturedAt?: string
+      identity?: { id: string; email?: string; sources: Record<string, string> }
+    },
   },
 }))
 
@@ -945,6 +950,26 @@ describe('<ProviderDetailPage> claim → person-attribute mapping', () => {
       expect(screen.queryByText(/“Engineering”/)).not.toBeInTheDocument()
     })
     expect(screen.getAllByText(/skipped: missing claim/).length).toBeGreaterThan(0)
+  })
+
+  it('prefers an in-session test over a persisted capture for the same provider', () => {
+    state.userAttributes = PEOPLE_ATTRS
+    ssoTestRef.current = {
+      registrationId: 'oidc_x',
+      capturedAt: '2026-09-02T00:00:00.000Z',
+      identity: { id: 'sub', email: 'alice@example.com', sources: { email: 'idToken' } },
+      claims: { department: 'From session' },
+    }
+    renderPage(
+      makeProvider({
+        lastTestCapture: matchingCapture,
+        claimMapping: {
+          attributes: { map: [{ claimPath: 'department', attributeKey: 'department' }] },
+        },
+      })
+    )
+    expect(screen.getByText(/“From session”/)).toBeInTheDocument()
+    expect(screen.queryByText(/“Engineering”/)).not.toBeInTheDocument()
   })
 
   it('hides the capture preview when the capture is for a different registrationId', () => {

--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-shared.test.ts
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-shared.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect } from 'vitest'
 import {
   identityMappingIssue,
   mergeClaimMapping,
+  normalizeAttributeMapping,
   normalizeRoleMapping,
   withAllowMissingEmail,
 } from '../provider-shared'
@@ -67,6 +68,45 @@ describe('withAllowMissingEmail', () => {
       sources: ['idToken'],
       allowMissingEmail: true,
     })
+  })
+})
+
+describe('normalizeAttributeMapping', () => {
+  it('drops empty rows and returns undefined when nothing remains', () => {
+    expect(
+      normalizeAttributeMapping({
+        map: [
+          { claimPath: '', attributeKey: 'department' },
+          { claimPath: 'dept', attributeKey: '  ' },
+        ],
+      })
+    ).toBeUndefined()
+    expect(normalizeAttributeMapping({ map: [] })).toBeUndefined()
+    expect(normalizeAttributeMapping(null)).toBeUndefined()
+  })
+
+  it('preserves flags on a non-empty mapping', () => {
+    expect(
+      normalizeAttributeMapping({
+        map: [{ claimPath: 'dept', attributeKey: 'department' }],
+        overrideExisting: true,
+        syncOnSignIn: true,
+      })
+    ).toEqual({
+      map: [{ claimPath: 'dept', attributeKey: 'department' }],
+      overrideExisting: true,
+      syncOnSignIn: true,
+    })
+  })
+
+  it('drops flags that are off so the stored shape stays sparse', () => {
+    expect(
+      normalizeAttributeMapping({
+        map: [{ claimPath: 'dept', attributeKey: 'department' }],
+        overrideExisting: false,
+        syncOnSignIn: false,
+      })
+    ).toEqual({ map: [{ claimPath: 'dept', attributeKey: 'department' }] })
   })
 })
 

--- a/apps/web/src/components/admin/settings/security/identity-providers/attribute-writes-preview.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/attribute-writes-preview.tsx
@@ -1,0 +1,147 @@
+/**
+ * Inline preview of claim → person-attribute writes, evaluated against the
+ * last matching test capture. Extracted from OutcomePreviewRail so the
+ * claim-mapping card can show it without mounting the unbuilt Identity
+ * pickers. `existing` is always `{}`: the preview has no access to the
+ * tester's stored attributes, so `kept_existing` cannot be shown truthfully.
+ */
+
+import { TimeAgo } from '@/components/ui/time-ago'
+import { Badge } from '@/components/ui/badge'
+import { getClaimByPath } from '@/lib/shared/oidc-claim-mapping'
+import { planClaimAttributeWrites } from '@/lib/shared/plan-claim-attribute-writes'
+import type { SsoTestCapture } from '@/lib/shared/sso-test-capture'
+import { TestSignInButton } from '../sso/test-sign-in-button'
+import { useUserAttributes } from '@/lib/client/hooks/use-user-attributes-queries'
+
+export function AttributeWritesPreview({
+  capture,
+  registrationId,
+  detailsChangedAt,
+  attributeRows,
+  overrideExisting,
+  syncOnSignIn,
+  canTest,
+}: {
+  capture: SsoTestCapture | null
+  registrationId: string
+  detailsChangedAt?: string | null
+  attributeRows: Array<{ claimPath: string; attributeKey: string }>
+  overrideExisting: boolean
+  syncOnSignIn: boolean
+  canTest: boolean
+}) {
+  const { data: attributes } = useUserAttributes()
+  const defs = (attributes ?? []).map((d) => ({
+    key: d.key,
+    type: d.type,
+    label: d.label,
+  }))
+
+  if (!capture) {
+    return (
+      <div className="space-y-2 rounded-md border border-border/40 bg-muted/20 px-3 py-3">
+        <p className="text-xs text-muted-foreground">
+          Run a test sign-in to preview what these mappings would write.
+        </p>
+        <TestSignInButton registrationId={registrationId} disabled={!canTest} />
+      </div>
+    )
+  }
+
+  const stale =
+    !!detailsChangedAt &&
+    new Date(detailsChangedAt).getTime() > new Date(capture.capturedAt).getTime()
+
+  const claims = capture.claims as Record<string, unknown>
+  const plan =
+    attributeRows.length > 0
+      ? planClaimAttributeWrites({
+          claims,
+          mapping: {
+            map: attributeRows.filter((r) => r.claimPath && r.attributeKey),
+            ...(overrideExisting ? { overrideExisting: true } : {}),
+            ...(syncOnSignIn ? { syncOnSignIn: true } : {}),
+          },
+          existing: {},
+          definitions: defs,
+          explain: true,
+        })
+      : null
+
+  return (
+    <div className="space-y-2 rounded-md border border-border/40 bg-muted/20 px-3 py-3 text-[12.5px]">
+      <div>
+        <div className="font-medium">Attribute writes from your last test sign-in</div>
+        <div className="mt-0.5 text-muted-foreground">
+          {capture.identity.email ?? capture.identity.id} · <TimeAgo date={capture.capturedAt} /> ·{' '}
+          <TestSignInButton
+            registrationId={registrationId}
+            variant="link"
+            size="sm"
+            disabled={!canTest}
+          >
+            Re-test
+          </TestSignInButton>
+        </div>
+      </div>
+
+      {plan && (Object.keys(plan.valid).length > 0 || (plan.skips?.length ?? 0) > 0) ? (
+        <dl className="grid grid-cols-[6.6em_1fr] gap-x-2.5 gap-y-1 text-[12px]">
+          {defs
+            .filter((d) => d.key in plan.valid || plan.skips?.some((s) => s.key === d.key))
+            .map((d) => {
+              const written = plan.valid[d.key]
+              const skip = plan.skips?.find((s) => s.key === d.key)
+              const row = attributeRows.find((r) => r.attributeKey === d.key)
+              const raw = row ? getClaimByPath(claims, row.claimPath) : undefined
+              const joined = Array.isArray(raw) && d.type === 'string' && written !== undefined
+              return (
+                <div key={d.key} className="contents">
+                  <dt className="text-muted-foreground">{d.label}</dt>
+                  <dd className="min-w-0 break-all">
+                    {written !== undefined ? (
+                      <>
+                        “{String(written)}”
+                        {joined && (
+                          <Badge variant="outline" className="ml-1 align-middle">
+                            array joined to text
+                          </Badge>
+                        )}
+                      </>
+                    ) : (
+                      <span className="text-muted-foreground">
+                        skipped: {skipReason(skip?.reason, raw)}
+                      </span>
+                    )}
+                  </dd>
+                </div>
+              )
+            })}
+        </dl>
+      ) : (
+        <p className="text-xs text-muted-foreground">No attribute mappings yet.</p>
+      )}
+
+      {stale ? (
+        <p className="text-xs text-amber-700 dark:text-amber-400">
+          Configuration changed since capture. Re-test.
+        </p>
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          Assumes the person has no attributes yet. With Overwrite off, someone who already has a
+          value keeps it.
+        </p>
+      )}
+    </div>
+  )
+}
+
+function skipReason(reason: string | undefined, raw: unknown): string {
+  if (reason === 'type_mismatch') {
+    const kind = raw === null ? 'null' : Array.isArray(raw) ? 'array' : typeof raw
+    return `type mismatch (${kind})`
+  }
+  if (reason === 'kept_existing') return 'kept existing'
+  return 'missing claim'
+}

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-attribute-mapping-editor.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-attribute-mapping-editor.tsx
@@ -1,0 +1,259 @@
+/**
+ * Claim → person-attribute mapping. A second disclosure under role mapping,
+ * same chrome. Writes the `attributes` section of `claim_mapping`. Opens when
+ * a mapping already exists. Empty definitions replace the rows with a link
+ * to People settings.
+ */
+import { useEffect, useState } from 'react'
+import { Link } from '@tanstack/react-router'
+import { AdjustmentsHorizontalIcon, PlusIcon, TrashIcon } from '@heroicons/react/24/solid'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Badge } from '@/components/ui/badge'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useUserAttributes } from '@/lib/client/hooks/use-user-attributes-queries'
+import type { UserAttributeType } from '@/lib/shared/db-types'
+import type { SsoTestCapture } from '@/lib/shared/sso-test-capture'
+import { ClaimPathInput } from './claim-path-input'
+import { AttributeWritesPreview } from './attribute-writes-preview'
+import type { AttributeMapping } from './provider-shared'
+
+const TYPE_LABEL: Record<UserAttributeType, string> = {
+  string: 'Text',
+  number: 'Number',
+  boolean: 'Boolean',
+  date: 'Date',
+  currency: 'Currency',
+}
+
+const EMPTY: AttributeMapping = { map: [] }
+
+export function ClaimAttributeMappingEditor({
+  mapping,
+  disabled,
+  registrationId,
+  canTest,
+  capture,
+  detailsChangedAt,
+  onChange,
+}: {
+  mapping: AttributeMapping | null
+  disabled: boolean
+  registrationId: string
+  canTest: boolean
+  capture: SsoTestCapture | null
+  detailsChangedAt?: string | null
+  onChange: (mapping: AttributeMapping | null) => void
+}) {
+  const current: AttributeMapping = mapping ?? EMPTY
+  const rows = current.map ?? []
+  const mappingCount = rows.filter((r) => r.claimPath && r.attributeKey).length
+  const hasConfig =
+    mapping != null && (rows.length > 0 || mapping.overrideExisting || mapping.syncOnSignIn)
+
+  const { data: definitions } = useUserAttributes()
+  const defs = definitions ?? []
+  const noDefinitions = definitions !== undefined && defs.length === 0
+
+  const [open, setOpen] = useState(hasConfig)
+  useEffect(() => {
+    if (hasConfig) setOpen(true)
+  }, [hasConfig])
+
+  const update = (patch: Partial<AttributeMapping>) =>
+    onChange({ ...current, ...patch, map: patch.map ?? current.map ?? [] })
+
+  const usedKeys = new Set(rows.map((r) => r.attributeKey).filter(Boolean))
+
+  return (
+    <div className="rounded-md border border-border/50 bg-muted/10">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex w-full items-center justify-between px-3 py-2 text-left"
+        aria-expanded={open}
+      >
+        <span className="flex items-center gap-2 text-sm font-medium">
+          <AdjustmentsHorizontalIcon className="size-4 text-muted-foreground" />
+          Copy claims into person attributes
+          {mappingCount > 0 && (
+            <span className="text-xs font-normal text-muted-foreground">
+              · {mappingCount} mapping{mappingCount === 1 ? '' : 's'}
+            </span>
+          )}
+        </span>
+        <span className="text-muted-foreground">{open ? '−' : '+'}</span>
+      </button>
+
+      {open && (
+        <div className="space-y-4 border-t border-border/40 px-3 py-3">
+          <p className="text-xs text-muted-foreground">
+            Fill person attributes from what the IdP sends, on every sign-in. Only attributes
+            defined under People can be written. Keys and values you set by hand or through your CDP
+            are kept unless you say otherwise.
+          </p>
+
+          {noDefinitions ? (
+            <div className="space-y-2">
+              <p className="text-xs text-muted-foreground">
+                No person attributes yet. Define one under People, then come back to map a claim to
+                it.
+              </p>
+              <Link
+                to="/admin/settings/people"
+                className="text-sm font-medium text-primary underline-offset-4 hover:underline"
+              >
+                Open People settings
+              </Link>
+            </div>
+          ) : (
+            <>
+              <div className="space-y-2">
+                {rows.map((row, index) => {
+                  const def = defs.find((d) => d.key === row.attributeKey)
+                  const orphan = row.attributeKey !== '' && !def
+                  const available = defs.filter(
+                    (d) => d.key === row.attributeKey || !usedKeys.has(d.key)
+                  )
+                  return (
+                    <div key={index} className="flex items-start gap-2">
+                      <ClaimPathInput
+                        value={row.claimPath}
+                        onChange={(claimPath) =>
+                          update({
+                            map: rows.map((r, i) => (i === index ? { ...r, claimPath } : r)),
+                          })
+                        }
+                        registrationId={registrationId}
+                        canTest={canTest}
+                        placeholder="department, extension_plan, org.costCenter"
+                        ariaLabel={`Claim path (mapping ${index + 1})`}
+                        disabled={disabled}
+                        capture={capture}
+                        suggestionsFor="attribute"
+                      />
+                      <span className="mt-2 shrink-0 text-xs text-muted-foreground">→</span>
+                      <div className="min-w-0 flex-1 space-y-1">
+                        <Select
+                          value={row.attributeKey}
+                          onValueChange={(attributeKey) =>
+                            update({
+                              map: rows.map((r, i) => (i === index ? { ...r, attributeKey } : r)),
+                            })
+                          }
+                          disabled={disabled}
+                        >
+                          <SelectTrigger
+                            className="w-full"
+                            aria-label={`Person attribute (mapping ${index + 1})`}
+                          >
+                            <SelectValue placeholder="Attribute" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {available.map((d) => (
+                              <SelectItem key={d.key} value={d.key}>
+                                <span className="flex flex-col text-left">
+                                  <span>{d.label}</span>
+                                  <span className="text-xs font-normal text-muted-foreground">
+                                    {d.key} · {TYPE_LABEL[d.type] ?? d.type}
+                                  </span>
+                                </span>
+                              </SelectItem>
+                            ))}
+                            {orphan && (
+                              <SelectItem value={row.attributeKey}>{row.attributeKey}</SelectItem>
+                            )}
+                          </SelectContent>
+                        </Select>
+                        {orphan && (
+                          <Badge
+                            variant="outline"
+                            className="border-amber-500/40 text-amber-700 dark:text-amber-400"
+                          >
+                            attribute no longer exists
+                          </Badge>
+                        )}
+                      </div>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="mt-0.5 h-9"
+                        aria-label={`Remove mapping ${index + 1}`}
+                        onClick={() => update({ map: rows.filter((_, i) => i !== index) })}
+                        disabled={disabled}
+                      >
+                        <TrashIcon className="size-3.5" />
+                      </Button>
+                    </div>
+                  )
+                })}
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-9"
+                  onClick={() => update({ map: [...rows, { claimPath: '', attributeKey: '' }] })}
+                  disabled={disabled}
+                >
+                  <PlusIcon className="size-3.5" />
+                  Add mapping
+                </Button>
+              </div>
+
+              <label className="flex items-start gap-2 text-sm">
+                <Checkbox
+                  checked={current.overrideExisting === true}
+                  onCheckedChange={(v) => update({ overrideExisting: v === true })}
+                  disabled={disabled}
+                  aria-label="Overwrite values that are already set"
+                  className="mt-0.5"
+                />
+                <span>
+                  Overwrite values that are already set
+                  <span className="mt-0.5 block text-xs text-muted-foreground">
+                    Off: a claim only fills an attribute that is empty, so values set by hand or
+                    from your CDP stay. On: the IdP&apos;s value wins on every sign-in.
+                  </span>
+                </span>
+              </label>
+
+              <label className="flex items-start gap-2 text-sm">
+                <Checkbox
+                  checked={current.syncOnSignIn === true}
+                  onCheckedChange={(v) => update({ syncOnSignIn: v === true })}
+                  disabled={disabled}
+                  aria-label="Clear an attribute when its claim is missing"
+                  className="mt-0.5"
+                />
+                <span>
+                  Clear an attribute when its claim is missing
+                  <span className="mt-0.5 block text-xs text-muted-foreground">
+                    On: if the IdP stops sending a mapped claim, the stored value is removed at the
+                    person&apos;s next sign-in. Off: a missing claim leaves the value alone.
+                  </span>
+                </span>
+              </label>
+
+              <AttributeWritesPreview
+                capture={capture}
+                registrationId={registrationId}
+                detailsChangedAt={detailsChangedAt}
+                attributeRows={rows}
+                overrideExisting={current.overrideExisting === true}
+                syncOnSignIn={current.syncOnSignIn === true}
+                canTest={canTest}
+              />
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-attribute-mapping-editor.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-attribute-mapping-editor.tsx
@@ -1,8 +1,8 @@
 /**
  * Claim → person-attribute mapping. A second disclosure under role mapping,
  * same chrome. Writes the `attributes` section of `claim_mapping`. Opens when
- * a mapping already exists. Empty definitions replace the rows with a link
- * to People settings.
+ * a mapping already exists. With no definitions and no rows, a link to People
+ * settings replaces the editor; existing rows stay removable regardless.
  */
 import { useEffect, useState } from 'react'
 import { Link } from '@tanstack/react-router'
@@ -60,6 +60,10 @@ export function ClaimAttributeMappingEditor({
   const { data: definitions } = useUserAttributes()
   const defs = definitions ?? []
   const noDefinitions = definitions !== undefined && defs.length === 0
+  // Existing rows stay visible with no definitions left, or an orphaned
+  // mapping could never be removed — and it would keep forcing a userinfo
+  // fetch on every sign-in.
+  const showEmptyState = noDefinitions && rows.length === 0
 
   const [open, setOpen] = useState(hasConfig)
   useEffect(() => {
@@ -99,7 +103,7 @@ export function ClaimAttributeMappingEditor({
             are kept unless you say otherwise.
           </p>
 
-          {noDefinitions ? (
+          {showEmptyState ? (
             <div className="space-y-2">
               <p className="text-xs text-muted-foreground">
                 No person attributes yet. Define one under People, then come back to map a claim to
@@ -194,17 +198,31 @@ export function ClaimAttributeMappingEditor({
                     </div>
                   )
                 })}
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="h-9"
-                  onClick={() => update({ map: [...rows, { claimPath: '', attributeKey: '' }] })}
-                  disabled={disabled}
-                >
-                  <PlusIcon className="size-3.5" />
-                  Add mapping
-                </Button>
+                {noDefinitions ? (
+                  <p className="text-xs text-muted-foreground">
+                    No person attributes are defined any more, so these mappings write nothing.
+                    Remove them, or{' '}
+                    <Link
+                      to="/admin/settings/people"
+                      className="font-medium text-primary underline-offset-4 hover:underline"
+                    >
+                      define attributes under People
+                    </Link>
+                    .
+                  </p>
+                ) : (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-9"
+                    onClick={() => update({ map: [...rows, { claimPath: '', attributeKey: '' }] })}
+                    disabled={disabled}
+                  >
+                    <PlusIcon className="size-3.5" />
+                    Add mapping
+                  </Button>
+                )}
               </div>
 
               <label className="flex items-start gap-2 text-sm">

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-card.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-card.tsx
@@ -38,11 +38,15 @@ export function ClaimMappingCard({ provider }: { provider: IdentityProvider }) {
     provider.claimMapping?.profile?.allowMissingEmail === true
   )
   const { lastSuccess } = useSsoTestSignIn()
+  // In-session lastSuccess is the test that just completed; the persisted
+  // capture is only reloaded with the provider row. Prefer the session copy
+  // so suggestions and preview update without a refresh.
   const capture =
-    provider.lastTestCapture && provider.lastTestCapture.registrationId === provider.registrationId
-      ? provider.lastTestCapture
-      : lastSuccess && lastSuccess.registrationId === provider.registrationId
-        ? lastSuccess
+    lastSuccess && lastSuccess.registrationId === provider.registrationId
+      ? lastSuccess
+      : provider.lastTestCapture &&
+          provider.lastTestCapture.registrationId === provider.registrationId
+        ? provider.lastTestCapture
         : null
 
   const handleSave = () =>

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-card.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-card.tsx
@@ -6,9 +6,9 @@
  * accounts, so packaging it under "create accounts for new people" would hide
  * a live control from exactly the workspaces most likely to need it.
  *
- * It writes two sections of the shared `claim_mapping` column (`profile` and
- * `role`) through `mergeClaimMapping`, which carries `attributes` — and the
- * parts of `profile` that have no UI — through verbatim.
+ * It writes three sections of the shared `claim_mapping` column (`profile`,
+ * `role`, and `attributes`) through `mergeClaimMapping`, which carries the
+ * parts of `profile` that have no UI through verbatim.
  */
 import { useState } from 'react'
 import { Button } from '@/components/ui/button'
@@ -16,10 +16,14 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { SettingsCard } from '@/components/admin/settings/settings-card'
 import type { IdentityProvider } from '@/lib/server/domains/settings/identity-providers.service'
 import { ClaimMappingEditor } from './claim-mapping-editor'
+import { ClaimAttributeMappingEditor } from './claim-attribute-mapping-editor'
+import { useSsoTestSignIn } from '../sso/use-sso-test-sign-in'
 import {
   mergeClaimMapping,
+  normalizeAttributeMapping,
   normalizeRoleMapping,
   withAllowMissingEmail,
+  type AttributeMapping,
   type RoleMapping,
 } from './provider-shared'
 import { useProviderSave } from './use-provider-save'
@@ -27,9 +31,19 @@ import { useProviderSave } from './use-provider-save'
 export function ClaimMappingCard({ provider }: { provider: IdentityProvider }) {
   const { saving, save } = useProviderSave(provider)
   const [mapping, setMapping] = useState<RoleMapping | null>(provider.claimMapping?.role ?? null)
+  const [attributes, setAttributes] = useState<AttributeMapping | null>(
+    provider.claimMapping?.attributes ?? null
+  )
   const [allowMissingEmail, setAllowMissingEmail] = useState(
     provider.claimMapping?.profile?.allowMissingEmail === true
   )
+  const { lastSuccess } = useSsoTestSignIn()
+  const capture =
+    provider.lastTestCapture && provider.lastTestCapture.registrationId === provider.registrationId
+      ? provider.lastTestCapture
+      : lastSuccess && lastSuccess.registrationId === provider.registrationId
+        ? lastSuccess
+        : null
 
   const handleSave = () =>
     void save(
@@ -37,6 +51,7 @@ export function ClaimMappingCard({ provider }: { provider: IdentityProvider }) {
         claimMapping: mergeClaimMapping(provider.claimMapping, {
           role: normalizeRoleMapping(mapping),
           profile: withAllowMissingEmail(provider.claimMapping?.profile, allowMissingEmail),
+          attributes: normalizeAttributeMapping(attributes),
         }),
       },
       'Claim mapping saved.'
@@ -77,6 +92,16 @@ export function ClaimMappingCard({ provider }: { provider: IdentityProvider }) {
           registrationId={provider.registrationId}
           canTest
           onChange={setMapping}
+        />
+
+        <ClaimAttributeMappingEditor
+          mapping={attributes}
+          disabled={saving}
+          registrationId={provider.registrationId}
+          canTest
+          capture={capture}
+          detailsChangedAt={provider.detailsChangedAt}
+          onChange={setAttributes}
         />
 
         <div className="flex justify-end border-t border-border/40 pt-5">

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-path-input.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-path-input.tsx
@@ -43,7 +43,7 @@ export function ClaimPathInput({
   suggestionsFor?: 'role' | 'attribute'
 }) {
   const { lastSuccess } = useSsoTestSignIn()
-  const fixture = fixtureFor(registrationId, capture) ?? fixtureFor(registrationId, lastSuccess)
+  const fixture = fixtureFor(registrationId, lastSuccess) ?? fixtureFor(registrationId, capture)
   const pathSuggestions = fixture
     ? suggestionsFor === 'attribute'
       ? deriveAttributeClaimPaths(fixture.claims).map((s) => ({
@@ -80,7 +80,7 @@ export function ClaimPathInput({
 
 export function useClaimSuggestions(registrationId: string, capture?: SsoTestCapture | null) {
   const { lastSuccess } = useSsoTestSignIn()
-  const fixture = fixtureFor(registrationId, capture) ?? fixtureFor(registrationId, lastSuccess)
+  const fixture = fixtureFor(registrationId, lastSuccess) ?? fixtureFor(registrationId, capture)
   if (!fixture) return null
   return deriveClaimSuggestions(fixture.claims)
 }

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-path-input.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-path-input.tsx
@@ -5,7 +5,7 @@
  */
 
 import { Autocomplete } from '@/components/ui/autocomplete'
-import { deriveClaimSuggestions } from '@/lib/shared/claim-suggestions'
+import { deriveAttributeClaimPaths, deriveClaimSuggestions } from '@/lib/shared/claim-suggestions'
 import type { SsoTestCapture } from '@/lib/shared/sso-test-capture'
 import { TestSignInButton } from '../sso/test-sign-in-button'
 import { useSsoTestSignIn } from '../sso/use-sso-test-sign-in'
@@ -27,6 +27,7 @@ export function ClaimPathInput({
   ariaLabel,
   disabled,
   capture,
+  suggestionsFor = 'role',
 }: {
   value: string
   onChange: (next: string) => void
@@ -37,11 +38,20 @@ export function ClaimPathInput({
   disabled?: boolean
   /** Session or persisted fixture. Falls back to the sitting's lastSuccess. */
   capture?: SsoTestCapture | null
+  /** Role suggestions are array-of-string paths; attribute suggestions are
+   *  scalar and array leaves, including profile claims. */
+  suggestionsFor?: 'role' | 'attribute'
 }) {
   const { lastSuccess } = useSsoTestSignIn()
   const fixture = fixtureFor(registrationId, capture) ?? fixtureFor(registrationId, lastSuccess)
-  const suggestions = fixture ? deriveClaimSuggestions(fixture.claims) : null
-  const pathSuggestions = (suggestions?.paths ?? []).map((p) => ({ value: p }))
+  const pathSuggestions = fixture
+    ? suggestionsFor === 'attribute'
+      ? deriveAttributeClaimPaths(fixture.claims).map((s) => ({
+          value: s.path,
+          description: s.description,
+        }))
+      : deriveClaimSuggestions(fixture.claims).paths.map((p) => ({ value: p }))
+    : []
 
   return (
     <Autocomplete

--- a/apps/web/src/components/admin/settings/security/identity-providers/outcome-preview-rail.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/outcome-preview-rail.tsx
@@ -9,12 +9,11 @@ import { Badge } from '@/components/ui/badge'
 import { MENU_LABEL } from '@/components/ui/menu'
 import { cn } from '@/lib/shared/utils'
 import { getClaimByPath } from '@/lib/shared/oidc-claim-mapping'
-import { planClaimAttributeWrites } from '@/lib/shared/plan-claim-attribute-writes'
 import { resolveSsoRoleMatch } from '@/lib/shared/resolve-sso-role'
 import type { SsoTestCapture } from '../sso/use-sso-test-sign-in'
 import { TestSignInButton } from '../sso/test-sign-in-button'
 import type { IdentityProvider } from '@/lib/server/domains/settings/identity-providers.service'
-import { useUserAttributes } from '@/lib/client/hooks/use-user-attributes-queries'
+import { AttributeWritesPreview } from './attribute-writes-preview'
 
 type RoleMapping = NonNullable<NonNullable<IdentityProvider['claimMapping']>['role']>
 
@@ -32,7 +31,8 @@ export function OutcomePreviewRail({
   nameClaim,
   roleMapping,
   attributeRows,
-  mirrorAttributes,
+  overrideExisting,
+  syncOnSignIn,
   registrationId,
 }: {
   capture: SsoTestCapture
@@ -42,7 +42,8 @@ export function OutcomePreviewRail({
   nameClaim: string
   roleMapping: RoleMapping | null
   attributeRows: Array<{ claimPath: string; attributeKey: string }>
-  mirrorAttributes: boolean
+  overrideExisting: boolean
+  syncOnSignIn: boolean
   registrationId: string
 }) {
   const stale =
@@ -61,26 +62,6 @@ export function OutcomePreviewRail({
 
   const match = resolveSsoRoleMatch(claims, roleMapping ?? undefined)
   const matchedRule = match && roleMapping ? roleMapping.rules[match.ruleIndex] : undefined
-
-  const { data: attributes } = useUserAttributes()
-  const defs = (attributes ?? []).map((d) => ({
-    key: d.key,
-    type: d.type,
-    label: d.label,
-  }))
-  const plan =
-    attributeRows.length > 0
-      ? planClaimAttributeWrites({
-          claims,
-          mapping: {
-            map: attributeRows.filter((r) => r.claimPath && r.attributeKey),
-            ...(mirrorAttributes ? { overrideExisting: true, syncOnSignIn: true } : {}),
-          },
-          existing: {},
-          definitions: defs,
-          explain: true,
-        })
-      : null
 
   const provenance = formatProvenance(capture.identity.sources)
 
@@ -144,43 +125,15 @@ export function OutcomePreviewRail({
       </div>
 
       <div className="border-t border-border/40 pt-3">
-        <h3 className={cn(MENU_LABEL, 'mb-2 font-mono')}>Attribute writes</h3>
-        {plan && (Object.keys(plan.valid).length > 0 || (plan.skips?.length ?? 0) > 0) ? (
-          <dl className="grid grid-cols-[6.6em_1fr] gap-x-2.5 gap-y-1 text-[12px]">
-            {defs
-              .filter((d) => d.key in plan.valid || plan.skips?.some((s) => s.key === d.key))
-              .map((d) => {
-                const written = plan.valid[d.key]
-                const skip = plan.skips?.find((s) => s.key === d.key)
-                const row = attributeRows.find((r) => r.attributeKey === d.key)
-                const raw = row ? getClaimByPath(claims, row.claimPath) : undefined
-                const joined = Array.isArray(raw) && d.type === 'string'
-                return (
-                  <div key={d.key} className="contents">
-                    <dt className="text-muted-foreground">{d.label}</dt>
-                    <dd className="min-w-0 break-all">
-                      {written !== undefined ? (
-                        <>
-                          “{String(written)}”
-                          {joined && (
-                            <Badge variant="outline" className="ml-1 align-middle">
-                              array joined to text
-                            </Badge>
-                          )}
-                        </>
-                      ) : (
-                        <span className="text-muted-foreground">
-                          skipped: {skipReason(skip?.reason, raw)}
-                        </span>
-                      )}
-                    </dd>
-                  </div>
-                )
-              })}
-          </dl>
-        ) : (
-          <p className="text-xs text-muted-foreground">No attribute mappings yet.</p>
-        )}
+        <AttributeWritesPreview
+          capture={capture}
+          registrationId={registrationId}
+          detailsChangedAt={provider?.detailsChangedAt}
+          attributeRows={attributeRows}
+          overrideExisting={overrideExisting}
+          syncOnSignIn={syncOnSignIn}
+          canTest={!!provider}
+        />
       </div>
 
       <div className="border-t border-border/40 pt-3 text-xs text-muted-foreground">
@@ -215,13 +168,4 @@ function formatProvenance(sources: SsoTestCapture['identity']['sources']): strin
   }
   if (seen.length === 0) return null
   return `Captured via ${seen.join(' + ')}.`
-}
-
-function skipReason(reason: string | undefined, raw: unknown): string {
-  if (reason === 'type_mismatch') {
-    const kind = raw === null ? 'null' : Array.isArray(raw) ? 'array' : typeof raw
-    return `type mismatch (${kind})`
-  }
-  if (reason === 'kept_existing') return 'kept existing'
-  return 'missing claim'
 }

--- a/apps/web/src/components/admin/settings/security/identity-providers/provider-shared.ts
+++ b/apps/web/src/components/admin/settings/security/identity-providers/provider-shared.ts
@@ -52,8 +52,7 @@ export function newRegistrationId(): string {
  *  enforcement on. Mirrors the server-side
  *  `isSsoEnforcementUnlocked(provider, null)` predicate. */
 export type ConnectionTestState =
-  | { kind: 'unsaved' | 'untested' | 'stale' }
-  | { kind: 'verified'; testedAt: string }
+  { kind: 'unsaved' | 'untested' | 'stale' } | { kind: 'verified'; testedAt: string }
 
 export function getConnectionTestState(provider: IdentityProvider | null): ConnectionTestState {
   if (!provider) return { kind: 'unsaved' }
@@ -115,6 +114,28 @@ export function withAllowMissingEmail(
  * persisted as absent (the canonical "no mapping" state). A custom claim path
  * on its own is inert.
  */
+/** The attributes section of `claim_mapping` — claim → person-attribute rows. */
+export type AttributeMapping = NonNullable<IdentityProviderClaimMapping['attributes']>
+
+/**
+ * Drop rows with an empty path or key. Persist `undefined` when nothing
+ * remains so `mergeClaimMapping` deletes the section. Flags are kept only
+ * when at least one row survives.
+ */
+export function normalizeAttributeMapping(
+  mapping: AttributeMapping | null | undefined
+): AttributeMapping | undefined {
+  if (!mapping) return undefined
+  const map = (mapping.map ?? []).filter(
+    (row) => row.claimPath.trim() !== '' && row.attributeKey.trim() !== ''
+  )
+  if (map.length === 0) return undefined
+  const next: AttributeMapping = { map }
+  if (mapping.overrideExisting === true) next.overrideExisting = true
+  if (mapping.syncOnSignIn === true) next.syncOnSignIn = true
+  return next
+}
+
 export function normalizeRoleMapping(mapping: RoleMapping | null): RoleMapping | undefined {
   if (!mapping) return undefined
   if (mapping.rules.length === 0 && mapping.syncOnEverySignIn !== true) return undefined

--- a/apps/web/src/lib/server/auth/__tests__/apply-claim-attributes.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/apply-claim-attributes.test.ts
@@ -94,4 +94,26 @@ describe('planClaimAttributeWrites', () => {
     })
     expect(valid).toEqual({ department: 'Eng' })
   })
+
+  it('treats an array of objects into a string attribute as a type mismatch', () => {
+    const { valid, skips } = planClaimAttributeWrites({
+      claims: { groups: [{ id: '1' }, { id: '2' }] },
+      mapping: { map: [{ claimPath: 'groups', attributeKey: 'department' }] },
+      existing: {},
+      definitions: defs,
+      explain: true,
+    })
+    expect(valid).toEqual({})
+    expect(skips).toEqual([{ key: 'department', reason: 'type_mismatch' }])
+  })
+
+  it('joins an array of primitives into a string attribute', () => {
+    const { valid } = planClaimAttributeWrites({
+      claims: { groups: ['eng', 'sales'] },
+      mapping: { map: [{ claimPath: 'groups', attributeKey: 'department' }] },
+      existing: {},
+      definitions: defs,
+    })
+    expect(valid).toEqual({ department: 'eng,sales' })
+  })
 })

--- a/apps/web/src/lib/server/auth/__tests__/hooks-after-integration.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/hooks-after-integration.test.ts
@@ -68,6 +68,7 @@ const mockGetPublicPortalConfig = vi.fn()
 const mockRecordAuditEvent = vi.fn(async (_spec: unknown) => undefined)
 const mockDeleteSessionCookie = vi.fn((_ctx: unknown) => undefined)
 const mockHasPlatformCredentials = vi.fn(async (_type: string) => true)
+const throwOnMetadataWrite = { value: false }
 
 vi.mock('@/lib/server/db', () => {
   const tx = {
@@ -89,11 +90,15 @@ vi.mock('@/lib/server/db', () => {
         account: { findFirst: mockAccountFindFirst },
       },
       update: () => ({
-        set: (patch: { role?: 'admin' | 'member' | 'user' }) => {
+        set: (patch: { role?: 'admin' | 'member' | 'user'; metadata?: string }) => {
           mockUpdateSet(patch)
+          if (throwOnMetadataWrite.value && typeof patch.metadata === 'string') {
+            throw new Error('claim-attribute db down')
+          }
           return { where: async () => undefined }
         },
       }),
+      select: () => ({ from: async () => [{ key: 'department', type: 'string' }] }),
       delete: (table: { __name: string }) => {
         mockDelete(table)
         if (table.__name === 'session') return { where: mockSessionDelete }
@@ -112,7 +117,9 @@ vi.mock('@/lib/server/db', () => {
     account: { __name: 'account', userId: 'account.userId', providerId: 'account.providerId' },
     and: vi.fn((...parts: unknown[]) => ({ op: 'and', parts })),
     eq: vi.fn((col: unknown, val: unknown) => ({ op: 'eq', col, val })),
+    desc: (col: unknown) => ({ op: 'desc', col }),
     sql: (strings: TemplateStringsArray) => ({ strings }),
+    userAttributeDefinitions: { __name: 'user_attribute_definitions' },
   }
 })
 
@@ -210,6 +217,7 @@ function ssoCallbackCtx(opts: { userId: string; email: string; token: string }) 
 
 beforeEach(() => {
   vi.clearAllMocks()
+  throwOnMetadataWrite.value = false
   state.role = 'user'
   mockTxPrincipalFindFirst.mockResolvedValue({ id: 'principal_existing_admin' })
   mockUserFindFirst.mockResolvedValue({ createdAt: new Date(Date.now() - 60 * 60_000) })
@@ -327,5 +335,63 @@ describe('hooksAfter — short-circuit on blocked sign-in', () => {
       .map(([spec]) => spec as { event: string })
       .find((spec) => spec.event === 'auth.signin.success')
     expect(successAudit).toBeUndefined()
+  })
+})
+
+describe('hooksAfter — claim attribute write failure does not block sign-in', () => {
+  it('swallows a DB throw, leaves the session, and continues the chain', async () => {
+    mockGetWorkspaceSettings.mockResolvedValue(
+      makeWorkspace({
+        authConfig: makeAuthConfig({
+          ssoOidc: { autoCreateUsers: true, autoProvisionRole: 'member' },
+        }),
+        verifiedDomains: [makeVerifiedDomain('acme.com', false)],
+      })
+    )
+    state.role = 'user'
+    mockListIdentityProviders.mockResolvedValue([
+      {
+        id: 'idp_sso',
+        registrationId: 'sso',
+        enabled: true,
+        autoCreateUsers: true,
+        autoProvisionRole: 'member',
+        claimMapping: {
+          attributes: { map: [{ claimPath: 'department', attributeKey: 'department' }] },
+        },
+        domains: [
+          {
+            name: 'acme.com',
+            verifiedAt: '2026-05-01T00:00:00.000Z',
+            enforced: false,
+          },
+        ],
+      },
+    ])
+    mockUserFindFirst.mockResolvedValue({
+      createdAt: new Date(Date.now() - 60 * 60_000),
+      metadata: '{}',
+    })
+    const payload = Buffer.from(
+      JSON.stringify({
+        department: 'Engineering',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      })
+    ).toString('base64url')
+    mockAccountFindFirst.mockResolvedValue({
+      idToken: `h.${payload}.s`,
+      accountId: 'sub-1',
+    })
+    throwOnMetadataWrite.value = true
+
+    await expect(
+      hooksAfter(ssoCallbackCtx({ userId: 'user_new', email: 'alice@acme.com', token: 'tok' }))
+    ).resolves.toBeUndefined()
+
+    expect(mockUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata: expect.any(String) })
+    )
+    expect(mockSessionDelete).not.toHaveBeenCalled()
+    expect(mockDeleteSessionCookie).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/lib/server/auth/__tests__/hooks-after-integration.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/hooks-after-integration.test.ts
@@ -367,7 +367,7 @@ describe('hooksAfter — claim attribute write failure does not block sign-in', 
           },
         ],
       },
-    ])
+    ] as never)
     mockUserFindFirst.mockResolvedValue({
       createdAt: new Date(Date.now() - 60 * 60_000),
       metadata: '{}',

--- a/apps/web/src/lib/server/auth/__tests__/hooks-apply-claim-attributes.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/hooks-apply-claim-attributes.test.ts
@@ -1,0 +1,245 @@
+/**
+ * `applyClaimAttributesAfter` — copy mapped IdP claims into person attributes
+ * on a successful OAuth callback.
+ *
+ * Mocks modelled on hooks-sso-callback-after.test.ts / jit-role.test.ts:
+ * spread the real db module, override the query/update surface this writer
+ * drives. The shared `readClaims` parameter is the take-once stash fix.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockUserFindFirst = vi.fn()
+const mockAccountFindFirst = vi.fn()
+const mockUpdateSet = vi.fn()
+const mockUpdateWhere = vi.fn()
+const mockSelectFrom = vi.fn()
+const mockLogInfo = vi.fn()
+const mockLogError = vi.fn()
+const mockLogDebug = vi.fn()
+
+vi.mock('@/lib/server/logger', () => ({
+  logger: {
+    child: () => ({
+      info: (...args: unknown[]) => mockLogInfo(...args),
+      error: (...args: unknown[]) => mockLogError(...args),
+      debug: (...args: unknown[]) => mockLogDebug(...args),
+    }),
+  },
+}))
+
+vi.mock('@/lib/server/db', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/server/db')>()),
+  db: {
+    query: {
+      user: { findFirst: (...args: unknown[]) => mockUserFindFirst(...args) },
+      account: { findFirst: (...args: unknown[]) => mockAccountFindFirst(...args) },
+    },
+    select: () => ({ from: (...args: unknown[]) => mockSelectFrom(...args) }),
+    update: () => ({
+      set: (...args: unknown[]) => {
+        mockUpdateSet(...args)
+        return { where: mockUpdateWhere }
+      },
+    }),
+  },
+}))
+
+const { applyClaimAttributesAfter } = await import('../apply-claim-attributes')
+
+const DEPARTMENT_DEF = { key: 'department', type: 'string' as const }
+
+type Provider = {
+  registrationId: string
+  claimMapping: unknown
+}
+
+function providersWith(over: { claimMapping?: unknown; registrationId?: string } = {}): Provider[] {
+  return [
+    {
+      registrationId: over.registrationId ?? 'sso',
+      claimMapping: over.claimMapping ?? {
+        attributes: { map: [{ claimPath: 'department', attributeKey: 'department' }] },
+      },
+    },
+  ]
+}
+
+function ctxFor(opts: { path?: string; providerId?: string; userId?: string | null } = {}) {
+  const userId = opts.userId === null ? undefined : (opts.userId ?? 'user_1')
+  return {
+    path: opts.path ?? '/oauth2/callback/:providerId',
+    params: { providerId: opts.providerId ?? 'sso' },
+    context: {
+      newSession: userId ? { user: { id: userId } } : null,
+    },
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockUpdateWhere.mockResolvedValue(undefined)
+  mockUserFindFirst.mockResolvedValue({ metadata: null })
+  mockSelectFrom.mockResolvedValue([DEPARTMENT_DEF])
+  mockAccountFindFirst.mockResolvedValue(null)
+})
+
+describe('applyClaimAttributesAfter', () => {
+  it('writes user.metadata with the coerced value for a mapped, defined key', async () => {
+    await applyClaimAttributesAfter(ctxFor(), providersWith(), new Set(['sso']), async () => ({
+      department: 'Engineering',
+    }))
+    expect(mockUpdateSet).toHaveBeenCalledWith({
+      metadata: JSON.stringify({ department: 'Engineering' }),
+    })
+    expect(mockLogInfo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'user_1',
+        provider_id: 'sso',
+        written: ['department'],
+        removed: [],
+      }),
+      'claim attributes written'
+    )
+  })
+
+  it('ignores an unknown attributeKey and creates nothing', async () => {
+    await applyClaimAttributesAfter(
+      ctxFor(),
+      providersWith({
+        claimMapping: { attributes: { map: [{ claimPath: 'department', attributeKey: 'nope' }] } },
+      }),
+      new Set(['sso']),
+      async () => ({ department: 'Engineering' })
+    )
+    expect(mockUpdateSet).not.toHaveBeenCalled()
+  })
+
+  it('keeps an existing value when override is off', async () => {
+    mockUserFindFirst.mockResolvedValue({ metadata: JSON.stringify({ department: 'Sales' }) })
+    await applyClaimAttributesAfter(ctxFor(), providersWith(), new Set(['sso']), async () => ({
+      department: 'Engineering',
+    }))
+    expect(mockUpdateSet).not.toHaveBeenCalled()
+  })
+
+  it('replaces an existing value when override is on', async () => {
+    mockUserFindFirst.mockResolvedValue({ metadata: JSON.stringify({ department: 'Sales' }) })
+    await applyClaimAttributesAfter(
+      ctxFor(),
+      providersWith({
+        claimMapping: {
+          attributes: {
+            map: [{ claimPath: 'department', attributeKey: 'department' }],
+            overrideExisting: true,
+          },
+        },
+      }),
+      new Set(['sso']),
+      async () => ({ department: 'Engineering' })
+    )
+    expect(mockUpdateSet).toHaveBeenCalledWith({
+      metadata: JSON.stringify({ department: 'Engineering' }),
+    })
+  })
+
+  it('syncOnSignIn removes a key whose claim is absent', async () => {
+    mockUserFindFirst.mockResolvedValue({ metadata: JSON.stringify({ department: 'Sales' }) })
+    await applyClaimAttributesAfter(
+      ctxFor(),
+      providersWith({
+        claimMapping: {
+          attributes: {
+            map: [{ claimPath: 'department', attributeKey: 'department' }],
+            syncOnSignIn: true,
+          },
+        },
+      }),
+      new Set(['sso']),
+      async () => ({})
+    )
+    expect(mockUpdateSet).toHaveBeenCalledWith({ metadata: JSON.stringify({}) })
+  })
+
+  it('leaves a missing claim alone when sync is off', async () => {
+    mockUserFindFirst.mockResolvedValue({ metadata: JSON.stringify({ department: 'Sales' }) })
+    await applyClaimAttributesAfter(ctxFor(), providersWith(), new Set(['sso']), async () => ({}))
+    expect(mockUpdateSet).not.toHaveBeenCalled()
+  })
+
+  it('keeps _externalUserId through the merge', async () => {
+    mockUserFindFirst.mockResolvedValue({
+      metadata: JSON.stringify({ _externalUserId: 'ext_1' }),
+    })
+    await applyClaimAttributesAfter(ctxFor(), providersWith(), new Set(['sso']), async () => ({
+      department: 'Engineering',
+    }))
+    expect(mockUpdateSet).toHaveBeenCalledWith({
+      metadata: JSON.stringify({ _externalUserId: 'ext_1', department: 'Engineering' }),
+    })
+  })
+
+  it('does not touch the DB off the callback path', async () => {
+    await applyClaimAttributesAfter(
+      ctxFor({ path: '/sign-in/email' }),
+      providersWith(),
+      new Set(['sso']),
+      async () => ({ department: 'Engineering' })
+    )
+    expect(mockUserFindFirst).not.toHaveBeenCalled()
+    expect(mockUpdateSet).not.toHaveBeenCalled()
+  })
+
+  it('does not touch the DB for an unregistered provider', async () => {
+    await applyClaimAttributesAfter(
+      ctxFor({ providerId: 'google' }),
+      providersWith(),
+      new Set(['sso']),
+      async () => ({ department: 'Engineering' })
+    )
+    expect(mockUserFindFirst).not.toHaveBeenCalled()
+  })
+
+  it('does not touch the DB when newSession is missing (cleanup revoked the session)', async () => {
+    await applyClaimAttributesAfter(
+      ctxFor({ userId: null }),
+      providersWith(),
+      new Set(['sso']),
+      async () => ({ department: 'Engineering' })
+    )
+    expect(mockUserFindFirst).not.toHaveBeenCalled()
+  })
+
+  it('throws on a DB error so hooksAfter can swallow it without blocking sign-in', async () => {
+    mockUpdateWhere.mockRejectedValue(new Error('db down'))
+    await expect(
+      applyClaimAttributesAfter(ctxFor(), providersWith(), new Set(['sso']), async () => ({
+        department: 'Engineering',
+      }))
+    ).rejects.toThrow('db down')
+  })
+
+  it('shared reader: a take-once source still feeds the writer after a prior read', async () => {
+    // Role provisioning drains a take-once stash. The memoised reader hooksAfter
+    // builds must hand the same claims to the attribute writer.
+    let taken = false
+    const stash = { department: 'Engineering' }
+    let cached: Promise<Record<string, unknown>> | undefined
+    const readClaims = () => {
+      if (!cached) {
+        cached = Promise.resolve(
+          (() => {
+            if (taken) return {}
+            taken = true
+            return stash
+          })()
+        )
+      }
+      return cached
+    }
+    await readClaims() // auto-provision reads first
+    await applyClaimAttributesAfter(ctxFor(), providersWith(), new Set(['sso']), readClaims)
+    expect(mockUpdateSet).toHaveBeenCalledWith({
+      metadata: JSON.stringify({ department: 'Engineering' }),
+    })
+  })
+})

--- a/apps/web/src/lib/server/auth/__tests__/hooks-apply-claim-attributes.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/hooks-apply-claim-attributes.test.ts
@@ -44,7 +44,20 @@ vi.mock('@/lib/server/db', async (importOriginal) => ({
   },
 }))
 
-const { applyClaimAttributesAfter } = await import('../apply-claim-attributes')
+const { applyClaimAttributesAfter: realApply } = await import('../apply-claim-attributes')
+
+// Loose cast: the real 2nd param is IdentityProvider[]; the synthesized row
+// carries only the fields the writer reads.
+const applyClaimAttributesAfter = realApply as unknown as (
+  ctx: {
+    path?: string
+    params?: Record<string, unknown>
+    context?: { newSession?: { user?: { id?: string } } | null }
+  },
+  providers: ReadonlyArray<Record<string, unknown>>,
+  registeredOidcIds: Set<string>,
+  readClaims?: () => Promise<Record<string, unknown>>
+) => Promise<void>
 
 const DEPARTMENT_DEF = { key: 'department', type: 'string' as const }
 

--- a/apps/web/src/lib/server/auth/__tests__/hooks-apply-claim-attributes.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/hooks-apply-claim-attributes.test.ts
@@ -56,8 +56,13 @@ const applyClaimAttributesAfter = realApply as unknown as (
   },
   providers: ReadonlyArray<Record<string, unknown>>,
   registeredOidcIds: Set<string>,
-  readClaims?: () => Promise<Record<string, unknown>>
+  readClaims?: () => Promise<{ claims: Record<string, unknown>; fresh: boolean }>
 ) => Promise<void>
+
+/** A reader whose claims came from the stash — this sign-in, every source. */
+const fresh = (claims: Record<string, unknown>) => async () => ({ claims, fresh: true })
+/** A reader that fell back to the stored ID token. */
+const stale = (claims: Record<string, unknown>) => async () => ({ claims, fresh: false })
 
 const DEPARTMENT_DEF = { key: 'department', type: 'string' as const }
 
@@ -98,9 +103,12 @@ beforeEach(() => {
 
 describe('applyClaimAttributesAfter', () => {
   it('writes user.metadata with the coerced value for a mapped, defined key', async () => {
-    await applyClaimAttributesAfter(ctxFor(), providersWith(), new Set(['sso']), async () => ({
-      department: 'Engineering',
-    }))
+    await applyClaimAttributesAfter(
+      ctxFor(),
+      providersWith(),
+      new Set(['sso']),
+      fresh({ department: 'Engineering' })
+    )
     expect(mockUpdateSet).toHaveBeenCalledWith({
       metadata: JSON.stringify({ department: 'Engineering' }),
     })
@@ -122,16 +130,19 @@ describe('applyClaimAttributesAfter', () => {
         claimMapping: { attributes: { map: [{ claimPath: 'department', attributeKey: 'nope' }] } },
       }),
       new Set(['sso']),
-      async () => ({ department: 'Engineering' })
+      fresh({ department: 'Engineering' })
     )
     expect(mockUpdateSet).not.toHaveBeenCalled()
   })
 
   it('keeps an existing value when override is off', async () => {
     mockUserFindFirst.mockResolvedValue({ metadata: JSON.stringify({ department: 'Sales' }) })
-    await applyClaimAttributesAfter(ctxFor(), providersWith(), new Set(['sso']), async () => ({
-      department: 'Engineering',
-    }))
+    await applyClaimAttributesAfter(
+      ctxFor(),
+      providersWith(),
+      new Set(['sso']),
+      fresh({ department: 'Engineering' })
+    )
     expect(mockUpdateSet).not.toHaveBeenCalled()
   })
 
@@ -148,7 +159,7 @@ describe('applyClaimAttributesAfter', () => {
         },
       }),
       new Set(['sso']),
-      async () => ({ department: 'Engineering' })
+      fresh({ department: 'Engineering' })
     )
     expect(mockUpdateSet).toHaveBeenCalledWith({
       metadata: JSON.stringify({ department: 'Engineering' }),
@@ -168,14 +179,46 @@ describe('applyClaimAttributesAfter', () => {
         },
       }),
       new Set(['sso']),
-      async () => ({})
+      fresh({})
     )
     expect(mockUpdateSet).toHaveBeenCalledWith({ metadata: JSON.stringify({}) })
   })
 
+  it('a fallback read still writes, but never clears under syncOnSignIn', async () => {
+    // The stored ID token cannot carry a userinfo-only claim, so a stash miss
+    // (overlapping callbacks for one subject, TTL, eviction) must not let
+    // syncOnSignIn read "absent" as "withdrawn" and delete a valid attribute.
+    mockSelectFrom.mockResolvedValue([DEPARTMENT_DEF, { key: 'plan', type: 'string' }])
+    mockUserFindFirst.mockResolvedValue({ metadata: JSON.stringify({ department: 'Sales' }) })
+    const providers = providersWith({
+      claimMapping: {
+        attributes: {
+          map: [
+            { claimPath: 'department', attributeKey: 'department' },
+            { claimPath: 'plan', attributeKey: 'plan' },
+          ],
+          syncOnSignIn: true,
+        },
+      },
+    })
+    await applyClaimAttributesAfter(ctxFor(), providers, new Set(['sso']), stale({ plan: 'pro' }))
+    expect(mockUpdateSet).toHaveBeenCalledWith({
+      metadata: JSON.stringify({ department: 'Sales', plan: 'pro' }),
+    })
+    expect(mockLogInfo).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: 'user_1', provider_id: 'sso' }),
+      expect.stringMatching(/sync skipped/)
+    )
+
+    // Same read, nothing to add: no write at all rather than a delete.
+    mockUpdateSet.mockClear()
+    await applyClaimAttributesAfter(ctxFor(), providers, new Set(['sso']), stale({}))
+    expect(mockUpdateSet).not.toHaveBeenCalled()
+  })
+
   it('leaves a missing claim alone when sync is off', async () => {
     mockUserFindFirst.mockResolvedValue({ metadata: JSON.stringify({ department: 'Sales' }) })
-    await applyClaimAttributesAfter(ctxFor(), providersWith(), new Set(['sso']), async () => ({}))
+    await applyClaimAttributesAfter(ctxFor(), providersWith(), new Set(['sso']), fresh({}))
     expect(mockUpdateSet).not.toHaveBeenCalled()
   })
 
@@ -183,9 +226,12 @@ describe('applyClaimAttributesAfter', () => {
     mockUserFindFirst.mockResolvedValue({
       metadata: JSON.stringify({ _externalUserId: 'ext_1' }),
     })
-    await applyClaimAttributesAfter(ctxFor(), providersWith(), new Set(['sso']), async () => ({
-      department: 'Engineering',
-    }))
+    await applyClaimAttributesAfter(
+      ctxFor(),
+      providersWith(),
+      new Set(['sso']),
+      fresh({ department: 'Engineering' })
+    )
     expect(mockUpdateSet).toHaveBeenCalledWith({
       metadata: JSON.stringify({ _externalUserId: 'ext_1', department: 'Engineering' }),
     })
@@ -196,7 +242,7 @@ describe('applyClaimAttributesAfter', () => {
       ctxFor({ path: '/sign-in/email' }),
       providersWith(),
       new Set(['sso']),
-      async () => ({ department: 'Engineering' })
+      fresh({ department: 'Engineering' })
     )
     expect(mockUserFindFirst).not.toHaveBeenCalled()
     expect(mockUpdateSet).not.toHaveBeenCalled()
@@ -207,7 +253,7 @@ describe('applyClaimAttributesAfter', () => {
       ctxFor({ providerId: 'google' }),
       providersWith(),
       new Set(['sso']),
-      async () => ({ department: 'Engineering' })
+      fresh({ department: 'Engineering' })
     )
     expect(mockUserFindFirst).not.toHaveBeenCalled()
   })
@@ -217,7 +263,7 @@ describe('applyClaimAttributesAfter', () => {
       ctxFor({ userId: null }),
       providersWith(),
       new Set(['sso']),
-      async () => ({ department: 'Engineering' })
+      fresh({ department: 'Engineering' })
     )
     expect(mockUserFindFirst).not.toHaveBeenCalled()
   })
@@ -225,9 +271,12 @@ describe('applyClaimAttributesAfter', () => {
   it('throws on a DB error so hooksAfter can swallow it without blocking sign-in', async () => {
     mockUpdateWhere.mockRejectedValue(new Error('db down'))
     await expect(
-      applyClaimAttributesAfter(ctxFor(), providersWith(), new Set(['sso']), async () => ({
-        department: 'Engineering',
-      }))
+      applyClaimAttributesAfter(
+        ctxFor(),
+        providersWith(),
+        new Set(['sso']),
+        fresh({ department: 'Engineering' })
+      )
     ).rejects.toThrow('db down')
   })
 
@@ -236,14 +285,14 @@ describe('applyClaimAttributesAfter', () => {
     // builds must hand the same claims to the attribute writer.
     let taken = false
     const stash = { department: 'Engineering' }
-    let cached: Promise<Record<string, unknown>> | undefined
+    let cached: Promise<{ claims: Record<string, unknown>; fresh: boolean }> | undefined
     const readClaims = () => {
       if (!cached) {
         cached = Promise.resolve(
           (() => {
-            if (taken) return {}
+            if (taken) return { claims: {}, fresh: false }
             taken = true
-            return stash
+            return { claims: stash, fresh: true }
           })()
         )
       }

--- a/apps/web/src/lib/server/auth/__tests__/provider-registration.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/provider-registration.test.ts
@@ -213,6 +213,49 @@ describe('buildGenericOAuthConfigs discovery + resolver wiring', () => {
     expect(discovery).not.toHaveBeenCalled()
   })
 
+  it('passes mapped claim paths to resolveIdentity so userinfo-only claims are fetched', async () => {
+    const fetchUserInfo = vi.fn(async () => ({ department: 'Engineering' }))
+    const idToken = (payload: Record<string, unknown>) =>
+      `x.${Buffer.from(JSON.stringify(payload)).toString('base64url')}.y`
+    const cfgs = await buildGenericOAuthConfigs({
+      providers: [
+        row({
+          userInfoUrl: 'https://idp/userinfo',
+          claimMapping: {
+            attributes: { map: [{ claimPath: 'department', attributeKey: 'department' }] },
+            role: { claimPath: 'groups', rules: [] },
+          },
+        }),
+      ] as never,
+      creds: async () => ({ clientId: 'c', clientSecret: 's' }),
+      tierAllowsOidc: true,
+      fetchUserInfo,
+    })
+    const info = await cfgs[0].getUserInfo?.({
+      idToken: idToken({ sub: 's1', email: 'e@x.com', name: 'N' }),
+      accessToken: 'at',
+    })
+    expect(fetchUserInfo).toHaveBeenCalledTimes(1)
+    expect(info?.department).toBe('Engineering')
+  })
+
+  it('keeps the zero-network fast path when nothing is mapped', async () => {
+    const fetchUserInfo = vi.fn(async () => ({ department: 'Engineering' }))
+    const idToken = (payload: Record<string, unknown>) =>
+      `x.${Buffer.from(JSON.stringify(payload)).toString('base64url')}.y`
+    const cfgs = await buildGenericOAuthConfigs({
+      providers: [row({ userInfoUrl: 'https://idp/userinfo' })] as never,
+      creds: async () => ({ clientId: 'c', clientSecret: 's' }),
+      tierAllowsOidc: true,
+      fetchUserInfo,
+    })
+    await cfgs[0].getUserInfo?.({
+      idToken: idToken({ sub: 's1', email: 'e@x.com', name: 'N' }),
+      accessToken: 'at',
+    })
+    expect(fetchUserInfo).not.toHaveBeenCalled()
+  })
+
   it('still builds when discovery is unreachable', async () => {
     // A discovery outage must not stop the provider registering — a complete
     // ID token needs no userinfo at all.

--- a/apps/web/src/lib/server/auth/__tests__/resolve-identity.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/resolve-identity.test.ts
@@ -104,6 +104,52 @@ describe('resolveIdentity — the fast path', () => {
     expect(result.identity.sources.email).toBe('idToken')
   })
 
+  it('treats a mapped null or empty string as unresolved and still fetches userinfo', async () => {
+    const fetchUserInfo = vi.fn(async () => ({
+      sub: WORLD_A.expect.id,
+      department: 'Engineering',
+    }))
+    const result = await resolveIdentity({
+      tokens: {
+        idToken: fakeJwt({
+          sub: WORLD_A.expect.id,
+          email: 'a@example.com',
+          name: 'World A',
+          department: '',
+        }),
+      },
+      fetchUserInfo,
+      requiredClaimPaths: ['department'],
+    })
+    expect(fetchUserInfo).toHaveBeenCalledTimes(1)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.identity.claims.department).toBe('Engineering')
+  })
+
+  it('gap-fills a nested required path from userinfo without replacing earlier keys', async () => {
+    const fetchUserInfo = vi.fn(async () => ({
+      sub: WORLD_A.expect.id,
+      org: { costCenter: 'cc-9', department: 'from-userinfo' },
+    }))
+    const result = await resolveIdentity({
+      tokens: {
+        idToken: fakeJwt({
+          sub: WORLD_A.expect.id,
+          email: 'a@example.com',
+          name: 'World A',
+          org: { department: 'from-token' },
+        }),
+      },
+      fetchUserInfo,
+      requiredClaimPaths: ['org.costCenter'],
+    })
+    expect(fetchUserInfo).toHaveBeenCalledTimes(1)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.identity.claims.org).toEqual({ department: 'from-token', costCenter: 'cc-9' })
+  })
+
   it('exhaustive fetches every source even when identity is complete', async () => {
     const fetchUserInfo = vi.fn(async () => ({
       sub: WORLD_A.expect.id,

--- a/apps/web/src/lib/server/auth/__tests__/resolve-identity.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/resolve-identity.test.ts
@@ -71,6 +71,55 @@ describe('resolveIdentity — the fast path', () => {
     await resolveIdentity({ tokens: { idToken: fakeJwt({ sub: 'x' }) }, fetchUserInfo })
     expect(fetchUserInfo).toHaveBeenCalledTimes(1)
   })
+
+  it('does not fetch userinfo when requiredClaimPaths are already in a complete ID token', async () => {
+    const fetchUserInfo = vi.fn(async () => ({ department: 'from-userinfo' }))
+    const result = await resolveIdentity({
+      tokens: WORLD_A.tokens,
+      fetchUserInfo,
+      requiredClaimPaths: ['email'],
+    })
+    expect(result.ok).toBe(true)
+    expect(fetchUserInfo).not.toHaveBeenCalled()
+  })
+
+  it('fetches userinfo when a required path is absent from a complete ID token', async () => {
+    const fetchUserInfo = vi.fn(async () => ({
+      sub: WORLD_A.expect.id,
+      email: 'a@example.com',
+      name: 'World A',
+      department: 'Engineering',
+    }))
+    const result = await resolveIdentity({
+      tokens: WORLD_A.tokens,
+      fetchUserInfo,
+      requiredClaimPaths: ['department'],
+    })
+    expect(fetchUserInfo).toHaveBeenCalledTimes(1)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.identity.claims.department).toBe('Engineering')
+    // Earlier source still wins on overlap.
+    expect(result.identity.email).toBe('a@example.com')
+    expect(result.identity.sources.email).toBe('idToken')
+  })
+
+  it('exhaustive fetches every source even when identity is complete', async () => {
+    const fetchUserInfo = vi.fn(async () => ({
+      sub: WORLD_A.expect.id,
+      department: 'Engineering',
+    }))
+    const result = await resolveIdentity({
+      tokens: WORLD_A.tokens,
+      fetchUserInfo,
+      exhaustive: true,
+    })
+    expect(fetchUserInfo).toHaveBeenCalledTimes(1)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.identity.claims.department).toBe('Engineering')
+    expect(result.identity.email).toBe('a@example.com')
+  })
 })
 
 describe('resolveIdentity — subject consistency (OIDC Core 5.3.2)', () => {

--- a/apps/web/src/lib/server/auth/__tests__/resolve-identity.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/resolve-identity.test.ts
@@ -150,6 +150,49 @@ describe('resolveIdentity — the fast path', () => {
     expect(result.identity.claims.org).toEqual({ department: 'from-token', costCenter: 'cc-9' })
   })
 
+  it('refuses a required path that would walk onto a prototype', async () => {
+    const fetchUserInfo = vi.fn(async () => ({
+      sub: WORLD_A.expect.id,
+      __proto__: { polluted: 'yes' },
+      constructor: { prototype: { polluted: 'yes' } },
+    }))
+    const result = await resolveIdentity({
+      tokens: WORLD_A.tokens,
+      fetchUserInfo,
+      requiredClaimPaths: ['__proto__.polluted', 'constructor.prototype.polluted'],
+    })
+    expect(result.ok).toBe(true)
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+    expect(Object.prototype).not.toHaveProperty('polluted')
+  })
+
+  it('does not re-key the account when userinfo was fetched only for a mapped claim', async () => {
+    // Before required paths existed a complete ID token never reached
+    // userinfo, so its subject always keyed the account. Adding a mapping must
+    // not change which account a person lands in.
+    const fetchUserInfo = vi.fn(async () => ({
+      sub: 'someone-else',
+      email: 'other@example.com',
+      name: 'Other',
+      department: 'Engineering',
+    }))
+    const result = await resolveIdentity({
+      tokens: WORLD_A.tokens,
+      fetchUserInfo,
+      requiredClaimPaths: ['department'],
+    })
+    expect(fetchUserInfo).toHaveBeenCalledTimes(1)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.identity.id).toBe(WORLD_A.expect.id)
+    expect(result.identity.email).toBe('a@example.com')
+    expect(result.identity.sources.id).toBe('idToken')
+    expect(result.identity.warnings).toContain('subject_mismatch')
+    // The mismatched response is discarded wholesale (OIDC Core 5.3.2), so
+    // the mapped claim is NOT taken from it either.
+    expect(result.identity.claims.department).toBeUndefined()
+  })
+
   it('exhaustive fetches every source even when identity is complete', async () => {
     const fetchUserInfo = vi.fn(async () => ({
       sub: WORLD_A.expect.id,

--- a/apps/web/src/lib/server/auth/__tests__/sso-test-callback.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/sso-test-callback.test.ts
@@ -15,6 +15,7 @@ const hoisted = vi.hoisted(() => ({
   cacheDel: vi.fn(),
   runHandshake: vi.fn(),
   userFindFirst: vi.fn(),
+  userUpdate: vi.fn(),
   markSsoTestSucceeded: vi.fn(),
   listIdentityProviders: vi.fn(),
   markTestSucceeded: vi.fn(),
@@ -38,6 +39,7 @@ vi.mock('@/lib/server/db', async (importOriginal) => ({
     query: {
       user: { findFirst: (...args: unknown[]) => hoisted.userFindFirst(...args) },
     },
+    update: (...args: unknown[]) => hoisted.userUpdate(...args),
   },
   eq: (col: unknown, val: unknown) => ({ __eq: [col, val] }),
 }))
@@ -267,6 +269,35 @@ describe('handleSsoTestCallback', () => {
       { result: okResult, identityMatched: false },
       600
     )
+  })
+
+  it('never writes user.metadata — a test callback must not copy claims onto the admin', async () => {
+    hoisted.cacheGet.mockResolvedValueOnce(validSession)
+    hoisted.listIdentityProviders.mockResolvedValueOnce([
+      { id: 'idp_sso', registrationId: 'sso', domains: [] },
+    ])
+    hoisted.runHandshake.mockResolvedValueOnce({
+      ok: true,
+      steps: [],
+      claims: {
+        iss: 'https://idp',
+        sub: 'u1',
+        aud: 'cid',
+        email: 'alice@example.com',
+        department: 'Engineering',
+      },
+      tokenInfo: { idTokenAlg: 'RS256', hasAccessToken: true, hasRefreshToken: false },
+    })
+    hoisted.userFindFirst.mockResolvedValueOnce({ email: 'alice@example.com' })
+
+    await handleSsoTestCallback({
+      state: 'state-xyz',
+      code: 'authcode',
+      error: null,
+      errorDescription: null,
+    })
+
+    expect(hoisted.userUpdate).not.toHaveBeenCalled()
   })
 
   it('no email claim still stamps but returns identityMatched=false and skips the user lookup', async () => {

--- a/apps/web/src/lib/server/auth/apply-claim-attributes.ts
+++ b/apps/web/src/lib/server/auth/apply-claim-attributes.ts
@@ -12,7 +12,7 @@ import {
   type AttributeDefinition,
 } from '@/lib/shared/plan-claim-attribute-writes'
 import { logger } from '@/lib/server/logger'
-import { readSsoClaims } from './read-sso-claims'
+import { readSsoClaimsWithProvenance, type ClaimRead } from './read-sso-claims'
 
 export { planClaimAttributeWrites }
 export type { AttributeDefinition }
@@ -25,8 +25,8 @@ const log = logger.child({ component: 'claim-attributes' })
  *
  * `readClaims`, when provided, is the shared per-callback reader so a
  * take-once stash is not drained by role provisioning first. Omitted, this
- * falls back to `readSsoClaims` so unit tests that call the writer directly
- * keep passing.
+ * falls back to `readSsoClaimsWithProvenance` so unit tests that call the
+ * writer directly keep passing.
  */
 export async function applyClaimAttributesAfter(
   ctx: {
@@ -42,7 +42,7 @@ export async function applyClaimAttributesAfter(
     >
   >,
   registeredOidcIds: Set<string>,
-  readClaims?: () => Promise<Record<string, unknown>>
+  readClaims?: () => Promise<ClaimRead>
 ): Promise<void> {
   if (ctx.path !== '/oauth2/callback/:providerId') return
   const providerId = ctx.params?.providerId
@@ -69,7 +69,22 @@ export async function applyClaimAttributesAfter(
   })
   if (!owner) return
 
-  const claims = await (readClaims ? readClaims() : readSsoClaims(userIdTyped, providerId))
+  const { claims, fresh } = await (readClaims
+    ? readClaims()
+    : readSsoClaimsWithProvenance(userIdTyped, providerId))
+
+  // Write from a fallback read, never clear on one. The stored ID token can
+  // never carry a userinfo-only claim, so its absence there is not the IdP
+  // withdrawing it — and a stash miss (overlapping callbacks for one subject,
+  // TTL, eviction) must not turn syncOnSignIn into a delete.
+  const syncSuppressed = !fresh && attributes.syncOnSignIn === true
+  const mapping = syncSuppressed ? { ...attributes, syncOnSignIn: false } : attributes
+  if (syncSuppressed) {
+    log.info(
+      { user_id: userId, provider_id: providerId },
+      'claim attribute sync skipped: claims read from stored ID token, not this sign-in'
+    )
+  }
 
   let existing: Record<string, unknown> = {}
   if (owner.metadata) {
@@ -84,7 +99,7 @@ export async function applyClaimAttributesAfter(
   const debug = process.env.AUTH_HOOKS_DEBUG === '1'
   const { valid, removals, skips } = planClaimAttributeWrites({
     claims,
-    mapping: attributes,
+    mapping,
     existing,
     definitions: definitions.map((d) => ({ key: d.key, type: d.type })),
     explain: debug,

--- a/apps/web/src/lib/server/auth/apply-claim-attributes.ts
+++ b/apps/web/src/lib/server/auth/apply-claim-attributes.ts
@@ -11,13 +11,22 @@ import {
   planClaimAttributeWrites,
   type AttributeDefinition,
 } from '@/lib/shared/plan-claim-attribute-writes'
+import { logger } from '@/lib/server/logger'
+import { readSsoClaims } from './read-sso-claims'
 
 export { planClaimAttributeWrites }
 export type { AttributeDefinition }
 
+const log = logger.child({ component: 'claim-attributes' })
+
 /**
  * Apply `claim_mapping.attributes` for the callback provider. Independent of
  * auto-create / role gates — identity resolution already ran.
+ *
+ * `readClaims`, when provided, is the shared per-callback reader so a
+ * take-once stash is not drained by role provisioning first. Omitted, this
+ * falls back to `readSsoClaims` so unit tests that call the writer directly
+ * keep passing.
  */
 export async function applyClaimAttributesAfter(
   ctx: {
@@ -32,7 +41,8 @@ export async function applyClaimAttributesAfter(
       typeof import('@/lib/server/domains/settings/identity-providers.service').listIdentityProviders
     >
   >,
-  registeredOidcIds: Set<string>
+  registeredOidcIds: Set<string>,
+  readClaims?: () => Promise<Record<string, unknown>>
 ): Promise<void> {
   if (ctx.path !== '/oauth2/callback/:providerId') return
   const providerId = ctx.params?.providerId
@@ -59,30 +69,7 @@ export async function applyClaimAttributesAfter(
   })
   if (!owner) return
 
-  const claims = await (async () => {
-    const { db: dbInner, account, and, eq: eqInner, desc } = await import('@/lib/server/db')
-    const { takeResolvedClaims } = await import('./resolved-claims-stash')
-    const row = await dbInner.query.account.findFirst({
-      where: and(eqInner(account.userId, userIdTyped), eqInner(account.providerId, providerId)),
-      columns: { idToken: true, accountId: true },
-      orderBy: desc(account.createdAt),
-    })
-    if (row?.accountId) {
-      const fresh = takeResolvedClaims(providerId, row.accountId)
-      if (fresh) return fresh
-    }
-    if (!row?.idToken) return {}
-    const parts = row.idToken.split('.')
-    if (parts.length !== 3) return {}
-    try {
-      return JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf-8')) as Record<
-        string,
-        unknown
-      >
-    } catch {
-      return {}
-    }
-  })()
+  const claims = await (readClaims ? readClaims() : readSsoClaims(userIdTyped, providerId))
 
   let existing: Record<string, unknown> = {}
   if (owner.metadata) {
@@ -94,15 +81,36 @@ export async function applyClaimAttributesAfter(
   }
 
   const definitions = await db.select().from(userAttributeDefinitions)
-  const { valid, removals } = planClaimAttributeWrites({
+  const debug = process.env.AUTH_HOOKS_DEBUG === '1'
+  const { valid, removals, skips } = planClaimAttributeWrites({
     claims,
     mapping: attributes,
     existing,
     definitions: definitions.map((d) => ({ key: d.key, type: d.type })),
+    explain: debug,
   })
+
+  if (debug) {
+    for (const skip of skips ?? []) {
+      log.debug(
+        { user_id: userId, provider_id: providerId, key: skip.key, reason: skip.reason },
+        'claim attribute write skipped'
+      )
+    }
+  }
+
   if (Object.keys(valid).length === 0 && removals.length === 0) return
 
   const next = mergeMetadata(owner.metadata, valid, removals)
   if (next === owner.metadata) return
   await db.update(userTable).set({ metadata: next }).where(eq(userTable.id, userIdTyped))
+  log.info(
+    {
+      user_id: userId,
+      provider_id: providerId,
+      written: Object.keys(valid),
+      removed: removals,
+    },
+    'claim attributes written'
+  )
 }

--- a/apps/web/src/lib/server/auth/build-oauth-configs.ts
+++ b/apps/web/src/lib/server/auth/build-oauth-configs.ts
@@ -23,7 +23,7 @@ import type { IdentityProvider } from '@/lib/server/domains/settings/identity-pr
 import { authorizeRequestFor, supportsPrompt } from '@/lib/shared/oidc-request'
 import { resolveIdentity } from './resolve-identity'
 import { synthesizeName } from './placeholder-identity'
-import { allowsMissingEmail } from '@/lib/shared/oidc-claim-mapping'
+import { allowsMissingEmail, claimMappingFor } from '@/lib/shared/oidc-claim-mapping'
 
 // Re-exported so server callers keep this import path. The implementation lives
 // in `shared` because the admin editor needs it too, and having exactly one
@@ -216,6 +216,11 @@ export async function buildGenericOAuthConfigs({
     // library's own behaviour, so withholding it from unmapped providers would
     // leave two resolution paths — the thing this work exists to remove.
     const resolvedUserInfoUrl = userInfoUrl
+    const mapping = claimMappingFor(provider.claimMapping)
+    const requiredClaimPaths = [
+      ...(mapping.attributes?.map ?? []).map((entry) => entry.claimPath),
+      ...(mapping.role?.claimPath ? [mapping.role.claimPath] : []),
+    ]
     const getUserInfo: NonNullable<GenericOAuthConfig['getUserInfo']> = async (tokens) => {
       const result = await resolveIdentity({
         tokens,
@@ -223,6 +228,7 @@ export async function buildGenericOAuthConfigs({
           resolvedUserInfoUrl && tokens.accessToken && fetchUserInfo
             ? await fetchUserInfo(resolvedUserInfoUrl, tokens.accessToken)
             : null,
+        requiredClaimPaths: requiredClaimPaths.length > 0 ? requiredClaimPaths : undefined,
       })
       if (!result.ok) return null
       const { id, email, name, emailVerified, claims, warnings } = result.identity

--- a/apps/web/src/lib/server/auth/hooks.ts
+++ b/apps/web/src/lib/server/auth/hooks.ts
@@ -45,8 +45,8 @@ import {
   markDeviceSeen,
 } from './signin-device-tracker'
 import { isSyntheticAnonEmail } from '@/lib/shared/anonymous-email'
-import { decodeSsoClaims } from './sso-claims-decode'
-import { takeResolvedClaims } from './resolved-claims-stash'
+import { readSsoClaims } from './read-sso-claims'
+import { applyClaimAttributesAfter } from './apply-claim-attributes'
 import { logger } from '@/lib/server/logger'
 
 const log = logger.child({ component: 'auth-hooks' })
@@ -601,7 +601,9 @@ export async function handleAutoProvisionAfter(
     >
   >,
   /** OIDC provider ids registered right now (from getRegisteredOidcProviderIds). */
-  registeredOidcIds: Set<string>
+  registeredOidcIds: Set<string>,
+  /** Shared per-callback claim reader. Omitted, falls back to `readSsoClaims`. */
+  readClaims?: () => Promise<Record<string, unknown>>
 ): Promise<void> {
   if (ctx.path !== '/oauth2/callback/:providerId') return
   const providerId = ctx.params?.providerId
@@ -631,7 +633,7 @@ export async function handleAutoProvisionAfter(
   const roleMapping = roleMappingFor(provider.claimMapping)
   let claimRole: Role | null = null
   if (roleMapping) {
-    const claims = await readSsoClaims(userIdTyped, providerId)
+    const claims = await (readClaims ? readClaims() : readSsoClaims(userIdTyped, providerId))
     const { resolveSsoRole } = await import('./resolve-sso-role')
     claimRole = resolveSsoRole(claims, roleMapping)
   }
@@ -710,47 +712,6 @@ export async function handleAutoProvisionAfter(
   }
 
   log.info({ user_id: userId, role: targetRole }, 'auto-provisioned verified-domain user via sso')
-}
-
-/**
- * Read the latest stored ID-token claims for a user's OIDC account.
- * Returns an empty object when no token is stored or the token is
- * malformed — caller should fall back to the legacy auto-provision
- * field in that case.
- *
- * `providerId` is the callback provider's registrationId (the account's
- * `provider_id`). It must match what just authenticated, else the row
- * lookup misses and attribute mapping silently returns {} → default role
- * for every non-`sso` provider.
- */
-async function readSsoClaims(
-  userId: `user_${string}`,
-  providerId: string
-): Promise<Record<string, unknown>> {
-  const { db, account, and, eq, desc } = await import('@/lib/server/db')
-  const row = await db.query.account.findFirst({
-    where: and(eq(account.userId, userId), eq(account.providerId, providerId)),
-    columns: { idToken: true, accountId: true },
-    // Deterministic ordering. There is no uniqueness constraint on
-    // (user_id, provider_id), so a duplicate account row — which a change in
-    // which claim supplies the account identifier can create — would otherwise
-    // leave this reading whichever row the database happened to return, quite
-    // possibly a stale one, on every sign-in.
-    orderBy: desc(account.createdAt),
-  })
-
-  // Prefer what the resolver actually validated this request. The stored ID
-  // token is a fallback: a provider resolving identity from userinfo or an
-  // access token has none, and would otherwise always land on the default role
-  // however its claims are mapped.
-  if (row?.accountId) {
-    const fresh = takeResolvedClaims(providerId, row.accountId)
-    if (fresh) return fresh
-  }
-
-  // Refuses an expired token; see sso-claims-decode.ts for why freshness is
-  // the property that matters when the signature is not verified.
-  return decodeSsoClaims(row?.idToken)
 }
 
 /**
@@ -1297,11 +1258,14 @@ export async function handleCountryCapture(ctx: {
  *     per-domain SSO enforcement or a disabled per-method toggle. SSO is
  *     allowed for every role, so verified-domain users pass this step; it
  *     gates the non-SSO providers.
- *  4. `handleSignInSuccessAudit` — emits `auth.signin.success` if a
+ *  4. `applyClaimAttributesAfter` — copy mapped IdP claims into person
+ *     attributes. After cleanup so a revoked session writes nothing;
+ *     wrapped in try/catch so a DB error never blocks sign-in.
+ *  5. `handleSignInSuccessAudit` — emits `auth.signin.success` if a
  *     session still exists at this point (i.e. wasn't revoked by
  *     prior steps). Runs after the gates so it only records sign-ins
  *     that actually stuck.
- *  5. `handleNewDeviceNotification` — sends a "new device" email +
+ *  6. `handleNewDeviceNotification` — sends a "new device" email +
  *     records an audit row when the user's UA + /24-IP combination
  *     hasn't been seen for them within the last 90 days.
  */
@@ -1312,9 +1276,10 @@ export const hooksAfter = createAuthMiddleware(async (ctx) => {
   }
 
   // The provider registry is only consulted by the OAuth-callback after-hooks
-  // (bootstrap promotion, auto-provision, policy cleanup). Skip the DB read on
-  // password / magic-link success paths — those callbacks early-return before
-  // touching `providers` / `registeredOidcIds`, so the empty defaults are safe.
+  // (bootstrap promotion, auto-provision, policy cleanup, claim attributes).
+  // Skip the DB read on password / magic-link success paths — those callbacks
+  // early-return before touching `providers` / `registeredOidcIds`, so the
+  // empty defaults are safe.
   let providers: Awaited<
     ReturnType<
       typeof import('@/lib/server/domains/settings/identity-providers.service').listIdentityProviders
@@ -1340,10 +1305,29 @@ export const hooksAfter = createAuthMiddleware(async (ctx) => {
   const { getWorkspaceSettings } = await import('@/lib/server/domains/settings/settings.service')
   const workspace = await getWorkspaceSettings()
 
+  // One claim read per callback. The stash is take-once, so role
+  // provisioning and attribute writes must share the result rather than
+  // each calling `takeResolvedClaims`.
+  let claimsPromise: Promise<Record<string, unknown>> | undefined
+  const callbackUserId = ctx.context?.newSession?.user?.id
+  const callbackProviderId = ctx.params?.providerId
+  const readClaims =
+    ctx.path === '/oauth2/callback/:providerId' &&
+    typeof callbackUserId === 'string' &&
+    typeof callbackProviderId === 'string'
+      ? () => {
+          if (!claimsPromise) {
+            claimsPromise = readSsoClaims(callbackUserId as `user_${string}`, callbackProviderId)
+          }
+          return claimsPromise
+        }
+      : undefined
+
   await handleAutoProvisionAfter(
     ctx as Parameters<typeof handleAutoProvisionAfter>[0],
     providers,
-    registeredOidcIds
+    registeredOidcIds,
+    readClaims
   )
   await handleCallbackPolicyCleanup(
     ctx as Parameters<typeof handleCallbackPolicyCleanup>[0],
@@ -1351,6 +1335,19 @@ export const hooksAfter = createAuthMiddleware(async (ctx) => {
     providers,
     registeredOidcIds
   )
+  try {
+    await applyClaimAttributesAfter(
+      ctx as Parameters<typeof applyClaimAttributesAfter>[0],
+      providers,
+      registeredOidcIds,
+      readClaims
+    )
+  } catch (err) {
+    log.error(
+      { err, user_id: callbackUserId, provider_id: callbackProviderId },
+      'claim attribute write failed'
+    )
+  }
   // SOC2 trail for user-initiated 2FA lifecycle (`two_factor.enabled`
   // and `two_factor.disabled`). Independent of sign-in success audit;
   // both can fire on the same request only for the verify-totp

--- a/apps/web/src/lib/server/auth/hooks.ts
+++ b/apps/web/src/lib/server/auth/hooks.ts
@@ -45,7 +45,7 @@ import {
   markDeviceSeen,
 } from './signin-device-tracker'
 import { isSyntheticAnonEmail } from '@/lib/shared/anonymous-email'
-import { readSsoClaims } from './read-sso-claims'
+import { readSsoClaims, readSsoClaimsWithProvenance, type ClaimRead } from './read-sso-claims'
 import { applyClaimAttributesAfter } from './apply-claim-attributes'
 import { logger } from '@/lib/server/logger'
 
@@ -603,7 +603,7 @@ export async function handleAutoProvisionAfter(
   /** OIDC provider ids registered right now (from getRegisteredOidcProviderIds). */
   registeredOidcIds: Set<string>,
   /** Shared per-callback claim reader. Omitted, falls back to `readSsoClaims`. */
-  readClaims?: () => Promise<Record<string, unknown>>
+  readClaims?: () => Promise<ClaimRead>
 ): Promise<void> {
   if (ctx.path !== '/oauth2/callback/:providerId') return
   const providerId = ctx.params?.providerId
@@ -633,7 +633,11 @@ export async function handleAutoProvisionAfter(
   const roleMapping = roleMappingFor(provider.claimMapping)
   let claimRole: Role | null = null
   if (roleMapping) {
-    const claims = await (readClaims ? readClaims() : readSsoClaims(userIdTyped, providerId))
+    // Role resolution is indifferent to provenance: a role claim absent from
+    // the stored token yields the default role either way.
+    const claims = readClaims
+      ? (await readClaims()).claims
+      : await readSsoClaims(userIdTyped, providerId)
     const { resolveSsoRole } = await import('./resolve-sso-role')
     claimRole = resolveSsoRole(claims, roleMapping)
   }
@@ -1308,7 +1312,7 @@ export const hooksAfter = createAuthMiddleware(async (ctx) => {
   // One claim read per callback. The stash is take-once, so role
   // provisioning and attribute writes must share the result rather than
   // each calling `takeResolvedClaims`.
-  let claimsPromise: Promise<Record<string, unknown>> | undefined
+  let claimsPromise: Promise<ClaimRead> | undefined
   const callbackUserId = ctx.context?.newSession?.user?.id
   const callbackProviderId = ctx.params?.providerId
   const readClaims =
@@ -1317,7 +1321,10 @@ export const hooksAfter = createAuthMiddleware(async (ctx) => {
     typeof callbackProviderId === 'string'
       ? () => {
           if (!claimsPromise) {
-            claimsPromise = readSsoClaims(callbackUserId as `user_${string}`, callbackProviderId)
+            claimsPromise = readSsoClaimsWithProvenance(
+              callbackUserId as `user_${string}`,
+              callbackProviderId
+            )
           }
           return claimsPromise
         }

--- a/apps/web/src/lib/server/auth/read-sso-claims.ts
+++ b/apps/web/src/lib/server/auth/read-sso-claims.ts
@@ -1,0 +1,52 @@
+/**
+ * One claim read for the OAuth callback after-hooks.
+ *
+ * Stash first (what the resolver actually validated this request), then the
+ * stored ID token with an expired-token-refusing decode. Shared by role
+ * provisioning and claim→attribute writes so a take-once stash cannot starve
+ * the second reader.
+ */
+
+import { decodeSsoClaims } from './sso-claims-decode'
+import { takeResolvedClaims } from './resolved-claims-stash'
+
+/**
+ * Read the latest stored ID-token claims for a user's OIDC account.
+ * Returns an empty object when no token is stored or the token is
+ * malformed — caller should fall back to the legacy auto-provision
+ * field in that case.
+ *
+ * `providerId` is the callback provider's registrationId (the account's
+ * `provider_id`). It must match what just authenticated, else the row
+ * lookup misses and attribute mapping silently returns {} → default role
+ * for every non-`sso` provider.
+ */
+export async function readSsoClaims(
+  userId: `user_${string}`,
+  providerId: string
+): Promise<Record<string, unknown>> {
+  const { db, account, and, eq, desc } = await import('@/lib/server/db')
+  const row = await db.query.account.findFirst({
+    where: and(eq(account.userId, userId), eq(account.providerId, providerId)),
+    columns: { idToken: true, accountId: true },
+    // Deterministic ordering. There is no uniqueness constraint on
+    // (user_id, provider_id), so a duplicate account row — which a change in
+    // which claim supplies the account identifier can create — would otherwise
+    // leave this reading whichever row the database happened to return, quite
+    // possibly a stale one, on every sign-in.
+    orderBy: desc(account.createdAt),
+  })
+
+  // Prefer what the resolver actually validated this request. The stored ID
+  // token is a fallback: a provider resolving identity from userinfo or an
+  // access token has none, and would otherwise always land on the default role
+  // however its claims are mapped.
+  if (row?.accountId) {
+    const fresh = takeResolvedClaims(providerId, row.accountId)
+    if (fresh) return fresh
+  }
+
+  // Refuses an expired token; see sso-claims-decode.ts for why freshness is
+  // the property that matters when the signature is not verified.
+  return decodeSsoClaims(row?.idToken)
+}

--- a/apps/web/src/lib/server/auth/read-sso-claims.ts
+++ b/apps/web/src/lib/server/auth/read-sso-claims.ts
@@ -10,6 +10,17 @@
 import { decodeSsoClaims } from './sso-claims-decode'
 import { takeResolvedClaims } from './resolved-claims-stash'
 
+export interface ClaimRead {
+  claims: Record<string, unknown>
+  /**
+   * True when the claims came from the stash — what the resolver validated in
+   * THIS request, every source included. False when they came from the stored
+   * ID token, which by construction never carries userinfo-only claims, so a
+   * claim missing from it proves nothing about what the IdP released.
+   */
+  fresh: boolean
+}
+
 /**
  * Read the latest stored ID-token claims for a user's OIDC account.
  * Returns an empty object when no token is stored or the token is
@@ -25,6 +36,14 @@ export async function readSsoClaims(
   userId: `user_${string}`,
   providerId: string
 ): Promise<Record<string, unknown>> {
+  return (await readSsoClaimsWithProvenance(userId, providerId)).claims
+}
+
+/** `readSsoClaims`, plus whether the stash hit. See `ClaimRead.fresh`. */
+export async function readSsoClaimsWithProvenance(
+  userId: `user_${string}`,
+  providerId: string
+): Promise<ClaimRead> {
   const { db, account, and, eq, desc } = await import('@/lib/server/db')
   const row = await db.query.account.findFirst({
     where: and(eq(account.userId, userId), eq(account.providerId, providerId)),
@@ -42,11 +61,11 @@ export async function readSsoClaims(
   // access token has none, and would otherwise always land on the default role
   // however its claims are mapped.
   if (row?.accountId) {
-    const fresh = takeResolvedClaims(providerId, row.accountId)
-    if (fresh) return fresh
+    const stashed = takeResolvedClaims(providerId, row.accountId)
+    if (stashed) return { claims: stashed, fresh: true }
   }
 
   // Refuses an expired token; see sso-claims-decode.ts for why freshness is
   // the property that matters when the signature is not verified.
-  return decodeSsoClaims(row?.idToken)
+  return { claims: decodeSsoClaims(row?.idToken), fresh: false }
 }

--- a/apps/web/src/lib/server/auth/resolve-identity.ts
+++ b/apps/web/src/lib/server/auth/resolve-identity.ts
@@ -127,21 +127,29 @@ function requiredPathsResolved(
   return paths.every((path) => !claimIsMissing(getClaimByPath(merged, path)))
 }
 
+/** Segments that would walk onto or rewrite a prototype rather than a claim. */
+const UNSAFE_SEGMENTS = new Set(['__proto__', 'constructor', 'prototype'])
+
 /**
  * Write a leaf onto `claims` without replacing an already-present parent
  * object. Used to gap-fill required nested paths (e.g. `org.costCenter`)
  * after the shallow earlier-source-wins merge has already taken `org`.
+ *
+ * The path is admin-configured, so a segment like `__proto__` is refused
+ * outright rather than followed: `current['__proto__']` is `Object.prototype`,
+ * and assigning the leaf there would pollute every object in the process.
  */
 function setClaimByPath(claims: Record<string, unknown>, path: string, value: unknown): void {
-  if (path in claims || path.includes('://') || !path.includes('.')) {
+  const segments = path.split('.')
+  if (segments.some((segment) => UNSAFE_SEGMENTS.has(segment))) return
+  if (Object.hasOwn(claims, path) || path.includes('://') || segments.length === 1) {
     claims[path] = value
     return
   }
-  const segments = path.split('.')
   let current: Record<string, unknown> = claims
   for (let i = 0; i < segments.length - 1; i++) {
     const segment = segments[i]
-    const next = current[segment]
+    const next = Object.hasOwn(current, segment) ? current[segment] : undefined
     if (next === null || typeof next !== 'object' || Array.isArray(next)) {
       current[segment] = {}
     }
@@ -199,7 +207,8 @@ export async function resolveIdentity({
     // Fast path: stop before any network call once identity is complete and
     // every mapped claim is already in `merged`. `exhaustive` disables this
     // so the connection test walks every source.
-    if (!exhaustive && id && email && name && requiredPathsResolved(merged, requiredClaimPaths)) {
+    const identityComplete = Boolean(id && email && name)
+    if (!exhaustive && identityComplete && requiredPathsResolved(merged, requiredClaimPaths)) {
       break
     }
 
@@ -234,6 +243,13 @@ export async function resolveIdentity({
         return { ok: false, reason: 'subject_mismatch', claims: merged }
       }
       warnings.push('subject_mismatch')
+      // The legacy re-key below only ever applied when the ID token was
+      // INCOMPLETE, because a complete one never reached userinfo. When this
+      // fetch happened solely for a mapped claim path (or the exhaustive test
+      // walk), the account is already keyed by the ID token and must stay so:
+      // adding an attribute mapping cannot be what links a different account.
+      // Per OIDC Core 5.3.2 the mismatched response is discarded outright.
+      if (identityComplete) continue
       // Legacy behaviour: userinfo wins wholesale, which means its subject is
       // what keys the account. Anything already taken from the ID token is
       // cleared so the two are never mixed.

--- a/apps/web/src/lib/server/auth/resolve-identity.ts
+++ b/apps/web/src/lib/server/auth/resolve-identity.ts
@@ -114,12 +114,54 @@ function asNonEmptyString(value: unknown): string | undefined {
   return undefined
 }
 
+/** Same missing-value rule as `planClaimAttributeWrites`. */
+function claimIsMissing(value: unknown): boolean {
+  return value === undefined || value === null || value === ''
+}
+
 function requiredPathsResolved(
   merged: Record<string, unknown>,
   paths: string[] | undefined
 ): boolean {
   if (!paths?.length) return true
-  return paths.every((path) => getClaimByPath(merged, path) !== undefined)
+  return paths.every((path) => !claimIsMissing(getClaimByPath(merged, path)))
+}
+
+/**
+ * Write a leaf onto `claims` without replacing an already-present parent
+ * object. Used to gap-fill required nested paths (e.g. `org.costCenter`)
+ * after the shallow earlier-source-wins merge has already taken `org`.
+ */
+function setClaimByPath(claims: Record<string, unknown>, path: string, value: unknown): void {
+  if (path in claims || path.includes('://') || !path.includes('.')) {
+    claims[path] = value
+    return
+  }
+  const segments = path.split('.')
+  let current: Record<string, unknown> = claims
+  for (let i = 0; i < segments.length - 1; i++) {
+    const segment = segments[i]
+    const next = current[segment]
+    if (next === null || typeof next !== 'object' || Array.isArray(next)) {
+      current[segment] = {}
+    }
+    current = current[segment] as Record<string, unknown>
+  }
+  current[segments[segments.length - 1]] = value
+}
+
+function fillRequiredLeaves(
+  merged: Record<string, unknown>,
+  source: Record<string, unknown>,
+  paths: string[] | undefined
+): void {
+  if (!paths?.length) return
+  for (const path of paths) {
+    if (!claimIsMissing(getClaimByPath(merged, path))) continue
+    const incoming = getClaimByPath(source, path)
+    if (claimIsMissing(incoming)) continue
+    setClaimByPath(merged, path, incoming)
+  }
 }
 
 export async function resolveIdentity({
@@ -208,6 +250,10 @@ export async function resolveIdentity({
     for (const [key, value] of Object.entries(claims)) {
       if (!(key in merged)) merged[key] = value
     }
+    // Nested required paths are not covered by the shallow merge: an ID token
+    // `org` object without `costCenter` would otherwise block userinfo's
+    // `org.costCenter`. Fill those leaves without rewriting earlier keys.
+    fillRequiredLeaves(merged, claims, requiredClaimPaths)
 
     if (!id && claimedId) {
       id = claimedId

--- a/apps/web/src/lib/server/auth/resolve-identity.ts
+++ b/apps/web/src/lib/server/auth/resolve-identity.ts
@@ -17,7 +17,7 @@
  */
 
 import { decodeJwt } from 'jose'
-import { isAffirmativeClaim } from '@/lib/shared/oidc-claim-mapping'
+import { getClaimByPath, isAffirmativeClaim } from '@/lib/shared/oidc-claim-mapping'
 
 /** Sources in the order they are consulted. */
 export type IdentitySource = 'idToken' | 'userinfo' | 'accessTokenJwt'
@@ -67,6 +67,19 @@ export interface ResolveIdentityArgs {
    * also break every provider currently relying on the old behaviour.
    */
   subjectMismatch?: 'observe' | 'enforce'
+  /**
+   * Extra claim paths that must be present in `merged` before the fast path
+   * may skip remaining sources. Production passes mapped attribute and role
+   * paths so a complete ID token still fetches userinfo when those claims
+   * live only there.
+   */
+  requiredClaimPaths?: string[]
+  /**
+   * Walk every configured source even when identity (and required paths) are
+   * already complete. The connection test uses this so the capture shows
+   * everything the IdP can release.
+   */
+  exhaustive?: boolean
 }
 
 /**
@@ -101,11 +114,21 @@ function asNonEmptyString(value: unknown): string | undefined {
   return undefined
 }
 
+function requiredPathsResolved(
+  merged: Record<string, unknown>,
+  paths: string[] | undefined
+): boolean {
+  if (!paths?.length) return true
+  return paths.every((path) => getClaimByPath(merged, path) !== undefined)
+}
+
 export async function resolveIdentity({
   tokens,
   fetchUserInfo,
   mapping,
   subjectMismatch = 'observe',
+  requiredClaimPaths,
+  exhaustive = false,
 }: ResolveIdentityArgs): Promise<ResolveResult> {
   const idClaim = mapping?.idClaim ?? 'sub'
   const nameClaim = mapping?.nameClaim ?? 'name'
@@ -131,9 +154,12 @@ export async function resolveIdentity({
   }
 
   for (const source of sources) {
-    // Fast path: stop before any network call once everything is resolved, so
-    // a compliant provider takes no added latency from the cascade existing.
-    if (id && email && name) break
+    // Fast path: stop before any network call once identity is complete and
+    // every mapped claim is already in `merged`. `exhaustive` disables this
+    // so the connection test walks every source.
+    if (!exhaustive && id && email && name && requiredPathsResolved(merged, requiredClaimPaths)) {
+      break
+    }
 
     const claims = await loadSource(source)
     if (!claims) continue

--- a/apps/web/src/lib/server/auth/sso-test-callback.ts
+++ b/apps/web/src/lib/server/auth/sso-test-callback.ts
@@ -49,6 +49,11 @@ export interface SsoTestCallbackHandled {
  * persists the wire-safe diagnostic for the polling fallback, and
  * returns the testId + diagnostic so the caller can render the popup
  * HTML.
+ *
+ * Isolation invariant: this path never writes `user.metadata`. The auth
+ * catch-all intercepts the test callback before Better-Auth, so
+ * `hooksAfter` (and `applyClaimAttributesAfter`) never run. A test
+ * sign-in must not copy claims onto the admin's person attributes.
  */
 export async function handleSsoTestCallback(
   input: SsoTestCallbackInput

--- a/apps/web/src/lib/server/auth/sso-test-handshake.ts
+++ b/apps/web/src/lib/server/auth/sso-test-handshake.ts
@@ -403,6 +403,7 @@ export async function runHandshake(input: HandshakeInput): Promise<HandshakeResu
   const resolution = await resolveIdentity({
     tokens: { idToken: tokens.id_token, accessToken: tokens.access_token },
     mapping: input.identityMapping,
+    exhaustive: true,
     fetchUserInfo: async () => {
       if (!discovery.userinfo_endpoint || !tokens.access_token) return null
       try {

--- a/apps/web/src/lib/server/domains/user-attributes/__tests__/coerce.test.ts
+++ b/apps/web/src/lib/server/domains/user-attributes/__tests__/coerce.test.ts
@@ -15,6 +15,11 @@ describe('coerceAttributeValue', () => {
       expect(coerceAttributeValue('hello', 'string')).toBe('hello')
     })
 
+    it('joins an array of primitives and refuses an array of objects', () => {
+      expect(coerceAttributeValue(['eng', 'sales'], 'string')).toBe('eng,sales')
+      expect(coerceAttributeValue([{ id: 1 }], 'string')).toBeUndefined()
+    })
+
     it('should coerce empty string', () => {
       expect(coerceAttributeValue('', 'string')).toBe('')
     })

--- a/apps/web/src/lib/shared/__tests__/claim-suggestions.test.ts
+++ b/apps/web/src/lib/shared/__tests__/claim-suggestions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { deriveClaimSuggestions } from '../claim-suggestions'
+import { deriveAttributeClaimPaths, deriveClaimSuggestions } from '../claim-suggestions'
 
 describe('deriveClaimSuggestions', () => {
   it('surfaces a top-level string[] claim as a path with its values', () => {
@@ -38,5 +38,46 @@ describe('deriveClaimSuggestions', () => {
     })
     expect(out.paths).toEqual(['groups'])
     expect(out.valuesByPath.groups).toEqual(['a', 'b'])
+  })
+})
+
+describe('deriveAttributeClaimPaths', () => {
+  it('includes scalars and arrays, with a truncated value preview', () => {
+    const out = deriveAttributeClaimPaths({
+      department: 'Engineering',
+      groups: ['admins', 'devs'],
+    })
+    expect(out.map((s) => s.path)).toEqual(['department', 'groups'])
+    expect(out.find((s) => s.path === 'department')?.description).toBe('Engineering')
+    expect(out.find((s) => s.path === 'groups')?.description).toBe('admins, devs')
+  })
+
+  it('walks nested objects to depth 2', () => {
+    const out = deriveAttributeClaimPaths({ org: { costCenter: 'cc-1' } })
+    expect(out.map((s) => s.path)).toEqual(['org.costCenter'])
+    expect(out[0]?.description).toBe('cc-1')
+  })
+
+  it('records a URL-shaped key literally', () => {
+    const out = deriveAttributeClaimPaths({ 'https://acme.com/plan': 'enterprise' })
+    expect(out.map((s) => s.path)).toEqual(['https://acme.com/plan'])
+  })
+
+  it('excludes protocol claims and keeps profile claims', () => {
+    const out = deriveAttributeClaimPaths({
+      iss: 'https://idp',
+      sub: 'u1',
+      aud: 'cid',
+      exp: 1,
+      email: 'a@b.com',
+      preferred_username: 'alice',
+      name: 'Alice',
+    })
+    const paths = out.map((s) => s.path)
+    expect(paths).toEqual(expect.arrayContaining(['email', 'preferred_username', 'name']))
+    expect(paths).not.toContain('iss')
+    expect(paths).not.toContain('sub')
+    expect(paths).not.toContain('aud')
+    expect(paths).not.toContain('exp')
   })
 })

--- a/apps/web/src/lib/shared/claim-suggestions.ts
+++ b/apps/web/src/lib/shared/claim-suggestions.ts
@@ -90,3 +90,86 @@ export function deriveClaimSuggestions(allClaims: Record<string, JsonValue>): Cl
 
   return { paths, valuesByPath }
 }
+
+/**
+ * Protocol claims that are never useful as person-attribute sources.
+ * Profile claims (`email`, `name`, `preferred_username`, …) stay — mapping
+ * `preferred_username` onto a username attribute is legitimate.
+ */
+const PROTOCOL_CLAIMS = new Set([
+  'iss',
+  'aud',
+  'exp',
+  'iat',
+  'nbf',
+  'jti',
+  'nonce',
+  'azp',
+  'at_hash',
+  'c_hash',
+  'sid',
+  'rh',
+  'uti',
+  'aio',
+  'ver',
+  'amr',
+  'acr',
+  'sub',
+])
+
+export type AttributeClaimPathSuggestion = {
+  path: string
+  description?: string
+}
+
+function truncatePreview(value: JsonValue, max = 48): string {
+  let text: string
+  if (Array.isArray(value)) {
+    text = value
+      .map((v) => (typeof v === 'string' || typeof v === 'number' ? String(v) : JSON.stringify(v)))
+      .join(', ')
+  } else if (value !== null && typeof value === 'object') {
+    text = JSON.stringify(value)
+  } else {
+    text = String(value)
+  }
+  return text.length > max ? `${text.slice(0, max - 1)}…` : text
+}
+
+function isLeaf(value: JsonValue): boolean {
+  return value === null || typeof value !== 'object' || Array.isArray(value)
+}
+
+/**
+ * Leaf claim paths (scalars and arrays) at depth ≤ 2, for mapping onto
+ * person attributes. URL-shaped keys are literal. Each suggestion carries a
+ * truncated observed value as `description`.
+ */
+export function deriveAttributeClaimPaths(
+  allClaims: Record<string, JsonValue>
+): AttributeClaimPathSuggestion[] {
+  const out: AttributeClaimPathSuggestion[] = []
+
+  const record = (path: string, value: JsonValue) => {
+    if (!isLeaf(value)) return
+    out.push({ path, description: truncatePreview(value) })
+  }
+
+  for (const [key, value] of Object.entries(allClaims)) {
+    if (PROTOCOL_CLAIMS.has(key)) continue
+    if (key.includes('://')) {
+      record(key, value)
+      continue
+    }
+    if (isLeaf(value)) {
+      record(key, value)
+    } else if (value !== null && typeof value === 'object') {
+      for (const [childKey, childValue] of Object.entries(value)) {
+        if (childKey.includes('://')) continue
+        record(`${key}.${childKey}`, childValue as JsonValue)
+      }
+    }
+  }
+
+  return out
+}

--- a/apps/web/src/lib/shared/coerce-attribute-value.ts
+++ b/apps/web/src/lib/shared/coerce-attribute-value.ts
@@ -14,6 +14,11 @@ export function coerceAttributeValue(value: unknown, type: UserAttributeType): u
   if (value === null || value === undefined) return undefined
   switch (type) {
     case 'string':
+      // Join arrays to text (`String(['a','b'])` → `a,b`). An array of
+      // objects would stringify as `[object Object]`; refuse that.
+      if (Array.isArray(value) && value.some((v) => v !== null && typeof v === 'object')) {
+        return undefined
+      }
       return String(value)
     case 'number':
     case 'currency': {


### PR DESCRIPTION
## Summary

The `claim_mapping.attributes` writer existed but was unimported, so mapped IdP claims never landed on `user.metadata`. This wires it into the OAuth callback and gives admins an editor for it.

- **Callback wiring.** `hooksAfter` builds one memoised claim reader (stash first, expired-token-refusing decode as fallback) and passes it to both role provisioning and `applyClaimAttributesAfter`. The writer runs after policy cleanup, in `try/catch`, so a blocked sign-in or a DB error never changes the browser response. Test sign-in still never writes — locked in with a test.
- **Userinfo-only claims.** `resolveIdentity` keeps the zero-network fast path unless a mapped attribute or role path is missing from the ID token (`requiredClaimPaths`). The connection test always walks every source (`exhaustive`) so autocomplete and preview see what the IdP can actually release.
- **Editor.** A second disclosure on the Claim mapping card: claim path → person attribute, plus separate Override / Clear-when-missing checkboxes (both default off). Preview evaluates the last matching test capture as you type. Unknown keys are dropped; `_externalUserId` survives the merge; orphaned rows get an amber badge.

## Test plan

- [x] Unit tests for the writer, shared reader, resolver fast-path/required paths/exhaustive, OAuth config wiring, planner array-of-objects guard, claim-path suggestions, `normalizeAttributeMapping`, and the provider-detail editor (add/remove/flags/empty/orphan/preview)
- [x] Existing JIT role tests and SSO test-callback suite still pass
- [ ] Manual (Doorkeeper): define `department` and `plan` under People, map the claims, test-sign-in as alice, then sign in and confirm `user.metadata`. Rebuild the Doorkeeper image and reset the sqlite volume first — seeds now give alice `department` (userinfo-only) and `plan` (id_token + userinfo).