### PR TITLE
feat(billing): treat pro as the entry tier

### DIFF
--- a/apps/web/src/components/admin/settings/billing/__tests__/add-seats-dialog.test.tsx
+++ b/apps/web/src/components/admin/settings/billing/__tests__/add-seats-dialog.test.tsx
@@ -8,7 +8,7 @@ import type { BillingCatalogue } from '@/lib/server/control-plane/client'
 import type { BillingProjectionOverview } from '@/lib/server/domains/billing/projection-overview'
 
 const overview: BillingProjectionOverview = {
-  plan: 'pro',
+  plan: 'business',
   planName: 'Business',
   status: 'active',
   trialActive: false,
@@ -19,8 +19,8 @@ const overview: BillingProjectionOverview = {
   canManageBilling: true,
   purchasablePlans: [
     { id: 'growth', name: 'Pro' },
-    { id: 'pro', name: 'Business' },
-    { id: 'scale', name: 'Enterprise' },
+    { id: 'business', name: 'Business' },
+    { id: 'enterprise', name: 'Enterprise' },
   ],
   seats: { used: 7, pending: 1, members: 6, purchased: 10 },
   ai: { includedCents: 3000, usedCents: 2520, extraCents: 1000 },
@@ -31,11 +31,11 @@ const catalogue: BillingCatalogue = {
   version: 1,
   currency: 'usd',
   annualDiscountMonths: 2,
-  recommendedPlanId: 'pro',
+  recommendedPlanId: 'growth',
   brandingRemoval: { monthlyCents: 5900, annualCents: 59000 },
   plans: [
     {
-      id: 'pro',
+      id: 'business',
       name: 'Business',
       rank: 2,
       priceMonthlyCents: 3000,

--- a/apps/web/src/components/admin/settings/billing/__tests__/billing-settings.test.tsx
+++ b/apps/web/src/components/admin/settings/billing/__tests__/billing-settings.test.tsx
@@ -10,9 +10,9 @@ const catalogue: BillingCatalogue = {
   version: 1,
   currency: 'usd',
   annualDiscountMonths: 2,
-  recommendedPlanId: 'pro',
+  recommendedPlanId: 'growth',
   brandingRemoval: { monthlyCents: 5900, annualCents: 59000 },
-  aiIncludedCentsPerMonth: { free: 0, growth: 1000, pro: 3000, scale: 10000 },
+  aiIncludedCentsPerMonth: { free: 0, growth: 1000, business: 3000, enterprise: 10000 },
   aiTopUpPackCents: 1000,
   aiBlendedCentsPerMTok: 500,
   emailTopUpPackCents: 1000,
@@ -41,7 +41,7 @@ const catalogue: BillingCatalogue = {
       recommended: false,
     },
     {
-      id: 'pro',
+      id: 'business',
       name: 'Business',
       rank: 2,
       priceMonthlyCents: 3000,
@@ -52,7 +52,7 @@ const catalogue: BillingCatalogue = {
       recommended: true,
     },
     {
-      id: 'scale',
+      id: 'enterprise',
       name: 'Enterprise',
       rank: 3,
       priceMonthlyCents: 5900,
@@ -66,7 +66,7 @@ const catalogue: BillingCatalogue = {
 }
 
 const paidOverview: BillingProjectionOverview = {
-  plan: 'pro',
+  plan: 'business',
   planName: 'Business',
   status: 'active',
   trialActive: false,
@@ -77,8 +77,8 @@ const paidOverview: BillingProjectionOverview = {
   canManageBilling: true,
   purchasablePlans: [
     { id: 'growth', name: 'Pro' },
-    { id: 'pro', name: 'Business' },
-    { id: 'scale', name: 'Enterprise' },
+    { id: 'business', name: 'Business' },
+    { id: 'enterprise', name: 'Enterprise' },
   ],
   seats: { used: 7, pending: 1, members: 6, purchased: 10 },
   ai: { includedCents: 3000, usedCents: 2520, extraCents: 1000 },
@@ -135,7 +135,7 @@ describe('BillingPlansView', () => {
     expect(screen.getByRole('button', { name: 'Switch to Pro' })).toBeInTheDocument()
     const switchLinks = screen.getAllByRole('link', { name: 'Switch to this plan' })
     expect(switchLinks.map((link) => link.getAttribute('href'))).toEqual([
-      '/admin/settings/billing/checkout?plan=scale&period=annual&seats=7',
+      '/admin/settings/billing/checkout?plan=enterprise&period=annual&seats=7',
     ])
     expect(screen.getByText('INV-1001')).toBeInTheDocument()
   })
@@ -183,7 +183,7 @@ describe('BillingPlansView', () => {
       catalogue: {
         ...catalogue,
         plans: catalogue.plans.map((plan) =>
-          plan.id === 'pro' ? { ...plan, billedPer: 'workspace' as const } : plan
+          plan.id === 'business' ? { ...plan, billedPer: 'workspace' as const } : plan
         ),
       },
     })
@@ -265,7 +265,7 @@ describe('BillingPlansView', () => {
         status: null,
         trialActive: false,
         trialEnded: true,
-        trialPlanId: 'pro',
+        trialPlanId: 'growth',
         trialPlanName: 'Pro',
         trialExpiresAt: '2026-08-18T00:00:00.000Z',
         canUpgrade: true,
@@ -350,7 +350,7 @@ describe('BillingPlansView', () => {
         status: null,
         trialActive: false,
         trialEnded: true,
-        trialPlanId: 'pro',
+        trialPlanId: 'business',
         trialPlanName: 'Business',
         trialExpiresAt: '2026-08-18T00:00:00.000Z',
         canUpgrade: true,
@@ -378,7 +378,7 @@ describe('BillingPlansView', () => {
         status: null,
         trialActive: false,
         trialEnded: true,
-        trialPlanId: 'pro',
+        trialPlanId: 'growth',
         trialPlanName: 'Pro',
         trialExpiresAt: '2026-08-18T00:00:00.000Z',
         canUpgrade: true,

--- a/apps/web/src/components/admin/settings/billing/__tests__/checkout-builder.test.tsx
+++ b/apps/web/src/components/admin/settings/billing/__tests__/checkout-builder.test.tsx
@@ -15,7 +15,7 @@ const catalogue: BillingCatalogue = {
   version: 1,
   currency: 'usd',
   annualDiscountMonths: 2,
-  recommendedPlanId: 'pro',
+  recommendedPlanId: 'growth',
   brandingRemoval: { monthlyCents: 5900, annualCents: 59000 },
   trialDays: 14,
   trialedPlanIds: [],
@@ -43,7 +43,7 @@ const catalogue: BillingCatalogue = {
       recommended: false,
     },
     {
-      id: 'pro',
+      id: 'business',
       name: 'Business',
       rank: 2,
       priceMonthlyCents: 5900,
@@ -54,7 +54,7 @@ const catalogue: BillingCatalogue = {
       recommended: true,
     },
     {
-      id: 'scale',
+      id: 'enterprise',
       name: 'Enterprise',
       rank: 3,
       priceMonthlyCents: 11500,
@@ -79,8 +79,8 @@ const freeOverview: BillingProjectionOverview = {
   canManageBilling: false,
   purchasablePlans: [
     { id: 'growth', name: 'Pro' },
-    { id: 'pro', name: 'Business' },
-    { id: 'scale', name: 'Enterprise' },
+    { id: 'business', name: 'Business' },
+    { id: 'enterprise', name: 'Enterprise' },
   ],
   seats: { used: 3, pending: 1, members: 2, purchased: null },
   ai: null,
@@ -89,7 +89,7 @@ const freeOverview: BillingProjectionOverview = {
 
 const proOverview: BillingProjectionOverview = {
   ...freeOverview,
-  plan: 'pro',
+  plan: 'business',
   planName: 'Business',
   status: 'active',
   canManageBilling: true,
@@ -105,7 +105,7 @@ function renderBuilder(
     <CheckoutBuilder
       overview={overview}
       catalogue={catalogue}
-      selection={{ plan: 'pro', period: 'annual', seats: 3, branding: false, ...selection }}
+      selection={{ plan: 'business', period: 'annual', seats: 3, branding: false, ...selection }}
       onChange={onChange}
     />
   )
@@ -135,7 +135,7 @@ describe('CheckoutBuilder', () => {
     expect(within(summary).getByText('$148/mo')).toBeInTheDocument()
 
     const form = checkoutForm()
-    expect(form?.querySelector('input[name="planId"]')).toHaveValue('pro')
+    expect(form?.querySelector('input[name="planId"]')).toHaveValue('business')
     expect(form?.querySelector('input[name="billingPeriod"]')).toHaveValue('annual')
     expect(form?.querySelector('input[name="quantity"]')).toHaveValue('3')
     expect(within(summary).getByRole('button', { name: 'Continue to payment' })).toBeEnabled()
@@ -153,7 +153,7 @@ describe('CheckoutBuilder', () => {
     fireEvent.click(screen.getByRole('radio', { name: /Monthly/ }))
     expect(onChange).toHaveBeenCalledWith({ period: 'monthly' })
     fireEvent.click(screen.getByRole('radio', { name: /^Enterprise/ }))
-    expect(onChange).toHaveBeenCalledWith({ plan: 'scale' })
+    expect(onChange).toHaveBeenCalledWith({ plan: 'enterprise' })
     fireEvent.click(screen.getByRole('button', { name: 'More seats' }))
     expect(onChange).toHaveBeenCalledWith({ seats: 4 })
   })
@@ -175,7 +175,7 @@ describe('CheckoutBuilder', () => {
   })
 
   it('marks the current plan and disables checkout for it', () => {
-    renderBuilder(proOverview, { plan: 'pro', seats: 7 })
+    renderBuilder(proOverview, { plan: 'business', seats: 7 })
     expect(screen.getAllByText('Current').length).toBeGreaterThan(0)
     expect(screen.getByRole('button', { name: 'Current plan' })).toBeDisabled()
     expect(checkoutForm()).toBeNull()
@@ -183,7 +183,7 @@ describe('CheckoutBuilder', () => {
   })
 
   it('explains pro-rata and end-of-period timing when moving between paid plans', () => {
-    renderBuilder(proOverview, { plan: 'scale', seats: 7 })
+    renderBuilder(proOverview, { plan: 'enterprise', seats: 7 })
     expect(screen.getByText(/Moving up applies now, billed pro-rata/)).toBeInTheDocument()
     renderBuilder(proOverview, { plan: 'growth', seats: 7 })
     expect(screen.getByText(/takes effect at the end of the current period/)).toBeInTheDocument()
@@ -221,12 +221,12 @@ describe('CheckoutBuilder', () => {
     expect(within(summary).getByText('$2,360/year')).toBeInTheDocument()
     expect(within(summary).getByText('$197/mo')).toBeInTheDocument()
     const form = checkoutForm()
-    expect(form?.querySelector('input[name="planId"]')).toHaveValue('pro')
+    expect(form?.querySelector('input[name="planId"]')).toHaveValue('business')
     expect(form?.querySelector('input[name="brandingRemoval"]')).toHaveValue('true')
   })
 
   it('sells the add-on on its own when the plan is the current one', () => {
-    renderBuilder(proOverview, { plan: 'pro', seats: 7, branding: true })
+    renderBuilder(proOverview, { plan: 'business', seats: 7, branding: true })
     const summary = screen.getByRole('complementary')
     expect(within(summary).queryByText(/7 seats ×/)).not.toBeInTheDocument()
     expect(within(summary).getAllByText('$590/year')).toHaveLength(2)

--- a/apps/web/src/components/admin/settings/billing/__tests__/subscribe-dialog.test.tsx
+++ b/apps/web/src/components/admin/settings/billing/__tests__/subscribe-dialog.test.tsx
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest'
 import { SubscribeDialog } from '../subscribe-dialog'
 
 const plan = {
-  id: 'pro' as const,
+  id: 'business' as const,
   name: 'Business',
   rank: 2,
   priceMonthlyCents: 3000,

--- a/apps/web/src/components/admin/settings/billing/trial-expired-billing.tsx
+++ b/apps/web/src/components/admin/settings/billing/trial-expired-billing.tsx
@@ -22,7 +22,7 @@ export function TrialExpiredBilling(props: {
 }) {
   const [period, setPeriod] = useState<'monthly' | 'annual'>('annual')
   const [selectedId, setSelectedId] = useState<PaidPlanId | 'free'>(
-    (props.overview.trialPlanId as PaidPlanId | undefined) ?? 'pro'
+    (props.overview.trialPlanId as PaidPlanId | undefined) ?? 'growth'
   )
   const [subscribeOpen, setSubscribeOpen] = useState(false)
   const [freeOpen, setFreeOpen] = useState(false)

--- a/apps/web/src/components/admin/settings/imports/export-workspace-action.tsx
+++ b/apps/web/src/components/admin/settings/imports/export-workspace-action.tsx
@@ -65,7 +65,7 @@ export function ExportWorkspaceAction() {
       <UpgradeModal
         open={upgradeOpen}
         onOpenChange={setUpgradeOpen}
-        description={describePlanUpgrade('Data export', 'pro')}
+        description={describePlanUpgrade('Data export', 'business')}
       />
     </div>
   )

--- a/apps/web/src/components/admin/upgrade/__tests__/upgrade-offer.test.tsx
+++ b/apps/web/src/components/admin/upgrade/__tests__/upgrade-offer.test.tsx
@@ -10,7 +10,7 @@ const catalogue: BillingCatalogue = {
   version: 1,
   currency: 'usd',
   annualDiscountMonths: 2,
-  recommendedPlanId: 'pro',
+  recommendedPlanId: 'growth',
   brandingRemoval: { monthlyCents: 5900, annualCents: 59000 },
   trialDays: 14,
   trialedPlanIds: [],
@@ -38,7 +38,7 @@ const catalogue: BillingCatalogue = {
       recommended: false,
     },
     {
-      id: 'pro',
+      id: 'business',
       name: 'Business',
       rank: 2,
       priceMonthlyCents: 5900,
@@ -49,7 +49,7 @@ const catalogue: BillingCatalogue = {
       recommended: true,
     },
     {
-      id: 'scale',
+      id: 'enterprise',
       name: 'Enterprise',
       rank: 3,
       priceMonthlyCents: 11500,
@@ -94,7 +94,7 @@ function renderOffer(
 }
 
 const onPro: UpgradeContext = {
-  currentPlan: 'pro',
+  currentPlan: 'business',
   currentPlanName: 'Business',
   trialActive: false,
   trialEligible: false,
@@ -125,7 +125,7 @@ describe('UpgradeOffer', () => {
     expect(screen.getByText('$89')).toBeTruthy()
     expect(screen.getByRole('link', { name: 'Upgrade to Enterprise' })).toHaveAttribute(
       'href',
-      '/admin/settings/billing/checkout?plan=scale&period=annual'
+      '/admin/settings/billing/checkout?plan=enterprise&period=annual'
     )
     expect(screen.getByRole('link', { name: /Compare all plans/ })).toHaveAttribute(
       'href',
@@ -139,7 +139,7 @@ describe('UpgradeOffer', () => {
     fireEvent.click(screen.getByRole('radio', { name: /Monthly/ }))
     expect(screen.getByRole('link', { name: 'Upgrade to Enterprise' })).toHaveAttribute(
       'href',
-      '/admin/settings/billing/checkout?plan=scale&period=monthly'
+      '/admin/settings/billing/checkout?plan=enterprise&period=monthly'
     )
   })
 
@@ -158,7 +158,9 @@ describe('UpgradeOffer', () => {
     expect(screen.getByText(/Free for 14 days, then the price above/)).toBeTruthy()
     const form = document.querySelector('form')
     expect(form?.getAttribute('action')).toBe('/api/billing/trial')
-    expect((document.querySelector('input[name="planId"]') as HTMLInputElement)?.value).toBe('pro')
+    expect((document.querySelector('input[name="planId"]') as HTMLInputElement)?.value).toBe(
+      'business'
+    )
     expect((document.querySelector('input[name="returnTo"]') as HTMLInputElement)?.value).toBe(
       '/admin/automation/workflows'
     )
@@ -167,7 +169,7 @@ describe('UpgradeOffer', () => {
   it('falls back to checkout once that plan has been tried', () => {
     renderOffer(onFree, {
       entitlement: 'workflows',
-      catalogue: { ...catalogue, trialedPlanIds: ['pro'] },
+      catalogue: { ...catalogue, trialedPlanIds: ['business'] },
     })
     expect(screen.getByRole('link', { name: 'Upgrade to Business' })).toBeTruthy()
     expect(screen.queryByText(/Free for 14 days/)).toBeNull()

--- a/apps/web/src/components/admin/upgrade/upgrade-offer.tsx
+++ b/apps/web/src/components/admin/upgrade/upgrade-offer.tsx
@@ -216,7 +216,7 @@ function trialPlanIdFor(
   catalogue: BillingCatalogue | null
 ): PaidPlanId | null {
   if (!plan || !context?.trialEligible) return null
-  if (plan.id !== 'growth' && plan.id !== 'pro' && plan.id !== 'scale') return null
+  if (plan.id !== 'growth' && plan.id !== 'business' && plan.id !== 'enterprise') return null
   return catalogueTrialedPlanIds(catalogue).includes(plan.id) ? null : plan.id
 }
 

--- a/apps/web/src/lib/server/control-plane/__tests__/client.test.ts
+++ b/apps/web/src/lib/server/control-plane/__tests__/client.test.ts
@@ -101,17 +101,28 @@ describe('workspace control-plane credential', () => {
     expect(init.body).toBeUndefined()
   })
 
-  it('normalises business/enterprise catalogue slugs to pro/scale', () => {
+  it('keeps business/enterprise catalogue slugs and maps pro/scale onto growth/enterprise', () => {
     const normalised = normalizeBillingCatalogue({
       version: 1,
       currency: 'usd',
       annualDiscountMonths: 2,
-      recommendedPlanId: 'business',
+      recommendedPlanId: 'pro',
       brandingRemoval: { monthlyCents: 5900, annualCents: 59000 },
-      lastTrialPlanId: 'enterprise',
-      trialedPlanIds: ['business', 'pro'],
-      aiIncludedCentsPerMonth: { business: 3000, enterprise: 10000 },
+      lastTrialPlanId: 'scale',
+      trialedPlanIds: ['pro', 'business'],
+      aiIncludedCentsPerMonth: { pro: 1000, business: 3000, scale: 10000 },
       plans: [
+        {
+          id: 'pro',
+          name: 'Pro',
+          rank: 1,
+          priceMonthlyCents: 3700,
+          priceYearlyCents: 34800,
+          billedPer: 'workspace',
+          bestFor: 'Small teams',
+          highlights: [],
+          recommended: true,
+        },
         {
           id: 'business',
           name: 'Business',
@@ -124,7 +135,7 @@ describe('workspace control-plane credential', () => {
           recommended: false,
         },
         {
-          id: 'enterprise',
+          id: 'scale',
           name: 'Enterprise',
           rank: 3,
           priceMonthlyCents: 12900,
@@ -136,11 +147,15 @@ describe('workspace control-plane credential', () => {
         },
       ],
     })
-    expect(normalised.recommendedPlanId).toBe('pro')
-    expect(normalised.lastTrialPlanId).toBe('scale')
-    expect(normalised.trialedPlanIds).toEqual(['pro'])
-    expect(normalised.aiIncludedCentsPerMonth).toEqual({ pro: 3000, scale: 10000 })
-    expect(normalised.plans.map((plan) => plan.id)).toEqual(['pro', 'scale'])
+    expect(normalised.recommendedPlanId).toBe('growth')
+    expect(normalised.lastTrialPlanId).toBe('enterprise')
+    expect(normalised.trialedPlanIds).toEqual(['growth', 'business'])
+    expect(normalised.aiIncludedCentsPerMonth).toEqual({
+      growth: 1000,
+      business: 3000,
+      enterprise: 10000,
+    })
+    expect(normalised.plans.map((plan) => plan.id)).toEqual(['growth', 'business', 'enterprise'])
   })
 
   it('forwards checkout and trial aliases as canonical plan ids', async () => {
@@ -149,21 +164,21 @@ describe('workspace control-plane credential', () => {
     )
     await createHostedBillingSession({
       action: 'checkout',
-      planId: 'enterprise',
+      planId: 'scale',
       billingPeriod: 'annual',
     })
     const [, checkoutInit] = hoisted.fetch.mock.calls[0] as [URL, RequestInit]
     expect(JSON.parse(String(checkoutInit.body))).toMatchObject({
       action: 'checkout',
-      planId: 'scale',
+      planId: 'enterprise',
     })
 
     hoisted.fetch.mockResolvedValue(
       new Response(JSON.stringify({ status: 'started' }), { status: 200 })
     )
-    await startWorkspaceTrial('business')
+    await startWorkspaceTrial('pro')
     const [, trialInit] = hoisted.fetch.mock.calls[1] as [URL, RequestInit]
-    expect(JSON.parse(String(trialInit.body))).toEqual({ planId: 'pro' })
+    expect(JSON.parse(String(trialInit.body))).toEqual({ planId: 'growth' })
   })
 
   it('lists owner workspaces over GET without a workspace id', async () => {

--- a/apps/web/src/lib/server/control-plane/__tests__/starter-trial.test.ts
+++ b/apps/web/src/lib/server/control-plane/__tests__/starter-trial.test.ts
@@ -106,7 +106,7 @@ describe('reportStarterTrialIfDue', () => {
   it('skips complimentary grants and paid plans that omit trial timestamps', async () => {
     hoisted.getCloudConfig.mockResolvedValueOnce({
       enabled: true,
-      plan: 'scale',
+      plan: 'enterprise',
       trialStartedAt: null,
       trialActive: false,
       subscriptionStatus: null,
@@ -114,7 +114,7 @@ describe('reportStarterTrialIfDue', () => {
     await expect(reportStarterTrialIfDue()).resolves.toBe('skipped')
     hoisted.getCloudConfig.mockResolvedValueOnce({
       enabled: true,
-      plan: 'pro',
+      plan: 'business',
       trialStartedAt: null,
       trialActive: false,
       subscriptionStatus: 'active',

--- a/apps/web/src/lib/server/control-plane/client.ts
+++ b/apps/web/src/lib/server/control-plane/client.ts
@@ -141,9 +141,9 @@ export async function fetchBillingInvoices(): Promise<CustomerInvoice[]> {
   return Array.isArray(result.invoices) ? result.invoices : []
 }
 
-export type CanonicalCataloguePlanId = 'free' | 'growth' | 'pro' | 'scale'
+export type CanonicalCataloguePlanId = 'free' | 'growth' | 'business' | 'enterprise'
 /** Incoming CP slugs; aliases are normalised to {@link CanonicalCataloguePlanId} on fetch. */
-export type CataloguePlanId = CanonicalCataloguePlanId | 'business' | 'enterprise'
+export type CataloguePlanId = CanonicalCataloguePlanId | 'pro' | 'scale'
 export type PaidCataloguePlanId = Exclude<CataloguePlanId, 'free'>
 
 export type BillingCatalogue = {
@@ -200,7 +200,7 @@ function remapPlanKeyedRecord<T>(
   return next
 }
 
-/** Maps `business`/`enterprise` onto stored `pro`/`scale` without dropping the payload. */
+/** Maps `pro`/`scale` onto stored `growth`/`enterprise` without dropping the payload. */
 export function normalizeBillingCatalogue(catalogue: BillingCatalogue): BillingCatalogue {
   return {
     ...catalogue,

--- a/apps/web/src/lib/server/domains/billing/__tests__/projection-overview.test.ts
+++ b/apps/web/src/lib/server/domains/billing/__tests__/projection-overview.test.ts
@@ -37,7 +37,7 @@ describe('composeAiUsage', () => {
 describe('purchasedSeatsFromProjection', () => {
   const billed = {
     billedPer: 'seat' as const,
-    plan: 'pro' as const,
+    plan: 'business' as const,
     trialActive: false,
     planLimitsMaxTeamSeats: 10,
   }
@@ -63,7 +63,7 @@ describe('trialPlanIdForOverview', () => {
         trialActive: true,
         trialEnded: false,
         plan: 'growth',
-        lastTrialPlanId: 'pro',
+        lastTrialPlanId: 'business',
       })
     ).toBe('growth')
   })
@@ -74,9 +74,9 @@ describe('trialPlanIdForOverview', () => {
         trialActive: false,
         trialEnded: true,
         plan: 'free',
-        lastTrialPlanId: 'pro',
+        lastTrialPlanId: 'business',
       })
-    ).toBe('pro')
+    ).toBe('business')
   })
 
   it('ignores historical trial plans on a paid workspace', () => {
@@ -84,7 +84,7 @@ describe('trialPlanIdForOverview', () => {
       trialPlanIdForOverview({
         trialActive: false,
         trialEnded: false,
-        plan: 'scale',
+        plan: 'enterprise',
         lastTrialPlanId: 'growth',
       })
     ).toBeNull()

--- a/apps/web/src/lib/server/domains/billing/projection-overview.ts
+++ b/apps/web/src/lib/server/domains/billing/projection-overview.ts
@@ -169,7 +169,7 @@ export async function getBillingProjectionOverview(): Promise<BillingProjectionO
     cancellationAt: cloud.cancellationAt,
     canUpgrade: cloud.canUpgrade,
     canManageBilling: cloud.canManageBilling,
-    purchasablePlans: (['growth', 'pro', 'scale'] as const).map((id) => ({
+    purchasablePlans: (['growth', 'business', 'enterprise'] as const).map((id) => ({
       id,
       name: PLAN_CATALOGUE[id].name,
     })),

--- a/apps/web/src/lib/server/domains/help-center/__tests__/help-center-domain-entitlement.test.ts
+++ b/apps/web/src/lib/server/domains/help-center/__tests__/help-center-domain-entitlement.test.ts
@@ -53,7 +53,7 @@ describe('setHelpCenterDomain — unconfigured install', () => {
 })
 
 describe('setHelpCenterDomain — cloud amputates the local writer', () => {
-  it.each(['free', 'growth', 'pro', 'scale'] as const)(
+  it.each(['free', 'growth', 'business', 'enterprise'] as const)(
     'refuses the local reverse-proxy writer on cloud %s',
     async (plan) => {
       withCloud({ enabled: true, plan })
@@ -66,7 +66,7 @@ describe('setHelpCenterDomain — cloud amputates the local writer', () => {
   )
 
   it('names the local writer so the refusal is distinguishable', async () => {
-    withCloud({ enabled: true, plan: 'pro' })
+    withCloud({ enabled: true, plan: 'business' })
     await expect(setHelpCenterDomain('help.acme.com')).rejects.toBeInstanceOf(ForbiddenError)
     await expect(setHelpCenterDomain('help.acme.com')).rejects.toThrow(
       'Cloud workspaces cannot use the local reverse-proxy domain writer.'

--- a/apps/web/src/lib/server/domains/macros/__tests__/macros-entitlement.test.ts
+++ b/apps/web/src/lib/server/domains/macros/__tests__/macros-entitlement.test.ts
@@ -113,7 +113,7 @@ describe('macro library — plan gate', () => {
     withCloud(storedCloud('free', { aiDrafts: true }))
     await expect(listMacros()).resolves.toEqual([ROW])
 
-    withCloud(storedCloud('scale', { aiDrafts: false }))
+    withCloud(storedCloud('enterprise', { aiDrafts: false }))
     await expect(listMacros()).rejects.toBeInstanceOf(EntitlementRequiredError)
   })
 })

--- a/apps/web/src/lib/server/domains/principals/__tests__/seat-limit.test.ts
+++ b/apps/web/src/lib/server/domains/principals/__tests__/seat-limit.test.ts
@@ -75,7 +75,7 @@ describe('enforceSeatLimit', () => {
     hoisted.countSeatUsage.mockResolvedValue({ members: 8, pendingInvites: 2, used: 10 })
     hoisted.getCloudConfig.mockResolvedValue({
       enabled: true,
-      plan: 'pro',
+      plan: 'business',
       trialActive: false,
     })
     hoisted.catalogueBilledPer.mockResolvedValue('seat')
@@ -138,7 +138,7 @@ describe('enforceSeatLimit', () => {
     })
     hoisted.getCloudConfig.mockResolvedValue({
       enabled: true,
-      plan: 'pro',
+      plan: 'business',
       trialActive: false,
     })
     hoisted.countSeatUsage.mockResolvedValue({ members: 10, pendingInvites: 0, used: 10 })

--- a/apps/web/src/lib/server/domains/principals/__tests__/seat-usage.db.test.ts
+++ b/apps/web/src/lib/server/domains/principals/__tests__/seat-usage.db.test.ts
@@ -103,7 +103,7 @@ async function seedInvite(
 }
 
 async function projectMaxTeamSeats(maxTeamSeats: number): Promise<void> {
-  const cloud = storedCloud('pro')
+  const cloud = storedCloud('business')
   const projection = {
     ...cloud,
     projection: {
@@ -134,7 +134,7 @@ describe.skipIf(!fixture.available)('countSeatUsage', () => {
     await fixture.begin()
     hoisted.getCloudConfig.mockResolvedValue({
       enabled: true,
-      plan: 'pro',
+      plan: 'business',
       trialActive: false,
     })
     invalidateTierLimitsCache()

--- a/apps/web/src/lib/server/domains/sentiment/__tests__/sentiment-entitlement.test.ts
+++ b/apps/web/src/lib/server/domains/sentiment/__tests__/sentiment-entitlement.test.ts
@@ -121,7 +121,7 @@ describe('analyzeSentiment — plan gate', () => {
       sentiment: 'positive',
     })
 
-    withCloud(storedCloud('scale', { aiInsights: false }))
+    withCloud(storedCloud('enterprise', { aiInsights: false }))
     await expect(analyzeSentiment('Title', 'Great feature!')).rejects.toBeInstanceOf(
       EntitlementRequiredError
     )

--- a/apps/web/src/lib/server/domains/settings/__tests__/tier-limits.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/tier-limits.test.ts
@@ -111,7 +111,7 @@ const PROJECTED_LIMITS: ProjectedLimits = {
 
 const PROJECTION: BillingProjection = {
   version: 1,
-  effectivePlan: 'pro',
+  effectivePlan: 'business',
   trialStartedAt: '2026-08-01T00:00:00.000Z',
   trialExpiresAt: '2026-08-15T00:00:00.000Z',
   subscriptionStatus: null,
@@ -198,14 +198,22 @@ describe('projected numeric limits', () => {
     expect(parseBillingProjection({ ...PROJECTION, trialExpiresAt: 'August 15' })).toBeNull()
   })
 
-  it('normalises business/enterprise projection slugs to pro/scale', () => {
+  it('keeps business/enterprise projection slugs and maps pro/scale onto growth/enterprise', () => {
     expect(parseBillingProjection({ ...PROJECTION, effectivePlan: 'business' })).toEqual({
       ...PROJECTION,
-      effectivePlan: 'pro',
+      effectivePlan: 'business',
     })
     expect(parseBillingProjection({ ...PROJECTION, effectivePlan: 'enterprise' })).toEqual({
       ...PROJECTION,
-      effectivePlan: 'scale',
+      effectivePlan: 'enterprise',
+    })
+    expect(parseBillingProjection({ ...PROJECTION, effectivePlan: 'pro' })).toEqual({
+      ...PROJECTION,
+      effectivePlan: 'growth',
+    })
+    expect(parseBillingProjection({ ...PROJECTION, effectivePlan: 'scale' })).toEqual({
+      ...PROJECTION,
+      effectivePlan: 'enterprise',
     })
   })
 
@@ -244,21 +252,23 @@ describe('resolveEffectiveTierLimits (cloud, no operator row)', () => {
     expect(effective.features.integrations).toBe(true)
   })
 
-  it('keeps Business/Enterprise aliases on the same PLAN_ONLY_FEATURES as pro/scale', () => {
-    const business = parseBillingProjection({ ...PROJECTION, effectivePlan: 'business' })
+  it('maps pro/scale aliases onto growth/enterprise PLAN_ONLY_FEATURES', () => {
+    const pro = parseBillingProjection({ ...PROJECTION, effectivePlan: 'pro' })
+    const growth = parseBillingProjection({ ...PROJECTION, effectivePlan: 'growth' })
+    const scale = parseBillingProjection({ ...PROJECTION, effectivePlan: 'scale' })
     const enterprise = parseBillingProjection({ ...PROJECTION, effectivePlan: 'enterprise' })
-    expect(business).not.toBeNull()
+    expect(pro).not.toBeNull()
+    expect(growth).not.toBeNull()
+    expect(scale).not.toBeNull()
     expect(enterprise).not.toBeNull()
-    const fromBusiness = resolveEffectiveTierLimits(null, business, beforeExpiry)
-    const fromPro = resolveEffectiveTierLimits(null, PROJECTION, beforeExpiry)
+    const fromPro = resolveEffectiveTierLimits(null, pro, beforeExpiry)
+    const fromGrowth = resolveEffectiveTierLimits(null, growth, beforeExpiry)
+    const fromScale = resolveEffectiveTierLimits(null, scale, beforeExpiry)
     const fromEnterprise = resolveEffectiveTierLimits(null, enterprise, beforeExpiry)
-    const fromScale = resolveEffectiveTierLimits(
-      null,
-      { ...PROJECTION, effectivePlan: 'scale' },
-      beforeExpiry
-    )
-    expect(fromBusiness.features).toEqual(fromPro.features)
-    expect(fromEnterprise.features).toEqual(fromScale.features)
+    expect(fromPro.features).toEqual(fromGrowth.features)
+    expect(fromScale.features).toEqual(fromEnterprise.features)
+    expect(fromPro.features.integrations).toBe(false)
+    expect(fromEnterprise.features.integrations).toBe(true)
   })
 
   it('keeps Growth feature flags closed for keys that are not entitlements', () => {

--- a/apps/web/src/lib/server/domains/settings/cloud/__tests__/billing-projection.test.ts
+++ b/apps/web/src/lib/server/domains/settings/cloud/__tests__/billing-projection.test.ts
@@ -29,7 +29,7 @@ const LIMITS = {
 
 const PROJECTION: BillingProjection = {
   version: 7,
-  effectivePlan: 'pro',
+  effectivePlan: 'business',
   trialStartedAt: '2026-08-01T00:00:00.000Z',
   trialExpiresAt: '2026-08-15T00:00:00.000Z',
   subscriptionStatus: null,
@@ -92,7 +92,7 @@ describe('billing projection monotonicity', () => {
 
   it('rejects different state under a reused version', () => {
     expect(() =>
-      decideBillingProjectionWrite(PROJECTION, { ...PROJECTION, effectivePlan: 'scale' })
+      decideBillingProjectionWrite(PROJECTION, { ...PROJECTION, effectivePlan: 'enterprise' })
     ).toThrow(new BillingProjectionWriteError('version_conflict'))
   })
 
@@ -118,7 +118,7 @@ describe('projected commercial state', () => {
     )
     expect(cloud).toMatchObject({
       enabled: true,
-      plan: 'pro',
+      plan: 'business',
       trialActive: true,
       canUpgrade: true,
       canManageBilling: false,
@@ -130,22 +130,22 @@ describe('projected commercial state', () => {
     })
   })
 
-  it('does not drop a projection whose effectivePlan is a business/enterprise alias', () => {
+  it('does not drop a projection whose effectivePlan is a pro/scale alias', () => {
     const cloud = resolveCloudConfig(
-      { enabled: true, projection: { ...PROJECTION, effectivePlan: 'business' } },
+      { enabled: true, projection: { ...PROJECTION, effectivePlan: 'pro' } },
       new Date('2026-08-14T23:59:59.999Z')
     )
     expect(cloud).toMatchObject({
       enabled: true,
-      plan: 'pro',
+      plan: 'growth',
       entitlements: { customDomain: true },
     })
     expect(
       resolveCloudConfig(
-        { enabled: true, projection: { ...PROJECTION, effectivePlan: 'enterprise' } },
+        { enabled: true, projection: { ...PROJECTION, effectivePlan: 'scale' } },
         new Date('2026-08-14T23:59:59.999Z')
       ).plan
-    ).toBe('scale')
+    ).toBe('enterprise')
   })
 
   it('falls back to Free at the exact projected expiry instant', () => {
@@ -157,7 +157,7 @@ describe('projected commercial state', () => {
       { enabled: true, projection: PROJECTION },
       new Date('2026-08-15T00:00:00.000Z')
     )
-    expect(before.plan).toBe('pro')
+    expect(before.plan).toBe('business')
     expect(before.entitlements.customDomain).toBe(true)
     expect(atExpiry.plan).toBe('free')
     expect(atExpiry.entitlements).toEqual({})
@@ -174,7 +174,7 @@ describe('projected commercial state', () => {
       new Date('2026-08-14T12:00:00.000Z')
     )
     expect(cloud.trialActive).toBe(false)
-    expect(cloud.plan).toBe('pro')
+    expect(cloud.plan).toBe('business')
   })
 
   it('does not treat a live Stripe subscription as a product trial', () => {
@@ -187,6 +187,6 @@ describe('projected commercial state', () => {
     )
     expect(cloud.trialActive).toBe(false)
     expect(cloud.subscriptionStatus).toBe('trialing')
-    expect(cloud.plan).toBe('pro')
+    expect(cloud.plan).toBe('business')
   })
 })

--- a/apps/web/src/lib/server/domains/settings/cloud/__tests__/entitlements.test.ts
+++ b/apps/web/src/lib/server/domains/settings/cloud/__tests__/entitlements.test.ts
@@ -44,7 +44,7 @@ const LIMITS = {
   apiRequestsPerMinute: 600,
 }
 
-function storedCloud(plan: 'free' | 'growth' | 'pro' | 'scale') {
+function storedCloud(plan: 'free' | 'growth' | 'business' | 'enterprise') {
   const grants = new Set(PLAN_CATALOGUE[plan].grants)
   return {
     enabled: true,
@@ -68,13 +68,13 @@ function storedCloud(plan: 'free' | 'growth' | 'pro' | 'scale') {
 
 describe('isEntitled', () => {
   it('grants what the plan grants', () => {
-    const config = cloud({ plan: 'pro' })
+    const config = cloud({ plan: 'business' })
     expect(isEntitled(config, 'customDomain')).toBe(true)
     expect(isEntitled(config, 'workflows')).toBe(true)
   })
 
   it('denies what the plan does not grant', () => {
-    const config = cloud({ plan: 'pro' })
+    const config = cloud({ plan: 'business' })
     expect(isEntitled(config, 'sso')).toBe(false)
     expect(isEntitled(config, 'auditLog')).toBe(false)
   })
@@ -89,7 +89,9 @@ describe('isEntitled', () => {
   })
 
   it('lets an explicit override close a feature the plan does include', () => {
-    expect(isEntitled(cloud({ plan: 'scale', entitlements: { sso: false } }), 'sso')).toBe(false)
+    expect(isEntitled(cloud({ plan: 'enterprise', entitlements: { sso: false } }), 'sso')).toBe(
+      false
+    )
   })
 
   it('denies everything when enabled with no plan (fail closed)', () => {
@@ -127,7 +129,7 @@ describe('the refusal names the plan', () => {
   it('does not invent an upsell when the workspace already has the plan', () => {
     // An explicit override denied a feature the top plan grants. Telling the
     // customer to upgrade to it would be nonsense.
-    const err = buildRefusal(cloud({ plan: 'scale', entitlements: { sso: false } }), 'sso')
+    const err = buildRefusal(cloud({ plan: 'enterprise', entitlements: { sso: false } }), 'sso')
     expect(err.requiredPlan).toBeNull()
     expect(err.message).toBe(
       'Single sign-on is not included in your plan. Your workspace is on Enterprise. Contact us to enable it.'
@@ -218,7 +220,7 @@ describe('requireEntitlement against a configured workspace', () => {
 
   it('allows what the plan grants', async () => {
     hoisted.mockGetWorkspaceSettings.mockResolvedValue({
-      settings: { id: 'ws_1', cloud: storedCloud('pro') },
+      settings: { id: 'ws_1', cloud: storedCloud('business') },
     })
     const { requireEntitlement } = await import('../entitlements')
     await expect(requireEntitlement('customDomain')).resolves.toBeUndefined()
@@ -261,7 +263,7 @@ describe('requireEntitlement against a configured workspace', () => {
 
   it('reports a different set one plan up, so the surface is not a constant', async () => {
     hoisted.mockGetWorkspaceSettings.mockResolvedValue({
-      settings: { id: 'ws_1', cloud: storedCloud('pro') },
+      settings: { id: 'ws_1', cloud: storedCloud('business') },
     })
     const { listEntitlements } = await import('../entitlements')
     expect(await listEntitlements()).toEqual({

--- a/apps/web/src/lib/server/domains/settings/cloud/__tests__/plan-catalogue.test.ts
+++ b/apps/web/src/lib/server/domains/settings/cloud/__tests__/plan-catalogue.test.ts
@@ -58,27 +58,27 @@ const INCLUDED_FROM: Partial<Record<EntitlementKey, PlanId>> = {
   mcpServer: 'growth',
   webhooks: 'growth',
   aiInsights: 'growth',
-  workflows: 'pro',
-  auditLog: 'scale',
-  sso: 'scale',
+  workflows: 'business',
+  auditLog: 'enterprise',
+  sso: 'enterprise',
 }
 
 const ADD_ON_KEYS: EntitlementKey[] = ['hideBranding']
 
 describe('the plan ladder', () => {
   it('is the four plans the product sells, cheapest first', () => {
-    expect(PLAN_IDS).toEqual(['free', 'growth', 'pro', 'scale'])
+    expect(PLAN_IDS).toEqual(['free', 'growth', 'business', 'enterprise'])
   })
 
   it('ranks each id at its position in the ladder', () => {
-    // Pinned as pairs rather than as a set. `pro` sitting at rank 2 is the
+    // Pinned as pairs rather than as a set. `business` sitting at rank 2 is the
     // whole point: a stored plan is a bare string, so an id that keeps its
     // name but changes rank hands a workspace a tier it never bought.
     expect(PLAN_DEFINITIONS.map((plan) => [plan.id, plan.rank])).toEqual([
       ['free', 0],
       ['growth', 1],
-      ['pro', 2],
-      ['scale', 3],
+      ['business', 2],
+      ['enterprise', 3],
     ])
   })
 
@@ -88,22 +88,26 @@ describe('the plan ladder', () => {
     ).toEqual(['a Free plan', 'a Pro plan', 'a Business plan', 'an Enterprise plan'])
   })
 
-  it('maps business/enterprise onto pro/scale without adding catalogue rows', () => {
-    expect(PLAN_ID_ALIASES).toEqual({ business: 'pro', enterprise: 'scale' })
-    expect(canonicalPlanId('business')).toBe('pro')
-    expect(canonicalPlanId('enterprise')).toBe('scale')
-    expect(canonicalPlanId('pro')).toBe('pro')
-    expect(canonicalPlanId('scale')).toBe('scale')
-    expect(isPlanId('business')).toBe(false)
-    expect(isPlanId('enterprise')).toBe(false)
-    expect(PLAN_CATALOGUE[canonicalPlanId('business')]).toEqual(PLAN_CATALOGUE.pro)
-    expect(PLAN_CATALOGUE[canonicalPlanId('enterprise')]).toEqual(PLAN_CATALOGUE.scale)
-    expect(PLAN_CATALOGUE[canonicalPlanId('business')].name).toBe('Business')
-    expect(PLAN_CATALOGUE[canonicalPlanId('enterprise')]).toMatchObject({
+  it('maps pro/scale onto growth/enterprise so Pro is the entry tier', () => {
+    expect(PLAN_ID_ALIASES).toEqual({ pro: 'growth', scale: 'enterprise' })
+    expect(canonicalPlanId('pro')).toBe('growth')
+    expect(canonicalPlanId('scale')).toBe('enterprise')
+    expect(canonicalPlanId('growth')).toBe('growth')
+    expect(canonicalPlanId('business')).toBe('business')
+    expect(canonicalPlanId('enterprise')).toBe('enterprise')
+    expect(isPlanId('pro')).toBe(false)
+    expect(isPlanId('scale')).toBe(false)
+    expect(isPlanId('business')).toBe(true)
+    expect(isPlanId('enterprise')).toBe(true)
+    expect(PLAN_CATALOGUE[canonicalPlanId('pro')]).toEqual(PLAN_CATALOGUE.growth)
+    expect(PLAN_CATALOGUE[canonicalPlanId('scale')]).toEqual(PLAN_CATALOGUE.enterprise)
+    expect(PLAN_CATALOGUE[canonicalPlanId('pro')].name).toBe('Pro')
+    expect(PLAN_CATALOGUE.business.name).toBe('Business')
+    expect(PLAN_CATALOGUE[canonicalPlanId('scale')]).toMatchObject({
       name: 'Enterprise',
       article: 'an',
-      rank: PLAN_CATALOGUE.scale.rank,
-      grants: PLAN_CATALOGUE.scale.grants,
+      rank: PLAN_CATALOGUE.enterprise.rank,
+      grants: PLAN_CATALOGUE.enterprise.grants,
     })
   })
 })
@@ -167,19 +171,19 @@ describe('the levels the price list moved', () => {
 
   it('starts workflows at Business, not at Pro', () => {
     expect(isEntitled(on('growth'), 'workflows')).toBe(false)
-    expect(isEntitled(on('pro'), 'workflows')).toBe(true)
+    expect(isEntitled(on('business'), 'workflows')).toBe(true)
   })
 
   it('starts the audit log at Enterprise, not at Business', () => {
-    expect(isEntitled(on('pro'), 'auditLog')).toBe(false)
-    expect(isEntitled(on('scale'), 'auditLog')).toBe(true)
+    expect(isEntitled(on('business'), 'auditLog')).toBe(false)
+    expect(isEntitled(on('enterprise'), 'auditLog')).toBe(true)
   })
 
   it('includes drafting and insights together on every paid plan', () => {
     expect(isEntitled(on('growth'), 'aiDrafts')).toBe(true)
     expect(isEntitled(on('growth'), 'aiInsights')).toBe(true)
-    expect(isEntitled(on('pro'), 'aiDrafts')).toBe(true)
-    expect(isEntitled(on('pro'), 'aiInsights')).toBe(true)
+    expect(isEntitled(on('business'), 'aiDrafts')).toBe(true)
+    expect(isEntitled(on('business'), 'aiInsights')).toBe(true)
   })
 
   it('never grants hideBranding from a plan; it is a purchased overlay', () => {

--- a/apps/web/src/lib/server/domains/settings/cloud/__tests__/refusal-copy.test.ts
+++ b/apps/web/src/lib/server/domains/settings/cloud/__tests__/refusal-copy.test.ts
@@ -97,7 +97,7 @@ describe('the defects that shipped', () => {
 
   it('agrees verb in the no-upgrade-available branch too', () => {
     // The "contact us" branch has its own copy path and was equally broken.
-    const config = cloud('scale', { entitlements: { customDomain: false } })
+    const config = cloud('enterprise', { entitlements: { customDomain: false } })
     expect(buildRefusal(config, 'customDomain').message).toBe(
       'Custom domains are not included in your plan. Your workspace is on Enterprise. Contact us to enable it.'
     )

--- a/apps/web/src/lib/server/domains/settings/cloud/__tests__/upgrade-context.test.ts
+++ b/apps/web/src/lib/server/domains/settings/cloud/__tests__/upgrade-context.test.ts
@@ -35,7 +35,7 @@ describe('upgradeContextFor', () => {
       trialActive: true,
       trialEligible: false,
     })
-    expect(upgradeContextFor(cloud({ plan: 'pro' }))?.trialEligible).toBe(false)
+    expect(upgradeContextFor(cloud({ plan: 'business' }))?.trialEligible).toBe(false)
     expect(upgradeContextFor(cloud({ subscriptionStatus: 'active' }))?.trialEligible).toBe(false)
     expect(upgradeContextFor(cloud({ subscriptionStatus: 'past_due' }))?.trialEligible).toBe(false)
     expect(upgradeContextFor(cloud({ canUpgrade: false }))?.trialEligible).toBe(false)

--- a/apps/web/src/lib/server/domains/settings/cloud/cloud.types.ts
+++ b/apps/web/src/lib/server/domains/settings/cloud/cloud.types.ts
@@ -16,19 +16,20 @@ import type { TierFeatureFlags } from '../tier-limits.types'
  * need a bespoke arrangement express it as explicit entitlement overrides on
  * top of a catalogue plan, not as a new plan id.
  *
- * Stored and projected ids stay `growth` / `pro` / `scale` until later remap
- * steps. Incoming CP/checkout slugs `business` and `enterprise` are aliases of
- * today's `pro` (Business) and `scale` (Enterprise); {@link canonicalPlanId}
- * maps them before catalogue lookup or storage.
+ * Canonical ids are `free` / `growth` / `business` / `enterprise`. Incoming
+ * `pro` is the entry tier (same grants as `growth`) so a later CP remap of
+ * `growth → pro` does not hand workflows to Pro workspaces. Incoming `scale`
+ * is Enterprise. {@link canonicalPlanId} maps those aliases before catalogue
+ * lookup or storage.
  */
-export const PLAN_IDS = ['free', 'growth', 'pro', 'scale'] as const
+export const PLAN_IDS = ['free', 'growth', 'business', 'enterprise'] as const
 
 export type PlanId = (typeof PLAN_IDS)[number]
 
 /** Incoming slugs that mean a canonical {@link PlanId} until later B steps. */
 export const PLAN_ID_ALIASES = {
-  business: 'pro',
-  enterprise: 'scale',
+  pro: 'growth',
+  scale: 'enterprise',
 } as const satisfies Record<string, PlanId>
 
 export type PlanIdAlias = keyof typeof PLAN_ID_ALIASES
@@ -38,8 +39,8 @@ export type PlanIdAlias = keyof typeof PLAN_ID_ALIASES
  * Unknown strings are returned as-is; {@link isPlanId} is the closed-set guard.
  */
 export function canonicalPlanId(id: string): PlanId {
-  if (id === 'business') return 'pro'
-  if (id === 'enterprise') return 'scale'
+  if (id === 'pro') return 'growth'
+  if (id === 'scale') return 'enterprise'
   return id as PlanId
 }
 
@@ -250,8 +251,8 @@ export const PLAN_CATALOGUE: Record<PlanId, PlanDefinition> = {
       'webhooks',
     ],
   },
-  pro: {
-    id: 'pro',
+  business: {
+    id: 'business',
     article: 'a',
     name: 'Business',
     rank: 2,
@@ -266,8 +267,8 @@ export const PLAN_CATALOGUE: Record<PlanId, PlanDefinition> = {
       'workflows',
     ],
   },
-  scale: {
-    id: 'scale',
+  enterprise: {
+    id: 'enterprise',
     article: 'an',
     name: 'Enterprise',
     rank: 3,

--- a/apps/web/src/lib/server/domains/settings/cloud/commercial-notice.ts
+++ b/apps/web/src/lib/server/domains/settings/cloud/commercial-notice.ts
@@ -8,7 +8,7 @@ export function plansActionUrl(config: Pick<CloudConfig, 'enabled' | 'canUpgrade
 
 function planLabel(config: CloudConfig, trialPlanName?: string | null): string {
   if (trialPlanName) return trialPlanName
-  return config.plan ? PLAN_CATALOGUE[config.plan].name : PLAN_CATALOGUE.pro.name
+  return config.plan ? PLAN_CATALOGUE[config.plan].name : PLAN_CATALOGUE.growth.name
 }
 
 /** Trial countdown derived from the control-plane-owned expiry timestamp. */

--- a/apps/web/src/lib/server/domains/settings/tier-limits.service.ts
+++ b/apps/web/src/lib/server/domains/settings/tier-limits.service.ts
@@ -58,13 +58,13 @@ const PLAN_ONLY_FEATURES: Record<
     customCss: false,
     integrations: false,
   },
-  pro: {
+  business: {
     analyticsExports: true,
     customColors: true,
     customCss: true,
     integrations: true,
   },
-  scale: {
+  enterprise: {
     analyticsExports: true,
     customColors: true,
     customCss: true,

--- a/apps/web/src/lib/server/domains/summary/__tests__/summary-entitlement.test.ts
+++ b/apps/web/src/lib/server/domains/summary/__tests__/summary-entitlement.test.ts
@@ -133,7 +133,7 @@ describe('generateAndSavePostSummary — plan gate', () => {
     await expect(generateAndSavePostSummary(POST_ID)).resolves.toBeUndefined()
     expect(hoisted.mockChat).toHaveBeenCalledOnce()
 
-    withCloud(storedCloud('scale', { aiInsights: false }))
+    withCloud(storedCloud('enterprise', { aiInsights: false }))
     await expect(generateAndSavePostSummary(POST_ID)).rejects.toBeInstanceOf(
       EntitlementRequiredError
     )

--- a/apps/web/src/lib/server/domains/webhooks/__tests__/webhooks-entitlement.test.ts
+++ b/apps/web/src/lib/server/domains/webhooks/__tests__/webhooks-entitlement.test.ts
@@ -133,7 +133,7 @@ describe('createWebhook — plan gate', () => {
     withCloud(storedCloud('free', { webhooks: true }))
     await expect(createWebhook(INPUT, CREATOR)).resolves.toBeDefined()
 
-    withCloud(storedCloud('scale', { webhooks: false }))
+    withCloud(storedCloud('enterprise', { webhooks: false }))
     await expect(createWebhook(INPUT, CREATOR)).rejects.toBeInstanceOf(EntitlementRequiredError)
   })
 })

--- a/apps/web/src/lib/server/domains/workflows/__tests__/workflows-entitlement.test.ts
+++ b/apps/web/src/lib/server/domains/workflows/__tests__/workflows-entitlement.test.ts
@@ -89,7 +89,7 @@ describe('createWorkflow — plan gate', () => {
   })
 
   it('creates the workflow on a plan that includes it', async () => {
-    withCloud(storedCloud('pro'))
+    withCloud(storedCloud('business'))
     await expect(createWorkflow(INPUT)).resolves.toMatchObject({ id: 'workflow_1' })
     expect(hoisted.mockInsert).toHaveBeenCalledOnce()
   })
@@ -98,7 +98,7 @@ describe('createWorkflow — plan gate', () => {
     withCloud(storedCloud('free', { workflows: true }))
     await expect(createWorkflow(INPUT)).resolves.toBeDefined()
 
-    withCloud(storedCloud('scale', { workflows: false }))
+    withCloud(storedCloud('enterprise', { workflows: false }))
     await expect(createWorkflow(INPUT)).rejects.toBeInstanceOf(EntitlementRequiredError)
   })
 })

--- a/apps/web/src/lib/server/functions/__tests__/audit-log-entitlement.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/audit-log-entitlement.test.ts
@@ -65,7 +65,7 @@ const LIMITS = {
 }
 
 function storedCloud(
-  plan: 'free' | 'growth' | 'pro' | 'scale',
+  plan: 'free' | 'growth' | 'business' | 'enterprise',
   entitlements?: Partial<Record<(typeof ENTITLEMENT_KEYS)[number], boolean>>
 ) {
   const grants = new Set(PLAN_CATALOGUE[plan].grants)
@@ -121,7 +121,7 @@ describe('listAuditEventsFn — no cloud config', () => {
 
 describe('listAuditEventsFn — plan gate', () => {
   it('refuses on a plan without the entitlement and names the plan that has it', async () => {
-    withCloud(storedCloud('pro'))
+    withCloud(storedCloud('business'))
 
     const refusal = await listAuditEvents({ data: {} }).catch((error: unknown) => error)
 
@@ -138,7 +138,7 @@ describe('listAuditEventsFn — plan gate', () => {
   })
 
   it('returns events on a plan that includes it', async () => {
-    withCloud(storedCloud('scale'))
+    withCloud(storedCloud('enterprise'))
     await expect(listAuditEvents({ data: {} })).resolves.toMatchObject({ hasMore: false })
     expect(hoisted.mockQueryAuditEvents).toHaveBeenCalledOnce()
   })
@@ -147,7 +147,7 @@ describe('listAuditEventsFn — plan gate', () => {
     withCloud(storedCloud('free', { auditLog: true }))
     await expect(listAuditEvents({ data: {} })).resolves.toBeDefined()
 
-    withCloud(storedCloud('scale', { auditLog: false }))
+    withCloud(storedCloud('enterprise', { auditLog: false }))
     await expect(listAuditEvents({ data: {} })).rejects.toBeInstanceOf(EntitlementRequiredError)
   })
 

--- a/apps/web/src/lib/server/functions/__tests__/invitations-accept.db.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/invitations-accept.db.test.ts
@@ -51,7 +51,7 @@ vi.mock('@/lib/server/domains/principals/membership-sync', () => ({
   enqueueMembershipSync: vi.fn(async () => {}),
 }))
 vi.mock('@/lib/server/domains/settings/cloud/cloud.service', () => ({
-  getCloudConfig: async () => ({ enabled: true, plan: 'pro', trialActive: false }),
+  getCloudConfig: async () => ({ enabled: true, plan: 'business', trialActive: false }),
 }))
 
 const { acceptInvitationFn } = await import('../invitations')
@@ -92,7 +92,7 @@ async function seedMember(email: string): Promise<UserId> {
 }
 
 async function projectMaxTeamSeats(maxTeamSeats: number): Promise<void> {
-  const cloud = storedCloud('pro')
+  const cloud = storedCloud('business')
   const projection = {
     ...cloud,
     projection: {

--- a/apps/web/src/lib/server/functions/__tests__/plan-notice-auth.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/plan-notice-auth.test.ts
@@ -133,7 +133,7 @@ describe('getPlanNotice — the trial countdown', () => {
     enabled: true,
     projection: {
       version: 1,
-      effectivePlan: 'pro',
+      effectivePlan: 'business',
       trialStartedAt: STARTED,
       trialExpiresAt: ENDS,
       subscriptionStatus: null,
@@ -194,7 +194,7 @@ describe('getPlanNotice — the trial countdown', () => {
 
   it('keeps a persistent ended banner after expiry', async () => {
     vi.setSystemTime(AFTER)
-    hoisted.mockFetchCatalogue.mockResolvedValue({ lastTrialPlanId: 'pro' })
+    hoisted.mockFetchCatalogue.mockResolvedValue({ lastTrialPlanId: 'business' })
     hoisted.mockGetWorkspaceSettings.mockResolvedValue({ settings: { cloud: trialing } })
     await expect(getPlanNoticeHandler()).resolves.toEqual(
       expect.objectContaining({
@@ -207,7 +207,7 @@ describe('getPlanNotice — the trial countdown', () => {
 
   it('still shows the ended banner more than seven days later', async () => {
     vi.setSystemTime(new Date('2026-03-23T00:00:00.000Z'))
-    hoisted.mockFetchCatalogue.mockResolvedValue({ lastTrialPlanId: 'pro' })
+    hoisted.mockFetchCatalogue.mockResolvedValue({ lastTrialPlanId: 'business' })
     hoisted.mockGetWorkspaceSettings.mockResolvedValue({ settings: { cloud: trialing } })
     await expect(getPlanNoticeHandler()).resolves.toEqual(
       expect.objectContaining({

--- a/apps/web/src/lib/server/functions/__tests__/sso-entitlement-gate.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/sso-entitlement-gate.test.ts
@@ -185,14 +185,17 @@ describe('plan gate on a workspace without the SSO entitlement', () => {
 describe('plan gate on a workspace that holds the entitlement', () => {
   it('allows creating a provider on Enterprise', async () => {
     hoisted.mockGetWorkspaceSettings.mockResolvedValue({
-      settings: { id: 'ws_1', cloud: { enabled: true, plan: 'scale' } },
+      settings: { id: 'ws_1', cloud: { enabled: true, plan: 'enterprise' } },
     })
     await expect(upsert({ data: { ...NEW_PROVIDER, enabled: true } })).resolves.toBeDefined()
   })
 
   it('allows creating a provider on a grandfathered override', async () => {
     hoisted.mockGetWorkspaceSettings.mockResolvedValue({
-      settings: { id: 'ws_1', cloud: { enabled: true, plan: 'pro', entitlements: { sso: true } } },
+      settings: {
+        id: 'ws_1',
+        cloud: { enabled: true, plan: 'business', entitlements: { sso: true } },
+      },
     })
     await expect(upsert({ data: { ...NEW_PROVIDER, enabled: true } })).resolves.toBeDefined()
   })

--- a/apps/web/src/lib/server/mcp/__tests__/mcp-entitlement.test.ts
+++ b/apps/web/src/lib/server/mcp/__tests__/mcp-entitlement.test.ts
@@ -132,7 +132,7 @@ describe('handleMcpRequest — plan gate', () => {
     withCloud(storedCloud('free', { mcpServer: true }))
     expect((await handleMcpRequest(mcpRequest())).status).toBe(200)
 
-    withCloud(storedCloud('scale', { mcpServer: false }))
+    withCloud(storedCloud('enterprise', { mcpServer: false }))
     expect((await handleMcpRequest(mcpRequest())).status).toBe(402)
   })
 

--- a/apps/web/src/lib/shared/__tests__/describe-upgrade.test.ts
+++ b/apps/web/src/lib/shared/__tests__/describe-upgrade.test.ts
@@ -15,15 +15,15 @@ const catalogue = {
   plans: [
     { id: 'free', name: 'Free', rank: 0, highlights: ['1 seat'] },
     { id: 'growth', name: 'Pro', rank: 1, highlights: ['Custom domain'] },
-    { id: 'pro', name: 'Business', rank: 2, highlights: ['Workflows'] },
-    { id: 'scale', name: 'Enterprise', rank: 3, highlights: ['Audit log', 'SSO'] },
+    { id: 'business', name: 'Business', rank: 2, highlights: ['Workflows'] },
+    { id: 'enterprise', name: 'Enterprise', rank: 3, highlights: ['Audit log', 'SSO'] },
   ],
 } as BillingCatalogue
 
 describe('describeEntitlementUpgrade', () => {
   it('names the cheapest catalogue plan for each wired key', () => {
     expect(describeEntitlementUpgrade('auditLog')).toMatchObject({
-      requiredPlan: 'scale',
+      requiredPlan: 'enterprise',
       requiredPlanName: 'Enterprise',
       headline: 'The audit log is available from the Enterprise plan',
       body: 'The audit log is an Enterprise feature. Upgrade to Enterprise to enable it.',
@@ -32,10 +32,10 @@ describe('describeEntitlementUpgrade', () => {
       headline: 'Webhooks are available from the Pro plan',
       body: 'Webhooks are a Pro feature. Upgrade to Pro to enable them.',
     })
-    expect(describeEntitlementUpgrade('sso').requiredPlan).toBe('scale')
+    expect(describeEntitlementUpgrade('sso').requiredPlan).toBe('enterprise')
     expect(describeEntitlementUpgrade('customDomain').requiredPlan).toBe('growth')
     expect(describeEntitlementUpgrade('webhooks').requiredPlan).toBe('growth')
-    expect(describeEntitlementUpgrade('workflows').requiredPlan).toBe('pro')
+    expect(describeEntitlementUpgrade('workflows').requiredPlan).toBe('business')
     expect(describeEntitlementUpgrade('mcpServer').requiredPlan).toBe('growth')
     expect(describeEntitlementUpgrade('aiDrafts').requiredPlan).toBe('growth')
     expect(describeEntitlementUpgrade('aiInsights').requiredPlan).toBe('growth')
@@ -80,15 +80,15 @@ describe('throwIfServerFnFailed', () => {
 
 describe('describePlanUpgrade', () => {
   it('builds the same sentence shape for a named feature', () => {
-    expect(describePlanUpgrade('Data export', 'pro')).toMatchObject({
-      requiredPlan: 'pro',
+    expect(describePlanUpgrade('Data export', 'business')).toMatchObject({
+      requiredPlan: 'business',
       headline: 'Data export is available from the Business plan',
       body: 'Data export is a Business feature. Upgrade to Business to enable it.',
     })
   })
 
   it('takes a plural verb when asked', () => {
-    expect(describePlanUpgrade('Integrations', 'pro', { plural: true })).toMatchObject({
+    expect(describePlanUpgrade('Integrations', 'business', { plural: true })).toMatchObject({
       headline: 'Integrations are available from the Business plan',
       body: 'Integrations are a Business feature. Upgrade to Business to enable them.',
     })
@@ -96,7 +96,7 @@ describe('describePlanUpgrade', () => {
 })
 
 describe('describePlanRefusal', () => {
-  const fallback = describePlanUpgrade('Custom colours', 'pro', { plural: true })
+  const fallback = describePlanUpgrade('Custom colours', 'business', { plural: true })
 
   it('names the feature and plan from an entitlement refusal', () => {
     expect(
@@ -106,7 +106,7 @@ describe('describePlanRefusal', () => {
         ),
         fallback
       )
-    ).toMatchObject({ feature: 'Workflows', requiredPlan: 'pro' })
+    ).toMatchObject({ feature: 'Workflows', requiredPlan: 'business' })
   })
 
   it('names the feature from a tier refusal and keeps the fallback plan', () => {
@@ -117,7 +117,7 @@ describe('describePlanRefusal', () => {
       )
     ).toMatchObject({
       feature: 'Custom CSS',
-      requiredPlan: 'pro',
+      requiredPlan: 'business',
       headline: 'Custom CSS is available from the Business plan',
     })
   })
@@ -145,32 +145,32 @@ describe('upgradeLead', () => {
 
 describe('unlockedHighlights', () => {
   it('lists the target plan and everything in between, cheapest first', () => {
-    expect(unlockedHighlights(catalogue, 'free', 'scale')).toEqual({
+    expect(unlockedHighlights(catalogue, 'free', 'enterprise')).toEqual({
       target: ['Audit log', 'SSO'],
       included: [
         { planName: 'Pro', highlights: ['Custom domain'] },
         { planName: 'Business', highlights: ['Workflows'] },
       ],
     })
-    expect(unlockedHighlights(catalogue, 'growth', 'pro')).toEqual({
+    expect(unlockedHighlights(catalogue, 'growth', 'business')).toEqual({
       target: ['Workflows'],
       included: [],
     })
   })
 
   it('shows only the target when the current plan is unknown or the catalogue is missing', () => {
-    expect(unlockedHighlights(catalogue, null, 'scale')).toEqual({
+    expect(unlockedHighlights(catalogue, null, 'enterprise')).toEqual({
       target: ['Audit log', 'SSO'],
       included: [],
     })
-    expect(unlockedHighlights(null, 'free', 'scale')).toEqual({ target: [], included: [] })
+    expect(unlockedHighlights(null, 'free', 'enterprise')).toEqual({ target: [], included: [] })
   })
 })
 
 describe('cataloguePlanFor', () => {
   it('returns the billing-page plan row', () => {
-    expect(cataloguePlanFor(catalogue, 'scale')?.highlights).toEqual(['Audit log', 'SSO'])
+    expect(cataloguePlanFor(catalogue, 'enterprise')?.highlights).toEqual(['Audit log', 'SSO'])
     expect(cataloguePlanFor(catalogue, 'free')?.id).toBe('free')
-    expect(cataloguePlanFor(null, 'scale')).toBeNull()
+    expect(cataloguePlanFor(null, 'enterprise')).toBeNull()
   })
 })

--- a/apps/web/src/lib/shared/billing/__tests__/checkout-flash.test.ts
+++ b/apps/web/src/lib/shared/billing/__tests__/checkout-flash.test.ts
@@ -6,7 +6,7 @@ import type { BillingCatalogue } from '@/lib/server/control-plane/client'
 const catalogue = {
   plans: [
     {
-      id: 'pro',
+      id: 'growth',
       name: 'Pro',
       rank: 2,
       priceMonthlyCents: 3000,
@@ -20,7 +20,7 @@ const catalogue = {
 } as unknown as BillingCatalogue
 
 const overview = {
-  plan: 'pro',
+  plan: 'growth',
   planName: 'Pro',
   status: 'active',
   trialActive: false,

--- a/apps/web/src/lib/shared/billing/__tests__/checkout-path.test.ts
+++ b/apps/web/src/lib/shared/billing/__tests__/checkout-path.test.ts
@@ -14,21 +14,25 @@ const pro = { priceMonthlyCents: 5900, priceYearlyCents: 59000, billedPer: 'seat
 describe('checkoutPath', () => {
   it('encodes only what was given', () => {
     expect(checkoutPath()).toBe('/admin/settings/billing/checkout')
-    expect(checkoutPath({ plan: 'pro' })).toBe('/admin/settings/billing/checkout?plan=pro')
-    expect(parsePaidPlanId('business')).toBe('pro')
-    expect(parsePaidPlanId('enterprise')).toBe('scale')
+    expect(checkoutPath({ plan: 'business' })).toBe(
+      '/admin/settings/billing/checkout?plan=business'
+    )
+    expect(parsePaidPlanId('pro')).toBe('growth')
+    expect(parsePaidPlanId('scale')).toBe('enterprise')
+    expect(parsePaidPlanId('business')).toBe('business')
+    expect(parsePaidPlanId('enterprise')).toBe('enterprise')
     expect(parsePaidPlanId('growth')).toBe('growth')
-    expect(checkoutPath({ plan: parsePaidPlanId('business') ?? 'pro' })).toBe(
-      '/admin/settings/billing/checkout?plan=pro'
+    expect(checkoutPath({ plan: parsePaidPlanId('pro') ?? 'growth' })).toBe(
+      '/admin/settings/billing/checkout?plan=growth'
     )
-    expect(checkoutPath({ plan: 'pro', period: 'monthly', seats: 3 })).toBe(
-      '/admin/settings/billing/checkout?plan=pro&period=monthly&seats=3'
+    expect(checkoutPath({ plan: 'business', period: 'monthly', seats: 3 })).toBe(
+      '/admin/settings/billing/checkout?plan=business&period=monthly&seats=3'
     )
-    expect(checkoutPath({ plan: 'pro', branding: true })).toBe(
-      '/admin/settings/billing/checkout?plan=pro&branding=true'
+    expect(checkoutPath({ plan: 'business', branding: true })).toBe(
+      '/admin/settings/billing/checkout?plan=business&branding=true'
     )
-    expect(checkoutPath({ plan: 'pro', branding: false })).toBe(
-      '/admin/settings/billing/checkout?plan=pro'
+    expect(checkoutPath({ plan: 'business', branding: false })).toBe(
+      '/admin/settings/billing/checkout?plan=business'
     )
   })
 })
@@ -38,7 +42,7 @@ describe('parseCheckoutSearch', () => {
     expect(
       parseCheckoutSearch({ plan: 'scale', period: 'annual', seats: '4', branding: 'true' })
     ).toEqual({
-      plan: 'scale',
+      plan: 'enterprise',
       period: 'annual',
       seats: 4,
       branding: true,
@@ -47,8 +51,9 @@ describe('parseCheckoutSearch', () => {
     expect(parseCheckoutSearch({ branding: 'false' })).toEqual({})
     expect(parseCheckoutSearch({ branding: 'yes' })).toEqual({})
     expect(parseCheckoutSearch({ plan: 'platinum', seats: 'lots' })).toEqual({})
-    expect(parseCheckoutSearch({ plan: 'enterprise' })).toEqual({ plan: 'scale' })
-    expect(parseCheckoutSearch({ plan: 'business' })).toEqual({ plan: 'pro' })
+    expect(parseCheckoutSearch({ plan: 'enterprise' })).toEqual({ plan: 'enterprise' })
+    expect(parseCheckoutSearch({ plan: 'pro' })).toEqual({ plan: 'growth' })
+    expect(parseCheckoutSearch({ plan: 'business' })).toEqual({ plan: 'business' })
     expect(parseCheckoutSearch({ seats: 2.5 })).toEqual({})
     expect(parseCheckoutSearch({ seats: '1001' })).toEqual({ seats: 1001 })
   })

--- a/apps/web/src/lib/shared/billing/__tests__/free-downgrade.test.ts
+++ b/apps/web/src/lib/shared/billing/__tests__/free-downgrade.test.ts
@@ -80,8 +80,16 @@ describe('planDowngradeIssues', () => {
 
 describe('featuresDisabledOnFree', () => {
   it('names Pro features when the trial plan is Pro', () => {
-    expect(featuresDisabledOnFree('pro')).toContain('Workflows and automations will be disabled')
     expect(featuresDisabledOnFree('pro')).toContain('MCP access will be revoked')
+    expect(featuresDisabledOnFree('pro')).not.toContain(
+      'Workflows and automations will be disabled'
+    )
+  })
+
+  it('names Business features when leaving Business', () => {
+    expect(featuresDisabledOnFree('business')).toContain(
+      'Workflows and automations will be disabled'
+    )
   })
 
   it('only lists disabled features when the target is Free', () => {

--- a/apps/web/src/lib/shared/billing/__tests__/plan-action.test.ts
+++ b/apps/web/src/lib/shared/billing/__tests__/plan-action.test.ts
@@ -14,8 +14,8 @@ const unpaidFree: BillingProjectionOverview = {
   canManageBilling: false,
   purchasablePlans: [
     { id: 'growth', name: 'Pro' },
-    { id: 'pro', name: 'Business' },
-    { id: 'scale', name: 'Enterprise' },
+    { id: 'business', name: 'Business' },
+    { id: 'enterprise', name: 'Enterprise' },
   ],
   seats: { used: 1, pending: 0, members: 1, purchased: null },
   ai: null,
@@ -26,7 +26,10 @@ describe('billingPlanAction', () => {
   it('offers a 7-day trial of untried paid plans on Free', () => {
     expect(billingPlanAction('free', unpaidFree).kind).toBe('current')
     expect(billingPlanAction('growth', unpaidFree)).toEqual({ kind: 'trial', planId: 'growth' })
-    expect(billingPlanAction('pro', unpaidFree)).toEqual({ kind: 'trial', planId: 'pro' })
+    expect(billingPlanAction('business', unpaidFree)).toEqual({
+      kind: 'trial',
+      planId: 'business',
+    })
   })
 
   it('does not re-trial a plan already in the ledger', () => {
@@ -34,9 +37,9 @@ describe('billingPlanAction', () => {
       kind: 'subscribe',
       planId: 'growth',
     })
-    expect(billingPlanAction('pro', unpaidFree, ['growth'])).toEqual({
+    expect(billingPlanAction('business', unpaidFree, ['growth'])).toEqual({
       kind: 'trial',
-      planId: 'pro',
+      planId: 'business',
     })
   })
 
@@ -50,7 +53,10 @@ describe('billingPlanAction', () => {
     }
     expect(billingPlanAction('growth', trialing).kind).toBe('current')
     expect(billingPlanAction('free', trialing).kind).toBe('downgrade')
-    expect(billingPlanAction('pro', trialing)).toEqual({ kind: 'subscribe', planId: 'pro' })
+    expect(billingPlanAction('business', trialing)).toEqual({
+      kind: 'subscribe',
+      planId: 'business',
+    })
   })
 
   it('switches paid plans and always allows a Free downgrade', () => {
@@ -64,9 +70,11 @@ describe('billingPlanAction', () => {
       renewalAt: '2026-09-14T00:00:00.000Z',
     }
     expect(billingPlanAction('growth', paid).kind).toBe('current')
-    expect(billingPlanAction('pro', paid)).toEqual({ kind: 'switch', planId: 'pro' })
+    expect(billingPlanAction('business', paid)).toEqual({ kind: 'switch', planId: 'business' })
     expect(billingPlanAction('free', paid)).toEqual({ kind: 'downgrade', planId: 'free' })
-    expect(billingPlanAction('growth', { ...paid, plan: 'pro', planName: 'Business' })).toEqual({
+    expect(
+      billingPlanAction('growth', { ...paid, plan: 'business', planName: 'Business' })
+    ).toEqual({
       kind: 'downgrade',
       planId: 'growth',
     })
@@ -82,41 +90,47 @@ describe('billingPlanAction', () => {
   it('does not let a complimentary grant self-downgrade', () => {
     const grant: BillingProjectionOverview = {
       ...unpaidFree,
-      plan: 'scale',
+      plan: 'enterprise',
       planName: 'Enterprise',
       status: null,
       canUpgrade: true,
       canManageBilling: false,
     }
-    expect(billingPlanAction('scale', grant).kind).toBe('current')
+    expect(billingPlanAction('enterprise', grant).kind).toBe('current')
     expect(billingPlanAction('free', grant).kind).toBe('unavailable')
-    expect(billingPlanAction('pro', grant)).toEqual({ kind: 'subscribe', planId: 'pro' })
+    expect(billingPlanAction('business', grant)).toEqual({
+      kind: 'subscribe',
+      planId: 'business',
+    })
   })
 
   it('treats an ended trial as choosing a plan, with Free as a gated downgrade', () => {
     const ended: BillingProjectionOverview = {
       ...unpaidFree,
       trialEnded: true,
-      trialPlanId: 'pro',
+      trialPlanId: 'business',
       trialPlanName: 'Business',
       trialExpiresAt: '2026-08-18T00:00:00.000Z',
     }
-    expect(billingPlanAction('pro', ended)).toEqual({ kind: 'subscribe', planId: 'pro' })
+    expect(billingPlanAction('business', ended)).toEqual({
+      kind: 'subscribe',
+      planId: 'business',
+    })
     expect(billingPlanAction('growth', ended)).toEqual({ kind: 'subscribe', planId: 'growth' })
     expect(billingPlanAction('free', ended).kind).toBe('downgrade')
   })
 
   it('covers every catalogue id', () => {
-    const ids: CataloguePlanId[] = ['free', 'growth', 'pro', 'scale']
+    const ids: CataloguePlanId[] = ['free', 'growth', 'business', 'enterprise']
     for (const id of ids) {
       expect(billingPlanAction(id, unpaidFree).kind).toBeTruthy()
     }
   })
 
-  it('treats business/enterprise as the current pro/scale actions', () => {
-    expect(billingPlanAction('business', unpaidFree)).toEqual(billingPlanAction('pro', unpaidFree))
-    expect(billingPlanAction('enterprise', unpaidFree)).toEqual(
-      billingPlanAction('scale', unpaidFree)
+  it('treats pro/scale as the current growth/enterprise actions', () => {
+    expect(billingPlanAction('pro', unpaidFree)).toEqual(billingPlanAction('growth', unpaidFree))
+    expect(billingPlanAction('scale', unpaidFree)).toEqual(
+      billingPlanAction('enterprise', unpaidFree)
     )
   })
 })

--- a/apps/web/src/lib/shared/billing/checkout-path.ts
+++ b/apps/web/src/lib/shared/billing/checkout-path.ts
@@ -15,7 +15,7 @@ export type CheckoutSearch = {
   branding?: boolean
 }
 
-const PAID_PLAN_IDS: readonly PaidPlanId[] = ['growth', 'pro', 'scale']
+const PAID_PLAN_IDS: readonly PaidPlanId[] = ['growth', 'business', 'enterprise']
 
 /** Checkout/trial forms accept these; aliases are stored and forwarded as canonical ids. */
 export const INCOMING_PAID_PLAN_IDS = ['growth', 'pro', 'scale', 'business', 'enterprise'] as const

--- a/apps/web/src/lib/shared/billing/plan-action.ts
+++ b/apps/web/src/lib/shared/billing/plan-action.ts
@@ -7,7 +7,7 @@ import {
   type PlanIdAlias,
 } from '@/lib/server/domains/settings/cloud/cloud.types'
 
-export type PaidPlanId = 'growth' | 'pro' | 'scale'
+export type PaidPlanId = 'growth' | 'business' | 'enterprise'
 export type CataloguePlanId = 'free' | PaidPlanId | PlanIdAlias
 export type DowngradePlanId = 'free' | PaidPlanId
 
@@ -21,7 +21,7 @@ export type BillingPlanAction =
 
 function isPaidPlanId(id: string): id is PaidPlanId {
   const canonical = canonicalPlanId(id)
-  return canonical === 'growth' || canonical === 'pro' || canonical === 'scale'
+  return canonical === 'growth' || canonical === 'business' || canonical === 'enterprise'
 }
 
 function hasLivePaidSub(overview: BillingProjectionOverview): boolean {

--- a/apps/web/src/lib/shared/billing/plan-downgrade.ts
+++ b/apps/web/src/lib/shared/billing/plan-downgrade.ts
@@ -37,7 +37,7 @@ export const PLAN_NUMERIC_CAPS: Record<
     maxCustomRoles: 0,
     maxSendingDomains: 1,
   },
-  pro: {
+  business: {
     maxBoards: null,
     maxPosts: null,
     maxTeamSeats: null,
@@ -45,7 +45,7 @@ export const PLAN_NUMERIC_CAPS: Record<
     maxCustomRoles: 5,
     maxSendingDomains: 3,
   },
-  scale: {
+  enterprise: {
     maxBoards: null,
     maxPosts: null,
     maxTeamSeats: null,
@@ -100,7 +100,7 @@ export const FREE_DISABLED_FEATURES: Record<string, string[]> = {
     'Webhooks will be disabled',
     'MCP access will be revoked',
   ],
-  pro: [
+  business: [
     'Custom domains will be disabled',
     'Workflows and automations will be disabled',
     'AI assistant, drafts and insights will be disabled',
@@ -108,7 +108,7 @@ export const FREE_DISABLED_FEATURES: Record<string, string[]> = {
     'Webhooks will be disabled',
     'MCP access will be revoked',
   ],
-  scale: [
+  enterprise: [
     'Custom domains will be disabled',
     'Workflows and automations will be disabled',
     'Single sign-on will be disabled',
@@ -158,8 +158,8 @@ export function freeDowngradeIssues(used: Record<string, number>): PlanDowngrade
 }
 
 export function featuresDisabledOnFree(planId: string | null | undefined): string[] {
-  if (!planId) return FREE_DISABLED_FEATURES.pro
-  return FREE_DISABLED_FEATURES[canonicalPlanId(planId)] ?? FREE_DISABLED_FEATURES.pro
+  if (!planId) return FREE_DISABLED_FEATURES.business
+  return FREE_DISABLED_FEATURES[canonicalPlanId(planId)] ?? FREE_DISABLED_FEATURES.business
 }
 
 export function featuresDisabledOnDowngrade(

--- a/apps/web/src/routes/admin/settings.integrations.index.tsx
+++ b/apps/web/src/routes/admin/settings.integrations.index.tsx
@@ -66,6 +66,8 @@ export function IntegrationsSettingsBody(props: {
   return props.enabled ? (
     <IntegrationList catalog={props.catalog} integrations={props.integrations} />
   ) : (
-    <UpgradeScreen description={describePlanUpgrade('Integrations', 'pro', { plural: true })} />
+    <UpgradeScreen
+      description={describePlanUpgrade('Integrations', 'business', { plural: true })}
+    />
   )
 }

--- a/apps/web/src/routes/admin/settings.portal.tsx
+++ b/apps/web/src/routes/admin/settings.portal.tsx
@@ -210,7 +210,10 @@ function PortalPage() {
     } catch (error) {
       if (isPlanRefusal(error)) {
         setUpgrade(
-          describePlanRefusal(error, describePlanUpgrade('Custom colours', 'pro', { plural: true }))
+          describePlanRefusal(
+            error,
+            describePlanUpgrade('Custom colours', 'business', { plural: true })
+          )
         )
       } else {
         toast.error(error instanceof Error ? error.message : "Couldn't save portal. Try again.")
@@ -542,7 +545,7 @@ function PortalPage() {
         onOpenChange={(open) => {
           if (!open) setUpgrade(null)
         }}
-        description={upgrade ?? describePlanUpgrade('Custom colours', 'pro', { plural: true })}
+        description={upgrade ?? describePlanUpgrade('Custom colours', 'business', { plural: true })}
       />
     </div>
   )

--- a/apps/web/src/routes/api/admin/assistant/__tests__/transform-entitlement.test.ts
+++ b/apps/web/src/routes/api/admin/assistant/__tests__/transform-entitlement.test.ts
@@ -187,7 +187,7 @@ describe('POST /api/admin/assistant/transform — plan gate', () => {
     withCloud({ enabled: true, plan: 'free', entitlements: { aiDrafts: true } })
     expect((await handleTransform({ request: makeRequest() })).status).toBe(200)
 
-    withCloud({ enabled: true, plan: 'scale', entitlements: { aiDrafts: false } })
+    withCloud({ enabled: true, plan: 'enterprise', entitlements: { aiDrafts: false } })
     expect((await handleTransform({ request: makeRequest() })).status).toBe(402)
   })
 })

--- a/apps/web/src/routes/api/billing/__tests__/session.test.ts
+++ b/apps/web/src/routes/api/billing/__tests__/session.test.ts
@@ -217,11 +217,11 @@ describe('POST /api/billing/session checkout', () => {
     })
   })
 
-  it('accepts business/enterprise checkout slugs and forwards canonical ids', async () => {
+  it('accepts business/enterprise checkout slugs and forwards those ids', async () => {
     hoisted.fetchBillingCatalogue.mockResolvedValue({
       plans: [
-        { id: 'pro', billedPer: 'workspace' },
-        { id: 'scale', billedPer: 'workspace' },
+        { id: 'business', billedPer: 'workspace' },
+        { id: 'enterprise', billedPer: 'workspace' },
       ],
     })
     await POST({
@@ -233,7 +233,7 @@ describe('POST /api/billing/session checkout', () => {
     })
     expect(hoisted.createHostedBillingSession).toHaveBeenCalledWith({
       action: 'checkout',
-      planId: 'pro',
+      planId: 'business',
       billingPeriod: 'monthly',
       quantity: 1,
     })
@@ -248,7 +248,7 @@ describe('POST /api/billing/session checkout', () => {
     })
     expect(hoisted.createHostedBillingSession).toHaveBeenCalledWith({
       action: 'checkout',
-      planId: 'scale',
+      planId: 'enterprise',
       billingPeriod: 'annual',
       quantity: 1,
     })

--- a/apps/web/src/routes/api/billing/__tests__/trial.test.ts
+++ b/apps/web/src/routes/api/billing/__tests__/trial.test.ts
@@ -49,18 +49,18 @@ describe('POST /api/billing/trial', () => {
     hoisted.startWorkspaceTrial.mockResolvedValue('started')
   })
 
-  it('accepts business/enterprise slugs and starts the canonical trial', async () => {
+  it('accepts business/enterprise slugs and starts those trials', async () => {
     const res = await POST({ request: formRequest({ planId: 'business' }) })
     expect(res.status).toBe(303)
-    expect(hoisted.startWorkspaceTrial).toHaveBeenCalledWith('pro')
+    expect(hoisted.startWorkspaceTrial).toHaveBeenCalledWith('business')
 
     hoisted.startWorkspaceTrial.mockClear()
     await POST({ request: formRequest({ planId: 'enterprise' }) })
-    expect(hoisted.startWorkspaceTrial).toHaveBeenCalledWith('scale')
+    expect(hoisted.startWorkspaceTrial).toHaveBeenCalledWith('enterprise')
   })
 
-  it('still starts a canonical paid trial', async () => {
+  it('maps a pro checkout slug onto the entry-tier trial', async () => {
     await POST({ request: formRequest({ planId: 'pro' }) })
-    expect(hoisted.startWorkspaceTrial).toHaveBeenCalledWith('pro')
+    expect(hoisted.startWorkspaceTrial).toHaveBeenCalledWith('growth')
   })
 })


### PR DESCRIPTION
Phase B3 of the Cloud plan-id remap.

**What changed**
- Canonical catalogue ids are `free` / `growth` / `business` / `enterprise`.
- Incoming `pro` is the entry tier (same grants and `PLAN_ONLY_FEATURES` as `growth`). Incoming `scale` is Enterprise.
- Checkout, trials, and hosted billing sessions forward `growth` / `business` / `enterprise` to the control plane (which already stores those ids after B2).
- Refusal copy for integrations, custom colours, and data export names Business.

**Why this order**
B2 already projects `business` / `enterprise`. If OSS kept aliasing those onto `pro` / `scale` while flipping `pro` to entry-tier grants, live Business workspaces would lose workflows. This PR un-aliases them in the same change.

`growth` stays the stored entry-tier id until B4 remaps it. Stripe lookup keys are unchanged.

**Not in this PR**
- CP `growth → pro`
- Website `?plan=` / recommended id
- Fleet promote (after merge)