### PR TITLE
feat(billing): drain leftover growth/scale from checkout POSTs

### DIFF
--- a/apps/web/src/lib/shared/billing/checkout-path.ts
+++ b/apps/web/src/lib/shared/billing/checkout-path.ts
@@ -15,9 +15,13 @@ export type CheckoutSearch = {
   branding?: boolean
 }
 
-const PAID_PLAN_IDS: readonly PaidPlanId[] = ['pro', 'business', 'enterprise']
+export const PAID_PLAN_IDS = ['pro', 'business', 'enterprise'] as const
 
-/** Checkout/trial forms accept these; leftover growth/scale alias onto canonical ids. */
+/**
+ * Leftover query/search slugs. Checkout and trial POSTs use {@link PAID_PLAN_IDS};
+ * {@link parsePaidPlanId} still maps these onto canonical ids so old
+ * `?plan=growth` / `?plan=scale` links keep working.
+ */
 export const INCOMING_PAID_PLAN_IDS = ['growth', 'pro', 'scale', 'business', 'enterprise'] as const
 
 export function isPaidPlanId(value: unknown): value is PaidPlanId {

--- a/apps/web/src/routes/api/billing/__tests__/session.test.ts
+++ b/apps/web/src/routes/api/billing/__tests__/session.test.ts
@@ -254,6 +254,26 @@ describe('POST /api/billing/session checkout', () => {
     })
   })
 
+  it('rejects leftover growth/scale checkout slugs', async () => {
+    const growth = await POST({
+      request: formRequest({
+        action: 'checkout',
+        planId: 'growth',
+        billingPeriod: 'monthly',
+      }),
+    })
+    expect(growth.headers.get('location')).toContain('billing_error=invalid')
+    const scale = await POST({
+      request: formRequest({
+        action: 'checkout',
+        planId: 'scale',
+        billingPeriod: 'annual',
+      }),
+    })
+    expect(scale.headers.get('location')).toContain('billing_error=invalid')
+    expect(hoisted.createHostedBillingSession).not.toHaveBeenCalled()
+  })
+
   it('forwards a quantity at or above live usage', async () => {
     const res = await POST({ request: checkoutRequest(8) })
     expect(res.status).toBe(303)

--- a/apps/web/src/routes/api/billing/__tests__/trial.test.ts
+++ b/apps/web/src/routes/api/billing/__tests__/trial.test.ts
@@ -63,4 +63,12 @@ describe('POST /api/billing/trial', () => {
     await POST({ request: formRequest({ planId: 'pro' }) })
     expect(hoisted.startWorkspaceTrial).toHaveBeenCalledWith('pro')
   })
+
+  it('rejects leftover growth/scale trial slugs', async () => {
+    const growth = await POST({ request: formRequest({ planId: 'growth' }) })
+    expect(growth.headers.get('location')).toContain('billing_error=invalid')
+    const scale = await POST({ request: formRequest({ planId: 'scale' }) })
+    expect(scale.headers.get('location')).toContain('billing_error=invalid')
+    expect(hoisted.startWorkspaceTrial).not.toHaveBeenCalled()
+  })
 })

--- a/apps/web/src/routes/api/billing/session.ts
+++ b/apps/web/src/routes/api/billing/session.ts
@@ -1,7 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { z } from 'zod'
 import { isSameOriginFormPost } from '@/lib/server/http/same-origin-form'
-import { INCOMING_PAID_PLAN_IDS, parsePaidPlanId } from '@/lib/shared/billing/checkout-path'
+import { PAID_PLAN_IDS, parsePaidPlanId } from '@/lib/shared/billing/checkout-path'
 import { PERMISSIONS } from '@/lib/shared/permissions'
 
 export function billingErrorCode(error: unknown): string {
@@ -45,7 +45,7 @@ const actionSchema = z.discriminatedUnion('action', [
   z.object({ action: z.literal('portal') }),
   z.object({
     action: z.literal('checkout'),
-    planId: z.enum(INCOMING_PAID_PLAN_IDS),
+    planId: z.enum(PAID_PLAN_IDS),
     billingPeriod: z.enum(['monthly', 'annual']),
     quantity: z.coerce.number().int().positive().optional(),
     // A checked checkbox posts "true"; an unchecked one posts nothing.
@@ -172,7 +172,7 @@ async function createSeatChangeSession(quantity: number) {
 /** Floor seat-billed checkout at live usage so a stale form cannot under-seat.
  *  Workspace-priced plans stay quantity 1. */
 async function createCheckoutSession(input: {
-  planId: (typeof INCOMING_PAID_PLAN_IDS)[number]
+  planId: (typeof PAID_PLAN_IDS)[number]
   billingPeriod: 'monthly' | 'annual'
   quantity?: number
   brandingRemoval?: 'true'

--- a/apps/web/src/routes/api/billing/trial.ts
+++ b/apps/web/src/routes/api/billing/trial.ts
@@ -1,12 +1,12 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { z } from 'zod'
 import { isSameOriginFormPost } from '@/lib/server/http/same-origin-form'
-import { INCOMING_PAID_PLAN_IDS, parsePaidPlanId } from '@/lib/shared/billing/checkout-path'
+import { PAID_PLAN_IDS, parsePaidPlanId } from '@/lib/shared/billing/checkout-path'
 import { PERMISSIONS } from '@/lib/shared/permissions'
 import { billingFormErrorResponse, billingSessionErrorResponse } from './session'
 
 const trialSchema = z.object({
-  planId: z.enum(INCOMING_PAID_PLAN_IDS),
+  planId: z.enum(PAID_PLAN_IDS),
   /** Admin page the prompt was raised on, so the trial lands back on the now-unlocked feature. */
   returnTo: z.string().optional(),
 })


### PR DESCRIPTION
## Why
B5 drain. Checkout and trial forms still accepted leftover `growth`/`scale` POST bodies, then mapped them to canonical ids.

## What
- Checkout and trial POSTs accept `pro | business | enterprise` only
- Leftover `?plan=growth` / `?plan=scale` links still map via parsePaidPlanId
- Control-plane client still canonicalises leftover ids on the wire
- Tests reject leftover form POSTs

No versioned release. Promote the fleet from `main` after merge.