### PR TITLE
fix(sso): honor stored profile mappings and stop leaking claim values

### DIFF
--- a/apps/web/src/lib/server/auth/__tests__/idp-audit-diff.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/idp-audit-diff.test.ts
@@ -65,7 +65,9 @@ describe('diffProviderAudit — update', () => {
     const mapping = { role: { claimPath: 'groups', rules: [], syncOnEverySignIn: false } }
     const changed = diffProviderAudit(prior, { ...next, claimMapping: mapping })
     expect(changed.before).toEqual({ claimMapping: null })
-    expect(changed.after.claimMapping).toEqual(mapping)
+    expect(changed.after.claimMapping).toEqual({
+      role: { claimPath: 'groups', ruleCount: 0, rules: [] },
+    })
 
     const unchanged = diffProviderAudit(
       { ...prior, claimMapping: mapping },
@@ -73,6 +75,69 @@ describe('diffProviderAudit — update', () => {
     )
     expect(unchanged.before).toEqual({})
     expect(unchanged.after).toEqual({})
+  })
+
+  it('audit never records captured role match values', () => {
+    const SENTINEL = 'CAPTURED_ROLE_VALUE_DO_NOT_AUDIT'
+    const mapping = {
+      profile: {
+        claims: { email: 'upn', id: 'oid' },
+        extraSecret: SENTINEL,
+      },
+      role: {
+        claimPath: 'groups',
+        rules: [{ whenContains: SENTINEL, role: 'admin' as const }],
+        syncOnEverySignIn: true,
+      },
+      attributes: {
+        map: [{ claimPath: 'department', attributeKey: 'dept' }],
+      },
+      unknownSection: { nested: { value: SENTINEL } },
+    }
+
+    const created = diffProviderAudit(null, { ...next, claimMapping: mapping })
+    const createdSerialized = JSON.stringify({ before: created.before, after: created.after })
+    expect(createdSerialized).not.toContain(SENTINEL)
+    expect(createdSerialized).not.toContain('whenContains')
+    expect(created.after.claimMapping).toEqual({
+      profile: { claims: { email: 'upn', id: 'oid' } },
+      role: {
+        claimPath: 'groups',
+        ruleCount: 1,
+        rules: [{ index: 0, role: 'admin' }],
+        syncOnEverySignIn: true,
+      },
+      attributes: { map: [{ claimPath: 'department', attributeKey: 'dept' }] },
+    })
+
+    const updated = diffProviderAudit(
+      { ...prior, claimMapping: mapping },
+      {
+        ...next,
+        claimMapping: {
+          ...mapping,
+          role: {
+            ...mapping.role,
+            rules: [{ whenContains: 'CHANGED_VALUE', role: 'admin' as const }],
+          },
+        },
+      }
+    )
+    const updatedSerialized = JSON.stringify({ before: updated.before, after: updated.after })
+    expect(updatedSerialized).not.toContain(SENTINEL)
+    expect(updatedSerialized).not.toContain('CHANGED_VALUE')
+    expect(updatedSerialized).not.toContain('whenContains')
+    expect(updated.after.claimMapping).toEqual({
+      profile: { claims: { email: 'upn', id: 'oid' } },
+      role: {
+        claimPath: 'groups',
+        ruleCount: 1,
+        rules: [{ index: 0, role: 'admin' }],
+        syncOnEverySignIn: true,
+        ruleValuesChanged: true,
+      },
+      attributes: { map: [{ claimPath: 'department', attributeKey: 'dept' }] },
+    })
   })
 
   it('records nothing when nothing changed', () => {

--- a/apps/web/src/lib/server/auth/__tests__/jit-role.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/jit-role.test.ts
@@ -289,6 +289,7 @@ describe('handleAutoProvisionAfter -- audit on role change', () => {
     expect(mockRecordAuditEvent).toHaveBeenCalledTimes(1)
     const call = mockRecordAuditEvent.mock.calls[0][0] as {
       event: string
+      actor: Record<string, unknown>
       before: { role: string }
       after: { role: string }
       metadata: Record<string, unknown>
@@ -297,6 +298,8 @@ describe('handleAutoProvisionAfter -- audit on role change', () => {
     expect(call.before.role).toBe('user')
     expect(call.after.role).toBe('member')
     expect(call.metadata.source).toBe('auto_provision')
+    expect(call.actor).toEqual({ userId: 'user_abc' })
+    expect(call.actor).not.toHaveProperty('email')
   })
 
   it('readSsoClaims queries the account by the CALLBACK provider id (not a hardcoded "sso")', async () => {

--- a/apps/web/src/lib/server/auth/__tests__/map-profile-claims.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/map-profile-claims.test.ts
@@ -46,4 +46,21 @@ describe('mapProfileClaims — emailVerified', () => {
     expect(mapProfileClaims({ email_verified: false }).emailVerified).toBe(false)
     expect(mapProfileClaims({ email_verified: null }).emailVerified).toBe(false)
   })
+
+  it('profile hook preserves resolved email verification provenance', () => {
+    // getUserInfo sets emailVerified from the source of the resolved address.
+    // A leftover raw email_verified from a different source must not win.
+    expect(
+      mapProfileClaims({
+        email_verified: true,
+        emailVerified: false,
+      }).emailVerified
+    ).toBe(false)
+    expect(
+      mapProfileClaims({
+        email_verified: false,
+        emailVerified: true,
+      }).emailVerified
+    ).toBe(true)
+  })
 })

--- a/apps/web/src/lib/server/auth/__tests__/provider-registration.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/provider-registration.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_OIDC_SCOPES,
 } from '../build-oauth-configs'
 import { getAllAuthProviders } from '../auth-providers'
+import { mapProfileClaims } from '../map-profile-claims'
 
 /** Minimal enabled provider row for the builder. */
 function row(over: Record<string, unknown> = {}) {
@@ -444,5 +445,225 @@ describe('avatar from the OIDC `picture` claim', () => {
     })
     expect(fetchUserInfo).toHaveBeenCalledWith('https://idp/userinfo', 'opaque')
     expect(info?.image).toBe('https://cdn.example.com/from-userinfo.png')
+  })
+})
+
+/**
+ * Production getUserInfo must honour stored profile claim paths and sources.
+ * The SSO test already forwarded them; production previously resolved only the
+ * OIDC defaults, so a stored `upn` mapping would pass the test and fail sign-in.
+ */
+describe('production profile mapping adapter', () => {
+  const idToken = (payload: Record<string, unknown>) =>
+    `x.${Buffer.from(JSON.stringify(payload)).toString('base64url')}.y`
+
+  it('production honors stored profile paths and sources', async () => {
+    const fetchUserInfo = vi.fn(async () => ({
+      sub: 'from-userinfo',
+      upn: 'mapped@x.com',
+      preferred_username: 'Mapped Name',
+    }))
+    const onIdentityFailure = vi.fn()
+    const cfgs = await buildGenericOAuthConfigs({
+      providers: [
+        row({
+          userInfoUrl: 'https://idp/userinfo',
+          claimMapping: {
+            profile: {
+              sources: ['userinfo'],
+              claims: { id: 'sub', email: 'upn', name: 'preferred_username' },
+            },
+          },
+        }),
+      ] as never,
+      creds: async () => ({ clientId: 'c', clientSecret: 's' }),
+      tierAllowsOidc: true,
+      fetchUserInfo,
+      onIdentityFailure,
+    })
+    const info = await cfgs[0].getUserInfo?.({
+      idToken: idToken({
+        sub: 'from-id-token',
+        email: 'raw@x.com',
+        name: 'Raw Name',
+        oid: 'oid-99',
+      }),
+      accessToken: 'at',
+    })
+    expect(fetchUserInfo).toHaveBeenCalledTimes(1)
+    expect(onIdentityFailure).not.toHaveBeenCalled()
+    expect(info?.id).toBe('from-userinfo')
+    expect(info?.email).toBe('mapped@x.com')
+    expect(info?.name).toBe('Mapped Name')
+  })
+
+  it('explicit mapped email cannot fall back to an unrelated raw email', async () => {
+    const onIdentityFailure = vi.fn()
+    const cfgs = await buildGenericOAuthConfigs({
+      providers: [
+        row({
+          claimMapping: { profile: { claims: { email: 'upn' } } },
+        }),
+      ] as never,
+      creds: async () => ({ clientId: 'c', clientSecret: 's' }),
+      tierAllowsOidc: true,
+      onIdentityFailure,
+    })
+    const info = await cfgs[0].getUserInfo?.({
+      idToken: idToken({
+        sub: 's1',
+        email: 'raw-default@x.com',
+        name: 'N',
+        mail: ['array@x.com'],
+      }),
+      accessToken: undefined,
+    })
+    expect(info).toBeNull()
+    expect(onIdentityFailure).toHaveBeenCalledTimes(1)
+    expect(onIdentityFailure).toHaveBeenCalledWith('oidc_abc', 'missing_email')
+    const [registrationId, reason] = onIdentityFailure.mock.calls[0] as [string, string]
+    expect(registrationId).toBe('oidc_abc')
+    expect(reason).toBe('missing_email')
+    expect(JSON.stringify(onIdentityFailure.mock.calls[0])).not.toMatch(/raw-default@x\.com/)
+  })
+
+  it('treats an array-valued mapped email as missing rather than using a raw default', async () => {
+    const onIdentityFailure = vi.fn()
+    const cfgs = await buildGenericOAuthConfigs({
+      providers: [
+        row({
+          claimMapping: { profile: { claims: { email: 'mail' } } },
+        }),
+      ] as never,
+      creds: async () => ({ clientId: 'c', clientSecret: 's' }),
+      tierAllowsOidc: true,
+      onIdentityFailure,
+    })
+    const info = await cfgs[0].getUserInfo?.({
+      idToken: idToken({
+        sub: 's1',
+        email: 'raw-default@x.com',
+        name: 'N',
+        mail: ['array@x.com'],
+      }),
+      accessToken: undefined,
+    })
+    expect(info).toBeNull()
+    expect(onIdentityFailure).toHaveBeenCalledWith('oidc_abc', 'missing_email')
+  })
+
+  it('mints a placeholder when opted in and leaves mapped email missing unverified', async () => {
+    const placeholderEmailFor = vi.fn(async () => 'sso-oidc-abc-deadbeef@anon.quackback.io')
+    const cfgs = await buildGenericOAuthConfigs({
+      providers: [
+        row({
+          claimMapping: {
+            profile: { allowMissingEmail: true, claims: { email: 'upn' } },
+          },
+        }),
+      ] as never,
+      creds: async () => ({ clientId: 'c', clientSecret: 's' }),
+      tierAllowsOidc: true,
+      placeholderEmailFor,
+    })
+    const info = await cfgs[0].getUserInfo?.({
+      idToken: idToken({
+        sub: 's1',
+        email: 'raw-default@x.com',
+        name: 'N',
+        email_verified: true,
+      }),
+      accessToken: undefined,
+    })
+    expect(placeholderEmailFor).toHaveBeenCalledWith('oidc_abc', 's1')
+    expect(info?.email).toBe('sso-oidc-abc-deadbeef@anon.quackback.io')
+    expect(info?.emailVerified).toBe(false)
+    expect(info?.email_verified).toBe(false)
+    expect(mapProfileClaims(info).emailVerified).toBe(false)
+  })
+
+  it('does not mint a placeholder when the mapped email is missing and opt-in is off', async () => {
+    const placeholderEmailFor = vi.fn(async () => 'should-not-mint@anon.quackback.io')
+    const onIdentityFailure = vi.fn()
+    const cfgs = await buildGenericOAuthConfigs({
+      providers: [
+        row({
+          claimMapping: { profile: { claims: { email: 'upn' } } },
+        }),
+      ] as never,
+      creds: async () => ({ clientId: 'c', clientSecret: 's' }),
+      tierAllowsOidc: true,
+      placeholderEmailFor,
+      onIdentityFailure,
+    })
+    const info = await cfgs[0].getUserInfo?.({
+      idToken: idToken({ sub: 's1', email: 'raw-default@x.com', name: 'N' }),
+      accessToken: undefined,
+    })
+    expect(placeholderEmailFor).not.toHaveBeenCalled()
+    expect(info).toBeNull()
+    expect(onIdentityFailure).toHaveBeenCalledWith('oidc_abc', 'missing_email')
+  })
+
+  it('profile hook preserves resolved email verification provenance', async () => {
+    // ID token asserts verified for a different address; the mapped email lives
+    // only at userinfo and carries no verification. The resolved address must
+    // stay unverified through getUserInfo and mapProfileToUser.
+    const fetchUserInfo = vi.fn(async () => ({
+      sub: 's1',
+      upn: 'from-userinfo@x.com',
+      name: 'N',
+    }))
+    const cfgs = await buildGenericOAuthConfigs({
+      providers: [
+        row({
+          userInfoUrl: 'https://idp/userinfo',
+          claimMapping: { profile: { claims: { email: 'upn' } } },
+        }),
+      ] as never,
+      creds: async () => ({ clientId: 'c', clientSecret: 's' }),
+      tierAllowsOidc: true,
+      fetchUserInfo,
+    })
+    const info = await cfgs[0].getUserInfo?.({
+      idToken: idToken({
+        sub: 's1',
+        name: 'N',
+        email: 'id-token@x.com',
+        email_verified: true,
+      }),
+      accessToken: 'at',
+    })
+    expect(info?.email).toBe('from-userinfo@x.com')
+    expect(info?.emailVerified).toBe(false)
+    expect(info?.email_verified).toBe(false)
+    expect(mapProfileClaims(info).emailVerified).toBe(false)
+  })
+
+  it('missing email fails before Better-Auth can log a claims profile', async () => {
+    const onIdentityFailure = vi.fn()
+    const cfgs = await buildGenericOAuthConfigs({
+      providers: [
+        row({
+          claimMapping: { profile: { claims: { email: 'upn' } } },
+        }),
+      ] as never,
+      creds: async () => ({ clientId: 'c', clientSecret: 's' }),
+      tierAllowsOidc: true,
+      onIdentityFailure,
+    })
+    const info = await cfgs[0].getUserInfo?.({
+      idToken: idToken({
+        sub: 's1',
+        email: 'raw-default@x.com',
+        name: 'N',
+        groups: ['captured-group'],
+      }),
+      accessToken: undefined,
+    })
+    // Returning a profile without email lets genericOAuth log the entire
+    // userInfo on email_is_missing. Null keeps the claims bag out of that path.
+    expect(info).toBeNull()
+    expect(onIdentityFailure.mock.calls).toEqual([['oidc_abc', 'missing_email']])
   })
 })

--- a/apps/web/src/lib/server/auth/__tests__/redirect-errors.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/redirect-errors.test.ts
@@ -112,4 +112,10 @@ describe('AUTH_BLOCK_MESSAGES', () => {
       expect(AUTH_BLOCK_MESSAGES[code]).toBeTruthy()
     }
   })
+
+  it('explains Better-Auth user_info_is_missing for both missing profile and mapped email', () => {
+    expect(AUTH_BLOCK_MESSAGES.user_info_is_missing).toMatch(/usable profile/i)
+    expect(AUTH_BLOCK_MESSAGES.user_info_is_missing).toMatch(/email/i)
+    expect(AUTH_BLOCK_MESSAGES.user_info_is_missing).toMatch(/map/i)
+  })
 })

--- a/apps/web/src/lib/server/auth/__tests__/resolve-sso-role.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/resolve-sso-role.test.ts
@@ -6,8 +6,20 @@
  * values, etc.).
  */
 import { describe, it, expect } from 'vitest'
-import { getNestedClaim, resolveSsoRole } from '../resolve-sso-role'
+import {
+  getNestedClaim as serverGetNestedClaim,
+  resolveSsoRole as serverResolveSsoRole,
+  resolveSsoRoleMatch as serverResolveSsoRoleMatch,
+} from '../resolve-sso-role'
+import {
+  getNestedClaim as previewGetNestedClaim,
+  resolveSsoRole as previewResolveSsoRole,
+  resolveSsoRoleMatch as previewResolveSsoRoleMatch,
+} from '@/lib/shared/resolve-sso-role'
 import type { ClaimRoleMapping } from '@/lib/server/db'
+
+const getNestedClaim = serverGetNestedClaim
+const resolveSsoRole = serverResolveSsoRole
 
 describe('getNestedClaim', () => {
   it('reads a dotted path', () => {
@@ -101,5 +113,48 @@ describe('resolveSsoRole', () => {
 
   it('returns null when no mapping is provided', () => {
     expect(resolveSsoRole({ groups: ['admin'] }, undefined)).toBeNull()
+  })
+
+  it('does not split CSV strings or match substrings', () => {
+    expect(
+      resolveSsoRole(
+        { groups: 'platform-admins,analysts' },
+        mapping([{ whenContains: 'analysts', role: 'member' }])
+      )
+    ).toBeNull()
+    expect(
+      resolveSsoRole(
+        { groups: 'platform-admins' },
+        mapping([{ whenContains: 'admin', role: 'admin' }])
+      )
+    ).toBeNull()
+    expect(
+      resolveSsoRole(
+        { groups: ['platform-admins'] },
+        mapping([{ whenContains: 'admin', role: 'admin' }])
+      )
+    ).toBeNull()
+  })
+
+  it('server and preview match literal dotted role claims identically', () => {
+    const claims = {
+      'realm_access.roles': ['nested-admin'],
+      realm_access: { roles: ['dotted-member'] },
+    }
+    const mappingFor = (whenContains: string, role: 'admin' | 'member'): ClaimRoleMapping => ({
+      claimPath: 'realm_access.roles',
+      rules: [{ whenContains, role }],
+    })
+    const literal = mappingFor('nested-admin', 'admin')
+    const nested = mappingFor('dotted-member', 'member')
+
+    expect(serverGetNestedClaim(claims, 'realm_access.roles')).toEqual(['nested-admin'])
+    expect(previewGetNestedClaim(claims, 'realm_access.roles')).toEqual(['nested-admin'])
+    expect(serverResolveSsoRole(claims, literal)).toBe('admin')
+    expect(previewResolveSsoRole(claims, literal)).toBe('admin')
+    expect(serverResolveSsoRole(claims, nested)).toBeNull()
+    expect(previewResolveSsoRole(claims, nested)).toBeNull()
+    expect(serverResolveSsoRoleMatch(claims, literal)).toEqual({ role: 'admin', ruleIndex: 0 })
+    expect(previewResolveSsoRoleMatch(claims, literal)).toEqual({ role: 'admin', ruleIndex: 0 })
   })
 })

--- a/apps/web/src/lib/server/auth/build-oauth-configs.ts
+++ b/apps/web/src/lib/server/auth/build-oauth-configs.ts
@@ -23,7 +23,14 @@ import type { IdentityProvider } from '@/lib/server/domains/settings/identity-pr
 import { authorizeRequestFor, supportsPrompt } from '@/lib/shared/oidc-request'
 import { resolveIdentity, pickAvatarUrl } from './resolve-identity'
 import { synthesizeName } from './placeholder-identity'
-import { allowsMissingEmail, claimMappingFor } from '@/lib/shared/oidc-claim-mapping'
+import {
+  allowsMissingEmail,
+  claimMappingFor,
+  identityMappingFor,
+} from '@/lib/shared/oidc-claim-mapping'
+
+/** Closed reasons the production adapter may report. Never include claims. */
+export type IdentityProfileFailureReason = 'no_identity' | 'subject_mismatch' | 'missing_email'
 
 // Re-exported so server callers keep this import path. The implementation lives
 // in `shared` because the admin editor needs it too, and having exactly one
@@ -126,6 +133,8 @@ export interface BuildGenericOAuthConfigsArgs {
   /** Called with the claims behind a successful resolution, so downstream
    *  consumers need not re-derive them from stored tokens. */
   onResolved?: (registrationId: string, accountId: string, claims: Record<string, unknown>) => void
+  /** Value-free failure signal. Callers may log the reason, never a profile. */
+  onIdentityFailure?: (registrationId: string, reason: IdentityProfileFailureReason) => void
   /**
    * Returns the placeholder address to use for a provider that released none.
    *
@@ -161,6 +170,7 @@ export async function buildGenericOAuthConfigs({
   fetchUserInfo,
   onResolutionWarning,
   onResolved,
+  onIdentityFailure,
   placeholderEmailFor,
   mapProfileToUser,
   buildLoginHintParams,
@@ -217,6 +227,7 @@ export async function buildGenericOAuthConfigs({
     // leave two resolution paths — the thing this work exists to remove.
     const resolvedUserInfoUrl = userInfoUrl
     const mapping = claimMappingFor(provider.claimMapping)
+    const identityMapping = identityMappingFor(provider.claimMapping)
     const requiredClaimPaths = [
       ...(mapping.attributes?.map ?? []).map((entry) => entry.claimPath),
       ...(mapping.role?.claimPath ? [mapping.role.claimPath] : []),
@@ -228,6 +239,7 @@ export async function buildGenericOAuthConfigs({
           resolvedUserInfoUrl && tokens.accessToken && fetchUserInfo
             ? await fetchUserInfo(resolvedUserInfoUrl, tokens.accessToken)
             : null,
+        mapping: identityMapping,
         requiredClaimPaths: requiredClaimPaths.length > 0 ? requiredClaimPaths : undefined,
         // Pursue the avatar through the cascade — a `picture` claim commonly
         // lives only at userinfo, past where id + email + name already stopped
@@ -235,7 +247,10 @@ export async function buildGenericOAuthConfigs({
         // backfill via `onResolved`.
         wantImage: true,
       })
-      if (!result.ok) return null
+      if (!result.ok) {
+        onIdentityFailure?.(provider.registrationId, result.reason)
+        return null
+      }
       const { id, email, name, image, emailVerified, claims, warnings } = result.identity
       // Phase one of observe-then-enforce: the discrepancy is recorded, not
       // acted on, so the real rate is known before a release starts refusing
@@ -258,8 +273,17 @@ export async function buildGenericOAuthConfigs({
       // off unless an admin turned it on.
       const resolvedName = name ?? synthesizeName(claims, id)
       let resolvedEmail = email
+      let resolvedEmailVerified = emailVerified
       if (!resolvedEmail && allowsMissingEmail(provider.claimMapping) && placeholderEmailFor) {
         resolvedEmail = await placeholderEmailFor(provider.registrationId, id)
+        resolvedEmailVerified = false
+      }
+
+      // Better-Auth logs the entire userInfo on email_is_missing. Returning
+      // null keeps a claims profile (and any leftover raw email) off that path.
+      if (!resolvedEmail) {
+        onIdentityFailure?.(provider.registrationId, 'missing_email')
+        return null
       }
 
       // Better-Auth's genericOAuth derives the avatar from `image` only, so
@@ -270,11 +294,14 @@ export async function buildGenericOAuthConfigs({
 
       // Raw claims first, mapped fields last: the mapped values are the
       // resolved answer and must not be shadowed by a same-named raw claim.
+      // email_verified is rewritten from the resolved address so mapProfileToUser
+      // cannot re-verify a leftover true from a different source.
       return {
         ...claims,
         id,
-        emailVerified,
-        ...(resolvedEmail ? { email: resolvedEmail } : {}),
+        email: resolvedEmail,
+        emailVerified: resolvedEmailVerified,
+        email_verified: resolvedEmailVerified,
         ...(resolvedName ? { name: resolvedName } : {}),
         ...(resolvedImage ? { image: resolvedImage } : {}),
       }

--- a/apps/web/src/lib/server/auth/hooks.ts
+++ b/apps/web/src/lib/server/auth/hooks.ts
@@ -710,7 +710,7 @@ export async function handleAutoProvisionAfter(
     await recordAuditEvent({
       event: 'user.role.changed',
       outcome: 'success',
-      actor: { email: email ?? null }, // SSO callback — no authenticated admin actor
+      actor: { userId: userIdTyped },
       target: { type: 'user', id: userIdTyped },
       before: { role: p.role },
       after: { role: targetRole },
@@ -1480,9 +1480,13 @@ export const hooksAfter = createAuthMiddleware(async (ctx) => {
       registeredOidcIds,
       readClaims
     )
-  } catch (err) {
+  } catch {
     log.error(
-      { err, user_id: callbackUserId, provider_id: callbackProviderId },
+      {
+        code: 'claim_attribute_write_failed',
+        user_id: callbackUserId,
+        provider_id: callbackProviderId,
+      },
       'claim attribute write failed'
     )
   }

--- a/apps/web/src/lib/server/auth/idp-audit-diff.ts
+++ b/apps/web/src/lib/server/auth/idp-audit-diff.ts
@@ -16,6 +16,7 @@
  */
 
 import type { JsonValue } from '@/lib/server/audit/log'
+import { claimMappingFor, type ClaimRoleMapping } from '@/lib/shared/oidc-claim-mapping'
 
 /** Every field worth an audit trace. The client secret is deliberately absent:
  *  it never travels through this DTO (it has its own credential function), so
@@ -56,6 +57,70 @@ function sameValue(a: unknown, b: unknown): boolean {
   return false
 }
 
+function roleValuesChanged(left: ClaimRoleMapping, right: ClaimRoleMapping): boolean {
+  const longest = Math.max(left.rules.length, right.rules.length)
+  for (let i = 0; i < longest; i++) {
+    if (left.rules[i]?.whenContains !== right.rules[i]?.whenContains) return true
+  }
+  return false
+}
+
+/**
+ * Configuration-only view of claim mapping. Paths, role targets, rule indices,
+ * and sync flags stay; match values, unknown subtrees, and raw snapshots do not.
+ */
+function projectClaimMapping(stored: unknown, comparedTo?: unknown): JsonValue | null {
+  if (stored == null) return null
+  const mapping = claimMappingFor(stored)
+  if (Object.keys(mapping).length === 0) return {}
+
+  const projected: Record<string, JsonValue> = {}
+
+  if (mapping.profile) {
+    const profile: Record<string, JsonValue> = {}
+    if (mapping.profile.sources) profile.sources = [...mapping.profile.sources]
+    if (mapping.profile.claims) profile.claims = { ...mapping.profile.claims }
+    if (mapping.profile.allowMissingEmail === true) profile.allowMissingEmail = true
+    projected.profile = profile
+  }
+
+  if (mapping.role) {
+    const role: Record<string, JsonValue> = {
+      claimPath: mapping.role.claimPath,
+      ruleCount: mapping.role.rules.length,
+      rules: mapping.role.rules.map((rule, index) => ({ index, role: rule.role })),
+    }
+    if (mapping.role.syncOnEverySignIn === true) role.syncOnEverySignIn = true
+    if (comparedTo != null) {
+      const other = claimMappingFor(comparedTo).role
+      if (other && roleValuesChanged(mapping.role, other)) {
+        role.ruleValuesChanged = true
+      }
+    }
+    projected.role = role
+  }
+
+  if (mapping.attributes) {
+    const attributes: Record<string, JsonValue> = {}
+    if (mapping.attributes.map) {
+      attributes.map = mapping.attributes.map.map((entry) => ({
+        claimPath: entry.claimPath,
+        attributeKey: entry.attributeKey,
+      }))
+    }
+    if (mapping.attributes.overrideExisting === true) attributes.overrideExisting = true
+    if (mapping.attributes.syncOnSignIn === true) attributes.syncOnSignIn = true
+    projected.attributes = attributes
+  }
+
+  return projected
+}
+
+function auditedValue(field: AuditedField, value: unknown, comparedTo?: unknown): JsonValue {
+  if (field === 'claimMapping') return projectClaimMapping(value, comparedTo)
+  return (value ?? null) as JsonValue
+}
+
 export interface ProviderAuditDiff {
   /** Null on create; otherwise the prior value of each changed field. */
   before: Record<string, JsonValue> | null
@@ -76,7 +141,7 @@ export function diffProviderAudit(
   if (!prior) {
     const after: Record<string, JsonValue> = {}
     for (const field of AUDITED_FIELDS) {
-      if (next[field] !== undefined) after[field] = next[field] as JsonValue
+      if (next[field] !== undefined) after[field] = auditedValue(field, next[field])
     }
     return { before: null, after }
   }
@@ -86,9 +151,11 @@ export function diffProviderAudit(
   for (const field of AUDITED_FIELDS) {
     const proposed = next[field]
     if (proposed === undefined) continue
-    if (sameValue(prior[field], proposed)) continue
-    before[field] = (prior[field] ?? null) as JsonValue
-    after[field] = proposed as JsonValue
+    const previous = auditedValue(field, prior[field] ?? null)
+    const nextValue = auditedValue(field, proposed, prior[field] ?? null)
+    if (sameValue(previous, nextValue)) continue
+    before[field] = previous
+    after[field] = nextValue
   }
   return { before, after }
 }

--- a/apps/web/src/lib/server/auth/index.ts
+++ b/apps/web/src/lib/server/auth/index.ts
@@ -279,6 +279,9 @@ async function createAuth() {
     onResolutionWarning: (registrationId, warnings) => {
       log.warn({ registrationId, warnings }, 'identity resolution discrepancy observed')
     },
+    onIdentityFailure: (registrationId, reason) => {
+      log.warn({ registrationId, reason }, 'identity profile resolution failed')
+    },
     placeholderEmailFor: resolvePlaceholderEmail,
     mapProfileToUser: mapProfileClaims,
     buildLoginHintParams,

--- a/apps/web/src/lib/server/auth/map-profile-claims.ts
+++ b/apps/web/src/lib/server/auth/map-profile-claims.ts
@@ -32,9 +32,21 @@ export type MappedProfileClaims = {
 }
 
 export function mapProfileClaims(profile: unknown): MappedProfileClaims {
-  const p = profile as { locale?: unknown; email_verified?: unknown } | null | undefined
+  const p = profile as
+    | {
+        locale?: unknown
+        email_verified?: unknown
+        emailVerified?: unknown
+      }
+    | null
+    | undefined
   return {
     locale: typeof p?.locale === 'string' && p.locale.length > 0 ? p.locale : null,
-    emailVerified: isAffirmativeClaim(p?.email_verified),
+    // Prefer the adapter's resolved flag so a leftover raw `email_verified`
+    // from a different source cannot re-verify the bound address.
+    emailVerified:
+      typeof p?.emailVerified === 'boolean'
+        ? p.emailVerified
+        : isAffirmativeClaim(p?.email_verified),
   }
 }

--- a/apps/web/src/lib/server/auth/resolve-sso-role.ts
+++ b/apps/web/src/lib/server/auth/resolve-sso-role.ts
@@ -1,64 +1,6 @@
 /**
- * IdP-attribute-driven role resolution.
- *
- * getNestedClaim pulls a value out of an ID-token claims object. The
- * path can be:
- *  - a dotted path on the JSON object (`realm_access.roles`)
- *  - a URL-shaped namespaced claim (`https://acme.com/roles`) — used
- *    as a single key, NOT split on slashes
- *
- * resolveSsoRole matches the resolved claim value against the
- * mapping's rules (first-match-wins). Arrays are scanned member-wise;
- * scalars are compared via case-insensitive equality. Returns null when
- * no rule matches (or no mapping is set) so the caller can fall back to
- * the provider's default role (`autoProvisionRole`).
+ * Compatibility re-export. Production and preview must share one matcher so a
+ * literal dotted claim key cannot resolve differently at sign-in than in the
+ * mapping preview.
  */
-
-import type { ClaimRoleMapping } from '@/lib/server/db'
-import type { Role } from '@/lib/shared/roles'
-
-type Claims = Record<string, unknown>
-
-/** Resolve a claim by dotted path OR by literal URL-shaped key. */
-export function getNestedClaim(claims: Claims, path: string): unknown {
-  // URL-shaped paths (containing `://`) are used as a single key on the
-  // top-level claims object — splitting on dots would mangle hostnames.
-  if (path.includes('://')) return claims[path]
-
-  const segments = path.split('.')
-  let current: unknown = claims
-  for (const segment of segments) {
-    if (current === null || current === undefined) return undefined
-    if (typeof current !== 'object') return undefined
-    current = (current as Record<string, unknown>)[segment]
-  }
-  return current
-}
-
-function matchesRule(claim: unknown, whenContains: string): boolean {
-  const needle = whenContains.toLowerCase()
-  if (Array.isArray(claim)) {
-    return claim.some((entry) => typeof entry === 'string' && entry.toLowerCase() === needle)
-  }
-  if (typeof claim === 'string') {
-    return claim.toLowerCase() === needle
-  }
-  return false
-}
-
-/**
- * Look up the user's role from their ID-token claims. Returns null
- * when no rule matches or the workspace hasn't configured role
- * mapping — the caller falls back to the provider's autoProvisionRole.
- */
-export function resolveSsoRole(claims: Claims, mapping: ClaimRoleMapping | undefined): Role | null {
-  if (!mapping) return null
-  const claim = getNestedClaim(claims, mapping.claimPath)
-  for (const rule of mapping.rules) {
-    if (matchesRule(claim, rule.whenContains)) {
-      return rule.role
-    }
-  }
-  // No rule matched — the caller falls back to the provider's default role.
-  return null
-}
+export { getNestedClaim, resolveSsoRole, resolveSsoRoleMatch } from '@/lib/shared/resolve-sso-role'

--- a/apps/web/src/lib/server/functions/__tests__/sso-test.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/sso-test.test.ts
@@ -18,6 +18,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { identityMappingFor } from '@/lib/shared/oidc-claim-mapping'
 
 type AnyHandler = (args: { data: Record<string, unknown> }) => Promise<unknown>
 
@@ -318,6 +319,50 @@ describe('startSsoTestFn', () => {
     // Session must carry the correct registrationId.
     const [, session] = hoisted.cacheSet.mock.calls[0] as [string, { registrationId: string }]
     expect(session.registrationId).toBe('oidc_abc123')
+  })
+
+  it('forwards stored profile paths through the shared identity mapping adapter', async () => {
+    const claimMapping = {
+      profile: {
+        sources: ['accessTokenJwt', 'idToken'],
+        claims: { id: 'oid', email: 'upn', name: 'preferred_username' },
+      },
+    }
+    hoisted.listIdentityProviders.mockResolvedValue([{ ...ssoProvider, claimMapping }])
+    hoisted.getIdentityProviderCredentials.mockResolvedValue({ clientSecret: 'secret' })
+    hoisted.safeFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          issuer: 'https://idp',
+          authorization_endpoint: 'https://idp/auth',
+          token_endpoint: 'https://idp/token',
+          jwks_uri: 'https://idp/jwks',
+        }),
+        { status: 200 }
+      )
+    )
+    hoisted.cacheSet.mockResolvedValue(undefined)
+
+    await startSsoTest({ data: { registrationId: 'sso' } })
+
+    const [, session] = hoisted.cacheSet.mock.calls[0] as [
+      string,
+      {
+        identityMapping?: {
+          sources?: string[]
+          idClaim?: string
+          emailClaim?: string
+          nameClaim?: string
+        }
+      },
+    ]
+    expect(session.identityMapping).toEqual(identityMappingFor(claimMapping))
+    expect(session.identityMapping).toEqual({
+      sources: ['accessTokenJwt', 'idToken'],
+      idClaim: 'oid',
+      emailClaim: 'upn',
+      nameClaim: 'preferred_username',
+    })
   })
 })
 

--- a/apps/web/src/lib/server/functions/sso-test.ts
+++ b/apps/web/src/lib/server/functions/sso-test.ts
@@ -28,11 +28,7 @@ import { PERMISSIONS } from '@/lib/shared/permissions'
 import type { DiagnosticStep, HandshakeStage } from '@/lib/server/auth/sso-test-handshake'
 import type { JsonValue } from '@/lib/server/audit/log'
 import { authorizeRequestFor } from '@/lib/shared/oidc-request'
-import {
-  allowsMissingEmail,
-  identitySourcesFor,
-  profileClaimFor,
-} from '@/lib/shared/oidc-claim-mapping'
+import { allowsMissingEmail, identityMappingFor } from '@/lib/shared/oidc-claim-mapping'
 import { ssoTestResultKey, ssoTestSessionKey } from '@/lib/shared/sso-test-keys'
 import type { IdentityMapping } from '@/lib/server/auth/resolve-identity'
 
@@ -191,12 +187,7 @@ export const startSsoTestFn = createServerFn({ method: 'POST' })
       requestedScopes,
       tokenAuth: request.tokenAuth,
       requestedPrompt: request.prompt,
-      identityMapping: {
-        sources: identitySourcesFor(provider.claimMapping),
-        idClaim: profileClaimFor(provider.claimMapping, 'id'),
-        emailClaim: profileClaimFor(provider.claimMapping, 'email'),
-        nameClaim: profileClaimFor(provider.claimMapping, 'name'),
-      },
+      identityMapping: identityMappingFor(provider.claimMapping),
       adminUserId: user.id,
       startedAt: Date.now(),
       detailsChangedAt: provider.detailsChangedAt,

--- a/apps/web/src/lib/shared/auth-block-messages.ts
+++ b/apps/web/src/lib/shared/auth-block-messages.ts
@@ -41,6 +41,7 @@ export type AuthBlockCode =
   | 'account_already_linked_to_different_user'
   | 'unable_to_link_account'
   | 'email_is_missing'
+  | 'user_info_is_missing'
   | 'email_not_found'
   | 'state_mismatch'
   | 'please_restart_the_process'
@@ -89,6 +90,8 @@ export const AUTH_BLOCK_MESSAGES: Record<AuthBlockCode, string> = {
   unable_to_link_account: 'Something went wrong while connecting your sign-in. Please try again.',
   email_is_missing:
     "Your identity provider didn't share an email address. Ask your administrator to enable the email scope for this app.",
+  user_info_is_missing:
+    "Your identity provider didn't share a usable profile. Ask your administrator to release an email address, or to map the claim that carries it.",
   email_not_found:
     "Your identity provider didn't share an email address. Ask your administrator to enable the email scope for this app.",
   state_mismatch: 'That sign-in attempt expired or was already used. Please try again.',

--- a/apps/web/src/lib/shared/oidc-claim-mapping.ts
+++ b/apps/web/src/lib/shared/oidc-claim-mapping.ts
@@ -169,6 +169,28 @@ export function identitySourcesFor(stored: unknown): IdentitySource[] {
   return claimMappingFor(stored).profile?.sources ?? DEFAULT_IDENTITY_SOURCES
 }
 
+/** String-only identity mapping shared by production sign-in and the SSO test. */
+export function identityMappingFor(stored: unknown): {
+  sources: IdentitySource[]
+  idClaim?: string
+  emailClaim?: string
+  nameClaim?: string
+} {
+  const mapping: {
+    sources: IdentitySource[]
+    idClaim?: string
+    emailClaim?: string
+    nameClaim?: string
+  } = { sources: identitySourcesFor(stored) }
+  const idClaim = profileClaimFor(stored, 'id')
+  const emailClaim = profileClaimFor(stored, 'email')
+  const nameClaim = profileClaimFor(stored, 'name')
+  if (idClaim) mapping.idClaim = idClaim
+  if (emailClaim) mapping.emailClaim = emailClaim
+  if (nameClaim) mapping.nameClaim = nameClaim
+  return mapping
+}
+
 /**
  * Resolve a claim path. An exact key match is tried first so namespaced claims
  * like `https://acme.com/email`, whose dots are not separators, still work.


### PR DESCRIPTION
## Summary

Production now honors stored profile claim paths and sources the same way the SSO connection test does. Missing mapped email fails closed before Better-Auth can log a claims profile. Role matching is a shared exact-key-first re-export, and mapping audit no longer records match values.

This is **PR 1 of 3** in the SSO claim-to-attribute mapping stack. It introduces no new stored mapping shape or UI.

**Stack:** #508 → #509 → #510 ([stack #511](https://github.com/QuackbackIO/quackback/issues/511))
**Plan:** `docs/superpowers/plans/2026-09-07-sso-claim-attribute-mapping.md` (Tasks 1–2)

## What changed

- Production `getUserInfo` and the SSO test share `identityMappingFor` (sources, `idClaim`, `emailClaim`, `nameClaim`).
- Explicit mapped fields override raw claims. A failed explicit email binding cannot fall back to a leftover default `email`.
- Missing required email returns `null` with a closed reason only (`no_identity` | `subject_mismatch` | `missing_email`).
- `email_verified` stays with the resolved address; placeholders stay unverified.
- Server role matcher re-exports shared `getNestedClaim` / `resolveSsoRole` / `resolveSsoRoleMatch`.
- Audit projections keep paths, targets, indices, and sync flags. Never `whenContains`, unknown subtrees, or full JSON snapshots.
- Role-change actor is the local user id, not the IdP email.

## Test plan

- [x] Named adapter tests: stored paths/sources, no raw-email fallback, verification provenance, missing email fails closed
- [x] `keeps the zero-network fast path when nothing is mapped` (token includes `picture`)
- [x] Server and preview match literal dotted role claims identically
- [x] Audit never records captured role match values
- [x] Existing JIT hook cases: off-domain match, domain-scoped fallback, auto-create off, sync/demotion
- [x] `cd apps/web && bun run typecheck`

## Rollout

Landing this PR makes previously test-only custom profile paths affect production sign-in. Inspect configured custom paths in a controlled admin/database view before deploy. Do not silently clear mappings to avoid the behavior change.