### PR TITLE
fix(test): stop Vite's SSR transform from dropping zod's `z` export

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -42,7 +42,17 @@ export default defineConfig({
     },
     deps: {
       optimizer: {
-        ssr: { enabled: true },
+        ssr: {
+          enabled: true,
+          // zod's entry does `import * as z from './v4/classic/external.js'`
+          // then `export * from` the same module plus `export { z }`. Vite's
+          // SSR transform drops the `z` binding in that combination, so
+          // `import { z } from 'zod'` lands as undefined and every schema in
+          // the codebase throws on load. Pre-bundling zod with esbuild
+          // sidesteps the SSR transform and re-exports it correctly.
+          // Externalizing it instead does NOT help — verified.
+          include: ['zod'],
+        },
       },
     },
   },


### PR DESCRIPTION
On a clean checkout with the committed lockfile, `bun run test` fails to run essentially the whole suite. Every module that declares a zod schema throws on load, which is most of the server.

## Cause

zod 4.4.3's entry point is:

```js
import * as z from "./v4/classic/external.js";
export * from "./v4/classic/external.js";
export { z };
export default z;
```

Vite's SSR transform loses the `z` binding in that specific combination — a namespace import that is re-exported by name alongside an `export *` of the same module. `import { z } from 'zod'` therefore arrives as `undefined`, while `import * as z from 'zod'` still works.

Minimal reproduction:

```ts
import { z } from 'zod'
it('z is defined', () => {
  expect(typeof z?.string).toBe('function')  // fails: z is undefined
})
```

## Fix

Add `zod` to the SSR optimizer's `include` list so esbuild pre-bundles it, which sidesteps the SSR transform and re-exports it correctly.

Two other plausible fixes were tried and do **not** work, which is why the comment records them:

- externalizing zod so Node loads it natively — still fails
- removing the SSR optimizer entirely — still fails

So this is specific to the SSR transform rather than to the optimizer being enabled.

## Verification

Confirmed against `main` (currently ce3d24547): the reproduction above fails without this change and passes with it.

Full suite against a real `pgvector/pgvector:pg17` Postgres with migrations applied: **13,946 passing**. The handful of remaining failures all pass when their files are run in isolation — they are pre-existing parallelism flakes under full-suite CPU contention, in auth components and email routing, unrelated to this change.

I hit this while working on something unrelated in a fork, and it looked worth sending upstream on its own.