### PR TITLE
fix(merge): strict item schema so OpenAI Structured Outputs accept the merge assessment request

### DIFF
--- a/apps/web/src/lib/server/domains/merge-suggestions/__tests__/merge-assessment.service.test.ts
+++ b/apps/web/src/lib/server/domains/merge-suggestions/__tests__/merge-assessment.service.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { z } from 'zod'
 import type { PostId } from '@quackback/ids'
 import type { MergeCandidate } from '../merge-search.service'
 
@@ -113,6 +114,17 @@ describe('merge-assessment.service', () => {
       expect(results[0].candidatePostId).toBe('post_cand1')
       expect(results[0].confidence).toBe(0.9)
       expect(results[0].reasoning).toBe('Both request dark mode')
+    })
+
+    it('sends an output schema OpenAI Structured Outputs accept — no propertyNames (#505)', async () => {
+      mockChat.mockResolvedValueOnce({ results: [] })
+
+      const { assessMergeCandidates } = await import('../merge-assessment.service')
+      await assessMergeCandidates(sourcePost, candidates, 'test-model')
+
+      const call = mockChat.mock.calls.at(-1)?.[0] as { outputSchema: z.ZodType }
+      const jsonSchema = JSON.stringify(z.toJSONSchema(call.outputSchema))
+      expect(jsonSchema).not.toContain('propertyNames')
     })
 
     it('should handle the { results: [...] } JSON shape', async () => {

--- a/apps/web/src/lib/server/domains/merge-suggestions/merge-assessment.service.ts
+++ b/apps/web/src/lib/server/domains/merge-suggestions/merge-assessment.service.ts
@@ -91,14 +91,7 @@ export interface MergeAssessment {
 
 const CONFIDENCE_THRESHOLD = 0.75
 
-// Items are a strict object rather than a loose `z.record`. The loose form
-// tolerated a single malformed item without failing the whole batch, but zod
-// renders it with a `propertyNames` keyword that OpenAI's Structured Outputs
-// reject, so the request 400s before the model ever runs (#505). Under
-// structured outputs that tolerance is moot: the provider guarantees the shape.
-// `results` keeps `.catch([])`, so a present-but-wrong-shaped top level still
-// degrades to "no assessments" rather than failing the request. The `typeof`
-// guards in the filter loop below stay, they simply stop being load-bearing.
+// Avoid z.record() — Zod emits `propertyNames`, which OpenAI Structured Outputs reject.
 const MergeAssessmentItemSchema = z.strictObject({
   candidatePostId: z.string(),
   isDuplicate: z.boolean(),
@@ -109,6 +102,7 @@ const MergeAssessmentItemSchema = z.strictObject({
 const MergeAssessmentResponseSchema = z.object({
   results: z.array(MergeAssessmentItemSchema).catch([]),
 })
+
 /**
  * Assess merge candidates using LLM verification.
  * Returns only confirmed duplicates above confidence threshold.

--- a/apps/web/src/lib/server/domains/merge-suggestions/merge-assessment.service.ts
+++ b/apps/web/src/lib/server/domains/merge-suggestions/merge-assessment.service.ts
@@ -91,20 +91,24 @@ export interface MergeAssessment {
 
 const CONFIDENCE_THRESHOLD = 0.75
 
-// Item fields are intentionally loose (not typed/required) rather than a
-// strict `z.object`: the old code tolerated individual malformed items by
-// skipping just that item (the typeof guards in the filter loop below), and
-// a strict per-item schema would instead fail the WHOLE batched response —
-// and thus the whole `chat()` call — over one bad item. `results` itself
-// gets `.catch([])` so a present-but-wrong-shaped `results` field degrades
-// to "no assessments" rather than failing the request; a genuinely missing
-// or non-object top level (e.g. a bare array, which older prompts/providers
-// could still emit) is treated as a parse failure by the catch in
-// `assessMergeCandidates`, matching the old code's parse-fail → `[]` branch.
-const MergeAssessmentResponseSchema = z.object({
-  results: z.array(z.record(z.string(), z.unknown())).catch([]),
+// Items are a strict object rather than a loose `z.record`. The loose form
+// tolerated a single malformed item without failing the whole batch, but zod
+// renders it with a `propertyNames` keyword that OpenAI's Structured Outputs
+// reject, so the request 400s before the model ever runs (#505). Under
+// structured outputs that tolerance is moot: the provider guarantees the shape.
+// `results` keeps `.catch([])`, so a present-but-wrong-shaped top level still
+// degrades to "no assessments" rather than failing the request. The `typeof`
+// guards in the filter loop below stay, they simply stop being load-bearing.
+const MergeAssessmentItemSchema = z.strictObject({
+  candidatePostId: z.string(),
+  isDuplicate: z.boolean(),
+  confidence: z.number(),
+  reasoning: z.string(),
 })
 
+const MergeAssessmentResponseSchema = z.object({
+  results: z.array(MergeAssessmentItemSchema).catch([]),
+})
 /**
  * Assess merge candidates using LLM verification.
  * Returns only confirmed duplicates above confidence threshold.


### PR DESCRIPTION
Fixes #505.

## What is broken

`assessMergeCandidates` describes its response items with `z.record(z.string(), z.unknown())`. zod renders that as:

```json
{"type":"object","propertyNames":{"type":"string"},"additionalProperties":{}}
```

OpenAI's Structured Outputs reject `propertyNames`, so the request is refused **before the model runs**:

```
400 Invalid schema for response_format 'structured_output':
In context=('properties', 'results', 'type', '0', 'items'), 'propertyNames' is not permitted.
```

Every merge check therefore fails against `api.openai.com`. Worse, `checkPostForMergeCandidates` only stamps `mergeCheckedAt` on success, so the sweep keeps retrying the same posts on every pass. Duplicate detection is permanently unavailable, and it is not model-specific — the schema is rejected, so switching chat models does not help.

## The change

Give the items the shape the system prompt already demands.

I want to be explicit that the loose shape was **deliberate**, and the comment says why: it let one malformed item be skipped rather than failing the whole batch. That reasoning does not survive structured outputs — the provider guarantees the shape, so there is no malformed item left to skip. Everything else is kept:

- `results` still has `.catch([])`, so a present-but-wrong-shaped top level degrades to "no assessments" instead of throwing.
- The `typeof` guards in the filter loop stay untouched. They simply stop being load-bearing.
- The comment is rewritten to record the new reason rather than deleted.

## Testing

Added one regression test to the existing suite. It asserts that the schema handed to `chat()` emits no `propertyNames`, taken from the actual `mockChat` call rather than from an exported internal, so nothing new had to be made public.

- `apps/web` merge-assessment suite: **13 passed** (12 existing + 1 new)
- Reverting only the service change makes exactly the new test fail, and the other 12 still pass — so the test targets this bug and nothing else
- `oxlint` and `prettier --check` clean on both files

Verified in production as well: with this change, a deliberately duplicated post is found by embedding similarity and confirmed by the model (confidence 0.95), and the merge suggestion is created. Running against `gpt-4.1-mini`.

## Note

Unrelated to this PR, but worth flagging for anyone testing on OpenAI directly: the `max_tokens` this service sends is rejected by the gpt-5 family, which wants `max_completion_tokens`. That is a separate matter and not touched here.
