### PR TITLE
feat(billing): flat-plan names, savings copy, upgrade-not-add-seat

### DIFF
--- a/apps/web/src/components/admin/__tests__/plan-notice-banner.test.tsx
+++ b/apps/web/src/components/admin/__tests__/plan-notice-banner.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { PlanNoticeBanner } from '../plan-notice-banner'
 
 const ENDED = {
-  label: 'Growth trial ended',
+  label: 'Pro trial ended',
   message: 'Your trial has come to an end.',
   expiresAt: '2026-08-18T00:00:00.000Z',
   actionLabel: 'Update billing',
@@ -25,7 +25,7 @@ describe('PlanNoticeBanner', () => {
 
   it('renders an ended-trial strip with no dismiss control', () => {
     render(<PlanNoticeBanner notice={ENDED} />)
-    expect(screen.getByText('Growth trial ended')).toBeInTheDocument()
+    expect(screen.getByText('Pro trial ended')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /Update billing/ })).toHaveAttribute(
       'href',
       '/admin/settings/billing'

--- a/apps/web/src/components/admin/automation/__tests__/workflows-manager-upgrade.test.tsx
+++ b/apps/web/src/components/admin/automation/__tests__/workflows-manager-upgrade.test.tsx
@@ -28,7 +28,7 @@ vi.mock('@/lib/server/functions/workflow-reporting', () => ({
 }))
 vi.mock('@/components/admin/upgrade', () => ({
   UpgradeModal: ({ open }: { open: boolean }) =>
-    open ? <p>Workflows are a Pro feature. Upgrade to Pro to enable it.</p> : null,
+    open ? <p>Workflows are a Business feature. Upgrade to Business to enable it.</p> : null,
 }))
 
 const { WorkflowsManager } = await import('../workflows-manager')
@@ -50,7 +50,7 @@ describe('WorkflowsManager create lock', () => {
     renderManager(false)
     await user.click(await screen.findByRole('button', { name: /New workflow/ }))
     await user.click(await screen.findByText('Create from scratch'))
-    expect(screen.getByText(/Workflows are a Pro feature/)).toBeTruthy()
+    expect(screen.getByText(/Workflows are a Business feature/)).toBeTruthy()
   })
 
   it('does not show the upgrade modal when the plan includes workflows', async () => {
@@ -58,6 +58,6 @@ describe('WorkflowsManager create lock', () => {
     renderManager(true)
     await user.click(await screen.findByRole('button', { name: /New workflow/ }))
     expect(screen.getByText('Create from scratch')).toBeTruthy()
-    expect(screen.queryByText(/Workflows are a Pro feature/)).toBeNull()
+    expect(screen.queryByText(/Workflows are a Business feature/)).toBeNull()
   })
 })

--- a/apps/web/src/components/admin/settings/billing/__tests__/add-seats-dialog.test.tsx
+++ b/apps/web/src/components/admin/settings/billing/__tests__/add-seats-dialog.test.tsx
@@ -9,7 +9,7 @@ import type { BillingProjectionOverview } from '@/lib/server/domains/billing/pro
 
 const overview: BillingProjectionOverview = {
   plan: 'pro',
-  planName: 'Pro',
+  planName: 'Business',
   status: 'active',
   trialActive: false,
   trialExpiresAt: null,
@@ -18,9 +18,9 @@ const overview: BillingProjectionOverview = {
   canUpgrade: false,
   canManageBilling: true,
   purchasablePlans: [
-    { id: 'growth', name: 'Growth' },
-    { id: 'pro', name: 'Pro' },
-    { id: 'scale', name: 'Scale' },
+    { id: 'growth', name: 'Pro' },
+    { id: 'pro', name: 'Business' },
+    { id: 'scale', name: 'Enterprise' },
   ],
   seats: { used: 7, pending: 1, members: 6, purchased: 10 },
   ai: { includedCents: 3000, usedCents: 2520, extraCents: 1000 },
@@ -36,7 +36,7 @@ const catalogue: BillingCatalogue = {
   plans: [
     {
       id: 'pro',
-      name: 'Pro',
+      name: 'Business',
       rank: 2,
       priceMonthlyCents: 3000,
       priceYearlyCents: 28800,
@@ -77,7 +77,7 @@ describe('AddSeatsDialog', () => {
   it('quotes the monthly sticker and due today, not yearly/12 totals', async () => {
     render(<AddSeatsDialog open onOpenChange={() => {}} />, { wrapper })
 
-    expect(await screen.findByText('Your Pro plan is $30/seat.')).toBeInTheDocument()
+    expect(await screen.findByText('Your Business plan is $30/seat.')).toBeInTheDocument()
     expect(screen.getByText('1 seat × $30/seat')).toBeInTheDocument()
     expect(screen.queryByText(/\/yr/)).not.toBeInTheDocument()
     expect(screen.queryByText(/\$24/)).not.toBeInTheDocument()

--- a/apps/web/src/components/admin/settings/billing/__tests__/billing-settings.test.tsx
+++ b/apps/web/src/components/admin/settings/billing/__tests__/billing-settings.test.tsx
@@ -338,6 +338,34 @@ describe('BillingPlansView', () => {
     expect(screen.getByText('$30')).toBeInTheDocument()
   })
 
+  it('shows annual savings for the selected expired-trial plan, not the recommended one', () => {
+    renderView({
+      overview: {
+        ...paidOverview,
+        plan: 'free',
+        planName: 'Free',
+        status: null,
+        trialActive: false,
+        trialEnded: true,
+        trialPlanId: 'pro',
+        trialPlanName: 'Business',
+        trialExpiresAt: '2026-08-18T00:00:00.000Z',
+        canUpgrade: true,
+        canManageBilling: false,
+        renewalAt: null,
+        seats: { used: 3, pending: 0, members: 3, purchased: null },
+      },
+    })
+    expect(screen.getByRole('radio', { name: /Save \$72\/yr/ })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /For small teams getting started/ }))
+    expect(screen.getByRole('radio', { name: /Save \$36\/yr/ })).toBeInTheDocument()
+    expect(screen.queryByRole('radio', { name: /Save \$72\/yr/ })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /For trying Quackback out/ }))
+    expect(screen.queryByText(/Save \$/)).not.toBeInTheDocument()
+  })
+
   it('opens the subscribe dialog on the selected billing period', () => {
     renderView({
       overview: {

--- a/apps/web/src/components/admin/settings/billing/__tests__/billing-settings.test.tsx
+++ b/apps/web/src/components/admin/settings/billing/__tests__/billing-settings.test.tsx
@@ -31,7 +31,7 @@ const catalogue: BillingCatalogue = {
     },
     {
       id: 'growth',
-      name: 'Growth',
+      name: 'Pro',
       rank: 1,
       priceMonthlyCents: 1500,
       priceYearlyCents: 14400,
@@ -42,7 +42,7 @@ const catalogue: BillingCatalogue = {
     },
     {
       id: 'pro',
-      name: 'Pro',
+      name: 'Business',
       rank: 2,
       priceMonthlyCents: 3000,
       priceYearlyCents: 28800,
@@ -53,7 +53,7 @@ const catalogue: BillingCatalogue = {
     },
     {
       id: 'scale',
-      name: 'Scale',
+      name: 'Enterprise',
       rank: 3,
       priceMonthlyCents: 5900,
       priceYearlyCents: 58800,
@@ -67,7 +67,7 @@ const catalogue: BillingCatalogue = {
 
 const paidOverview: BillingProjectionOverview = {
   plan: 'pro',
-  planName: 'Pro',
+  planName: 'Business',
   status: 'active',
   trialActive: false,
   trialExpiresAt: null,
@@ -76,9 +76,9 @@ const paidOverview: BillingProjectionOverview = {
   canUpgrade: false,
   canManageBilling: true,
   purchasablePlans: [
-    { id: 'growth', name: 'Growth' },
-    { id: 'pro', name: 'Pro' },
-    { id: 'scale', name: 'Scale' },
+    { id: 'growth', name: 'Pro' },
+    { id: 'pro', name: 'Business' },
+    { id: 'scale', name: 'Enterprise' },
   ],
   seats: { used: 7, pending: 1, members: 6, purchased: 10 },
   ai: { includedCents: 3000, usedCents: 2520, extraCents: 1000 },
@@ -118,7 +118,7 @@ describe('BillingPlansView', () => {
   it('renders the active paid plan, seat meter, and invoices', () => {
     renderView()
 
-    expect(screen.getByRole('heading', { level: 2, name: 'Pro' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 2, name: 'Business' })).toBeInTheDocument()
     expect(screen.getByText('Active')).toBeInTheDocument()
     expect(screen.getByText(/Renews/)).toBeInTheDocument()
     expect(screen.getByText(/10 seats × \$30\/seat/)).toBeInTheDocument()
@@ -171,7 +171,7 @@ describe('BillingPlansView', () => {
     expect(screen.queryByRole('button', { name: 'Add' })).not.toBeInTheDocument()
   })
 
-  it('hides the seat meter on a grandfathered flat plan', () => {
+  it('hides Add seats on a workspace-billed plan', () => {
     renderView({
       overview: {
         ...paidOverview,
@@ -187,7 +187,7 @@ describe('BillingPlansView', () => {
     })
     expect(screen.queryByText(/of \d+ used/)).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Add seats' })).not.toBeInTheDocument()
-    expect(screen.getByText(/Switching plans moves you onto per-seat pricing/)).toBeInTheDocument()
+    expect(screen.queryByText(/per-seat pricing/)).not.toBeInTheDocument()
   })
 
   it('shows leftover AI extra credit on Free', () => {
@@ -230,28 +230,26 @@ describe('BillingPlansView', () => {
     expect(screen.queryByRole('button', { name: 'Switch to Free' })).not.toBeInTheDocument()
   })
 
-  it('shows trial expiry, Continue with the plan, and uncapped seats', () => {
+  it('shows trial expiry, Continue with the plan, and included seats', () => {
     renderView({
       overview: {
         ...paidOverview,
         plan: 'growth',
-        planName: 'Growth',
+        planName: 'Pro',
         status: null,
         trialActive: true,
         trialPlanId: 'growth',
-        trialPlanName: 'Growth',
+        trialPlanName: 'Pro',
         trialExpiresAt: '2026-09-01T00:00:00.000Z',
         canUpgrade: true,
         canManageBilling: false,
-        seats: { used: 4, pending: 1, members: 3, purchased: null },
+        seats: { used: 3, pending: 0, members: 3, purchased: null, limit: 5 },
       },
     })
     expect(screen.getAllByText('Trial').length).toBeGreaterThan(0)
     expect(screen.getByText(/Trial ends/)).toBeInTheDocument()
-    expect(screen.getByText(/Uncapped during your trial/)).toBeInTheDocument()
-    expect(screen.getAllByRole('button', { name: 'Continue with Growth' }).length).toBeGreaterThan(
-      0
-    )
+    expect(screen.getByText('3 of 5 seats included with Pro')).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: 'Continue with Pro' }).length).toBeGreaterThan(0)
     expect(screen.queryByRole('button', { name: 'Add seats' })).not.toBeInTheDocument()
   })
 
@@ -306,11 +304,11 @@ describe('BillingPlansView', () => {
       overview: {
         ...paidOverview,
         plan: 'growth',
-        planName: 'Growth',
+        planName: 'Pro',
         status: null,
         trialActive: true,
         trialPlanId: 'growth',
-        trialPlanName: 'Growth',
+        trialPlanName: 'Pro',
         trialExpiresAt: '2026-09-01T00:00:00.000Z',
         canUpgrade: true,
         canManageBilling: false,

--- a/apps/web/src/components/admin/settings/billing/__tests__/checkout-builder.test.tsx
+++ b/apps/web/src/components/admin/settings/billing/__tests__/checkout-builder.test.tsx
@@ -32,7 +32,7 @@ const catalogue: BillingCatalogue = {
     },
     {
       id: 'growth',
-      name: 'Growth',
+      name: 'Pro',
       rank: 1,
       priceMonthlyCents: 2900,
       priceYearlyCents: 29000,
@@ -43,7 +43,7 @@ const catalogue: BillingCatalogue = {
     },
     {
       id: 'pro',
-      name: 'Pro',
+      name: 'Business',
       rank: 2,
       priceMonthlyCents: 5900,
       priceYearlyCents: 59000,
@@ -54,7 +54,7 @@ const catalogue: BillingCatalogue = {
     },
     {
       id: 'scale',
-      name: 'Scale',
+      name: 'Enterprise',
       rank: 3,
       priceMonthlyCents: 11500,
       priceYearlyCents: 106800,
@@ -77,9 +77,9 @@ const freeOverview: BillingProjectionOverview = {
   canUpgrade: true,
   canManageBilling: false,
   purchasablePlans: [
-    { id: 'growth', name: 'Growth' },
-    { id: 'pro', name: 'Pro' },
-    { id: 'scale', name: 'Scale' },
+    { id: 'growth', name: 'Pro' },
+    { id: 'pro', name: 'Business' },
+    { id: 'scale', name: 'Enterprise' },
   ],
   seats: { used: 3, pending: 1, members: 2, purchased: null },
   ai: null,
@@ -89,7 +89,7 @@ const freeOverview: BillingProjectionOverview = {
 const proOverview: BillingProjectionOverview = {
   ...freeOverview,
   plan: 'pro',
-  planName: 'Pro',
+  planName: 'Business',
   status: 'active',
   canManageBilling: true,
   seats: { used: 7, pending: 1, members: 6, purchased: 10 },
@@ -123,12 +123,12 @@ describe('CheckoutBuilder', () => {
     renderBuilder(freeOverview)
 
     expect(screen.getByRole('radio', { name: /Yearly/ })).toHaveAttribute('aria-checked', 'true')
-    expect(screen.getByRole('radio', { name: /Save 17%/ })).toBeInTheDocument()
-    expect(screen.getByRole('radio', { name: /^Pro/ })).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByRole('radio', { name: /Save \$118\/yr/ })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: /^Business/ })).toHaveAttribute('aria-checked', 'true')
     expect(screen.getByText('Workflows & SLAs')).toBeInTheDocument()
 
     const summary = screen.getByRole('complementary')
-    expect(within(summary).getByText('Pro plan')).toBeInTheDocument()
+    expect(within(summary).getByText('Business plan')).toBeInTheDocument()
     expect(within(summary).getByText('3 seats × $590/year')).toBeInTheDocument()
     expect(within(summary).getAllByText('$1,770/year')).toHaveLength(2)
     expect(within(summary).getByText('$148/mo')).toBeInTheDocument()
@@ -142,14 +142,16 @@ describe('CheckoutBuilder', () => {
 
   it('offers the trial as an alternative to a Free workspace that has not tried the plan', () => {
     renderBuilder(freeOverview)
-    expect(screen.getByRole('button', { name: /Or try Pro free for 14 days/ })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /Or try Business free for 14 days/ })
+    ).toBeInTheDocument()
   })
 
   it('reports selection changes without clearing the plan', () => {
     const { onChange } = renderBuilder(freeOverview)
     fireEvent.click(screen.getByRole('radio', { name: /Monthly/ }))
     expect(onChange).toHaveBeenCalledWith({ period: 'monthly' })
-    fireEvent.click(screen.getByRole('radio', { name: /^Scale/ }))
+    fireEvent.click(screen.getByRole('radio', { name: /^Enterprise/ }))
     expect(onChange).toHaveBeenCalledWith({ plan: 'scale' })
     fireEvent.click(screen.getByRole('button', { name: 'More seats' }))
     expect(onChange).toHaveBeenCalledWith({ seats: 4 })

--- a/apps/web/src/components/admin/settings/billing/__tests__/subscribe-dialog.test.tsx
+++ b/apps/web/src/components/admin/settings/billing/__tests__/subscribe-dialog.test.tsx
@@ -6,7 +6,7 @@ import { SubscribeDialog } from '../subscribe-dialog'
 
 const plan = {
   id: 'pro' as const,
-  name: 'Pro',
+  name: 'Business',
   rank: 2,
   priceMonthlyCents: 3000,
   priceYearlyCents: 28800,

--- a/apps/web/src/components/admin/settings/billing/billing-settings.tsx
+++ b/apps/web/src/components/admin/settings/billing/billing-settings.tsx
@@ -10,6 +10,7 @@ import { Progress } from '@/components/ui/progress'
 import { ConfirmDialog } from '@/components/shared/confirm-dialog'
 import { cn } from '@/lib/shared/utils'
 import { formatUsd } from '@/lib/shared/format-usd'
+import { annualSavingsLabel } from '@/lib/shared/billing/checkout-path'
 import { seatUnitCents } from './seat-price'
 import { hasTopUpPackPrice } from './topup-price'
 import {
@@ -74,9 +75,10 @@ export function BillingPlansView(props: {
   const trialDays = catalogueTrialDays(catalogue)
   const trialedPlanIds = catalogueTrialedPlanIds(catalogue)
   const checkoutQuantity = Math.max(overview.seats?.used ?? 1, 1)
-  const currentCataloguePlan = catalogue?.plans.find((plan) => plan.id === overview.plan)
-  const grandfatheredFlat =
-    currentCataloguePlan?.billedPer === 'workspace' && overview.plan !== 'free'
+  const savingsPlan =
+    catalogue?.plans.find((plan) => plan.recommended) ??
+    catalogue?.plans.find((plan) => plan.id !== 'free') ??
+    null
 
   if (overview.trialEnded) {
     return (
@@ -112,12 +114,12 @@ export function BillingPlansView(props: {
             <p className="mt-1 text-xs text-muted-foreground">
               Moving up applies now, billed pro-rata. Moving to a lower plan waits until the end of
               the current period. You can try each paid plan once for {trialDays} days.
-              {grandfatheredFlat ? ' Switching plans moves you onto per-seat pricing.' : null}
             </p>
           </div>
           <PeriodToggle
             value={period}
             discountMonths={catalogue?.annualDiscountMonths ?? 2}
+            savingsLabel={annualSavingsLabel(savingsPlan)}
             onChange={setPeriod}
           />
         </div>
@@ -297,15 +299,17 @@ function CurrentPlanCard(props: {
 function TrialSeatsRow(props: { overview: BillingProjectionOverview }) {
   const seats = props.overview.seats
   const used = seats?.used ?? 0
-  const members = seats?.members ?? used
-  const pending = seats?.pending ?? 0
+  const cap = seats?.limit
+  const planName = props.overview.planName
+  const included =
+    cap === null
+      ? `Unlimited seats included with ${planName}`
+      : typeof cap === 'number'
+        ? `${used} of ${cap} seats included with ${planName}`
+        : `${used} ${used === 1 ? 'seat' : 'seats'} included with ${planName}`
   return (
     <div className="border-t border-border/50 px-6 py-5">
-      <p className="text-[13px] text-muted-foreground">
-        Uncapped during your trial · {members} {members === 1 ? 'member' : 'members'} · {pending}{' '}
-        pending {pending === 1 ? 'invite' : 'invites'} · checkout starts at your current {used}{' '}
-        {used === 1 ? 'seat' : 'seats'}
-      </p>
+      <p className="text-[13px] text-muted-foreground">{included}</p>
     </div>
   )
 }
@@ -776,6 +780,7 @@ function DowngradeButton() {
 function PeriodToggle(props: {
   value: 'monthly' | 'annual'
   discountMonths: number
+  savingsLabel: string | null
   onChange: (next: 'monthly' | 'annual') => void
 }) {
   return (
@@ -799,11 +804,11 @@ function PeriodToggle(props: {
           )}
         >
           {option === 'annual' ? 'Annual' : 'Monthly'}
-          {option === 'annual' && (
+          {option === 'annual' && props.savingsLabel ? (
             <span className="ms-1.5 text-[11px] font-semibold text-primary">
-              {props.discountMonths} mo free
+              {props.savingsLabel}
             </span>
-          )}
+          ) : null}
         </button>
       ))}
     </div>

--- a/apps/web/src/components/admin/settings/billing/checkout-builder.tsx
+++ b/apps/web/src/components/admin/settings/billing/checkout-builder.tsx
@@ -16,7 +16,7 @@ import {
   type PaidPlanId,
 } from '@/lib/shared/billing/plan-action'
 import {
-  annualSavingsPercent,
+  annualSavingsLabel,
   checkoutSummary,
   isPaidPlanId,
   type BillingPeriod,
@@ -68,7 +68,7 @@ export function CheckoutBuilder(props: {
   const trialDays = catalogueTrialDays(catalogue)
   const savingsReference =
     selectedPlan ?? paidPlans.find((plan) => plan.recommended) ?? paidPlans[0]
-  const savings = savingsReference ? annualSavingsPercent(savingsReference) : null
+  const savings = annualSavingsLabel(savingsReference)
   const freeAction = freePlan ? billingPlanAction('free', overview, trialedPlanIds) : null
   const canPurchase = overview.canUpgrade || overview.canManageBilling
   const branding = catalogue.brandingRemoval ?? null
@@ -83,7 +83,7 @@ export function CheckoutBuilder(props: {
           <SectionTitle>Billing cycle</SectionTitle>
           <CycleToggle
             value={selection.period}
-            savingsPercent={savings}
+            savingsLabel={savings}
             discountMonths={catalogue.annualDiscountMonths}
             onChange={(period) => props.onChange({ period })}
           />
@@ -181,7 +181,7 @@ function SectionTitle(props: { children: React.ReactNode }) {
 
 function CycleToggle(props: {
   value: BillingPeriod
-  savingsPercent: number | null
+  savingsLabel: string | null
   discountMonths: number
   onChange: (next: BillingPeriod) => void
 }) {
@@ -208,11 +208,9 @@ function CycleToggle(props: {
             )}
           >
             {option === 'annual' ? 'Yearly' : 'Monthly'}
-            {option === 'annual' ? (
+            {option === 'annual' && props.savingsLabel ? (
               <Badge size="sm" shape="pill" variant={active ? 'default' : 'secondary'}>
-                {props.savingsPercent != null
-                  ? `Save ${props.savingsPercent}%`
-                  : `${props.discountMonths} mo free`}
+                {props.savingsLabel}
               </Badge>
             ) : null}
           </button>

--- a/apps/web/src/components/admin/settings/billing/subscribe-dialog.tsx
+++ b/apps/web/src/components/admin/settings/billing/subscribe-dialog.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { formatUsd } from '@/lib/shared/format-usd'
+import { annualSavingsLabel } from '@/lib/shared/billing/checkout-path'
 import { cn } from '@/lib/shared/utils'
 import type { BillingCatalogue } from '@/lib/server/control-plane/client'
 import { QuantityStepper } from './quantity-stepper'
@@ -32,6 +33,7 @@ export function SubscribeDialog(props: {
   const monthlyCents = isAnnual
     ? Math.round(props.plan.priceYearlyCents / 12)
     : props.plan.priceMonthlyCents
+  const savingsLabel = annualSavingsLabel(props.plan)
 
   return (
     <Dialog open={props.open} onOpenChange={props.onOpenChange}>
@@ -65,11 +67,11 @@ export function SubscribeDialog(props: {
               )}
             >
               {option === 'annual' ? 'Annual' : 'Monthly'}
-              {option === 'annual' && (
+              {option === 'annual' && savingsLabel ? (
                 <span className="ms-1.5 text-[11px] font-semibold text-primary">
-                  {props.discountMonths} mo free
+                  {savingsLabel}
                 </span>
-              )}
+              ) : null}
             </button>
           ))}
         </div>

--- a/apps/web/src/components/admin/settings/billing/trial-expired-billing.tsx
+++ b/apps/web/src/components/admin/settings/billing/trial-expired-billing.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { cn } from '@/lib/shared/utils'
 import { formatUsd } from '@/lib/shared/format-usd'
+import { annualSavingsLabel } from '@/lib/shared/billing/checkout-path'
 import {
   billingPlanAction,
   catalogueTrialedPlanIds,
@@ -31,6 +32,10 @@ export function TrialExpiredBilling(props: {
   const paidSelected = selected && selected.id !== 'free' ? selected : null
   const checkoutQuantity = Math.max(overview.seats?.used ?? 1, 1)
   const trialName = overview.trialPlanName ?? 'your plan'
+  const savingsPlan =
+    catalogue?.plans.find((plan) => plan.recommended) ??
+    catalogue?.plans.find((plan) => plan.id !== 'free') ??
+    null
 
   return (
     <div className="space-y-6">
@@ -51,6 +56,7 @@ export function TrialExpiredBilling(props: {
             <PeriodToggle
               value={period}
               discountMonths={catalogue?.annualDiscountMonths ?? 2}
+              savingsLabel={annualSavingsLabel(savingsPlan)}
               onChange={setPeriod}
             />
           </div>
@@ -217,6 +223,7 @@ function OrderSummary(props: {
 function PeriodToggle(props: {
   value: 'monthly' | 'annual'
   discountMonths: number
+  savingsLabel: string | null
   onChange: (next: 'monthly' | 'annual') => void
 }) {
   return (
@@ -242,9 +249,11 @@ function PeriodToggle(props: {
           {option === 'annual' ? (
             <>
               Yearly
-              <span className="ms-1.5 text-[11px] font-semibold text-primary">
-                {props.discountMonths} mo free
-              </span>
+              {props.savingsLabel ? (
+                <span className="ms-1.5 text-[11px] font-semibold text-primary">
+                  {props.savingsLabel}
+                </span>
+              ) : null}
             </>
           ) : (
             'Monthly'

--- a/apps/web/src/components/admin/settings/billing/trial-expired-billing.tsx
+++ b/apps/web/src/components/admin/settings/billing/trial-expired-billing.tsx
@@ -32,10 +32,6 @@ export function TrialExpiredBilling(props: {
   const paidSelected = selected && selected.id !== 'free' ? selected : null
   const checkoutQuantity = Math.max(overview.seats?.used ?? 1, 1)
   const trialName = overview.trialPlanName ?? 'your plan'
-  const savingsPlan =
-    catalogue?.plans.find((plan) => plan.recommended) ??
-    catalogue?.plans.find((plan) => plan.id !== 'free') ??
-    null
 
   return (
     <div className="space-y-6">
@@ -56,7 +52,7 @@ export function TrialExpiredBilling(props: {
             <PeriodToggle
               value={period}
               discountMonths={catalogue?.annualDiscountMonths ?? 2}
-              savingsLabel={annualSavingsLabel(savingsPlan)}
+              savingsLabel={annualSavingsLabel(paidSelected)}
               onChange={setPeriod}
             />
           </div>

--- a/apps/web/src/components/admin/settings/mcp/__tests__/mcp-server-settings.test.tsx
+++ b/apps/web/src/components/admin/settings/mcp/__tests__/mcp-server-settings.test.tsx
@@ -14,7 +14,7 @@ vi.mock('@/lib/server/functions/settings', () => ({
 
 vi.mock('@/components/admin/upgrade', () => ({
   UpgradeModal: ({ open }: { open: boolean }) =>
-    open ? <p>The MCP server is a Growth feature. Upgrade to Growth to enable it.</p> : null,
+    open ? <p>The MCP server is a Pro feature. Upgrade to Pro to enable it.</p> : null,
 }))
 
 const { McpServerSettings } = await import('../mcp-server-settings')
@@ -29,7 +29,7 @@ describe('McpServerSettings enable lock', () => {
       />
     )
     fireEvent.click(screen.getByLabelText('Enable MCP Server'))
-    expect(screen.getByText(/The MCP server is a Growth feature/)).toBeTruthy()
+    expect(screen.getByText(/The MCP server is a Pro feature/)).toBeTruthy()
     expect(save).not.toHaveBeenCalled()
     expect((screen.getByLabelText('Enable MCP Server') as HTMLButtonElement).dataset.state).toBe(
       'unchecked'
@@ -42,7 +42,7 @@ describe('McpServerSettings enable lock', () => {
     await waitFor(() => {
       expect(save).toHaveBeenCalledWith({ data: { mcpEnabled: true } })
     })
-    expect(screen.queryByText(/The MCP server is a Growth feature/)).toBeNull()
+    expect(screen.queryByText(/The MCP server is a Pro feature/)).toBeNull()
   })
 
   it('still allows turning MCP off when locked', async () => {
@@ -51,6 +51,6 @@ describe('McpServerSettings enable lock', () => {
     await waitFor(() => {
       expect(save).toHaveBeenCalledWith({ data: { mcpEnabled: false } })
     })
-    expect(screen.queryByText(/The MCP server is a Growth feature/)).toBeNull()
+    expect(screen.queryByText(/The MCP server is a Pro feature/)).toBeNull()
   })
 })

--- a/apps/web/src/components/admin/settings/security/__tests__/auth-settings.test.tsx
+++ b/apps/web/src/components/admin/settings/security/__tests__/auth-settings.test.tsx
@@ -19,7 +19,7 @@ vi.mock('../audit-log-page', () => ({
   AuditLogPage: () => <div>audit-feed</div>,
 }))
 vi.mock('@/components/admin/upgrade', () => ({
-  UpgradeScreen: () => <div>The audit log is a Scale feature</div>,
+  UpgradeScreen: () => <div>The audit log is an Enterprise feature</div>,
 }))
 
 const { AuthSettings } = await import('../auth-settings')
@@ -41,7 +41,7 @@ describe('AuthSettings audit tab', () => {
     )
     expect(screen.getByText('portal-access-body')).toBeDefined()
     expect(screen.queryByText('audit-feed')).toBeNull()
-    expect(screen.queryByText(/The audit log is a Scale feature/)).toBeNull()
+    expect(screen.queryByText(/The audit log is an Enterprise feature/)).toBeNull()
   })
 
   it('shows an upgrade notice on the audit tab instead of the feed', () => {
@@ -55,7 +55,7 @@ describe('AuthSettings audit tab', () => {
         auditEntitled={false}
       />
     )
-    expect(screen.getByText(/The audit log is a Scale feature/)).toBeDefined()
+    expect(screen.getByText(/The audit log is an Enterprise feature/)).toBeDefined()
     expect(screen.queryByText('audit-feed')).toBeNull()
   })
 
@@ -71,7 +71,7 @@ describe('AuthSettings audit tab', () => {
       />
     )
     expect(screen.getByText('audit-feed')).toBeDefined()
-    expect(screen.queryByText(/The audit log is a Scale feature/)).toBeNull()
+    expect(screen.queryByText(/The audit log is an Enterprise feature/)).toBeNull()
   })
 
   it('keeps the audit tab reachable so the upgrade is discoverable', () => {

--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-list.test.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-list.test.tsx
@@ -21,7 +21,9 @@ const { upsertSpy } = vi.hoisted(() => ({
 }))
 
 vi.mock('@/components/admin/upgrade', () => ({
-  UpgradeNotice: () => <p>Single sign-on is a Scale feature. Upgrade to Scale to enable it.</p>,
+  UpgradeNotice: () => (
+    <p>Single sign-on is an Enterprise feature. Upgrade to Enterprise to enable it.</p>
+  ),
 }))
 
 vi.mock('@tanstack/react-router', () => ({
@@ -187,7 +189,7 @@ describe('<IdentityProvidersSection>', () => {
 })
 
 describe('plan gate', () => {
-  it('hides Add provider and names Scale when SSO is not entitled', () => {
+  it('hides Add provider and names Enterprise when SSO is not entitled', () => {
     const qc = new QueryClient()
     qc.setQueryData(['settings', 'identityProviders'], [buttonProvider, routedProvider])
     render(
@@ -196,7 +198,7 @@ describe('plan gate', () => {
       </QueryClientProvider>
     )
     expect(screen.queryByRole('link', { name: /add provider/i })).toBeNull()
-    expect(screen.getByText(/Single sign-on is a Scale feature/)).toBeTruthy()
+    expect(screen.getByText(/Single sign-on is an Enterprise feature/)).toBeTruthy()
   })
 })
 

--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/sso-upgrade-notice.test.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/sso-upgrade-notice.test.tsx
@@ -4,8 +4,10 @@ import { ssoUpgradePlanName } from '../sso-upgrade-notice'
 import { describeEntitlementUpgrade } from '@/lib/shared/describe-upgrade'
 
 describe('SsoUpgradeNotice', () => {
-  it('names Scale as the cheapest plan that grants SSO', () => {
-    expect(ssoUpgradePlanName()).toBe('Scale')
-    expect(describeEntitlementUpgrade('sso').body).toMatch(/Single sign-on is a Scale feature/)
+  it('names Enterprise as the cheapest plan that grants SSO', () => {
+    expect(ssoUpgradePlanName()).toBe('Enterprise')
+    expect(describeEntitlementUpgrade('sso').body).toMatch(
+      /Single sign-on is an Enterprise feature/
+    )
   })
 })

--- a/apps/web/src/components/admin/settings/security/identity-providers/sso-upgrade-notice.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/sso-upgrade-notice.tsx
@@ -3,7 +3,7 @@ import { UpgradeNotice } from '@/components/admin/upgrade'
 
 /** @deprecated Use describeEntitlementUpgrade('sso') */
 export function ssoUpgradePlanName(): string {
-  return describeEntitlementUpgrade('sso').requiredPlanName ?? 'Scale'
+  return describeEntitlementUpgrade('sso').requiredPlanName ?? 'Enterprise'
 }
 
 export function SsoUpgradeNotice() {

--- a/apps/web/src/components/admin/settings/webhooks/__tests__/webhooks-settings.test.tsx
+++ b/apps/web/src/components/admin/settings/webhooks/__tests__/webhooks-settings.test.tsx
@@ -5,7 +5,7 @@ import type { Webhook } from '@/lib/shared/types'
 
 vi.mock('@/components/admin/upgrade', () => ({
   UpgradeModal: ({ open }: { open: boolean }) =>
-    open ? <p>Webhooks are a Growth feature. Upgrade to Growth to enable it.</p> : null,
+    open ? <p>Webhooks are a Pro feature. Upgrade to Pro to enable it.</p> : null,
 }))
 
 vi.mock('../create-webhook-dialog', () => ({
@@ -24,7 +24,7 @@ describe('WebhooksSettings create lock', () => {
   it('opens the upgrade modal instead of the create form when locked', () => {
     render(<WebhooksSettings webhooks={[]} entitled={false} />)
     fireEvent.click(screen.getByRole('button', { name: /Create your first webhook/ }))
-    expect(screen.getByText(/Webhooks are a Growth feature/)).toBeTruthy()
+    expect(screen.getByText(/Webhooks are a Pro feature/)).toBeTruthy()
     expect(screen.queryByText('Create webhook form')).toBeNull()
   })
 
@@ -32,7 +32,7 @@ describe('WebhooksSettings create lock', () => {
     render(<WebhooksSettings webhooks={[]} entitled />)
     fireEvent.click(screen.getByRole('button', { name: /Create your first webhook/ }))
     expect(screen.getByText('Create webhook form')).toBeTruthy()
-    expect(screen.queryByText(/Webhooks are a Growth feature/)).toBeNull()
+    expect(screen.queryByText(/Webhooks are a Pro feature/)).toBeNull()
   })
 
   it('keeps existing webhooks visible when create is locked', () => {
@@ -52,6 +52,6 @@ describe('WebhooksSettings create lock', () => {
     render(<WebhooksSettings webhooks={[webhook]} entitled={false} />)
     expect(screen.getByText('https://example.com/hook')).toBeTruthy()
     fireEvent.click(screen.getByRole('button', { name: /Create Webhook/ }))
-    expect(screen.getByText(/Webhooks are a Growth feature/)).toBeTruthy()
+    expect(screen.getByText(/Webhooks are a Pro feature/)).toBeTruthy()
   })
 })

--- a/apps/web/src/components/admin/upgrade/__tests__/upgrade-offer.test.tsx
+++ b/apps/web/src/components/admin/upgrade/__tests__/upgrade-offer.test.tsx
@@ -28,7 +28,7 @@ const catalogue: BillingCatalogue = {
     },
     {
       id: 'growth',
-      name: 'Growth',
+      name: 'Pro',
       rank: 1,
       priceMonthlyCents: 2900,
       priceYearlyCents: 29000,
@@ -39,7 +39,7 @@ const catalogue: BillingCatalogue = {
     },
     {
       id: 'pro',
-      name: 'Pro',
+      name: 'Business',
       rank: 2,
       priceMonthlyCents: 5900,
       priceYearlyCents: 59000,
@@ -50,7 +50,7 @@ const catalogue: BillingCatalogue = {
     },
     {
       id: 'scale',
-      name: 'Scale',
+      name: 'Enterprise',
       rank: 3,
       priceMonthlyCents: 11500,
       priceYearlyCents: 106800,
@@ -95,7 +95,7 @@ function renderOffer(
 
 const onPro: UpgradeContext = {
   currentPlan: 'pro',
-  currentPlanName: 'Pro',
+  currentPlanName: 'Business',
   trialActive: false,
   trialEligible: false,
 }
@@ -116,14 +116,14 @@ describe('UpgradeOffer', () => {
   it('names the feature, both plans, the unlock list and the price on the first paint', () => {
     renderOffer(onPro)
     expect(
-      screen.getByRole('heading', { name: 'The audit log is available from the Scale plan' })
+      screen.getByRole('heading', { name: 'The audit log is available from the Enterprise plan' })
     ).toBeTruthy()
-    expect(screen.getByText('Upgrade from Pro to Scale to unlock:')).toBeTruthy()
+    expect(screen.getByText('Upgrade from Business to Enterprise to unlock:')).toBeTruthy()
     expect(screen.getByText('Audit log')).toBeTruthy()
     expect(screen.getByText('SSO')).toBeTruthy()
     expect(screen.queryByText(/Plus everything in/)).toBeNull()
     expect(screen.getByText('$89')).toBeTruthy()
-    expect(screen.getByRole('link', { name: 'Upgrade to Scale' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Upgrade to Enterprise' })).toHaveAttribute(
       'href',
       '/admin/settings/billing/checkout?plan=scale&period=annual'
     )
@@ -137,7 +137,7 @@ describe('UpgradeOffer', () => {
   it('carries the chosen billing cycle into the configurator', () => {
     renderOffer(onPro)
     fireEvent.click(screen.getByRole('radio', { name: /Monthly/ }))
-    expect(screen.getByRole('link', { name: 'Upgrade to Scale' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Upgrade to Enterprise' })).toHaveAttribute(
       'href',
       '/admin/settings/billing/checkout?plan=scale&period=monthly'
     )
@@ -145,16 +145,16 @@ describe('UpgradeOffer', () => {
 
   it('folds in the plans between the current one and the target', () => {
     renderOffer({ ...onFree, trialEligible: false })
-    expect(screen.getByText('Upgrade from Free to Scale to unlock:')).toBeTruthy()
-    expect(screen.getByText('Plus everything in Growth:')).toBeTruthy()
-    expect(screen.getByText(/Custom domain · API, MCP & webhooks/)).toBeTruthy()
+    expect(screen.getByText('Upgrade from Free to Enterprise to unlock:')).toBeTruthy()
     expect(screen.getByText('Plus everything in Pro:')).toBeTruthy()
+    expect(screen.getByText(/Custom domain · API, MCP & webhooks/)).toBeTruthy()
+    expect(screen.getByText('Plus everything in Business:')).toBeTruthy()
   })
 
   it('offers a first-time trial that returns to the page that raised the prompt', () => {
     renderOffer(onFree, { entitlement: 'workflows' })
-    expect(screen.getByRole('button', { name: 'Try Pro free for 14 days' })).toBeTruthy()
-    expect(screen.queryByRole('link', { name: 'Upgrade to Pro' })).toBeNull()
+    expect(screen.getByRole('button', { name: 'Try Business free for 14 days' })).toBeTruthy()
+    expect(screen.queryByRole('link', { name: 'Upgrade to Business' })).toBeNull()
     expect(screen.getByText(/Free for 14 days, then the price above/)).toBeTruthy()
     const form = document.querySelector('form')
     expect(form?.getAttribute('action')).toBe('/api/billing/trial')
@@ -169,23 +169,23 @@ describe('UpgradeOffer', () => {
       entitlement: 'workflows',
       catalogue: { ...catalogue, trialedPlanIds: ['pro'] },
     })
-    expect(screen.getByRole('link', { name: 'Upgrade to Pro' })).toBeTruthy()
+    expect(screen.getByRole('link', { name: 'Upgrade to Business' })).toBeTruthy()
     expect(screen.queryByText(/Free for 14 days/)).toBeNull()
   })
 
   it('acknowledges a running trial', () => {
     renderOffer(
-      { currentPlan: 'growth', currentPlanName: 'Growth', trialActive: true, trialEligible: false },
+      { currentPlan: 'growth', currentPlanName: 'Pro', trialActive: true, trialEligible: false },
       { entitlement: 'workflows' }
     )
-    expect(screen.getByText("You're trialing Growth. Upgrade to Pro to unlock:")).toBeTruthy()
-    expect(screen.getByRole('link', { name: 'Upgrade to Pro' })).toBeTruthy()
+    expect(screen.getByText("You're trialing Pro. Upgrade to Business to unlock:")).toBeTruthy()
+    expect(screen.getByRole('link', { name: 'Upgrade to Business' })).toBeTruthy()
   })
 
   it('uses plan-only copy when the current plan is unknown', () => {
     renderOffer(null)
-    expect(screen.getByText('Upgrade to Scale to unlock:')).toBeTruthy()
-    expect(screen.getByRole('link', { name: 'Upgrade to Scale' })).toBeTruthy()
+    expect(screen.getByText('Upgrade to Enterprise to unlock:')).toBeTruthy()
+    expect(screen.getByRole('link', { name: 'Upgrade to Enterprise' })).toBeTruthy()
   })
 
   it('tells teammates without billing access who can act instead of linking to a page they cannot open', () => {
@@ -206,7 +206,7 @@ describe('UpgradeOffer', () => {
         <UpgradeOffer description={describeEntitlementUpgrade('auditLog')} />
       </QueryClientProvider>
     )
-    expect(screen.getByText(/The audit log is a Scale feature/)).toBeTruthy()
+    expect(screen.getByText(/The audit log is an Enterprise feature/)).toBeTruthy()
     expect(screen.getByRole('link', { name: 'View & compare plans' })).toHaveAttribute(
       'href',
       '/admin/settings/billing'
@@ -218,9 +218,9 @@ describe('UpgradeOffer', () => {
     routerState.billingEnabled = false
     renderOffer(onPro)
     expect(
-      screen.getByRole('heading', { name: 'The audit log is available from the Scale plan' })
+      screen.getByRole('heading', { name: 'The audit log is available from the Enterprise plan' })
     ).toBeTruthy()
-    expect(screen.getByText(/The audit log is a Scale feature/)).toBeTruthy()
+    expect(screen.getByText(/The audit log is an Enterprise feature/)).toBeTruthy()
     expect(document.querySelector('form')).toBeNull()
     expect(screen.queryByRole('link')).toBeNull()
   })

--- a/apps/web/src/components/admin/upgrade/upgrade-offer.tsx
+++ b/apps/web/src/components/admin/upgrade/upgrade-offer.tsx
@@ -12,7 +12,7 @@ import {
   catalogueTrialedPlanIds,
   type PaidPlanId,
 } from '@/lib/shared/billing/plan-action'
-import { checkoutPath, isPaidPlanId } from '@/lib/shared/billing/checkout-path'
+import { annualSavingsLabel, checkoutPath, isPaidPlanId } from '@/lib/shared/billing/checkout-path'
 import {
   cataloguePlanFor,
   unlockedHighlights,
@@ -250,6 +250,7 @@ function PriceRow(props: {
         <PeriodToggle
           value={props.period}
           discountMonths={props.discountMonths}
+          savingsLabel={annualSavingsLabel(props.plan)}
           onChange={props.onPeriodChange}
         />
       </div>
@@ -266,6 +267,7 @@ function PriceRow(props: {
 function PeriodToggle(props: {
   value: BillingPeriod
   discountMonths: number
+  savingsLabel: string | null
   onChange: (next: BillingPeriod) => void
 }) {
   return (
@@ -289,9 +291,9 @@ function PeriodToggle(props: {
           )}
         >
           {option === 'annual' ? 'Annual' : 'Monthly'}
-          {option === 'annual' ? (
+          {option === 'annual' && props.savingsLabel ? (
             <span className="ms-1 text-[11px] font-semibold text-primary">
-              {props.discountMonths} mo free
+              {props.savingsLabel}
             </span>
           ) : null}
         </button>

--- a/apps/web/src/components/shared/__tests__/error-page.test.tsx
+++ b/apps/web/src/components/shared/__tests__/error-page.test.tsx
@@ -23,7 +23,7 @@ describe('isEntitlementError', () => {
     expect(
       isEntitlementError(
         new Error(
-          'The audit log is a Scale feature. Your workspace is on Pro. Upgrade to Scale to enable it.'
+          'The audit log is an Enterprise feature. Your workspace is on Business. Upgrade to Enterprise to enable it.'
         )
       )
     ).toBe(true)
@@ -65,7 +65,7 @@ describe('DefaultErrorPage', () => {
       <DefaultErrorPage
         error={
           new Error(
-            'The audit log is a Scale feature. Your workspace is on Pro. Upgrade to Scale to enable it.'
+            'The audit log is an Enterprise feature. Your workspace is on Business. Upgrade to Enterprise to enable it.'
           )
         }
       />
@@ -74,9 +74,9 @@ describe('DefaultErrorPage', () => {
     expect(screen.queryByText(/Something went wrong/i)).toBeNull()
     expect(screen.queryByText(/Technical details/i)).toBeNull()
     expect(
-      screen.getByRole('heading', { name: 'The audit log is available from the Scale plan' })
+      screen.getByRole('heading', { name: 'The audit log is available from the Enterprise plan' })
     ).toBeInTheDocument()
-    expect(screen.getByText(/The audit log is a Scale feature/)).toBeInTheDocument()
+    expect(screen.getByText(/The audit log is an Enterprise feature/)).toBeInTheDocument()
   })
 
   it('keeps the generic plan headline when the refusal names no plan', () => {

--- a/apps/web/src/lib/server/control-plane/client.ts
+++ b/apps/web/src/lib/server/control-plane/client.ts
@@ -167,6 +167,7 @@ export type BillingCatalogue = {
     priceMonthlyCents: number
     priceYearlyCents: number
     billedPer: 'seat' | 'workspace'
+    annualSavingsCents?: number
     bestFor: string
     highlights: string[]
     recommended: boolean

--- a/apps/web/src/lib/server/domains/billing/projection-overview.ts
+++ b/apps/web/src/lib/server/domains/billing/projection-overview.ts
@@ -8,6 +8,8 @@ export type BillingSeatsOverview = {
   pending: number
   members: number
   purchased: number | null
+  /** Plan/enforcement cap. Null means unlimited. */
+  limit?: number | null
 }
 
 export type BillingAiOverview = {
@@ -168,10 +170,19 @@ export async function getBillingProjectionOverview(): Promise<BillingProjectionO
       pending: seats.pendingInvites,
       members: seats.members,
       purchased,
+      limit: limits.maxTeamSeats,
     },
     ai,
     hideBranding: cloud.entitlements.hideBranding === true,
   }
+}
+
+export async function catalogueBilledPer(
+  planId: PlanId | null | undefined
+): Promise<'seat' | 'workspace' | undefined> {
+  if (!planId) return undefined
+  const catalogue = await loadCatalogue()
+  return catalogue?.plans.find((plan) => plan.id === planId)?.billedPer
 }
 
 async function loadCatalogue(): Promise<BillingCatalogue | null> {

--- a/apps/web/src/lib/server/domains/conversation/__tests__/conversation-assistant-turn.test.ts
+++ b/apps/web/src/lib/server/domains/conversation/__tests__/conversation-assistant-turn.test.ts
@@ -351,7 +351,7 @@ describe('runAssistantTurnForConversation gate', () => {
         currentPlan: 'free',
         currentPlanName: 'Free',
         requiredPlan: 'growth',
-        requiredPlanName: 'Growth',
+        requiredPlanName: 'Pro',
       })
     )
     await runAssistantTurnForConversation(CONV)

--- a/apps/web/src/lib/server/domains/macros/__tests__/macros-entitlement.test.ts
+++ b/apps/web/src/lib/server/domains/macros/__tests__/macros-entitlement.test.ts
@@ -87,10 +87,10 @@ describe('macro library — plan gate', () => {
     expect(refusal).toBeInstanceOf(EntitlementRequiredError)
     const error = refusal as EntitlementRequiredError
     expect(error.entitlement).toBe('aiDrafts')
-    expect(error.requiredPlanName).toBe('Growth')
+    expect(error.requiredPlanName).toBe('Pro')
     expect(error.statusCode).toBe(402)
     expect(error.message).toBe(
-      'AI drafts are a Growth feature. Your workspace is on Free. Upgrade to Growth to enable it.'
+      'AI drafts are a Pro feature. Your workspace is on Free. Upgrade to Pro to enable it.'
     )
     expect(hoisted.mockSelect).not.toHaveBeenCalled()
   })

--- a/apps/web/src/lib/server/domains/principals/__tests__/seat-limit.test.ts
+++ b/apps/web/src/lib/server/domains/principals/__tests__/seat-limit.test.ts
@@ -26,6 +26,19 @@ vi.mock('@/lib/server/domains/billing/projection-overview', () => ({
 import { enforceSeatLimit } from '../seat-limit'
 import { getTierLimits } from '@/lib/server/domains/settings/tier-limits.service'
 import { OSS_TIER_LIMITS } from '@/lib/server/domains/settings/tier-limits.types'
+import type { SeatExecutor } from '../seat-usage'
+
+function lockingExecutor(forUpdate: () => Promise<unknown>): SeatExecutor {
+  return {
+    select: () => ({
+      from: () => ({
+        limit: () => ({
+          for: forUpdate,
+        }),
+      }),
+    }),
+  } as unknown as SeatExecutor
+}
 
 describe('enforceSeatLimit', () => {
   beforeEach(() => {
@@ -110,5 +123,48 @@ describe('enforceSeatLimit', () => {
     await expect(enforceSeatLimit({ convertingInvite: true })).rejects.toBeInstanceOf(
       TierLimitError
     )
+  })
+
+  it('resolves catalogue billedPer before taking the settings-row lock', async () => {
+    const order: string[] = []
+    let releaseCatalogue: () => void = () => {}
+    const catalogueGate = new Promise<void>((resolve) => {
+      releaseCatalogue = resolve
+    })
+    hoisted.catalogueBilledPer.mockImplementation(async () => {
+      order.push('catalogue')
+      await catalogueGate
+      return 'seat'
+    })
+    hoisted.getCloudConfig.mockResolvedValue({
+      enabled: true,
+      plan: 'pro',
+      trialActive: false,
+    })
+    hoisted.countSeatUsage.mockResolvedValue({ members: 10, pendingInvites: 0, used: 10 })
+    vi.mocked(getTierLimits).mockResolvedValue({ ...OSS_TIER_LIMITS, maxTeamSeats: 10 })
+
+    const forUpdate = vi.fn(async () => {
+      order.push('lock')
+      return [{ id: 'set_1' }]
+    })
+
+    const pending = enforceSeatLimit({ executor: lockingExecutor(forUpdate) })
+    await vi.waitFor(() => expect(hoisted.catalogueBilledPer).toHaveBeenCalledOnce())
+    expect(forUpdate).not.toHaveBeenCalled()
+    releaseCatalogue()
+    await expect(pending).rejects.toThrow('All 10 seats are in use. Add a seat to invite more.')
+    expect(order).toEqual(['catalogue', 'lock'])
+  })
+
+  it('does not fetch the catalogue when the locked path is under the cap', async () => {
+    vi.mocked(getTierLimits).mockResolvedValue({ ...OSS_TIER_LIMITS, maxTeamSeats: 10 })
+    hoisted.countSeatUsage.mockResolvedValue({ members: 4, pendingInvites: 1, used: 5 })
+    const forUpdate = vi.fn(async () => [{ id: 'set_1' }])
+    await expect(
+      enforceSeatLimit({ executor: lockingExecutor(forUpdate) })
+    ).resolves.toBeUndefined()
+    expect(hoisted.catalogueBilledPer).not.toHaveBeenCalled()
+    expect(forUpdate).toHaveBeenCalledOnce()
   })
 })

--- a/apps/web/src/lib/server/domains/principals/__tests__/seat-limit.test.ts
+++ b/apps/web/src/lib/server/domains/principals/__tests__/seat-limit.test.ts
@@ -4,6 +4,7 @@ import { TierLimitError } from '@/lib/server/errors/tier-limit-error'
 const hoisted = vi.hoisted(() => ({
   countSeatUsage: vi.fn(),
   getCloudConfig: vi.fn(),
+  catalogueBilledPer: vi.fn(),
 }))
 
 vi.mock('@/lib/server/domains/settings/tier-limits.service', () => ({
@@ -16,6 +17,10 @@ vi.mock('../seat-usage', () => ({
 
 vi.mock('@/lib/server/domains/settings/cloud/cloud.service', () => ({
   getCloudConfig: () => hoisted.getCloudConfig(),
+}))
+
+vi.mock('@/lib/server/domains/billing/projection-overview', () => ({
+  catalogueBilledPer: (...args: unknown[]) => hoisted.catalogueBilledPer(...args),
 }))
 
 import { enforceSeatLimit } from '../seat-limit'
@@ -31,6 +36,7 @@ describe('enforceSeatLimit', () => {
       plan: null,
       trialActive: false,
     })
+    hoisted.catalogueBilledPer.mockResolvedValue(undefined)
   })
 
   it('does nothing when maxTeamSeats is null (OSS default)', async () => {
@@ -51,7 +57,7 @@ describe('enforceSeatLimit', () => {
     await expect(enforceSeatLimit()).rejects.toBeInstanceOf(TierLimitError)
   })
 
-  it('uses seat-specific copy on a paid plan', async () => {
+  it('uses seat-specific copy on a grandfathered per-seat plan', async () => {
     vi.mocked(getTierLimits).mockResolvedValue({ ...OSS_TIER_LIMITS, maxTeamSeats: 10 })
     hoisted.countSeatUsage.mockResolvedValue({ members: 8, pendingInvites: 2, used: 10 })
     hoisted.getCloudConfig.mockResolvedValue({
@@ -59,8 +65,23 @@ describe('enforceSeatLimit', () => {
       plan: 'pro',
       trialActive: false,
     })
+    hoisted.catalogueBilledPer.mockResolvedValue('seat')
     await expect(enforceSeatLimit()).rejects.toThrow(
       'All 10 seats are in use. Add a seat to invite more.'
+    )
+  })
+
+  it('uses upgrade copy when the catalogue plan is billed per workspace', async () => {
+    vi.mocked(getTierLimits).mockResolvedValue({ ...OSS_TIER_LIMITS, maxTeamSeats: 5 })
+    hoisted.countSeatUsage.mockResolvedValue({ members: 5, pendingInvites: 0, used: 5 })
+    hoisted.getCloudConfig.mockResolvedValue({
+      enabled: true,
+      plan: 'growth',
+      trialActive: false,
+    })
+    hoisted.catalogueBilledPer.mockResolvedValue('workspace')
+    await expect(enforceSeatLimit()).rejects.toThrow(
+      "You've reached your plan's team seats limit (5). Upgrade to add more."
     )
   })
 

--- a/apps/web/src/lib/server/domains/principals/__tests__/seat-usage.db.test.ts
+++ b/apps/web/src/lib/server/domains/principals/__tests__/seat-usage.db.test.ts
@@ -168,7 +168,7 @@ describe.skipIf(!fixture.available)('countSeatUsage', () => {
     await seedInvite('team', inviterId)
     await expect(enforceSeatLimit()).rejects.toBeInstanceOf(TierLimitError)
     await expect(enforceSeatLimit()).rejects.toThrow(
-      /All \d+ seats are in use\. Add a seat to invite more\./
+      /You've reached your plan's team seats limit \(\d+\)\. Upgrade to add more\./
     )
   })
 

--- a/apps/web/src/lib/server/domains/principals/seat-limit.ts
+++ b/apps/web/src/lib/server/domains/principals/seat-limit.ts
@@ -41,9 +41,13 @@ export async function enforceSeatLimit(opts?: {
 async function seatCapMessage(limit: number): Promise<string> {
   try {
     const { getCloudConfig } = await import('@/lib/server/domains/settings/cloud/cloud.service')
+    const { catalogueBilledPer } = await import('@/lib/server/domains/billing/projection-overview')
     const cloud = await getCloudConfig()
     if (cloud.enabled && cloud.plan && cloud.plan !== 'free' && !cloud.trialActive) {
-      return `All ${limit} seats are in use. Add a seat to invite more.`
+      const billedPer = await catalogueBilledPer(cloud.plan)
+      if (billedPer === 'seat') {
+        return `All ${limit} seats are in use. Add a seat to invite more.`
+      }
     }
   } catch {
     // Fall through to the generic upgrade sentence.

--- a/apps/web/src/lib/server/domains/principals/seat-limit.ts
+++ b/apps/web/src/lib/server/domains/principals/seat-limit.ts
@@ -21,6 +21,12 @@ export async function enforceSeatLimit(opts?: {
   if (limits.maxTeamSeats === null) return
 
   const executor = opts?.executor
+  // Catalogue billedPer is a control-plane round-trip (10s timeout). Resolve
+  // it before FOR UPDATE so CP latency cannot hold the settings-row lock.
+  const billedPer = executor
+    ? await billedPerIfAlreadyAtCap(limits.maxTeamSeats, opts?.convertingInvite, executor)
+    : undefined
+
   if (executor) {
     const [row] = await executor.select({ id: settings.id }).from(settings).limit(1).for('update')
     if (!row) throw new Error('Workspace is not set up yet')
@@ -34,23 +40,41 @@ export async function enforceSeatLimit(opts?: {
     limit: 'maxTeamSeats',
     current,
     max: limits.maxTeamSeats,
-    message: await seatCapMessage(limits.maxTeamSeats),
+    message: seatCapMessage(
+      limits.maxTeamSeats,
+      billedPer ?? (executor ? undefined : await resolveSeatBilledPer())
+    ),
   })
 }
 
-async function seatCapMessage(limit: number): Promise<string> {
+async function billedPerIfAlreadyAtCap(
+  limit: number,
+  convertingInvite: boolean | undefined,
+  executor: SeatExecutor
+): Promise<'seat' | 'workspace' | undefined> {
+  const peek = await countSeatUsage(executor)
+  const current = convertingInvite ? peek.members : peek.used
+  if (current < limit) return undefined
+  return resolveSeatBilledPer()
+}
+
+async function resolveSeatBilledPer(): Promise<'seat' | 'workspace' | undefined> {
   try {
     const { getCloudConfig } = await import('@/lib/server/domains/settings/cloud/cloud.service')
     const { catalogueBilledPer } = await import('@/lib/server/domains/billing/projection-overview')
     const cloud = await getCloudConfig()
     if (cloud.enabled && cloud.plan && cloud.plan !== 'free' && !cloud.trialActive) {
-      const billedPer = await catalogueBilledPer(cloud.plan)
-      if (billedPer === 'seat') {
-        return `All ${limit} seats are in use. Add a seat to invite more.`
-      }
+      return await catalogueBilledPer(cloud.plan)
     }
   } catch {
-    // Fall through to the generic upgrade sentence.
+    // Missing catalogue uses the generic upgrade sentence.
+  }
+  return undefined
+}
+
+function seatCapMessage(limit: number, billedPer: 'seat' | 'workspace' | undefined): string {
+  if (billedPer === 'seat') {
+    return `All ${limit} seats are in use. Add a seat to invite more.`
   }
   return `You've reached your plan's team seats limit (${limit}). Upgrade to add more.`
 }

--- a/apps/web/src/lib/server/domains/sentiment/__tests__/sentiment-entitlement.test.ts
+++ b/apps/web/src/lib/server/domains/sentiment/__tests__/sentiment-entitlement.test.ts
@@ -96,10 +96,10 @@ describe('analyzeSentiment — plan gate', () => {
     expect(refusal).toBeInstanceOf(EntitlementRequiredError)
     const error = refusal as EntitlementRequiredError
     expect(error.entitlement).toBe('aiInsights')
-    expect(error.requiredPlanName).toBe('Growth')
+    expect(error.requiredPlanName).toBe('Pro')
     expect(error.statusCode).toBe(402)
     expect(error.message).toBe(
-      'AI insights are a Growth feature. Your workspace is on Free. Upgrade to Growth to enable it.'
+      'AI insights are a Pro feature. Your workspace is on Free. Upgrade to Pro to enable it.'
     )
     // No model call, no spend.
     expect(hoisted.mockChat).not.toHaveBeenCalled()

--- a/apps/web/src/lib/server/domains/settings/__tests__/developer-config-entitlement.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/developer-config-entitlement.test.ts
@@ -88,7 +88,7 @@ describe('updateDeveloperConfig — mcpServer entitlement', () => {
         currentPlan: 'free',
         currentPlanName: 'Free',
         requiredPlan: 'growth',
-        requiredPlanName: 'Growth',
+        requiredPlanName: 'Pro',
       })
     )
 
@@ -99,7 +99,7 @@ describe('updateDeveloperConfig — mcpServer entitlement', () => {
     expect(refusal).toBeInstanceOf(EntitlementRequiredError)
     const error = refusal as EntitlementRequiredError
     expect(error.entitlement).toBe('mcpServer')
-    expect(error.requiredPlanName).toBe('Growth')
+    expect(error.requiredPlanName).toBe('Pro')
     expect(error.statusCode).toBe(402)
     expect(hoisted.requireEntitlement).toHaveBeenCalledWith('mcpServer')
     expect(hoisted.mockDbUpdate).not.toHaveBeenCalled()

--- a/apps/web/src/lib/server/domains/settings/__tests__/wrap-db-error.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/wrap-db-error.test.ts
@@ -22,7 +22,7 @@ describe('wrapDbError', () => {
       currentPlan: 'free',
       currentPlanName: 'Free',
       requiredPlan: 'growth',
-      requiredPlanName: 'Growth',
+      requiredPlanName: 'Pro',
     })
     expect(() => wrapDbError('update developer config', err)).toThrow(err)
   })

--- a/apps/web/src/lib/server/domains/settings/cloud/__tests__/commercial-notice.test.ts
+++ b/apps/web/src/lib/server/domains/settings/cloud/__tests__/commercial-notice.test.ts
@@ -25,7 +25,7 @@ describe('trialNotice', () => {
   it('keeps See plans until the last three days', () => {
     const notice = trialNotice(config({ trialExpiresAt: '2026-08-30T00:00:00.000Z' }), NOW)
     expect(notice).toMatchObject({
-      label: 'Growth trial',
+      label: 'Pro trial',
       actionLabel: 'See plans',
       message: expect.stringContaining('pick a paid plan'),
     })
@@ -33,7 +33,7 @@ describe('trialNotice', () => {
 
   it('switches the action to Continue with the plan in the last three days', () => {
     const notice = trialNotice(config({ trialExpiresAt: '2026-08-21T12:00:00.000Z' }), NOW)
-    expect(notice?.actionLabel).toBe('Continue with Growth')
+    expect(notice?.actionLabel).toBe('Continue with Pro')
   })
 })
 
@@ -45,10 +45,10 @@ describe('trialEndedNotice', () => {
         trialActive: false,
         trialExpiresAt: '2026-08-18T00:00:00.000Z',
       }),
-      { trialPlanName: 'Growth', now: NOW }
+      { trialPlanName: 'Pro', now: NOW }
     )
     expect(notice).toMatchObject({
-      label: 'Growth trial ended',
+      label: 'Pro trial ended',
       actionLabel: 'Update billing',
     })
     expect(notice?.message).toMatch(/trial has come to an end/)

--- a/apps/web/src/lib/server/domains/settings/cloud/__tests__/entitlements.test.ts
+++ b/apps/web/src/lib/server/domains/settings/cloud/__tests__/entitlements.test.ts
@@ -108,11 +108,11 @@ describe('the refusal names the plan', () => {
   it('names the cheapest plan that would grant the feature', () => {
     const err = buildRefusal(cloud({ plan: 'free' }), 'customDomain')
     expect(err.requiredPlan).toBe('growth')
-    expect(err.requiredPlanName).toBe('Growth')
+    expect(err.requiredPlanName).toBe('Pro')
     expect(err.currentPlan).toBe('free')
     expect(err.currentPlanName).toBe('Free')
     expect(err.message).toBe(
-      'Custom domains are a Growth feature. Your workspace is on Free. Upgrade to Growth to enable it.'
+      'Custom domains are a Pro feature. Your workspace is on Free. Upgrade to Pro to enable it.'
     )
   })
 
@@ -120,8 +120,8 @@ describe('the refusal names the plan', () => {
     // The MCP server is included from the cheapest paid plan; the audit log
     // only from the dearest. A refusal that always pointed at the top plan
     // would over-sell and read as dishonest.
-    expect(buildRefusal(cloud({ plan: 'free' }), 'mcpServer').requiredPlanName).toBe('Growth')
-    expect(buildRefusal(cloud({ plan: 'free' }), 'auditLog').requiredPlanName).toBe('Scale')
+    expect(buildRefusal(cloud({ plan: 'free' }), 'mcpServer').requiredPlanName).toBe('Pro')
+    expect(buildRefusal(cloud({ plan: 'free' }), 'auditLog').requiredPlanName).toBe('Enterprise')
   })
 
   it('does not invent an upsell when the workspace already has the plan', () => {
@@ -130,15 +130,15 @@ describe('the refusal names the plan', () => {
     const err = buildRefusal(cloud({ plan: 'scale', entitlements: { sso: false } }), 'sso')
     expect(err.requiredPlan).toBeNull()
     expect(err.message).toBe(
-      'Single sign-on is not included in your plan. Your workspace is on Scale. Contact us to enable it.'
+      'Single sign-on is not included in your plan. Your workspace is on Enterprise. Contact us to enable it.'
     )
   })
 
   it('still names a plan when the workspace has none', () => {
     const err = buildRefusal(cloud({ plan: null }), 'workflows')
     expect(err.currentPlan).toBeNull()
-    expect(err.requiredPlanName).toBe('Pro')
-    expect(err.message).toBe('Workflows are a Pro feature. Upgrade to Pro to enable it.')
+    expect(err.requiredPlanName).toBe('Business')
+    expect(err.message).toBe('Workflows are a Business feature. Upgrade to Business to enable it.')
   })
 
   it.each(ENTITLEMENT_KEYS.filter((key) => key !== 'hideBranding'))(
@@ -180,11 +180,11 @@ describe('the refusal reuses the existing 402 plumbing', () => {
       limit: 'entitlements.mcpServer',
       entitlement: 'mcpServer',
       message:
-        'The MCP server is a Growth feature. Your workspace is on Free. Upgrade to Growth to enable it.',
+        'The MCP server is a Pro feature. Your workspace is on Free. Upgrade to Pro to enable it.',
       currentPlan: 'free',
       currentPlanName: 'Free',
       requiredPlan: 'growth',
-      requiredPlanName: 'Growth',
+      requiredPlanName: 'Pro',
       upgradeUrl: '/admin/settings/billing',
     })
   })
@@ -212,7 +212,7 @@ describe('requireEntitlement against a configured workspace', () => {
     })
     const { requireEntitlement } = await import('../entitlements')
     await expect(requireEntitlement('customDomain')).rejects.toThrow(
-      /Custom domains are a Growth feature/
+      /Custom domains are a Pro feature/
     )
   })
 
@@ -235,7 +235,7 @@ describe('requireEntitlement against a configured workspace', () => {
     await expect(requireEntitlement('mcpServer')).resolves.toBeUndefined()
     await expect(requireEntitlement('aiInsights')).resolves.toBeUndefined()
     await expect(requireEntitlement('workflows')).rejects.toThrow(
-      /Workflows are a Pro feature. Your workspace is on Growth./
+      /Workflows are a Business feature. Your workspace is on Pro./
     )
   })
 

--- a/apps/web/src/lib/server/domains/settings/cloud/__tests__/plan-catalogue.test.ts
+++ b/apps/web/src/lib/server/domains/settings/cloud/__tests__/plan-catalogue.test.ts
@@ -82,7 +82,7 @@ describe('the plan ladder', () => {
   it('reads correctly in refusal copy, article and all', () => {
     expect(
       PLAN_IDS.map((id) => `${PLAN_CATALOGUE[id].article} ${PLAN_CATALOGUE[id].name} plan`)
-    ).toEqual(['a Free plan', 'a Growth plan', 'a Pro plan', 'a Scale plan'])
+    ).toEqual(['a Free plan', 'a Pro plan', 'a Business plan', 'an Enterprise plan'])
   })
 })
 
@@ -133,22 +133,22 @@ describe('the levels the price list moved', () => {
   // One test per correction. Each states the level it moved FROM as well as
   // the one it moved to, so a catalogue that simply granted more would fail.
 
-  it('includes the MCP server from Growth, the cheapest paid plan', () => {
+  it('includes the MCP server from Pro, the cheapest paid plan', () => {
     expect(isEntitled(on('free'), 'mcpServer')).toBe(false)
     expect(isEntitled(on('growth'), 'mcpServer')).toBe(true)
   })
 
-  it('includes AI insights from Growth, the cheapest paid plan', () => {
+  it('includes AI insights from Pro, the cheapest paid plan', () => {
     expect(isEntitled(on('free'), 'aiInsights')).toBe(false)
     expect(isEntitled(on('growth'), 'aiInsights')).toBe(true)
   })
 
-  it('starts workflows at Pro, not at Growth', () => {
+  it('starts workflows at Business, not at Pro', () => {
     expect(isEntitled(on('growth'), 'workflows')).toBe(false)
     expect(isEntitled(on('pro'), 'workflows')).toBe(true)
   })
 
-  it('starts the audit log at Scale, not at Pro', () => {
+  it('starts the audit log at Enterprise, not at Business', () => {
     expect(isEntitled(on('pro'), 'auditLog')).toBe(false)
     expect(isEntitled(on('scale'), 'auditLog')).toBe(true)
   })

--- a/apps/web/src/lib/server/domains/settings/cloud/__tests__/refusal-copy.test.ts
+++ b/apps/web/src/lib/server/domains/settings/cloud/__tests__/refusal-copy.test.ts
@@ -79,9 +79,9 @@ describe('the defects that shipped', () => {
     // Every plan name in today's catalogue takes "a", so this pins that the
     // copy carries one at all and carries the right plan. The vowel case is
     // covered by the consistency check below, which survives a rename.
-    expect(buildRefusal(cloud('free'), 'sso').message).toContain('a Scale feature')
-    expect(buildRefusal(cloud('free'), 'customDomain').message).toContain('a Growth feature')
-    expect(buildRefusal(cloud('free'), 'auditLog').message).toContain('a Scale feature')
+    expect(buildRefusal(cloud('free'), 'sso').message).toContain('an Enterprise feature')
+    expect(buildRefusal(cloud('free'), 'customDomain').message).toContain('a Pro feature')
+    expect(buildRefusal(cloud('free'), 'auditLog').message).toContain('an Enterprise feature')
   })
 
   it('never emits "a" before a vowel-initial plan name or vice versa', () => {
@@ -100,7 +100,7 @@ describe('the defects that shipped', () => {
     // The "contact us" branch has its own copy path and was equally broken.
     const config = cloud('scale', { entitlements: { customDomain: false } })
     expect(buildRefusal(config, 'customDomain').message).toBe(
-      'Custom domains are not included in your plan. Your workspace is on Scale. Contact us to enable it.'
+      'Custom domains are not included in your plan. Your workspace is on Enterprise. Contact us to enable it.'
     )
   })
 })

--- a/apps/web/src/lib/server/domains/settings/cloud/__tests__/refusal-copy.test.ts
+++ b/apps/web/src/lib/server/domains/settings/cloud/__tests__/refusal-copy.test.ts
@@ -76,9 +76,8 @@ describe('the defects that shipped', () => {
   })
 
   it('takes the article from the plan it names', () => {
-    // Every plan name in today's catalogue takes "a", so this pins that the
-    // copy carries one at all and carries the right plan. The vowel case is
-    // covered by the consistency check below, which survives a rename.
+    // Pins that the copy carries an article and the right plan. Enterprise is
+    // today's `an` case; the loop below is the invariant that survives a rename.
     expect(buildRefusal(cloud('free'), 'sso').message).toContain('an Enterprise feature')
     expect(buildRefusal(cloud('free'), 'customDomain').message).toContain('a Pro feature')
     expect(buildRefusal(cloud('free'), 'auditLog').message).toContain('an Enterprise feature')

--- a/apps/web/src/lib/server/domains/settings/cloud/__tests__/upgrade-context.test.ts
+++ b/apps/web/src/lib/server/domains/settings/cloud/__tests__/upgrade-context.test.ts
@@ -31,7 +31,7 @@ describe('upgradeContextFor', () => {
   it('withholds the trial while one is running, on a paid plan, with a live sub, or without canUpgrade', () => {
     expect(upgradeContextFor(cloud({ trialActive: true, plan: 'growth' }))).toMatchObject({
       currentPlan: 'growth',
-      currentPlanName: 'Growth',
+      currentPlanName: 'Pro',
       trialActive: true,
       trialEligible: false,
     })

--- a/apps/web/src/lib/server/domains/settings/cloud/cloud.types.ts
+++ b/apps/web/src/lib/server/domains/settings/cloud/cloud.types.ts
@@ -31,10 +31,9 @@ export interface PlanDefinition {
   rank: number
   /**
    * Indefinite article for {@link name} in refusal copy ("a Pro feature",
-   * "an Advanced feature"). Declared rather than derived: an initial-vowel
+   * "an Enterprise feature"). Declared rather than derived: an initial-vowel
    * test is wrong for names like "Unlimited" ("an Unlimited plan") and
-   * "One" ("a One plan"), and there are only a handful of plans. Every plan
-   * in today's catalogue happens to take "a".
+   * "One" ("a One plan"), and there are only a handful of plans.
    */
   article: 'a' | 'an'
   /** Entitlements this plan grants by default. */
@@ -216,7 +215,7 @@ export const PLAN_CATALOGUE: Record<PlanId, PlanDefinition> = {
   growth: {
     id: 'growth',
     article: 'a',
-    name: 'Growth',
+    name: 'Pro',
     rank: 1,
     grants: [
       'customDomain',
@@ -231,7 +230,7 @@ export const PLAN_CATALOGUE: Record<PlanId, PlanDefinition> = {
   pro: {
     id: 'pro',
     article: 'a',
-    name: 'Pro',
+    name: 'Business',
     rank: 2,
     grants: [
       'customDomain',
@@ -246,8 +245,8 @@ export const PLAN_CATALOGUE: Record<PlanId, PlanDefinition> = {
   },
   scale: {
     id: 'scale',
-    article: 'a',
-    name: 'Scale',
+    article: 'an',
+    name: 'Enterprise',
     rank: 3,
     grants: [
       'customDomain',

--- a/apps/web/src/lib/server/domains/settings/settings.service.ts
+++ b/apps/web/src/lib/server/domains/settings/settings.service.ts
@@ -665,7 +665,7 @@ export async function updateDeveloperConfig(
 ): Promise<DeveloperConfig> {
   log.info('update developer config')
   try {
-    // Plan first (names Growth), then the operator-cap overlay. Disabling MCP
+    // Plan first (names the plan), then the operator-cap overlay. Disabling MCP
     // stays open so a downgraded workspace can turn the endpoint off.
     if (input.mcpEnabled === true) {
       const { requireEntitlement } =

--- a/apps/web/src/lib/server/domains/settings/tier-limits.service.ts
+++ b/apps/web/src/lib/server/domains/settings/tier-limits.service.ts
@@ -110,7 +110,7 @@ function featuresFromProjection(projection: BillingProjection, now: Date): TierL
  *
  * No row + cloud off (no projection) stays OSS unlimited. No row + a
  * projection must not inherit that unlimited default — otherwise every
- * cloud Free/Growth workspace is uncapped.
+ * cloud Free/Pro workspace is uncapped.
  */
 export function resolveEffectiveTierLimits(
   stored: StoredTierLimits | null,

--- a/apps/web/src/lib/server/domains/summary/__tests__/summary-entitlement.test.ts
+++ b/apps/web/src/lib/server/domains/summary/__tests__/summary-entitlement.test.ts
@@ -107,10 +107,10 @@ describe('generateAndSavePostSummary — plan gate', () => {
     expect(refusal).toBeInstanceOf(EntitlementRequiredError)
     const error = refusal as EntitlementRequiredError
     expect(error.entitlement).toBe('aiInsights')
-    expect(error.requiredPlanName).toBe('Growth')
+    expect(error.requiredPlanName).toBe('Pro')
     expect(error.statusCode).toBe(402)
     expect(error.message).toBe(
-      'AI insights are a Growth feature. Your workspace is on Free. Upgrade to Growth to enable it.'
+      'AI insights are a Pro feature. Your workspace is on Free. Upgrade to Pro to enable it.'
     )
     // No model call, no spend, nothing written.
     expect(hoisted.mockChat).not.toHaveBeenCalled()

--- a/apps/web/src/lib/server/domains/webhooks/__tests__/webhooks-entitlement.test.ts
+++ b/apps/web/src/lib/server/domains/webhooks/__tests__/webhooks-entitlement.test.ts
@@ -112,10 +112,10 @@ describe('createWebhook — plan gate', () => {
     expect(refusal).toBeInstanceOf(EntitlementRequiredError)
     const error = refusal as EntitlementRequiredError
     expect(error.entitlement).toBe('webhooks')
-    expect(error.requiredPlanName).toBe('Growth')
+    expect(error.requiredPlanName).toBe('Pro')
     expect(error.statusCode).toBe(402)
     expect(error.message).toBe(
-      'Webhooks are a Growth feature. Your workspace is on Free. Upgrade to Growth to enable it.'
+      'Webhooks are a Pro feature. Your workspace is on Free. Upgrade to Pro to enable it.'
     )
     // Nothing was written.
     expect(hoisted.mockInsert).not.toHaveBeenCalled()

--- a/apps/web/src/lib/server/domains/workflows/__tests__/workflows-entitlement.test.ts
+++ b/apps/web/src/lib/server/domains/workflows/__tests__/workflows-entitlement.test.ts
@@ -71,8 +71,8 @@ describe('createWorkflow — no cloud config', () => {
 
 describe('createWorkflow — plan gate', () => {
   it('refuses on a plan without the entitlement and names the plan that has it', async () => {
-    // Growth, not Free: the refusal has to name the cheapest plan that GRANTS
-    // workflows (Pro), not merely the next plan up from the workspace's own.
+    // Pro, not Free: the refusal has to name the cheapest plan that GRANTS
+    // workflows (Business), not merely the next plan up from the workspace's own.
     withCloud(storedCloud('growth'))
 
     const refusal = await createWorkflow(INPUT).catch((error: unknown) => error)
@@ -80,10 +80,10 @@ describe('createWorkflow — plan gate', () => {
     expect(refusal).toBeInstanceOf(EntitlementRequiredError)
     const error = refusal as EntitlementRequiredError
     expect(error.entitlement).toBe('workflows')
-    expect(error.requiredPlanName).toBe('Pro')
+    expect(error.requiredPlanName).toBe('Business')
     expect(error.statusCode).toBe(402)
     expect(error.message).toBe(
-      'Workflows are a Pro feature. Your workspace is on Growth. Upgrade to Pro to enable it.'
+      'Workflows are a Business feature. Your workspace is on Pro. Upgrade to Business to enable it.'
     )
     expect(hoisted.mockInsert).not.toHaveBeenCalled()
   })

--- a/apps/web/src/lib/server/functions/__tests__/audit-log-entitlement.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/audit-log-entitlement.test.ts
@@ -128,10 +128,10 @@ describe('listAuditEventsFn — plan gate', () => {
     expect(refusal).toBeInstanceOf(EntitlementRequiredError)
     const error = refusal as EntitlementRequiredError
     expect(error.entitlement).toBe('auditLog')
-    expect(error.requiredPlanName).toBe('Scale')
+    expect(error.requiredPlanName).toBe('Enterprise')
     expect(error.statusCode).toBe(402)
     expect(error.message).toBe(
-      'The audit log is a Scale feature. Your workspace is on Pro. Upgrade to Scale to enable it.'
+      'The audit log is an Enterprise feature. Your workspace is on Business. Upgrade to Enterprise to enable it.'
     )
     // No read happened.
     expect(hoisted.mockQueryAuditEvents).not.toHaveBeenCalled()

--- a/apps/web/src/lib/server/functions/__tests__/auth-provider-credentials-tier-gate.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/auth-provider-credentials-tier-gate.test.ts
@@ -57,7 +57,7 @@ describe('saveAuthProviderCredentialsFn — customOidcProvider gate', () => {
     expect(hoisted.mockSavePlatformCredentials).not.toHaveBeenCalled()
   })
 
-  it('allows generic-oauth save when feature is on (Scale tier / OSS default)', async () => {
+  it('allows generic-oauth save when feature is on (Enterprise tier / OSS default)', async () => {
     hoisted.mockGetTierLimits.mockResolvedValue(OSS_TIER_LIMITS)
 
     await saveAuthProviderCredentialsFn({

--- a/apps/web/src/lib/server/functions/__tests__/plan-notice-auth.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/plan-notice-auth.test.ts
@@ -170,7 +170,7 @@ describe('getPlanNotice — the trial countdown', () => {
   it('counts down while the trial is running', async () => {
     hoisted.mockGetWorkspaceSettings.mockResolvedValue({ settings: { cloud: trialing } })
     await expect(getPlanNoticeHandler()).resolves.toEqual(
-      expect.objectContaining({ label: 'Pro trial', expiresAt: ENDS })
+      expect.objectContaining({ label: 'Business trial', expiresAt: ENDS })
     )
   })
 
@@ -188,7 +188,7 @@ describe('getPlanNotice — the trial countdown', () => {
       .mockResolvedValueOnce({ settings: { cloud: preTrial } })
       .mockResolvedValueOnce({ settings: { cloud: trialing } })
     await expect(getPlanNoticeHandler()).resolves.toEqual(
-      expect.objectContaining({ label: 'Pro trial', expiresAt: ENDS })
+      expect.objectContaining({ label: 'Business trial', expiresAt: ENDS })
     )
   })
 
@@ -198,7 +198,7 @@ describe('getPlanNotice — the trial countdown', () => {
     hoisted.mockGetWorkspaceSettings.mockResolvedValue({ settings: { cloud: trialing } })
     await expect(getPlanNoticeHandler()).resolves.toEqual(
       expect.objectContaining({
-        label: 'Pro trial ended',
+        label: 'Business trial ended',
         ended: true,
         actionLabel: 'Update billing',
       })
@@ -211,7 +211,7 @@ describe('getPlanNotice — the trial countdown', () => {
     hoisted.mockGetWorkspaceSettings.mockResolvedValue({ settings: { cloud: trialing } })
     await expect(getPlanNoticeHandler()).resolves.toEqual(
       expect.objectContaining({
-        label: 'Pro trial ended',
+        label: 'Business trial ended',
         ended: true,
         actionLabel: 'Update billing',
       })

--- a/apps/web/src/lib/server/functions/__tests__/sso-entitlement-gate.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/sso-entitlement-gate.test.ts
@@ -158,7 +158,7 @@ describe('plan gate on a workspace without the SSO entitlement', () => {
       caught = err as EntitlementRequiredError
     }
     expect(caught!.message).toBe(
-      'Single sign-on is a Scale feature. Your workspace is on Free. Upgrade to Scale to enable it.'
+      'Single sign-on is an Enterprise feature. Your workspace is on Free. Upgrade to Enterprise to enable it.'
     )
     expect(caught!.statusCode).toBe(402)
   })
@@ -183,7 +183,7 @@ describe('plan gate on a workspace without the SSO entitlement', () => {
 })
 
 describe('plan gate on a workspace that holds the entitlement', () => {
-  it('allows creating a provider on Scale', async () => {
+  it('allows creating a provider on Enterprise', async () => {
     hoisted.mockGetWorkspaceSettings.mockResolvedValue({
       settings: { id: 'ws_1', cloud: { enabled: true, plan: 'scale' } },
     })

--- a/apps/web/src/lib/server/functions/auth-provider-credentials.ts
+++ b/apps/web/src/lib/server/functions/auth-provider-credentials.ts
@@ -49,7 +49,7 @@ export const saveAuthProviderCredentialsFn = createServerFn({ method: 'POST' })
 
     // Built-in social providers (Google/GitHub/etc.) are operator-level
     // infrastructure for self-hosters and not gated. Only generic-oauth
-    // (the customer's own IdP via custom OIDC) hits the Scale paywall.
+    // (the customer's own IdP via custom OIDC) hits the Enterprise paywall.
     if (provider.type === 'generic-oauth') {
       const { assertTierFeature } = await import('@/lib/server/domains/settings/tier-enforce')
       await assertTierFeature('customOidcProvider', 'Single sign-on (custom OIDC)')

--- a/apps/web/src/lib/server/functions/settings.ts
+++ b/apps/web/src/lib/server/functions/settings.ts
@@ -248,6 +248,8 @@ export const fetchTeamMembersAndInvitations = createServerFn({ method: 'GET' }).
       countSeatUsage(),
       getCloudConfig(),
     ])
+    const { catalogueBilledPer } = await import('@/lib/server/domains/billing/projection-overview')
+    const billedPer = await catalogueBilledPer(cloud.plan)
     const addSeatAvailable =
       cloud.enabled &&
       cloud.canManageBilling &&
@@ -255,7 +257,8 @@ export const fetchTeamMembersAndInvitations = createServerFn({ method: 'GET' }).
       cloud.plan != null &&
       cloud.plan !== 'free' &&
       !cloud.trialActive &&
-      limits.maxTeamSeats != null
+      limits.maxTeamSeats != null &&
+      billedPer === 'seat'
     const seatUsage = {
       used: seats.used,
       members: seats.members,

--- a/apps/web/src/lib/server/functions/settings.ts
+++ b/apps/web/src/lib/server/functions/settings.ts
@@ -248,9 +248,7 @@ export const fetchTeamMembersAndInvitations = createServerFn({ method: 'GET' }).
       countSeatUsage(),
       getCloudConfig(),
     ])
-    const { catalogueBilledPer } = await import('@/lib/server/domains/billing/projection-overview')
-    const billedPer = await catalogueBilledPer(cloud.plan)
-    const addSeatAvailable =
+    const addSeatEligible =
       cloud.enabled &&
       cloud.canManageBilling &&
       auth.permissions.includes(PERMISSIONS.BILLING_MANAGE) &&
@@ -258,7 +256,14 @@ export const fetchTeamMembersAndInvitations = createServerFn({ method: 'GET' }).
       cloud.plan !== 'free' &&
       !cloud.trialActive &&
       limits.maxTeamSeats != null &&
-      billedPer === 'seat'
+      seats.used >= limits.maxTeamSeats
+    let billedPer: 'seat' | 'workspace' | undefined
+    if (addSeatEligible) {
+      const { catalogueBilledPer } =
+        await import('@/lib/server/domains/billing/projection-overview')
+      billedPer = await catalogueBilledPer(cloud.plan)
+    }
+    const addSeatAvailable = addSeatEligible && billedPer === 'seat'
     const seatUsage = {
       used: seats.used,
       members: seats.members,

--- a/apps/web/src/lib/server/mcp/__tests__/mcp-entitlement.test.ts
+++ b/apps/web/src/lib/server/mcp/__tests__/mcp-entitlement.test.ts
@@ -107,14 +107,14 @@ describe('handleMcpRequest — plan gate', () => {
       error: { message: string; data: Record<string, unknown> }
     }
     expect(body.error.message).toBe(
-      'The MCP server is a Growth feature. Your workspace is on Free. Upgrade to Growth to enable it.'
+      'The MCP server is a Pro feature. Your workspace is on Free. Upgrade to Pro to enable it.'
     )
     expect(body.error.data).toMatchObject({
       error: 'entitlement_required',
       entitlement: 'mcpServer',
       currentPlan: 'free',
       requiredPlan: 'growth',
-      requiredPlanName: 'Growth',
+      requiredPlanName: 'Pro',
     })
     // The server was never built, so no tool could run.
     expect(hoisted.mockCreateMcpServer).not.toHaveBeenCalled()

--- a/apps/web/src/lib/server/policy/dep-graph/GRAPH.md
+++ b/apps/web/src/lib/server/policy/dep-graph/GRAPH.md
@@ -57,7 +57,7 @@ Edges (26):
 ## 3. Server domains (lib/server/domains)
 
 Nodes (49): activity, ai, analytics, api, api-keys, assistant, billing, boards, changelog, channel-accounts, channels, comments, companies, company-attributes, conversation, conversation-attributes, conversation-views, embeddings, export, help-center, import, inbox, macros, merge-suggestions, moderation, notifications, office-hours, platform-credentials, post-tags, post-views, posts, principals, push-devices, roadmaps, roles, segments, sentiment, settings, sla, status, statuses, subscriptions, summary, teams, tickets, user-attributes, users, webhooks, workflows
-Edges (115):
+Edges (116):
 
 - analytics -> api
 - analytics -> assistant
@@ -140,6 +140,7 @@ Edges (115):
 - posts -> principals
 - posts -> settings
 - posts -> subscriptions
+- principals -> billing
 - principals -> roles
 - principals -> settings
 - principals -> teams
@@ -179,6 +180,7 @@ Edges (115):
 
 Strongly connected components with more than one domain. A new entry here is a new cycle and needs an explicit decision.
 
+- api <-> api-keys <-> billing <-> principals
 - assistant <-> channel-accounts <-> channels <-> conversation <-> conversation-attributes <-> inbox <-> tickets <-> workflows
 - changelog <-> embeddings <-> merge-suggestions <-> posts <-> subscriptions
 - settings <-> sla

--- a/apps/web/src/lib/shared/__tests__/describe-upgrade.test.ts
+++ b/apps/web/src/lib/shared/__tests__/describe-upgrade.test.ts
@@ -14,9 +14,9 @@ import {
 const catalogue = {
   plans: [
     { id: 'free', name: 'Free', rank: 0, highlights: ['1 seat'] },
-    { id: 'growth', name: 'Growth', rank: 1, highlights: ['Custom domain'] },
-    { id: 'pro', name: 'Pro', rank: 2, highlights: ['Workflows'] },
-    { id: 'scale', name: 'Scale', rank: 3, highlights: ['Audit log', 'SSO'] },
+    { id: 'growth', name: 'Pro', rank: 1, highlights: ['Custom domain'] },
+    { id: 'pro', name: 'Business', rank: 2, highlights: ['Workflows'] },
+    { id: 'scale', name: 'Enterprise', rank: 3, highlights: ['Audit log', 'SSO'] },
   ],
 } as BillingCatalogue
 
@@ -24,13 +24,13 @@ describe('describeEntitlementUpgrade', () => {
   it('names the cheapest catalogue plan for each wired key', () => {
     expect(describeEntitlementUpgrade('auditLog')).toMatchObject({
       requiredPlan: 'scale',
-      requiredPlanName: 'Scale',
-      headline: 'The audit log is available from the Scale plan',
-      body: 'The audit log is a Scale feature. Upgrade to Scale to enable it.',
+      requiredPlanName: 'Enterprise',
+      headline: 'The audit log is available from the Enterprise plan',
+      body: 'The audit log is an Enterprise feature. Upgrade to Enterprise to enable it.',
     })
     expect(describeEntitlementUpgrade('webhooks')).toMatchObject({
-      headline: 'Webhooks are available from the Growth plan',
-      body: 'Webhooks are a Growth feature. Upgrade to Growth to enable them.',
+      headline: 'Webhooks are available from the Pro plan',
+      body: 'Webhooks are a Pro feature. Upgrade to Pro to enable them.',
     })
     expect(describeEntitlementUpgrade('sso').requiredPlan).toBe('scale')
     expect(describeEntitlementUpgrade('customDomain').requiredPlan).toBe('growth')
@@ -46,7 +46,7 @@ describe('isPlanRefusal', () => {
   it('recognizes a 402 and the entitlement sentence', () => {
     expect(isPlanRefusal({ statusCode: 402, message: 'locked' })).toBe(true)
     expect(
-      isPlanRefusal(new Error('Webhooks are a Growth feature. Upgrade to Growth to enable it.'))
+      isPlanRefusal(new Error('Webhooks are a Pro feature. Upgrade to Pro to enable it.'))
     ).toBe(true)
     expect(isPlanRefusal(new Error('boom'))).toBe(false)
     expect(isPlanRefusal(null)).toBe(false)
@@ -82,15 +82,15 @@ describe('describePlanUpgrade', () => {
   it('builds the same sentence shape for a named feature', () => {
     expect(describePlanUpgrade('Data export', 'pro')).toMatchObject({
       requiredPlan: 'pro',
-      headline: 'Data export is available from the Pro plan',
-      body: 'Data export is a Pro feature. Upgrade to Pro to enable it.',
+      headline: 'Data export is available from the Business plan',
+      body: 'Data export is a Business feature. Upgrade to Business to enable it.',
     })
   })
 
   it('takes a plural verb when asked', () => {
     expect(describePlanUpgrade('Integrations', 'pro', { plural: true })).toMatchObject({
-      headline: 'Integrations are available from the Pro plan',
-      body: 'Integrations are a Pro feature. Upgrade to Pro to enable them.',
+      headline: 'Integrations are available from the Business plan',
+      body: 'Integrations are a Business feature. Upgrade to Business to enable them.',
     })
   })
 })
@@ -102,7 +102,7 @@ describe('describePlanRefusal', () => {
     expect(
       describePlanRefusal(
         new Error(
-          'Workflows are a Pro feature. Your workspace is on Growth. Upgrade to Pro to enable it.'
+          'Workflows are a Business feature. Your workspace is on Pro. Upgrade to Business to enable it.'
         ),
         fallback
       )
@@ -118,7 +118,7 @@ describe('describePlanRefusal', () => {
     ).toMatchObject({
       feature: 'Custom CSS',
       requiredPlan: 'pro',
-      headline: 'Custom CSS is available from the Pro plan',
+      headline: 'Custom CSS is available from the Business plan',
     })
   })
 
@@ -130,15 +130,15 @@ describe('describePlanRefusal', () => {
 
 describe('upgradeLead', () => {
   it('names both ends of the move when the current plan is known', () => {
-    expect(upgradeLead('Free', 'Pro')).toBe('Upgrade from Free to Pro to unlock:')
-    expect(upgradeLead(null, 'Pro')).toBe('Upgrade to Pro to unlock:')
-    expect(upgradeLead('Pro', 'Pro')).toBe('Upgrade to Pro to unlock:')
+    expect(upgradeLead('Free', 'Business')).toBe('Upgrade from Free to Business to unlock:')
+    expect(upgradeLead(null, 'Business')).toBe('Upgrade to Business to unlock:')
+    expect(upgradeLead('Business', 'Business')).toBe('Upgrade to Business to unlock:')
     expect(upgradeLead('Free', null)).toBe('Upgrade your plan to unlock:')
   })
 
   it('acknowledges a running trial', () => {
-    expect(upgradeLead('Growth', 'Pro', { trialActive: true })).toBe(
-      "You're trialing Growth. Upgrade to Pro to unlock:"
+    expect(upgradeLead('Pro', 'Business', { trialActive: true })).toBe(
+      "You're trialing Pro. Upgrade to Business to unlock:"
     )
   })
 })
@@ -148,8 +148,8 @@ describe('unlockedHighlights', () => {
     expect(unlockedHighlights(catalogue, 'free', 'scale')).toEqual({
       target: ['Audit log', 'SSO'],
       included: [
-        { planName: 'Growth', highlights: ['Custom domain'] },
-        { planName: 'Pro', highlights: ['Workflows'] },
+        { planName: 'Pro', highlights: ['Custom domain'] },
+        { planName: 'Business', highlights: ['Workflows'] },
       ],
     })
     expect(unlockedHighlights(catalogue, 'growth', 'pro')).toEqual({

--- a/apps/web/src/lib/shared/billing/__tests__/checkout-path.test.ts
+++ b/apps/web/src/lib/shared/billing/__tests__/checkout-path.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
+  annualSavingsCents,
+  annualSavingsLabel,
   annualSavingsPercent,
   checkoutPath,
   checkoutSummary,
@@ -74,5 +76,15 @@ describe('annualSavingsPercent', () => {
     expect(annualSavingsPercent(pro)).toBe(17)
     expect(annualSavingsPercent({ priceMonthlyCents: 1000, priceYearlyCents: 12000 })).toBeNull()
     expect(annualSavingsPercent({ priceMonthlyCents: 0, priceYearlyCents: 0 })).toBeNull()
+  })
+})
+
+describe('annualSavingsLabel', () => {
+  it('quotes the yearly dollar saving and prefers a catalogue amount', () => {
+    expect(annualSavingsCents(pro)).toBe(11800)
+    expect(annualSavingsLabel(pro)).toBe('Save $118/yr')
+    expect(annualSavingsLabel({ ...pro, annualSavingsCents: 9600 })).toBe('Save $96/yr')
+    expect(annualSavingsLabel({ priceMonthlyCents: 1000, priceYearlyCents: 12000 })).toBeNull()
+    expect(annualSavingsLabel(null)).toBeNull()
   })
 })

--- a/apps/web/src/lib/shared/billing/__tests__/plan-action.test.ts
+++ b/apps/web/src/lib/shared/billing/__tests__/plan-action.test.ts
@@ -13,9 +13,9 @@ const unpaidFree: BillingProjectionOverview = {
   canUpgrade: true,
   canManageBilling: false,
   purchasablePlans: [
-    { id: 'growth', name: 'Growth' },
-    { id: 'pro', name: 'Pro' },
-    { id: 'scale', name: 'Scale' },
+    { id: 'growth', name: 'Pro' },
+    { id: 'pro', name: 'Business' },
+    { id: 'scale', name: 'Enterprise' },
   ],
   seats: { used: 1, pending: 0, members: 1, purchased: null },
   ai: null,
@@ -44,7 +44,7 @@ describe('billingPlanAction', () => {
     const trialing: BillingProjectionOverview = {
       ...unpaidFree,
       plan: 'growth',
-      planName: 'Growth',
+      planName: 'Pro',
       trialActive: true,
       trialExpiresAt: '2026-09-01T00:00:00.000Z',
     }
@@ -57,7 +57,7 @@ describe('billingPlanAction', () => {
     const paid: BillingProjectionOverview = {
       ...unpaidFree,
       plan: 'growth',
-      planName: 'Growth',
+      planName: 'Pro',
       status: 'active',
       canUpgrade: false,
       canManageBilling: true,
@@ -72,7 +72,7 @@ describe('billingPlanAction', () => {
     const grant: BillingProjectionOverview = {
       ...unpaidFree,
       plan: 'scale',
-      planName: 'Scale',
+      planName: 'Enterprise',
       status: null,
       canUpgrade: true,
       canManageBilling: false,

--- a/apps/web/src/lib/shared/billing/__tests__/plan-action.test.ts
+++ b/apps/web/src/lib/shared/billing/__tests__/plan-action.test.ts
@@ -87,7 +87,7 @@ describe('billingPlanAction', () => {
       ...unpaidFree,
       trialEnded: true,
       trialPlanId: 'pro',
-      trialPlanName: 'Pro',
+      trialPlanName: 'Business',
       trialExpiresAt: '2026-08-18T00:00:00.000Z',
     }
     expect(billingPlanAction('pro', ended)).toEqual({ kind: 'subscribe', planId: 'pro' })

--- a/apps/web/src/lib/shared/billing/checkout-path.ts
+++ b/apps/web/src/lib/shared/billing/checkout-path.ts
@@ -1,4 +1,5 @@
 import type { BillingCatalogue } from '@/lib/server/control-plane/client'
+import { formatUsd } from '@/lib/shared/format-usd'
 import type { PaidPlanId } from './plan-action'
 
 export const CHECKOUT_PATH = '/admin/settings/billing/checkout'
@@ -79,11 +80,30 @@ export function checkoutSummary(
   }
 }
 
+type PricedPlan = Pick<
+  BillingCatalogue['plans'][number],
+  'priceMonthlyCents' | 'priceYearlyCents'
+> & { annualSavingsCents?: number }
+
 /** Whole-percent saving of paying yearly over twelve monthly payments; null when there is none. */
-export function annualSavingsPercent(
-  plan: Pick<BillingCatalogue['plans'][number], 'priceMonthlyCents' | 'priceYearlyCents'>
-): number | null {
+export function annualSavingsPercent(plan: PricedPlan): number | null {
   const yearOfMonthly = plan.priceMonthlyCents * 12
   if (yearOfMonthly <= 0 || plan.priceYearlyCents >= yearOfMonthly) return null
   return Math.round((1 - plan.priceYearlyCents / yearOfMonthly) * 100)
+}
+
+/** Yearly sticker versus twelve monthly payments. Prefers a catalogue-supplied amount. */
+export function annualSavingsCents(plan: PricedPlan): number {
+  if (typeof plan.annualSavingsCents === 'number' && Number.isFinite(plan.annualSavingsCents)) {
+    return plan.annualSavingsCents
+  }
+  return plan.priceMonthlyCents * 12 - plan.priceYearlyCents
+}
+
+/** Annual-toggle badge. Null when yearly is not cheaper. */
+export function annualSavingsLabel(plan: PricedPlan | null | undefined): string | null {
+  if (!plan) return null
+  const cents = annualSavingsCents(plan)
+  if (cents <= 0) return null
+  return `Save ${formatUsd(cents, 0)}/yr`
 }

--- a/apps/web/src/lib/shared/describe-upgrade.ts
+++ b/apps/web/src/lib/shared/describe-upgrade.ts
@@ -88,8 +88,8 @@ export type UnlockedHighlights = {
 
 /**
  * Everything the workspace gains by moving from `currentPlan` to `requiredPlan`.
- * Catalogue highlights are incremental per plan, so a Free → Pro move also
- * brings Growth's list. Unknown current plan means only the target's list.
+ * Catalogue highlights are incremental per plan, so a Free → Business move also
+ * brings Pro's list. Unknown current plan means only the target's list.
  */
 export function unlockedHighlights(
   catalogue: BillingCatalogue | null | undefined,

--- a/apps/web/src/routes/admin/__tests__/settings.domains.test.tsx
+++ b/apps/web/src/routes/admin/__tests__/settings.domains.test.tsx
@@ -4,7 +4,7 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/components/admin/upgrade', () => ({
-  UpgradeNotice: () => <p>Custom domains are a Growth feature. Upgrade to Growth to enable it.</p>,
+  UpgradeNotice: () => <p>Custom domains are a Pro feature. Upgrade to Pro to enable it.</p>,
 }))
 
 const { DomainsCard, QuackbackUrlCard } = await import('../settings.domains')
@@ -34,7 +34,7 @@ describe('domains card', () => {
         onRemove={vi.fn()}
       />
     )
-    expect(screen.getByText(/Custom domains are a Growth feature/)).toBeInTheDocument()
+    expect(screen.getByText(/Custom domains are a Pro feature/)).toBeInTheDocument()
     expect(screen.queryByLabelText('Hostname')).not.toBeInTheDocument()
   })
 

--- a/apps/web/src/routes/admin/__tests__/settings.integrations.test.tsx
+++ b/apps/web/src/routes/admin/__tests__/settings.integrations.test.tsx
@@ -14,13 +14,13 @@ const { IntegrationsSettingsBody } = await import('../settings.integrations.inde
 describe('integrations settings page', () => {
   it('shows the in-route upgrade screen when integrations are off', () => {
     render(<IntegrationsSettingsBody enabled={false} catalog={[]} integrations={[]} />)
-    expect(screen.getByText(/Integrations are a Pro feature/)).toBeTruthy()
+    expect(screen.getByText(/Integrations are a Business feature/)).toBeTruthy()
     expect(screen.queryByText('integration catalog')).toBeNull()
   })
 
   it('shows the catalog when integrations are on', () => {
     render(<IntegrationsSettingsBody enabled catalog={[]} integrations={[]} />)
     expect(screen.getByText('integration catalog')).toBeTruthy()
-    expect(screen.queryByText(/Integrations are a Pro feature/)).toBeNull()
+    expect(screen.queryByText(/Integrations are a Business feature/)).toBeNull()
   })
 })

--- a/apps/web/src/routes/admin/__tests__/settings.macros.test.tsx
+++ b/apps/web/src/routes/admin/__tests__/settings.macros.test.tsx
@@ -6,7 +6,7 @@ vi.mock('@/components/admin/conversation/macros-manager', () => ({
   MacrosManager: () => <p>macro library</p>,
 }))
 vi.mock('@/components/admin/upgrade', () => ({
-  UpgradeScreen: () => <p>AI drafts are a Growth feature. Upgrade to Growth to enable it.</p>,
+  UpgradeScreen: () => <p>AI drafts are a Pro feature. Upgrade to Pro to enable it.</p>,
 }))
 
 const { MacrosSettingsBody } = await import('../settings.macros')
@@ -14,13 +14,13 @@ const { MacrosSettingsBody } = await import('../settings.macros')
 describe('macros settings page', () => {
   it('shows the in-route upgrade screen when macros are not on the plan', () => {
     render(<MacrosSettingsBody entitled={false} />)
-    expect(screen.getByText(/AI drafts are a Growth feature/)).toBeTruthy()
+    expect(screen.getByText(/AI drafts are a Pro feature/)).toBeTruthy()
     expect(screen.queryByText('macro library')).toBeNull()
   })
 
   it('shows the library when the plan includes macros', () => {
     render(<MacrosSettingsBody entitled />)
     expect(screen.getByText('macro library')).toBeTruthy()
-    expect(screen.queryByText(/AI drafts are a Growth feature/)).toBeNull()
+    expect(screen.queryByText(/AI drafts are a Pro feature/)).toBeNull()
   })
 })

--- a/apps/web/src/routes/admin/settings.billing.tsx
+++ b/apps/web/src/routes/admin/settings.billing.tsx
@@ -14,6 +14,7 @@ import { cn } from '@/lib/shared/utils'
 
 const BILLING_ERROR_COPY: Record<string, string> = {
   seats_below_usage: 'Pick at least as many seats as people you already have.',
+  seat_cap_exceeded: 'Remove extra members or choose Business.',
   over_free_limits: 'Remove anything that is over the Free plan before switching.',
   already_on_plan: 'You are already on this plan.',
   already_on_addon: 'Branding removal is already on this workspace.',

--- a/apps/web/src/routes/admin/settings.security.authentication.tsx
+++ b/apps/web/src/routes/admin/settings.security.authentication.tsx
@@ -34,7 +34,7 @@ export const Route = createFileRoute('/admin/settings/security/authentication')(
     assertRoutePermission(context.permissions, PERMISSIONS.AUTH_MANAGE)
 
     const { queryClient } = context
-    // Auth + SSO reads are cheap and never 402. The audit feed is a Scale
+    // Auth + SSO reads are cheap and never 402. The audit feed is an Enterprise
     // entitlement: prefetching it here took down Portal access and Sign-in
     // on every other plan. The audit tab loads that query only when entitled.
     const { listEntitlementsFn } = await import('@/lib/server/functions/entitlement-status')

--- a/apps/web/src/routes/api/admin/assistant/__tests__/transform-entitlement.test.ts
+++ b/apps/web/src/routes/api/admin/assistant/__tests__/transform-entitlement.test.ts
@@ -86,9 +86,10 @@ function makeRequest(): Request {
   })
 }
 
-const NULL_LIMITS = Object.fromEntries(
-  PROJECTED_LIMIT_KEYS.map((key) => [key, null])
-) as Record<(typeof PROJECTED_LIMIT_KEYS)[number], null>
+const NULL_LIMITS = Object.fromEntries(PROJECTED_LIMIT_KEYS.map((key) => [key, null])) as Record<
+  (typeof PROJECTED_LIMIT_KEYS)[number],
+  null
+>
 
 /**
  * Build the stored cloud block the resolver actually accepts: commercial state
@@ -161,14 +162,14 @@ describe('POST /api/admin/assistant/transform — plan gate', () => {
     }
     expect(body.error.code).toBe('ENTITLEMENT_REQUIRED')
     expect(body.error.message).toBe(
-      'AI drafts are a Growth feature. Your workspace is on Free. Upgrade to Growth to enable it.'
+      'AI drafts are a Pro feature. Your workspace is on Free. Upgrade to Pro to enable it.'
     )
     expect(body.error.details).toMatchObject({
       error: 'entitlement_required',
       entitlement: 'aiDrafts',
       currentPlan: 'free',
       requiredPlan: 'growth',
-      requiredPlanName: 'Growth',
+      requiredPlanName: 'Pro',
     })
     // No model work was started.
     expect(mockRunCopilotTransform).not.toHaveBeenCalled()

--- a/apps/web/src/routes/api/billing/__tests__/session-error.test.ts
+++ b/apps/web/src/routes/api/billing/__tests__/session-error.test.ts
@@ -51,6 +51,12 @@ describe('billingSessionErrorResponse', () => {
     expect(location(res)).toBe('/admin/settings/billing?billing_error=seats_below_usage')
   })
 
+  it('names a checkout that would exceed the target plan seat cap', () => {
+    const res = billingSessionErrorResponse(new Error('seat_cap_exceeded'))
+    expect(res.status).toBe(303)
+    expect(location(res)).toBe('/admin/settings/billing?billing_error=seat_cap_exceeded')
+  })
+
   it('does not leak unknown failure text into the URL', () => {
     const res = billingSessionErrorResponse(new Error('stripe down'))
     expect(res.status).toBe(303)

--- a/apps/web/src/routes/api/billing/session.ts
+++ b/apps/web/src/routes/api/billing/session.ts
@@ -9,6 +9,7 @@ export function billingErrorCode(error: unknown): string {
   if (message === 'already_on_addon') return 'already_on_addon'
   if (message === 'not_on_addon') return 'not_on_addon'
   if (message === 'seats_below_usage') return 'seats_below_usage'
+  if (message === 'seat_cap_exceeded') return 'seat_cap_exceeded'
   if (message === 'over_free_limits') return 'over_free_limits'
   if (message === 'Authentication required') return 'unauthorized'
   if (message === 'Access denied: Not a team member') return 'not_teammate'


### PR DESCRIPTION
## Summary

OSS billing UI for Phase A flat workspace prices. **Slugs stay `growth` / `pro` / `scale`.** Display names: Growth→Pro, Pro→Business, Scale→Enterprise.

- Deleted “Switching plans moves you onto per-seat pricing.”
- Add-a-seat only when catalogue `billedPer === 'seat'` (grandfathered). Otherwise upgrade copy.
- Annual badge is `Save $N/yr`, not “N mo free”. `annualDiscountMonths` is still read, not rendered.
- Trial seats: “3 of 5 seats included with Pro”.
- `seat_cap_exceeded` → “Remove extra members or choose Business.”
- SSO fallback is “an Enterprise feature”.
- Seat dialogs kept behind `billedPer === 'seat'`.

Pair with the CP catalogue + checkout PRs. After merge: cut a release and promote the fleet.

## Test plan

- [ ] Billing page: Pro / Business / Enterprise names, `/mo`, savings badge, no per-seat copy
- [ ] Members invite at cap: Upgrade, not Add a seat
- [ ] Trial: seat meter uses the plan cap
- [ ] Desktop + mobile billing + invite gate
