### PR TITLE
docs(workspaces): describe the dormancy rule without deployment specifics

### DIFF
--- a/apps/web/src/lib/server/workspaces/TENANCY.md
+++ b/apps/web/src/lib/server/workspaces/TENANCY.md
@@ -567,9 +567,10 @@ job claim.
 
 ### 5.2a Dormant workspaces get neither
 
-"Always-on" was measured against a fleet where 105 of 111 active registry
-workspaces had no users: every one of them had a poll loop, a dozen cron
-enqueues an hour, and a scope opened by every fleet sweep. `activity.ts` is
+"Always-on" costs the same for a workspace nobody has visited in weeks as
+for one in daily use: a poll loop, a dozen cron enqueues an hour, and a scope
+opened by every fleet sweep. In a pooled fleet most trials go quiet after
+signup, so that idle majority is most of the background load. `activity.ts` is
 the rule that stops that. A workspace nobody has sent a request to for
 `WORKSPACE_DORMANT_AFTER_HOURS` (default 168) is **dormant**: the worker parks
 its loop and `runFleetPass` skips it. The request path stamps
@@ -580,8 +581,8 @@ the stamp and starts the loop again. Health probes bypass the hook, so the
 platform cannot wake anything.
 
 Not every served request is a stamp. A wildcard domain is crawled all day
-(`GET /.env`, anonymous `GET /`), and the first rollout showed that "any
-request" would re-wake the fleet in days. `isActivitySignal` counts a
+(`GET /.env`, anonymous `GET /`), and that traffic reaches a parked workspace
+within minutes, so "any request" would re-wake the fleet in days. `isActivitySignal` counts a
 mutation, or a read carrying a session cookie or bearer token; an anonymous
 read is served exactly as before and simply does not count. An anonymous
 visitor who then posts or votes wakes the loop with that POST, within the

--- a/apps/web/src/lib/server/workspaces/activity.ts
+++ b/apps/web/src/lib/server/workspaces/activity.ts
@@ -1,14 +1,15 @@
 /**
  * Which pooled workspaces are worth running background work for.
  *
- * ## The measurement
+ * ## The problem
  *
- * A fleet of 111 active registry workspaces had 6 with any users. The job worker
- * ran a poll loop for all 111 — a scope open, a schedule tick and a `job_queue`
- * claim every few seconds, plus a dozen cron enqueues an hour, plus every fleet
- * sweep (`runFleetPass`) opening every database twice an hour — and the 105 that
- * nobody had visited in weeks cost the same as the 6 that were in use. On the
- * primary that was most of the connection churn and most of the hot page cache.
+ * The job worker ran a poll loop for every active registry workspace — a scope
+ * open, a schedule tick and a `job_queue` claim every few seconds, plus a dozen
+ * cron enqueues an hour, plus every fleet sweep (`runFleetPass`) opening every
+ * database twice an hour — so a workspace nobody had visited in weeks cost the
+ * same as one in daily use. In a pooled fleet, where most trials go quiet after
+ * signup, that idle majority is most of the primary's connection churn and hot
+ * page cache.
  *
  * ## The rule
  *
@@ -23,11 +24,10 @@
  * forever. Health probes never reach the request hook (`request-scope.ts`
  * `FLEET_PATHS`), so the platform's probing cannot wake anything either.
  *
- * Not every request counts. Measured on the first rollout: ten of the forty
- * parked workspaces woke within ten minutes of the web deploy, every one from
- * `GET /.env` scanners or an anonymous `GET /` — a wildcard domain is crawled
- * continuously, so "any request" would re-wake the whole fleet in days. A
- * request is evidence of use (`isActivitySignal`) when it is a mutation, or
+ * Not every request counts. A wildcard domain is crawled continuously —
+ * `GET /.env` scanners, anonymous `GET /` — and that traffic reaches parked
+ * workspaces within minutes, so "any request" would re-wake the whole fleet in
+ * days. A request is evidence of use (`isActivitySignal`) when it is a mutation, or
  * when it carries a session cookie or bearer token. An anonymous GET is not;
  * the portal still serves it (the request path is untouched), and if the
  * visitor then posts or votes, that POST wakes the loop within a minute — the


### PR DESCRIPTION
## Summary
- Rewrites the `activity.ts` header and the TENANCY.md §5.2a note to explain the dormancy policy in general terms. Comment-only; no behaviour change.

## Test plan
- [x] prettier

Made with [Cursor](https://cursor.com)