### PR TITLE
feat(billing): accept business/enterprise as aliases of pro/scale

### DIFF
--- a/apps/web/src/lib/server/control-plane/__tests__/client.test.ts
+++ b/apps/web/src/lib/server/control-plane/__tests__/client.test.ts
@@ -23,6 +23,8 @@ import {
   reportWorkspaceUsage,
   requestWorkspaceIdentityMutation,
   createHostedBillingSession,
+  normalizeBillingCatalogue,
+  startWorkspaceTrial,
 } from '../client'
 
 beforeEach(() => {
@@ -97,6 +99,71 @@ describe('workspace control-plane credential', () => {
     expect(String(url)).toContain('/api/v1/internal/billing/catalogue')
     expect(init.method).toBe('GET')
     expect(init.body).toBeUndefined()
+  })
+
+  it('normalises business/enterprise catalogue slugs to pro/scale', () => {
+    const normalised = normalizeBillingCatalogue({
+      version: 1,
+      currency: 'usd',
+      annualDiscountMonths: 2,
+      recommendedPlanId: 'business',
+      brandingRemoval: { monthlyCents: 5900, annualCents: 59000 },
+      lastTrialPlanId: 'enterprise',
+      trialedPlanIds: ['business', 'pro'],
+      aiIncludedCentsPerMonth: { business: 3000, enterprise: 10000 },
+      plans: [
+        {
+          id: 'business',
+          name: 'Business',
+          rank: 2,
+          priceMonthlyCents: 7500,
+          priceYearlyCents: 70800,
+          billedPer: 'workspace',
+          bestFor: 'Growing teams',
+          highlights: [],
+          recommended: false,
+        },
+        {
+          id: 'enterprise',
+          name: 'Enterprise',
+          rank: 3,
+          priceMonthlyCents: 12900,
+          priceYearlyCents: 118800,
+          billedPer: 'workspace',
+          bestFor: 'Security',
+          highlights: [],
+          recommended: false,
+        },
+      ],
+    })
+    expect(normalised.recommendedPlanId).toBe('pro')
+    expect(normalised.lastTrialPlanId).toBe('scale')
+    expect(normalised.trialedPlanIds).toEqual(['pro'])
+    expect(normalised.aiIncludedCentsPerMonth).toEqual({ pro: 3000, scale: 10000 })
+    expect(normalised.plans.map((plan) => plan.id)).toEqual(['pro', 'scale'])
+  })
+
+  it('forwards checkout and trial aliases as canonical plan ids', async () => {
+    hoisted.fetch.mockResolvedValue(
+      new Response(JSON.stringify({ url: 'https://billing.example.com/checkout' }), { status: 200 })
+    )
+    await createHostedBillingSession({
+      action: 'checkout',
+      planId: 'enterprise',
+      billingPeriod: 'annual',
+    })
+    const [, checkoutInit] = hoisted.fetch.mock.calls[0] as [URL, RequestInit]
+    expect(JSON.parse(String(checkoutInit.body))).toMatchObject({
+      action: 'checkout',
+      planId: 'scale',
+    })
+
+    hoisted.fetch.mockResolvedValue(
+      new Response(JSON.stringify({ status: 'started' }), { status: 200 })
+    )
+    await startWorkspaceTrial('business')
+    const [, trialInit] = hoisted.fetch.mock.calls[1] as [URL, RequestInit]
+    expect(JSON.parse(String(trialInit.body))).toEqual({ planId: 'pro' })
   })
 
   it('lists owner workspaces over GET without a workspace id', async () => {

--- a/apps/web/src/lib/server/control-plane/client.ts
+++ b/apps/web/src/lib/server/control-plane/client.ts
@@ -1,4 +1,5 @@
 import { createHmac } from 'node:crypto'
+import { canonicalPlanId, isPlanId } from '@/lib/server/domains/settings/cloud/cloud.types'
 import {
   getCurrentWorkspace,
   getWorkspaceSecretKey,
@@ -127,7 +128,10 @@ async function requestWorkspaceControlPlane<T>(
 }
 
 export async function fetchBillingCatalogue(): Promise<BillingCatalogue> {
-  return getWorkspaceControlPlane<BillingCatalogue>('/api/v1/internal/billing/catalogue')
+  const catalogue = await getWorkspaceControlPlane<BillingCatalogue>(
+    '/api/v1/internal/billing/catalogue'
+  )
+  return normalizeBillingCatalogue(catalogue)
 }
 
 export async function fetchBillingInvoices(): Promise<CustomerInvoice[]> {
@@ -137,13 +141,16 @@ export async function fetchBillingInvoices(): Promise<CustomerInvoice[]> {
   return Array.isArray(result.invoices) ? result.invoices : []
 }
 
-export type CataloguePlanId = 'free' | 'growth' | 'pro' | 'scale'
+export type CanonicalCataloguePlanId = 'free' | 'growth' | 'pro' | 'scale'
+/** Incoming CP slugs; aliases are normalised to {@link CanonicalCataloguePlanId} on fetch. */
+export type CataloguePlanId = CanonicalCataloguePlanId | 'business' | 'enterprise'
+export type PaidCataloguePlanId = Exclude<CataloguePlanId, 'free'>
 
 export type BillingCatalogue = {
   version: 1
   currency: 'usd'
   annualDiscountMonths: number
-  recommendedPlanId: 'growth' | 'pro' | 'scale'
+  recommendedPlanId: PaidCataloguePlanId
   /** @deprecated unread; older catalogues may still send this. */
   aiOutcomePriceCents?: number
   /** @deprecated unread; older catalogues may still send this. */
@@ -173,8 +180,52 @@ export type BillingCatalogue = {
     recommended: boolean
   }>
   trialDays?: number
-  trialedPlanIds?: Array<'growth' | 'pro' | 'scale'>
-  lastTrialPlanId?: 'growth' | 'pro' | 'scale' | null
+  trialedPlanIds?: PaidCataloguePlanId[]
+  lastTrialPlanId?: PaidCataloguePlanId | null
+}
+
+function canonicalCataloguePlanId(id: string): CataloguePlanId {
+  const canonical = canonicalPlanId(id)
+  return isPlanId(canonical) ? canonical : (id as CataloguePlanId)
+}
+
+function remapPlanKeyedRecord<T>(
+  record: Partial<Record<CataloguePlanId, T>> | undefined
+): Partial<Record<CataloguePlanId, T>> | undefined {
+  if (!record) return record
+  const next: Partial<Record<CataloguePlanId, T>> = {}
+  for (const [key, value] of Object.entries(record)) {
+    next[canonicalCataloguePlanId(key)] = value as T
+  }
+  return next
+}
+
+/** Maps `business`/`enterprise` onto stored `pro`/`scale` without dropping the payload. */
+export function normalizeBillingCatalogue(catalogue: BillingCatalogue): BillingCatalogue {
+  return {
+    ...catalogue,
+    recommendedPlanId: canonicalCataloguePlanId(catalogue.recommendedPlanId) as PaidCataloguePlanId,
+    lastTrialPlanId:
+      catalogue.lastTrialPlanId == null
+        ? catalogue.lastTrialPlanId
+        : (canonicalCataloguePlanId(catalogue.lastTrialPlanId) as PaidCataloguePlanId),
+    trialedPlanIds: catalogue.trialedPlanIds
+      ? [
+          ...new Set(
+            catalogue.trialedPlanIds.map(
+              (id) => canonicalCataloguePlanId(id) as PaidCataloguePlanId
+            )
+          ),
+        ]
+      : undefined,
+    plans: catalogue.plans.map((plan) => ({
+      ...plan,
+      id: canonicalCataloguePlanId(plan.id),
+    })),
+    liteSeatsIncluded: remapPlanKeyedRecord(catalogue.liteSeatsIncluded) as
+      Record<CataloguePlanId, number | null> | undefined,
+    aiIncludedCentsPerMonth: remapPlanKeyedRecord(catalogue.aiIncludedCentsPerMonth),
+  }
 }
 
 export type CustomerInvoice = {
@@ -191,7 +242,7 @@ export type HostedBillingSessionInput =
   | { action: 'portal' }
   | {
       action: 'checkout'
-      planId: 'growth' | 'pro' | 'scale'
+      planId: PaidCataloguePlanId
       billingPeriod: 'monthly' | 'annual'
       quantity?: number
       /** Bundle branding removal into the same subscription and checkout. */
@@ -208,12 +259,19 @@ export type HostedBillingSessionResult = {
   status?: 'downgraded' | 'scheduled' | 'updated'
 }
 
+function canonicalizeSessionInput(input: HostedBillingSessionInput): HostedBillingSessionInput {
+  if (input.action !== 'checkout') return input
+  const planId = canonicalCataloguePlanId(input.planId)
+  return { ...input, planId: planId as PaidCataloguePlanId }
+}
+
 export async function createHostedBillingSession(
   input: HostedBillingSessionInput
 ): Promise<HostedBillingSessionResult> {
+  const payload = canonicalizeSessionInput(input)
   const result = await callWorkspaceControlPlane<{ url?: unknown; status?: unknown }>(
     '/api/v1/internal/billing/session',
-    input
+    payload
   )
   if (typeof result.url === 'string' && result.url.startsWith('https://')) {
     return { url: result.url }
@@ -276,11 +334,11 @@ export async function reportWorkspaceUsage(report: WorkspaceUsageReport): Promis
 }
 
 export async function startWorkspaceTrial(
-  planId: 'growth' | 'pro' | 'scale'
+  planId: PaidCataloguePlanId
 ): Promise<'started' | 'already_started'> {
   const result = await callWorkspaceControlPlane<{ status?: unknown }>(
     '/api/v1/internal/billing/start-trial',
-    { planId }
+    { planId: canonicalCataloguePlanId(planId) }
   )
   if (result.status !== 'started' && result.status !== 'already_started') {
     throw new ControlPlaneUnavailableError()

--- a/apps/web/src/lib/server/domains/billing/projection-overview.ts
+++ b/apps/web/src/lib/server/domains/billing/projection-overview.ts
@@ -1,5 +1,10 @@
 import { getCloudConfig } from '@/lib/server/domains/settings/cloud/cloud.service'
-import { PLAN_CATALOGUE, type PlanId } from '@/lib/server/domains/settings/cloud/cloud.types'
+import {
+  PLAN_CATALOGUE,
+  canonicalPlanId,
+  isPlanId,
+  type PlanId,
+} from '@/lib/server/domains/settings/cloud/cloud.types'
 import type { BillingCatalogue, CataloguePlanId } from '@/lib/server/control-plane/client'
 import { isTrialEnded } from '@/lib/shared/billing/trial-state'
 
@@ -55,7 +60,7 @@ export function catalogueAiIncludedCents(
   catalogue: BillingCatalogue | null,
   plan: PlanId
 ): number | null {
-  const value = catalogue?.aiIncludedCentsPerMonth?.[plan as CataloguePlanId]
+  const value = catalogue?.aiIncludedCentsPerMonth?.[canonicalPlanId(plan) as CataloguePlanId]
   return typeof value === 'number' && Number.isFinite(value) ? value : null
 }
 
@@ -115,7 +120,9 @@ export async function getBillingProjectionOverview(): Promise<BillingProjectionO
     projectedPlanLimitsMaxTeamSeats(),
   ])
 
-  const billedPer = catalogue?.plans.find((plan) => plan.id === cloud.plan)?.billedPer
+  const billedPer = catalogue?.plans.find(
+    (plan) => canonicalPlanId(plan.id) === cloud.plan
+  )?.billedPer
   const purchased = purchasedSeatsFromProjection({
     billedPer,
     plan: cloud.plan,
@@ -140,7 +147,8 @@ export async function getBillingProjectionOverview(): Promise<BillingProjectionO
     trialExpiresAt: cloud.trialExpiresAt,
     status: cloud.subscriptionStatus,
   })
-  const lastTrialPlanId = catalogue?.lastTrialPlanId ?? null
+  const lastRaw = catalogue?.lastTrialPlanId ? canonicalPlanId(catalogue.lastTrialPlanId) : null
+  const lastTrialPlanId = lastRaw && lastRaw !== 'free' && isPlanId(lastRaw) ? lastRaw : null
   const trialPlanId = trialPlanIdForOverview({
     trialActive: cloud.trialActive,
     trialEnded,
@@ -182,7 +190,7 @@ export async function catalogueBilledPer(
 ): Promise<'seat' | 'workspace' | undefined> {
   if (!planId) return undefined
   const catalogue = await loadCatalogue()
-  return catalogue?.plans.find((plan) => plan.id === planId)?.billedPer
+  return catalogue?.plans.find((plan) => canonicalPlanId(plan.id) === planId)?.billedPer
 }
 
 async function loadCatalogue(): Promise<BillingCatalogue | null> {

--- a/apps/web/src/lib/server/domains/settings/__tests__/tier-limits.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/tier-limits.test.ts
@@ -194,8 +194,19 @@ describe('projected numeric limits', () => {
   })
 
   it('rejects unrecognised plans and non-canonical dates', () => {
-    expect(parseBillingProjection({ ...PROJECTION, effectivePlan: 'enterprise' })).toBeNull()
+    expect(parseBillingProjection({ ...PROJECTION, effectivePlan: 'platinum' })).toBeNull()
     expect(parseBillingProjection({ ...PROJECTION, trialExpiresAt: 'August 15' })).toBeNull()
+  })
+
+  it('normalises business/enterprise projection slugs to pro/scale', () => {
+    expect(parseBillingProjection({ ...PROJECTION, effectivePlan: 'business' })).toEqual({
+      ...PROJECTION,
+      effectivePlan: 'pro',
+    })
+    expect(parseBillingProjection({ ...PROJECTION, effectivePlan: 'enterprise' })).toEqual({
+      ...PROJECTION,
+      effectivePlan: 'scale',
+    })
   })
 
   it('ignores unknown entitlement keys so a newer control plane cannot drop the projection', () => {
@@ -231,6 +242,23 @@ describe('resolveEffectiveTierLimits (cloud, no operator row)', () => {
     expect(effective.features.customColors).toBe(true)
     expect(effective.features.customCss).toBe(true)
     expect(effective.features.integrations).toBe(true)
+  })
+
+  it('keeps Business/Enterprise aliases on the same PLAN_ONLY_FEATURES as pro/scale', () => {
+    const business = parseBillingProjection({ ...PROJECTION, effectivePlan: 'business' })
+    const enterprise = parseBillingProjection({ ...PROJECTION, effectivePlan: 'enterprise' })
+    expect(business).not.toBeNull()
+    expect(enterprise).not.toBeNull()
+    const fromBusiness = resolveEffectiveTierLimits(null, business, beforeExpiry)
+    const fromPro = resolveEffectiveTierLimits(null, PROJECTION, beforeExpiry)
+    const fromEnterprise = resolveEffectiveTierLimits(null, enterprise, beforeExpiry)
+    const fromScale = resolveEffectiveTierLimits(
+      null,
+      { ...PROJECTION, effectivePlan: 'scale' },
+      beforeExpiry
+    )
+    expect(fromBusiness.features).toEqual(fromPro.features)
+    expect(fromEnterprise.features).toEqual(fromScale.features)
   })
 
   it('keeps Growth feature flags closed for keys that are not entitlements', () => {

--- a/apps/web/src/lib/server/domains/settings/cloud/__tests__/billing-projection.test.ts
+++ b/apps/web/src/lib/server/domains/settings/cloud/__tests__/billing-projection.test.ts
@@ -130,6 +130,24 @@ describe('projected commercial state', () => {
     })
   })
 
+  it('does not drop a projection whose effectivePlan is a business/enterprise alias', () => {
+    const cloud = resolveCloudConfig(
+      { enabled: true, projection: { ...PROJECTION, effectivePlan: 'business' } },
+      new Date('2026-08-14T23:59:59.999Z')
+    )
+    expect(cloud).toMatchObject({
+      enabled: true,
+      plan: 'pro',
+      entitlements: { customDomain: true },
+    })
+    expect(
+      resolveCloudConfig(
+        { enabled: true, projection: { ...PROJECTION, effectivePlan: 'enterprise' } },
+        new Date('2026-08-14T23:59:59.999Z')
+      ).plan
+    ).toBe('scale')
+  })
+
   it('falls back to Free at the exact projected expiry instant', () => {
     const before = resolveCloudConfig(
       { enabled: true, projection: PROJECTION },

--- a/apps/web/src/lib/server/domains/settings/cloud/__tests__/plan-catalogue.test.ts
+++ b/apps/web/src/lib/server/domains/settings/cloud/__tests__/plan-catalogue.test.ts
@@ -24,7 +24,10 @@ import {
   ENTITLEMENT_KEYS,
   PLAN_CATALOGUE,
   PLAN_DEFINITIONS,
+  PLAN_ID_ALIASES,
   PLAN_IDS,
+  canonicalPlanId,
+  isPlanId,
   minimumPlanFor,
   type CloudConfig,
   type EntitlementKey,
@@ -83,6 +86,25 @@ describe('the plan ladder', () => {
     expect(
       PLAN_IDS.map((id) => `${PLAN_CATALOGUE[id].article} ${PLAN_CATALOGUE[id].name} plan`)
     ).toEqual(['a Free plan', 'a Pro plan', 'a Business plan', 'an Enterprise plan'])
+  })
+
+  it('maps business/enterprise onto pro/scale without adding catalogue rows', () => {
+    expect(PLAN_ID_ALIASES).toEqual({ business: 'pro', enterprise: 'scale' })
+    expect(canonicalPlanId('business')).toBe('pro')
+    expect(canonicalPlanId('enterprise')).toBe('scale')
+    expect(canonicalPlanId('pro')).toBe('pro')
+    expect(canonicalPlanId('scale')).toBe('scale')
+    expect(isPlanId('business')).toBe(false)
+    expect(isPlanId('enterprise')).toBe(false)
+    expect(PLAN_CATALOGUE[canonicalPlanId('business')]).toEqual(PLAN_CATALOGUE.pro)
+    expect(PLAN_CATALOGUE[canonicalPlanId('enterprise')]).toEqual(PLAN_CATALOGUE.scale)
+    expect(PLAN_CATALOGUE[canonicalPlanId('business')].name).toBe('Business')
+    expect(PLAN_CATALOGUE[canonicalPlanId('enterprise')]).toMatchObject({
+      name: 'Enterprise',
+      article: 'an',
+      rank: PLAN_CATALOGUE.scale.rank,
+      grants: PLAN_CATALOGUE.scale.grants,
+    })
   })
 })
 

--- a/apps/web/src/lib/server/domains/settings/cloud/billing-projection.ts
+++ b/apps/web/src/lib/server/domains/settings/cloud/billing-projection.ts
@@ -3,6 +3,7 @@ import {
   BILLING_STATUSES,
   ENTITLEMENT_KEYS,
   PLAN_IDS,
+  canonicalPlanId,
   type BillingStatus,
   type PlanId,
 } from './cloud.types'
@@ -112,9 +113,9 @@ export function parseBillingProjection(value: unknown): BillingProjection | null
     return null
   }
   if (!Number.isSafeInteger(projection.version) || Number(projection.version) < 1) return null
-  if (typeof projection.effectivePlan !== 'string' || !PLAN_IDS_SET.has(projection.effectivePlan)) {
-    return null
-  }
+  if (typeof projection.effectivePlan !== 'string') return null
+  const effectivePlan = canonicalPlanId(projection.effectivePlan)
+  if (!PLAN_IDS_SET.has(effectivePlan)) return null
   if (
     !isNullableIsoDate(projection.trialStartedAt) ||
     !isNullableIsoDate(projection.trialExpiresAt) ||
@@ -141,7 +142,7 @@ export function parseBillingProjection(value: unknown): BillingProjection | null
   ) {
     return null
   }
-  return { ...projection, entitlements, freeLimits, planLimits } as BillingProjection
+  return { ...projection, effectivePlan, entitlements, freeLimits, planLimits } as BillingProjection
 }
 
 /** Preserve unlimited or higher operator limits while raising lower plan limits. */

--- a/apps/web/src/lib/server/domains/settings/cloud/cloud.types.ts
+++ b/apps/web/src/lib/server/domains/settings/cloud/cloud.types.ts
@@ -15,10 +15,33 @@ import type { TierFeatureFlags } from '../tier-limits.types'
  * derive what it grants. A free-form string can do none of those. Operators who
  * need a bespoke arrangement express it as explicit entitlement overrides on
  * top of a catalogue plan, not as a new plan id.
+ *
+ * Stored and projected ids stay `growth` / `pro` / `scale` until later remap
+ * steps. Incoming CP/checkout slugs `business` and `enterprise` are aliases of
+ * today's `pro` (Business) and `scale` (Enterprise); {@link canonicalPlanId}
+ * maps them before catalogue lookup or storage.
  */
 export const PLAN_IDS = ['free', 'growth', 'pro', 'scale'] as const
 
 export type PlanId = (typeof PLAN_IDS)[number]
+
+/** Incoming slugs that mean a canonical {@link PlanId} until later B steps. */
+export const PLAN_ID_ALIASES = {
+  business: 'pro',
+  enterprise: 'scale',
+} as const satisfies Record<string, PlanId>
+
+export type PlanIdAlias = keyof typeof PLAN_ID_ALIASES
+
+/**
+ * Maps incoming CP/checkout slugs onto stored catalogue ids.
+ * Unknown strings are returned as-is; {@link isPlanId} is the closed-set guard.
+ */
+export function canonicalPlanId(id: string): PlanId {
+  if (id === 'business') return 'pro'
+  if (id === 'enterprise') return 'scale'
+  return id as PlanId
+}
 
 export interface PlanDefinition {
   id: PlanId

--- a/apps/web/src/lib/server/domains/settings/index.ts
+++ b/apps/web/src/lib/server/domains/settings/index.ts
@@ -74,12 +74,14 @@ export type {
   CloudConfig,
   BillingStatus,
   PlanId,
+  PlanIdAlias,
   PlanDefinition,
   EntitlementKey,
   EntitlementDefinition,
 } from './cloud/cloud.types'
 export {
   PLAN_IDS,
+  PLAN_ID_ALIASES,
   PLAN_CATALOGUE,
   PLAN_DEFINITIONS,
   ENTITLEMENTS,
@@ -87,5 +89,6 @@ export {
   DISABLED_CLOUD_CONFIG,
   minimumPlanFor,
   isPlanId,
+  canonicalPlanId,
   isEntitlementKey,
 } from './cloud/cloud.types'

--- a/apps/web/src/lib/server/domains/settings/tier-limits.service.ts
+++ b/apps/web/src/lib/server/domains/settings/tier-limits.service.ts
@@ -7,7 +7,7 @@ import {
   type BillingProjection,
   type ProjectedLimits,
 } from './cloud/billing-projection'
-import type { PlanId } from './cloud/cloud.types'
+import { canonicalPlanId, isPlanId, type PlanId } from './cloud/cloud.types'
 
 type StoredTierLimits = Partial<Omit<TierLimits, 'features'>> & {
   features?: Partial<TierLimits['features']>
@@ -94,7 +94,8 @@ function featuresFromProjection(projection: BillingProjection, now: Date): TierL
     projection.planLimitsExpireAt !== null &&
     now.getTime() >= Date.parse(projection.planLimitsExpireAt)
   const entitlements = expired ? {} : projection.entitlements
-  const planId: PlanId = expired ? 'free' : projection.effectivePlan
+  const resolved = expired ? 'free' : canonicalPlanId(projection.effectivePlan)
+  const planId: PlanId = isPlanId(resolved) ? resolved : 'free'
   return {
     ...CLOSED_CLOUD_FEATURES,
     ...PLAN_ONLY_FEATURES[planId],

--- a/apps/web/src/lib/server/functions/plan-notice.ts
+++ b/apps/web/src/lib/server/functions/plan-notice.ts
@@ -36,10 +36,11 @@ export const getPlanNotice = createServerFn({ method: 'GET' }).handler(
 
     try {
       const { fetchBillingCatalogue } = await import('@/lib/server/control-plane/client')
-      const { PLAN_CATALOGUE } = await import('@/lib/server/domains/settings/cloud/cloud.types')
+      const { PLAN_CATALOGUE, canonicalPlanId, isPlanId } =
+        await import('@/lib/server/domains/settings/cloud/cloud.types')
       const catalogue = await fetchBillingCatalogue()
-      const last = catalogue.lastTrialPlanId
-      if (last && last in PLAN_CATALOGUE) {
+      const last = catalogue.lastTrialPlanId ? canonicalPlanId(catalogue.lastTrialPlanId) : null
+      if (last && isPlanId(last) && last in PLAN_CATALOGUE) {
         return trialEndedNotice(cloud, { trialPlanName: PLAN_CATALOGUE[last].name })
       }
     } catch {

--- a/apps/web/src/lib/shared/billing/__tests__/checkout-path.test.ts
+++ b/apps/web/src/lib/shared/billing/__tests__/checkout-path.test.ts
@@ -6,6 +6,7 @@ import {
   checkoutPath,
   checkoutSummary,
   parseCheckoutSearch,
+  parsePaidPlanId,
 } from '../checkout-path'
 
 const pro = { priceMonthlyCents: 5900, priceYearlyCents: 59000, billedPer: 'seat' as const }
@@ -14,6 +15,12 @@ describe('checkoutPath', () => {
   it('encodes only what was given', () => {
     expect(checkoutPath()).toBe('/admin/settings/billing/checkout')
     expect(checkoutPath({ plan: 'pro' })).toBe('/admin/settings/billing/checkout?plan=pro')
+    expect(parsePaidPlanId('business')).toBe('pro')
+    expect(parsePaidPlanId('enterprise')).toBe('scale')
+    expect(parsePaidPlanId('growth')).toBe('growth')
+    expect(checkoutPath({ plan: parsePaidPlanId('business') ?? 'pro' })).toBe(
+      '/admin/settings/billing/checkout?plan=pro'
+    )
     expect(checkoutPath({ plan: 'pro', period: 'monthly', seats: 3 })).toBe(
       '/admin/settings/billing/checkout?plan=pro&period=monthly&seats=3'
     )
@@ -39,7 +46,9 @@ describe('parseCheckoutSearch', () => {
     expect(parseCheckoutSearch({ plan: 'free', period: 'weekly', seats: '0' })).toEqual({})
     expect(parseCheckoutSearch({ branding: 'false' })).toEqual({})
     expect(parseCheckoutSearch({ branding: 'yes' })).toEqual({})
-    expect(parseCheckoutSearch({ plan: 'enterprise', seats: 'lots' })).toEqual({})
+    expect(parseCheckoutSearch({ plan: 'platinum', seats: 'lots' })).toEqual({})
+    expect(parseCheckoutSearch({ plan: 'enterprise' })).toEqual({ plan: 'scale' })
+    expect(parseCheckoutSearch({ plan: 'business' })).toEqual({ plan: 'pro' })
     expect(parseCheckoutSearch({ seats: 2.5 })).toEqual({})
     expect(parseCheckoutSearch({ seats: '1001' })).toEqual({ seats: 1001 })
   })

--- a/apps/web/src/lib/shared/billing/__tests__/plan-action.test.ts
+++ b/apps/web/src/lib/shared/billing/__tests__/plan-action.test.ts
@@ -101,4 +101,11 @@ describe('billingPlanAction', () => {
       expect(billingPlanAction(id, unpaidFree).kind).toBeTruthy()
     }
   })
+
+  it('treats business/enterprise as the current pro/scale actions', () => {
+    expect(billingPlanAction('business', unpaidFree)).toEqual(billingPlanAction('pro', unpaidFree))
+    expect(billingPlanAction('enterprise', unpaidFree)).toEqual(
+      billingPlanAction('scale', unpaidFree)
+    )
+  })
 })

--- a/apps/web/src/lib/shared/billing/checkout-flash.ts
+++ b/apps/web/src/lib/shared/billing/checkout-flash.ts
@@ -1,5 +1,6 @@
 import type { BillingCatalogue } from '@/lib/server/control-plane/client'
 import type { BillingProjectionOverview } from '@/lib/server/domains/billing/projection-overview'
+import { canonicalPlanId } from '@/lib/server/domains/settings/cloud/cloud.types'
 
 export function checkoutSuccessCopy(
   overview: BillingProjectionOverview | null | undefined,
@@ -11,7 +12,7 @@ export function checkoutSuccessCopy(
       body: 'Your plan, seats, and invoices are on this page. You can change them any time.',
     }
   }
-  const plan = catalogue?.plans.find((entry) => entry.id === overview.plan)
+  const plan = catalogue?.plans.find((entry) => canonicalPlanId(entry.id) === overview.plan)
   const seats = overview.seats?.purchased ?? overview.seats?.used ?? 0
   const bits = [`You're on ${overview.planName}`]
   if (plan?.billedPer === 'seat' && seats > 0) {

--- a/apps/web/src/lib/shared/billing/checkout-path.ts
+++ b/apps/web/src/lib/shared/billing/checkout-path.ts
@@ -1,4 +1,5 @@
 import type { BillingCatalogue } from '@/lib/server/control-plane/client'
+import { canonicalPlanId } from '@/lib/server/domains/settings/cloud/cloud.types'
 import { formatUsd } from '@/lib/shared/format-usd'
 import type { PaidPlanId } from './plan-action'
 
@@ -16,14 +17,25 @@ export type CheckoutSearch = {
 
 const PAID_PLAN_IDS: readonly PaidPlanId[] = ['growth', 'pro', 'scale']
 
+/** Checkout/trial forms accept these; aliases are stored and forwarded as canonical ids. */
+export const INCOMING_PAID_PLAN_IDS = ['growth', 'pro', 'scale', 'business', 'enterprise'] as const
+
 export function isPaidPlanId(value: unknown): value is PaidPlanId {
   return typeof value === 'string' && (PAID_PLAN_IDS as readonly string[]).includes(value)
+}
+
+/** Accepts `business`/`enterprise` and returns the canonical paid id, or null. */
+export function parsePaidPlanId(value: unknown): PaidPlanId | null {
+  if (typeof value !== 'string') return null
+  const canonical = canonicalPlanId(value)
+  return isPaidPlanId(canonical) ? canonical : null
 }
 
 /** Tolerant: an unknown or malformed value is dropped rather than failing the route. */
 export function parseCheckoutSearch(raw: Record<string, unknown>): CheckoutSearch {
   const search: CheckoutSearch = {}
-  if (isPaidPlanId(raw.plan)) search.plan = raw.plan
+  const plan = parsePaidPlanId(raw.plan)
+  if (plan) search.plan = plan
   if (raw.period === 'monthly' || raw.period === 'annual') search.period = raw.period
   const seats = typeof raw.seats === 'string' ? Number(raw.seats) : raw.seats
   // Same bound as the checkout API (any positive integer): a workspace already
@@ -38,7 +50,7 @@ export function parseCheckoutSearch(raw: Record<string, unknown>): CheckoutSearc
 /** Deep link into the configurator with a plan (and optionally period / seats / add-on) preselected. */
 export function checkoutPath(search: CheckoutSearch = {}): string {
   const params = new URLSearchParams()
-  if (search.plan) params.set('plan', search.plan)
+  if (search.plan) params.set('plan', parsePaidPlanId(search.plan) ?? search.plan)
   if (search.period) params.set('period', search.period)
   if (search.seats != null) params.set('seats', String(search.seats))
   if (search.branding) params.set('branding', 'true')

--- a/apps/web/src/lib/shared/billing/plan-action.ts
+++ b/apps/web/src/lib/shared/billing/plan-action.ts
@@ -1,8 +1,9 @@
 import type { BillingProjectionOverview } from '@/lib/server/domains/billing/projection-overview'
 import type { BillingCatalogue } from '@/lib/server/control-plane/client'
+import { canonicalPlanId, type PlanIdAlias } from '@/lib/server/domains/settings/cloud/cloud.types'
 
 export type PaidPlanId = 'growth' | 'pro' | 'scale'
-export type CataloguePlanId = 'free' | PaidPlanId
+export type CataloguePlanId = 'free' | PaidPlanId | PlanIdAlias
 
 export type BillingPlanAction =
   | { kind: 'current' }
@@ -13,7 +14,8 @@ export type BillingPlanAction =
   | { kind: 'unavailable' }
 
 function isPaidPlanId(id: string): id is PaidPlanId {
-  return id === 'growth' || id === 'pro' || id === 'scale'
+  const canonical = canonicalPlanId(id)
+  return canonical === 'growth' || canonical === 'pro' || canonical === 'scale'
 }
 
 function hasLivePaidSub(overview: BillingProjectionOverview): boolean {
@@ -25,35 +27,36 @@ export function billingPlanAction(
   overview: BillingProjectionOverview,
   trialedPlanIds: readonly string[] = []
 ): BillingPlanAction {
+  const id = canonicalPlanId(planId)
   const canAct = overview.canUpgrade || overview.canManageBilling
   if (overview.trialEnded && overview.trialPlanId) {
     if (!canAct) return { kind: 'unavailable' }
-    if (planId === 'free') return { kind: 'downgrade' }
-    if (isPaidPlanId(planId)) return { kind: 'subscribe', planId }
+    if (id === 'free') return { kind: 'downgrade' }
+    if (isPaidPlanId(id)) return { kind: 'subscribe', planId: id }
     return { kind: 'unavailable' }
   }
-  if (overview.plan === planId) return { kind: 'current' }
+  if (overview.plan === id) return { kind: 'current' }
   if (!canAct) return { kind: 'unavailable' }
 
-  if (planId === 'free') {
+  if (id === 'free') {
     if (overview.trialActive || hasLivePaidSub(overview)) return { kind: 'downgrade' }
     return { kind: 'unavailable' }
   }
 
-  if (!isPaidPlanId(planId)) return { kind: 'unavailable' }
+  if (!isPaidPlanId(id)) return { kind: 'unavailable' }
 
-  if (hasLivePaidSub(overview)) return { kind: 'switch', planId }
+  if (hasLivePaidSub(overview)) return { kind: 'switch', planId: id }
 
   // Complimentary grant: convert via checkout, never a second product trial.
   if (overview.plan !== 'free' && !overview.trialActive) {
-    return { kind: 'subscribe', planId }
+    return { kind: 'subscribe', planId: id }
   }
 
-  const alreadyTrialed = trialedPlanIds.includes(planId)
+  const alreadyTrialed = trialedPlanIds.map(canonicalPlanId).includes(id)
   if (!alreadyTrialed && !overview.trialActive && overview.canUpgrade) {
-    return { kind: 'trial', planId }
+    return { kind: 'trial', planId: id }
   }
-  return { kind: 'subscribe', planId }
+  return { kind: 'subscribe', planId: id }
 }
 
 export function catalogueTrialDays(catalogue: BillingCatalogue | null): number {
@@ -61,5 +64,10 @@ export function catalogueTrialDays(catalogue: BillingCatalogue | null): number {
 }
 
 export function catalogueTrialedPlanIds(catalogue: BillingCatalogue | null): PaidPlanId[] {
-  return (catalogue?.trialedPlanIds ?? []).filter(isPaidPlanId)
+  const seen = new Set<PaidPlanId>()
+  for (const id of catalogue?.trialedPlanIds ?? []) {
+    const canonical = canonicalPlanId(id)
+    if (isPaidPlanId(canonical)) seen.add(canonical)
+  }
+  return [...seen]
 }

--- a/apps/web/src/lib/shared/describe-upgrade.ts
+++ b/apps/web/src/lib/shared/describe-upgrade.ts
@@ -1,6 +1,7 @@
 import {
   ENTITLEMENTS,
   PLAN_CATALOGUE,
+  canonicalPlanId,
   minimumPlanFor,
   type EntitlementKey,
   type PlanId,
@@ -112,7 +113,7 @@ export function cataloguePlanFor(
   planId: PlanId | null | undefined
 ): BillingCatalogue['plans'][number] | null {
   if (!catalogue || !planId) return null
-  return catalogue.plans.find((plan) => plan.id === planId) ?? null
+  return catalogue.plans.find((plan) => canonicalPlanId(plan.id) === planId) ?? null
 }
 
 function refusalMessage(error: unknown): string {

--- a/apps/web/src/routes/api/billing/__tests__/session.test.ts
+++ b/apps/web/src/routes/api/billing/__tests__/session.test.ts
@@ -217,6 +217,43 @@ describe('POST /api/billing/session checkout', () => {
     })
   })
 
+  it('accepts business/enterprise checkout slugs and forwards canonical ids', async () => {
+    hoisted.fetchBillingCatalogue.mockResolvedValue({
+      plans: [
+        { id: 'pro', billedPer: 'workspace' },
+        { id: 'scale', billedPer: 'workspace' },
+      ],
+    })
+    await POST({
+      request: formRequest({
+        action: 'checkout',
+        planId: 'business',
+        billingPeriod: 'monthly',
+      }),
+    })
+    expect(hoisted.createHostedBillingSession).toHaveBeenCalledWith({
+      action: 'checkout',
+      planId: 'pro',
+      billingPeriod: 'monthly',
+      quantity: 1,
+    })
+
+    hoisted.createHostedBillingSession.mockClear()
+    await POST({
+      request: formRequest({
+        action: 'checkout',
+        planId: 'enterprise',
+        billingPeriod: 'annual',
+      }),
+    })
+    expect(hoisted.createHostedBillingSession).toHaveBeenCalledWith({
+      action: 'checkout',
+      planId: 'scale',
+      billingPeriod: 'annual',
+      quantity: 1,
+    })
+  })
+
   it('forwards a quantity at or above live usage', async () => {
     const res = await POST({ request: checkoutRequest(8) })
     expect(res.status).toBe(303)

--- a/apps/web/src/routes/api/billing/__tests__/trial.test.ts
+++ b/apps/web/src/routes/api/billing/__tests__/trial.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const hoisted = vi.hoisted(() => ({
+  requireAuth: vi.fn(),
+  getCloudConfig: vi.fn(),
+  startWorkspaceTrial: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: vi.fn(() => (opts: unknown) => ({ options: opts })),
+}))
+
+vi.mock('@/lib/server/functions/auth-helpers', () => ({
+  requireAuth: (...args: unknown[]) => hoisted.requireAuth(...args),
+}))
+
+vi.mock('@/lib/server/domains/settings/cloud/cloud.service', () => ({
+  getCloudConfig: (...args: unknown[]) => hoisted.getCloudConfig(...args),
+}))
+
+vi.mock('@/lib/server/control-plane/client', () => ({
+  startWorkspaceTrial: (...args: unknown[]) => hoisted.startWorkspaceTrial(...args),
+}))
+
+import { Route } from '../trial'
+
+type Handlers = { POST: (args: { request: Request }) => Promise<Response> }
+type RouteOpts = { server: { handlers: Handlers } }
+const { POST } = (Route as unknown as { options: RouteOpts }).options.server.handlers
+
+function formRequest(body: Record<string, string>): Request {
+  return new Request('https://app.example.com/api/billing/trial', {
+    method: 'POST',
+    headers: {
+      origin: 'https://app.example.com',
+      host: 'app.example.com',
+      'content-type': 'application/x-www-form-urlencoded',
+    },
+    body: new URLSearchParams(body),
+  })
+}
+
+describe('POST /api/billing/trial', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    hoisted.requireAuth.mockResolvedValue({ user: { id: 'user_1' } })
+    hoisted.getCloudConfig.mockResolvedValue({ enabled: true, canUpgrade: true })
+    hoisted.startWorkspaceTrial.mockResolvedValue('started')
+  })
+
+  it('accepts business/enterprise slugs and starts the canonical trial', async () => {
+    const res = await POST({ request: formRequest({ planId: 'business' }) })
+    expect(res.status).toBe(303)
+    expect(hoisted.startWorkspaceTrial).toHaveBeenCalledWith('pro')
+
+    hoisted.startWorkspaceTrial.mockClear()
+    await POST({ request: formRequest({ planId: 'enterprise' }) })
+    expect(hoisted.startWorkspaceTrial).toHaveBeenCalledWith('scale')
+  })
+
+  it('still starts a canonical paid trial', async () => {
+    await POST({ request: formRequest({ planId: 'pro' }) })
+    expect(hoisted.startWorkspaceTrial).toHaveBeenCalledWith('pro')
+  })
+})

--- a/apps/web/src/routes/api/billing/session.ts
+++ b/apps/web/src/routes/api/billing/session.ts
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { z } from 'zod'
 import { isSameOriginFormPost } from '@/lib/server/http/same-origin-form'
+import { INCOMING_PAID_PLAN_IDS, parsePaidPlanId } from '@/lib/shared/billing/checkout-path'
 import { PERMISSIONS } from '@/lib/shared/permissions'
 
 export function billingErrorCode(error: unknown): string {
@@ -43,7 +44,7 @@ const actionSchema = z.discriminatedUnion('action', [
   z.object({ action: z.literal('portal') }),
   z.object({
     action: z.literal('checkout'),
-    planId: z.enum(['growth', 'pro', 'scale']),
+    planId: z.enum(INCOMING_PAID_PLAN_IDS),
     billingPeriod: z.enum(['monthly', 'annual']),
     quantity: z.coerce.number().int().positive().optional(),
     // A checked checkbox posts "true"; an unchecked one posts nothing.
@@ -158,11 +159,13 @@ async function createSeatChangeSession(quantity: number) {
 /** Floor seat-billed checkout at live usage so a stale form cannot under-seat.
  *  Workspace-priced plans stay quantity 1. */
 async function createCheckoutSession(input: {
-  planId: 'growth' | 'pro' | 'scale'
+  planId: (typeof INCOMING_PAID_PLAN_IDS)[number]
   billingPeriod: 'monthly' | 'annual'
   quantity?: number
   brandingRemoval?: 'true'
 }) {
+  const planId = parsePaidPlanId(input.planId)
+  if (!planId) throw new Error('invalid')
   const { countSeatUsage } = await import('@/lib/server/domains/principals/seat-usage')
   const { createHostedBillingSession, fetchBillingCatalogue } =
     await import('@/lib/server/control-plane/client')
@@ -171,12 +174,14 @@ async function createCheckoutSession(input: {
       countSeatUsage(tx),
       fetchBillingCatalogue().catch(() => null),
     ])
-    const billedPer = catalogue?.plans.find((plan) => plan.id === input.planId)?.billedPer
+    const billedPer = catalogue?.plans.find(
+      (plan) => parsePaidPlanId(plan.id) === planId
+    )?.billedPer
     const quantity =
       billedPer === 'workspace' ? 1 : Math.max(input.quantity ?? seats.used, seats.used, 1)
     return createHostedBillingSession({
       action: 'checkout',
-      planId: input.planId,
+      planId,
       billingPeriod: input.billingPeriod,
       quantity,
       ...(input.brandingRemoval === 'true' ? { brandingRemoval: true } : {}),

--- a/apps/web/src/routes/api/billing/trial.ts
+++ b/apps/web/src/routes/api/billing/trial.ts
@@ -1,11 +1,12 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { z } from 'zod'
 import { isSameOriginFormPost } from '@/lib/server/http/same-origin-form'
+import { INCOMING_PAID_PLAN_IDS, parsePaidPlanId } from '@/lib/shared/billing/checkout-path'
 import { PERMISSIONS } from '@/lib/shared/permissions'
 import { billingFormErrorResponse, billingSessionErrorResponse } from './session'
 
 const trialSchema = z.object({
-  planId: z.enum(['growth', 'pro', 'scale']),
+  planId: z.enum(INCOMING_PAID_PLAN_IDS),
   /** Admin page the prompt was raised on, so the trial lands back on the now-unlocked feature. */
   returnTo: z.string().optional(),
 })
@@ -43,8 +44,12 @@ export const Route = createFileRoute('/api/billing/trial')({
           if (!cloud.enabled || !cloud.canUpgrade) {
             return billingFormErrorResponse(null, 'unavailable')
           }
+          const planId = parsePaidPlanId(parsed.data.planId)
+          if (!planId) {
+            return billingFormErrorResponse(null, 'invalid')
+          }
           const { startWorkspaceTrial } = await import('@/lib/server/control-plane/client')
-          await startWorkspaceTrial(parsed.data.planId)
+          await startWorkspaceTrial(planId)
           return new Response(null, {
             status: 303,
             headers: { location: trialReturnPath(parsed.data.returnTo) },


### PR DESCRIPTION
## Summary

Phase B1 of the Cloud tier slug remap (`CLOUD-TIERS-REPRICE-PLAN.md`). OSS now **accepts** incoming plan ids `business` and `enterprise` as aliases of today's stored `pro` (Business) and `scale` (Enterprise). Canonical stored/projected ids remain `growth` / `pro` / `scale`.

This must land on the fleet via `main` (image promote, **no semver cut**) **before** the control plane rewrites slugs in B2. An older workspace image that still rejects `enterprise` would drop the entire billing projection (400 / entitlements gone) the moment CP starts sending the new ids.

### Mapping

| Incoming | Canonical stored id | Display | Rank / grants / PLAN_ONLY_FEATURES |
|---|---|---|---|
| `business` | `pro` | Business | same as current `pro` |
| `enterprise` | `scale` | Enterprise (`an`) | same as current `scale` |

`pro` still means Business. Do **not** flip `pro` to the entry tier — that is B3.

### What changed

- `canonicalPlanId()` maps aliases before catalogue lookup and storage.
- `parseBillingProjection` accepts `business`/`enterprise` and stores `pro`/`scale` (previously `effectivePlan: 'enterprise'` **nullified the whole projection**).
- Checkout and trial form enums accept the aliases, then forward canonical ids to the CP.
- Catalogue fetch remaps plan ids / recommended / trial ledger keys the same way.
- Purchasable checkout URLs stay `growth|pro|scale`. `purchasablePlans` is unchanged.

## Test plan

- [x] Unit: aliases map to the same grants, rank, display name, article, and `PLAN_ONLY_FEATURES` as `pro`/`scale`.
- [x] Unit: `PLAN_IDS` remains `['free','growth','pro','scale']`; unknown ids like `platinum` still fail closed.
- [x] Projection parse + `resolveCloudConfig` keep a `business`/`enterprise` payload instead of disabling cloud.
- [x] Checkout `POST` with `planId=business|enterprise` forwards `pro|scale` to the CP.
- [x] Trial `POST` with those slugs starts the canonical trial.
- [x] Catalogue normaliser remaps `recommendedPlanId`, `trialedPlanIds`, `lastTrialPlanId`, plan rows, and AI cents keys.
- [ ] After merge: promote the `main` image to the fleet before CP B2.