### PR TITLE
fix(workspaces): anonymous reads no longer count as workspace activity

### DIFF
--- a/apps/web/src/lib/server/workspaces/TENANCY.md
+++ b/apps/web/src/lib/server/workspaces/TENANCY.md
@@ -579,6 +579,14 @@ minutes), and the worker's next registry refresh — at most 60 s later — sees
 the stamp and starts the loop again. Health probes bypass the hook, so the
 platform cannot wake anything.
 
+Not every served request is a stamp. A wildcard domain is crawled all day
+(`GET /.env`, anonymous `GET /`), and the first rollout showed that "any
+request" would re-wake the fleet in days. `isActivitySignal` counts a
+mutation, or a read carrying a session cookie or bearer token; an anonymous
+read is served exactly as before and simply does not count. An anonymous
+visitor who then posts or votes wakes the loop with that POST, within the
+same minute the loop cadence already implies.
+
 Idle is not the same as nothing to do. Before parking, the worker asks the
 workspace's own database two questions it already knows how to answer —
 `earliestPendingJobAt()` (a delayed hook retry, a scheduled publish) and

--- a/apps/web/src/lib/server/workspaces/__tests__/activity.test.ts
+++ b/apps/web/src/lib/server/workspaces/__tests__/activity.test.ts
@@ -66,6 +66,40 @@ describe('isPastDormancyThreshold', () => {
   })
 })
 
+describe('isActivitySignal', () => {
+  // Not a real `Request`: happy-dom's strips the forbidden `cookie` header,
+  // which is precisely the header under test. The predicate needs only this shape.
+  const req = (method: string, headers: Record<string, string> = {}) => ({
+    method,
+    headers: { get: (name: string) => headers[name.toLowerCase()] ?? null },
+  })
+
+  it('ignores anonymous reads — what crawlers and scanners send', async () => {
+    const { isActivitySignal } = await load()
+    expect(isActivitySignal(req('GET'))).toBe(false)
+    expect(isActivitySignal(req('HEAD'))).toBe(false)
+    expect(isActivitySignal(req('OPTIONS'))).toBe(false)
+    expect(isActivitySignal(req('GET', { cookie: 'theme=dark' }))).toBe(false)
+    expect(isActivitySignal(req('GET', { authorization: 'Basic abc' }))).toBe(false)
+  })
+
+  it('counts every mutation', async () => {
+    const { isActivitySignal } = await load()
+    for (const method of ['POST', 'PUT', 'PATCH', 'DELETE']) {
+      expect(isActivitySignal(req(method))).toBe(true)
+    }
+  })
+
+  it('counts a read from a signed-in session or a bearer token', async () => {
+    const { isActivitySignal } = await load()
+    expect(isActivitySignal(req('GET', { cookie: 'a=1; better-auth.session_token=t' }))).toBe(true)
+    expect(isActivitySignal(req('GET', { cookie: '__Secure-better-auth.session_token=t' }))).toBe(
+      true
+    )
+    expect(isActivitySignal(req('GET', { authorization: 'Bearer qb_key' }))).toBe(true)
+  })
+})
+
 describe('noteWorkspaceActivity', () => {
   it('upserts the stamp once, then throttles the same workspace', async () => {
     const { noteWorkspaceActivity, STAMP_INTERVAL_MS } = await load()

--- a/apps/web/src/lib/server/workspaces/__tests__/request-scope.test.ts
+++ b/apps/web/src/lib/server/workspaces/__tests__/request-scope.test.ts
@@ -14,21 +14,36 @@ const acquireScopeForHost = vi.fn()
 const noteWorkspaceActivity = vi.fn(() => Promise.resolve())
 
 vi.mock('@/lib/server/workspaces/resolver', () => ({ acquireScopeForHost }))
-vi.mock('../activity', () => ({ noteWorkspaceActivity }))
+vi.mock('../activity', async (importOriginal) => ({
+  // The real predicate decides which requests count; only the write is mocked.
+  isActivitySignal: (await importOriginal<typeof import('../activity')>()).isActivitySignal,
+  noteWorkspaceActivity,
+}))
 
 const silentLog = { warn: vi.fn(), error: vi.fn(), info: vi.fn() }
 
 async function serve(
   host: string | null,
-  options: { url?: string; method?: string } = {}
+  options: { url?: string; method?: string; headers?: Record<string, string> } = {}
 ): Promise<Response | string> {
   const { resolveWorkspaceAndContinue } = await import('../request-scope')
   const request = new Request(options.url ?? 'http://example.com/anything', {
     method: options.method,
     headers: host === null ? {} : { host },
   })
+  // happy-dom's `Request` drops forbidden headers (`cookie`), so extra headers
+  // are layered over the real ones rather than passed through the constructor.
+  const extra = Object.fromEntries(
+    Object.entries(options.headers ?? {}).map(([k, v]) => [k.toLowerCase(), v])
+  )
+  const headers = {
+    get: (name: string) => extra[name.toLowerCase()] ?? request.headers.get(name),
+  }
   return resolveWorkspaceAndContinue({
-    request,
+    request: new Proxy(request, {
+      // Receiver must be the real Request: its accessors read internal slots.
+      get: (target, prop) => (prop === 'headers' ? headers : Reflect.get(target, prop, target)),
+    }),
     next: async () => 'served the workspace',
     log: silentLog as never,
   }) as Promise<Response | string>
@@ -64,7 +79,10 @@ describe('resolveWorkspaceAndContinue', () => {
     const { resolveWorkspaceAndContinue } = await import('../request-scope')
     const seen: unknown[] = []
     const result = await resolveWorkspaceAndContinue({
-      request: new Request('http://example.com/', { headers: { host: 't1.localhost' } }),
+      request: new Request('http://example.com/', {
+        method: 'POST',
+        headers: { host: 't1.localhost' },
+      }),
       next: async () => {
         seen.push(getScopedDatabase())
         return 'served'
@@ -75,15 +93,50 @@ describe('resolveWorkspaceAndContinue', () => {
     expect(result).toBe('served')
     // The scope must be live INSIDE next(), which is the only place it matters.
     expect(seen).toEqual([handle])
-    // A served request is what keeps the workspace out of dormancy.
+    // A served mutation keeps the workspace out of dormancy.
     expect(noteWorkspaceActivity).toHaveBeenCalledWith('inst_a')
   })
 
   it('does not stamp activity for a refusal or a fleet path', async () => {
     acquireScopeForHost.mockResolvedValue({ kind: 'unknown_host', hostname: 'nope.localhost' })
-    await serve('nope.localhost')
-    await serve('t1.localhost', { url: 'http://example.com/api/health' })
+    await serve('nope.localhost', { method: 'POST' })
+    await serve('t1.localhost', { url: 'http://example.com/api/health', method: 'POST' })
     expect(noteWorkspaceActivity).not.toHaveBeenCalled()
+  })
+
+  describe('which served requests count as activity', () => {
+    const okScope = async () => {
+      const { createWorkspaceScope } = await import('../workspace-context')
+      acquireScopeForHost.mockResolvedValue({
+        kind: 'ok',
+        scope: createWorkspaceScope({
+          workspace: { workspaceKey: 'inst_a' },
+          db: {},
+          sql: {},
+          origin: 'request',
+          secrets: { secretKey: 'd'.repeat(64), storage: null, storageProblem: 'not read here' },
+        } as never),
+      })
+    }
+
+    it('serves an anonymous GET without stamping — crawlers must not wake a workspace', async () => {
+      await okScope()
+      expect(await serve('t1.localhost', { url: 'http://example.com/.env' })).toBe(
+        'served the workspace'
+      )
+      expect(await serve('t1.localhost', { url: 'http://example.com/', method: 'HEAD' })).toBe(
+        'served the workspace'
+      )
+      expect(noteWorkspaceActivity).not.toHaveBeenCalled()
+    })
+
+    it('stamps for a mutation, a session cookie, or a bearer token', async () => {
+      await okScope()
+      await serve('t1.localhost', { method: 'POST' })
+      await serve('t1.localhost', { headers: { cookie: 'a=1; better-auth.session_token=x' } })
+      await serve('t1.localhost', { headers: { authorization: 'Bearer qb_widget' } })
+      expect(noteWorkspaceActivity).toHaveBeenCalledTimes(3)
+    })
   })
 
   it('resolves a third-party custom host from a signed customer-host header on a trusted origin', async () => {

--- a/apps/web/src/lib/server/workspaces/activity.ts
+++ b/apps/web/src/lib/server/workspaces/activity.ts
@@ -23,6 +23,16 @@
  * forever. Health probes never reach the request hook (`request-scope.ts`
  * `FLEET_PATHS`), so the platform's probing cannot wake anything either.
  *
+ * Not every request counts. Measured on the first rollout: ten of the forty
+ * parked workspaces woke within ten minutes of the web deploy, every one from
+ * `GET /.env` scanners or an anonymous `GET /` — a wildcard domain is crawled
+ * continuously, so "any request" would re-wake the whole fleet in days. A
+ * request is evidence of use (`isActivitySignal`) when it is a mutation, or
+ * when it carries a session cookie or bearer token. An anonymous GET is not;
+ * the portal still serves it (the request path is untouched), and if the
+ * visitor then posts or votes, that POST wakes the loop within a minute — the
+ * job it enqueues waits at most that long, which is the existing loop cadence.
+ *
  * ## What idleness is not allowed to skip
  *
  * "Nobody visited" is not the same as "nothing to do". A workspace can be idle
@@ -80,6 +90,26 @@ export function isPastDormancyThreshold(
   const ms = lastActiveAt.getTime()
   if (Number.isNaN(ms)) return false
   return now - ms > thresholdHours * 3_600_000
+}
+
+/** Same marker `auth-helpers.ts` `hasAuthCredentials` uses; matched by substring. */
+const SESSION_COOKIE_MARKER = 'better-auth.session_token'
+
+const READ_METHODS = new Set(['GET', 'HEAD', 'OPTIONS'])
+
+/**
+ * Does this request count as someone using the workspace?
+ *
+ * Mutations always do. Reads do only when a session cookie or bearer token
+ * identifies a caller — an anonymous read is what crawlers and scanners send.
+ */
+export function isActivitySignal(request: {
+  method: string
+  headers: { get(name: string): string | null }
+}): boolean {
+  if (!READ_METHODS.has(request.method.toUpperCase())) return true
+  if ((request.headers.get('cookie') ?? '').includes(SESSION_COOKIE_MARKER)) return true
+  return (request.headers.get('authorization') ?? '').startsWith('Bearer ')
 }
 
 /**

--- a/apps/web/src/lib/server/workspaces/request-scope.ts
+++ b/apps/web/src/lib/server/workspaces/request-scope.ts
@@ -36,7 +36,7 @@ import {
   SCHEMA_FLOOR_MISCONFIGURED_CODE,
   SCHEMA_FLOOR_REFUSAL_CODE,
 } from '@/lib/server/fleet/schema-floor'
-import { noteWorkspaceActivity } from './activity'
+import { isActivitySignal, noteWorkspaceActivity } from './activity'
 import { isIdentityFailureCode, isKeyCustodyFailureCode } from './fingerprint'
 import { acquireScopeForHost } from './resolver'
 import { requestWorkspaceHost } from './saas-edge-host'
@@ -87,10 +87,13 @@ export async function resolveWorkspaceAndContinue<T>({
 
   switch (acquisition.kind) {
     case 'ok':
-      // A served request is what keeps a workspace out of dormancy
-      // (`activity.ts`). Not awaited: the stamp is a throttled control-plane
-      // write the request must neither wait on nor fail because of.
-      void noteWorkspaceActivity(acquisition.scope.workspace.workspaceKey)
+      // A served request from someone using the workspace is what keeps it out
+      // of dormancy (`activity.ts`); anonymous reads are crawler noise and do
+      // not count. Not awaited: the stamp is a throttled control-plane write
+      // the request must neither wait on nor fail because of.
+      if (isActivitySignal(request)) {
+        void noteWorkspaceActivity(acquisition.scope.workspace.workspaceKey)
+      }
       return runWithWorkspaceScope(acquisition.scope, next)
 
     case 'unknown_host':


### PR DESCRIPTION
## Summary
- Follow-up to #500. After rolling it out, a quarter of the parked workspaces woke within minutes — all from `GET /.env` scanners or anonymous `GET /` (307 to login). On a wildcard domain that traffic is continuous, so the policy would have eroded to nothing within days.
- `isActivitySignal(request)`: a served request stamps `cp_workspace_activity` only when it is a mutation, or a read carrying a `better-auth.session_token` cookie or `Authorization: Bearer`. Anonymous reads are served exactly as before; they just don't count.
- An anonymous portal visitor who posts/votes wakes the loop with that POST (≤60s), which is the latency the loop already implies.

## Test plan
- [x] `activity.test.ts`: predicate table (anonymous GET/HEAD/OPTIONS false; mutations true; session cookie / bearer true)
- [x] `request-scope.test.ts`: anonymous GET served without stamp; POST / cookie / bearer stamp
- [x] tsc, oxlint, prettier
- [ ] After roll: dormant count stops decaying under scanner traffic; `workspace.woke` only follows authenticated or mutating requests

Made with [Cursor](https://cursor.com)