### PR TITLE
feat(sso): share claim binder, V2 test capture, and lossless mapping saves

### DIFF
--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-detail-page.test.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-detail-page.test.tsx
@@ -67,14 +67,17 @@ const { discoveryScopesSpy } = vi.hoisted(() => ({
   discoveryScopesSpy: vi.fn(async () => ({ scopesSupported: null as string[] | null })),
 }))
 
+type SessionCapture = {
+  registrationId: string
+  claims: Record<string, unknown>
+  capturedAt?: string
+  identity?: { id: string; email?: string; sources: Record<string, string> }
+}
+
 const { ssoTestRef } = vi.hoisted(() => ({
   ssoTestRef: {
-    current: null as null | {
-      registrationId: string
-      claims: Record<string, unknown>
-      capturedAt?: string
-      identity?: { id: string; email?: string; sources: Record<string, string> }
-    },
+    current: null as null | SessionCapture,
+    lastCapture: undefined as undefined | null | SessionCapture,
   },
 }))
 
@@ -105,7 +108,7 @@ vi.mock('../../sso/use-sso-test-sign-in', () => ({
   useSsoTestSignIn: () => ({
     open: vi.fn(),
     lastSuccess: ssoTestRef.current,
-    lastCapture: ssoTestRef.current,
+    lastCapture: ssoTestRef.lastCapture !== undefined ? ssoTestRef.lastCapture : ssoTestRef.current,
   }),
   SsoTestSignInProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }))
@@ -297,6 +300,7 @@ beforeEach(() => {
   discoveryScopesSpy.mockClear()
   discoveryScopesSpy.mockResolvedValue({ scopesSupported: null })
   ssoTestRef.current = null
+  ssoTestRef.lastCapture = undefined
   state.userAttributes = []
   state.authConfig = { oauth: { password: true } }
   state.credentialStatus = { _emailConfigured: true }
@@ -1026,6 +1030,32 @@ describe('<ProviderDetailPage> claim → person-attribute mapping', () => {
       })
     )
     expect(screen.getByText(/“From session”/)).toBeInTheDocument()
+    expect(screen.queryByText(/“Engineering”/)).not.toBeInTheDocument()
+  })
+
+  it('feeds a mapping-failure capture into the editor over an earlier success', () => {
+    state.userAttributes = PEOPLE_ATTRS
+    ssoTestRef.current = {
+      registrationId: 'oidc_x',
+      capturedAt: '2026-09-01T00:00:00.000Z',
+      identity: { id: 'sub', email: 'alice@example.com', sources: { email: 'idToken' } },
+      claims: { department: 'From success' },
+    }
+    ssoTestRef.lastCapture = {
+      registrationId: 'oidc_x',
+      capturedAt: '2026-09-03T00:00:00.000Z',
+      claims: { department: 'From failed mapping' },
+    }
+    renderPage(
+      makeProvider({
+        lastTestCapture: matchingCapture,
+        claimMapping: {
+          attributes: { map: [{ claimPath: 'department', attributeKey: 'department' }] },
+        },
+      })
+    )
+    expect(screen.getByText(/“From failed mapping”/)).toBeInTheDocument()
+    expect(screen.queryByText(/“From success”/)).not.toBeInTheDocument()
     expect(screen.queryByText(/“Engineering”/)).not.toBeInTheDocument()
   })
 

--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-detail-page.test.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-detail-page.test.tsx
@@ -20,6 +20,7 @@ import type { IdentityProviderId } from '@quackback/ids'
 import type { IdentityProvider } from '@/lib/server/domains/settings/identity-providers.service'
 import type { VerifiedDomain } from '@/lib/server/domains/settings/settings.types'
 import { ProviderDetailPage } from '../provider-detail-page'
+import { applyClaimMappingEdits } from '@/lib/shared/sso-claim-mapping-edit'
 
 beforeAll(() => {
   Element.prototype.scrollIntoView = vi.fn()
@@ -28,7 +29,17 @@ beforeAll(() => {
   Element.prototype.releasePointerCapture = vi.fn()
 })
 
-const { upsertSpy, deleteSpy, credentialsSpy } = vi.hoisted(() => ({
+const { upsertSpy, mappingSpy, deleteSpy, credentialsSpy } = vi.hoisted(() => ({
+  mappingSpy: vi.fn(
+    async (_args: {
+      data: {
+        expectedClaimMapping: unknown
+        operations: unknown[]
+        acknowledgeIdentifierChange?: boolean
+        acknowledgeAdminRules?: boolean
+      }
+    }) => undefined
+  ),
   upsertSpy: vi.fn(
     async (_args: {
       data: {
@@ -91,7 +102,11 @@ const { state } = vi.hoisted(() => ({
 }))
 
 vi.mock('../../sso/use-sso-test-sign-in', () => ({
-  useSsoTestSignIn: () => ({ open: vi.fn(), lastSuccess: ssoTestRef.current }),
+  useSsoTestSignIn: () => ({
+    open: vi.fn(),
+    lastSuccess: ssoTestRef.current,
+    lastCapture: ssoTestRef.current,
+  }),
   SsoTestSignInProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }))
 
@@ -122,6 +137,7 @@ vi.mock('@tanstack/react-router', () => ({
 
 vi.mock('@/lib/server/functions/sso', () => ({
   upsertIdentityProviderFn: upsertSpy,
+  saveIdentityProviderClaimMappingFn: mappingSpy,
   setProviderCredentialsFn: credentialsSpy,
   deleteIdentityProviderFn: deleteSpy,
   addProviderDomainFn: vi.fn(),
@@ -259,12 +275,23 @@ function renderPage(provider: IdentityProvider) {
 
 const saveConnection = () =>
   fireEvent.click(screen.getByRole('button', { name: 'Save connection' }))
-const saveMapping = () =>
+const saveMapping = () => {
   fireEvent.click(screen.getByRole('button', { name: 'Save claim mapping' }))
+  const confirm = screen.queryByRole('button', { name: 'Save mappings' })
+  if (confirm) fireEvent.click(confirm)
+}
 const lastUpsert = () => upsertSpy.mock.calls.at(-1)![0].data
+const lastMapping = () => mappingSpy.mock.calls.at(-1)![0].data
+const lastSavedMapping = () =>
+  applyClaimMappingEdits(
+    lastMapping().expectedClaimMapping,
+    lastMapping()
+      .operations as import('@/lib/shared/sso-claim-mapping-edit').ClaimMappingOperation[]
+  )
 
 beforeEach(() => {
   upsertSpy.mockClear()
+  mappingSpy.mockClear()
   deleteSpy.mockClear()
   credentialsSpy.mockClear()
   discoveryScopesSpy.mockClear()
@@ -369,8 +396,8 @@ describe('<ProviderDetailPage> provisioning consolidation', () => {
   it('persists claimMapping=null when saved with no rules and sync off', async () => {
     renderPage(makeProvider({ autoCreateUsers: true, claimMapping: null }))
     saveMapping()
-    await waitFor(() => expect(upsertSpy).toHaveBeenCalled())
-    expect(lastUpsert().claimMapping).toBeNull()
+    await waitFor(() => expect(mappingSpy).toHaveBeenCalled())
+    expect(lastSavedMapping()).toBeNull()
   })
 
   it('nulls the default role when auto-create is turned off', async () => {
@@ -771,8 +798,8 @@ describe('<ProviderDetailPage> identity fields', () => {
     )
     await userEvent.click(screen.getByLabelText(/allow accounts without an email/i))
     saveMapping()
-    await waitFor(() => expect(upsertSpy).toHaveBeenCalled())
-    const sent = lastUpsert().claimMapping as {
+    await waitFor(() => expect(mappingSpy).toHaveBeenCalled())
+    const sent = lastSavedMapping() as {
       profile?: { allowMissingEmail?: boolean }
       role?: { claimPath?: string }
     }
@@ -785,8 +812,8 @@ describe('<ProviderDetailPage> identity fields', () => {
     // would make an untouched provider look deliberately configured.
     renderPage(makeProvider({ claimMapping: null }))
     saveMapping()
-    await waitFor(() => expect(upsertSpy).toHaveBeenCalled())
-    expect(lastUpsert().claimMapping).toBeNull()
+    await waitFor(() => expect(mappingSpy).toHaveBeenCalled())
+    expect(lastSavedMapping()).toBeNull()
   })
 
   it('carries the attributes section through a mapping save verbatim', async () => {
@@ -796,8 +823,8 @@ describe('<ProviderDetailPage> identity fields', () => {
     renderPage(makeProvider({ claimMapping: { attributes } }))
     await userEvent.click(screen.getByLabelText(/allow accounts without an email/i))
     saveMapping()
-    await waitFor(() => expect(upsertSpy).toHaveBeenCalled())
-    expect((lastUpsert().claimMapping as { attributes?: unknown }).attributes).toEqual(attributes)
+    await waitFor(() => expect(mappingSpy).toHaveBeenCalled())
+    expect((lastSavedMapping() as { attributes?: unknown }).attributes).toEqual(attributes)
   })
 })
 
@@ -852,8 +879,8 @@ describe('<ProviderDetailPage> claim → person-attribute mapping', () => {
     fireEvent.click(screen.getByRole('combobox', { name: /Person attribute \(mapping 1\)/ }))
     fireEvent.click(screen.getByRole('option', { name: /Department/ }))
     saveMapping()
-    await waitFor(() => expect(upsertSpy).toHaveBeenCalled())
-    const sent = lastUpsert().claimMapping as {
+    await waitFor(() => expect(mappingSpy).toHaveBeenCalled())
+    const sent = lastSavedMapping() as {
       attributes?: { map?: Array<{ claimPath: string; attributeKey: string }> }
       role?: unknown
       profile?: unknown
@@ -874,8 +901,8 @@ describe('<ProviderDetailPage> claim → person-attribute mapping', () => {
     )
     fireEvent.click(screen.getByRole('button', { name: /Remove mapping 1/ }))
     saveMapping()
-    await waitFor(() => expect(upsertSpy).toHaveBeenCalled())
-    expect(lastUpsert().claimMapping).toBeNull()
+    await waitFor(() => expect(mappingSpy).toHaveBeenCalled())
+    expect(lastSavedMapping()).toBeNull()
   })
 
   it('persists overrideExisting and syncOnSignIn independently', async () => {
@@ -889,18 +916,18 @@ describe('<ProviderDetailPage> claim → person-attribute mapping', () => {
     )
     await userEvent.click(screen.getByLabelText('Overwrite values that are already set'))
     saveMapping()
-    await waitFor(() => expect(upsertSpy).toHaveBeenCalled())
-    const first = lastUpsert().claimMapping as {
+    await waitFor(() => expect(mappingSpy).toHaveBeenCalled())
+    const first = lastSavedMapping() as {
       attributes?: { overrideExisting?: boolean; syncOnSignIn?: boolean }
     }
     expect(first.attributes?.overrideExisting).toBe(true)
     expect(first.attributes?.syncOnSignIn).toBeUndefined()
 
-    upsertSpy.mockClear()
+    mappingSpy.mockClear()
     await userEvent.click(screen.getByLabelText('Clear an attribute when its claim is missing'))
     saveMapping()
-    await waitFor(() => expect(upsertSpy).toHaveBeenCalled())
-    const second = lastUpsert().claimMapping as {
+    await waitFor(() => expect(mappingSpy).toHaveBeenCalled())
+    const second = lastSavedMapping() as {
       attributes?: { overrideExisting?: boolean; syncOnSignIn?: boolean }
     }
     expect(second.attributes?.overrideExisting).toBe(true)
@@ -935,8 +962,8 @@ describe('<ProviderDetailPage> claim → person-attribute mapping', () => {
     expect(screen.queryByRole('button', { name: /Add mapping/ })).not.toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /Remove mapping 1/ }))
     saveMapping()
-    await waitFor(() => expect(upsertSpy).toHaveBeenCalled())
-    expect(lastUpsert().claimMapping).toBeNull()
+    await waitFor(() => expect(mappingSpy).toHaveBeenCalled())
+    expect(lastSavedMapping()).toBeNull()
   })
 
   it('renders an orphan-row warning when the attribute no longer exists', () => {

--- a/apps/web/src/components/admin/settings/security/identity-providers/attribute-writes-preview.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/attribute-writes-preview.tsx
@@ -10,7 +10,7 @@ import { TimeAgo } from '@/components/ui/time-ago'
 import { Badge } from '@/components/ui/badge'
 import { getClaimByPath } from '@/lib/shared/oidc-claim-mapping'
 import { planClaimAttributeWrites } from '@/lib/shared/plan-claim-attribute-writes'
-import type { SsoTestCapture } from '@/lib/shared/sso-test-capture'
+import { captureIdentityCaption, type SsoTestCapture } from '@/lib/shared/sso-test-capture'
 import { TestSignInButton } from '../sso/test-sign-in-button'
 import { useUserAttributes } from '@/lib/client/hooks/use-user-attributes-queries'
 
@@ -74,7 +74,7 @@ export function AttributeWritesPreview({
       <div>
         <div className="font-medium">Attribute writes from your last test sign-in</div>
         <div className="mt-0.5 text-muted-foreground">
-          {capture.identity.email ?? capture.identity.id} · <TimeAgo date={capture.capturedAt} /> ·{' '}
+          {captureIdentityCaption(capture)} · <TimeAgo date={capture.capturedAt} /> ·{' '}
           <TestSignInButton
             registrationId={registrationId}
             variant="link"

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-card.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-card.tsx
@@ -30,11 +30,7 @@ import {
   type RoleMapping,
 } from './provider-shared'
 import { useProviderSave } from './use-provider-save'
-import {
-  applyClaimMappingEdits,
-  diffClaimMappingOperations,
-  mappingSaveRisks,
-} from '@/lib/shared/sso-claim-mapping-edit'
+import { diffClaimMappingOperations, mappingSaveRisks } from '@/lib/shared/sso-claim-mapping-edit'
 
 export function ClaimMappingCard({ provider }: { provider: IdentityProvider }) {
   const { saving, saveClaimMapping } = useProviderSave(provider)
@@ -62,8 +58,7 @@ export function ClaimMappingCard({ provider }: { provider: IdentityProvider }) {
     attributes: normalizeAttributeMapping(attributes),
   })
   const operations = diffClaimMappingOperations(provider.claimMapping, proposed)
-  const nextMapping = applyClaimMappingEdits(provider.claimMapping, operations)
-  const risks = mappingSaveRisks(provider.claimMapping, nextMapping)
+  const risks = mappingSaveRisks(provider.claimMapping, proposed)
 
   const persist = (acks?: {
     acknowledgeIdentifierChange?: boolean

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-card.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-card.tsx
@@ -14,6 +14,7 @@ import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { SettingsCard } from '@/components/admin/settings/settings-card'
+import { ConfirmDialog } from '@/components/shared/confirm-dialog'
 import type { IdentityProvider } from '@/lib/server/domains/settings/identity-providers.service'
 import { ClaimMappingEditor } from './claim-mapping-editor'
 import { ClaimAttributeMappingEditor } from './claim-attribute-mapping-editor'
@@ -27,9 +28,15 @@ import {
   type RoleMapping,
 } from './provider-shared'
 import { useProviderSave } from './use-provider-save'
+import {
+  applyClaimMappingEdits,
+  diffClaimMappingOperations,
+  mappingSaveRisks,
+} from '@/lib/shared/sso-claim-mapping-edit'
 
 export function ClaimMappingCard({ provider }: { provider: IdentityProvider }) {
-  const { saving, save } = useProviderSave(provider)
+  const { saving, saveClaimMapping } = useProviderSave(provider)
+  const [confirmOpen, setConfirmOpen] = useState(false)
   const [mapping, setMapping] = useState<RoleMapping | null>(provider.claimMapping?.role ?? null)
   const [attributes, setAttributes] = useState<AttributeMapping | null>(
     provider.claimMapping?.attributes ?? null
@@ -49,17 +56,35 @@ export function ClaimMappingCard({ provider }: { provider: IdentityProvider }) {
         ? provider.lastTestCapture
         : null
 
-  const handleSave = () =>
-    void save(
+  const proposed = mergeClaimMapping(provider.claimMapping, {
+    role: normalizeRoleMapping(mapping),
+    profile: withAllowMissingEmail(provider.claimMapping?.profile, allowMissingEmail),
+    attributes: normalizeAttributeMapping(attributes),
+  })
+  const operations = diffClaimMappingOperations(provider.claimMapping, proposed)
+  const nextMapping = applyClaimMappingEdits(provider.claimMapping, operations)
+  const risks = mappingSaveRisks(provider.claimMapping, nextMapping)
+
+  const persist = (acks?: {
+    acknowledgeIdentifierChange?: boolean
+    acknowledgeAdminRules?: boolean
+  }) =>
+    void saveClaimMapping(
       {
-        claimMapping: mergeClaimMapping(provider.claimMapping, {
-          role: normalizeRoleMapping(mapping),
-          profile: withAllowMissingEmail(provider.claimMapping?.profile, allowMissingEmail),
-          attributes: normalizeAttributeMapping(attributes),
-        }),
+        operations,
+        acknowledgeIdentifierChange: acks?.acknowledgeIdentifierChange,
+        acknowledgeAdminRules: acks?.acknowledgeAdminRules,
       },
       'Claim mapping saved.'
     )
+
+  const handleSave = () => {
+    if (operations.length > 0 && (risks.identifierChanged || risks.hasAdminRules)) {
+      setConfirmOpen(true)
+      return
+    }
+    persist()
+  }
 
   return (
     <div id="mapping" className="scroll-mt-6">
@@ -114,6 +139,36 @@ export function ClaimMappingCard({ provider }: { provider: IdentityProvider }) {
           </Button>
         </div>
       </SettingsCard>
+      <ConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        title="Confirm mapping changes"
+        confirmLabel="Save mappings"
+        description={
+          <div className="space-y-2 text-sm">
+            {risks.identifierChanged ? (
+              <p>
+                Changing the identifier can stop existing account matches and create another
+                account. Existing accounts will not be migrated. This invalidates the connection
+                test.
+              </p>
+            ) : null}
+            {risks.hasAdminRules ? (
+              <p>
+                This can grant admin access even when the person&apos;s email is outside this
+                provider&apos;s verified domains.
+              </p>
+            ) : null}
+          </div>
+        }
+        onConfirm={() => {
+          setConfirmOpen(false)
+          persist({
+            acknowledgeIdentifierChange: risks.identifierChanged,
+            acknowledgeAdminRules: risks.hasAdminRules,
+          })
+        }}
+      />
     </div>
   )
 }

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-card.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-card.tsx
@@ -6,9 +6,10 @@
  * accounts, so packaging it under "create accounts for new people" would hide
  * a live control from exactly the workspaces most likely to need it.
  *
- * It writes three sections of the shared `claim_mapping` column (`profile`,
- * `role`, and `attributes`) through `mergeClaimMapping`, which carries the
- * parts of `profile` that have no UI through verbatim.
+ * It diffs the three sections of the shared `claim_mapping` column (`profile`,
+ * `role`, and `attributes`) into closed operations and persists through
+ * `saveClaimMapping`. `mergeClaimMapping` only builds the proposed editor
+ * state for that diff; unedited stored JSON is not rewritten.
  */
 import { useState } from 'react'
 import { Button } from '@/components/ui/button'

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-card.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-card.tsx
@@ -19,6 +19,7 @@ import { ConfirmDialog } from '@/components/shared/confirm-dialog'
 import type { IdentityProvider } from '@/lib/server/domains/settings/identity-providers.service'
 import { ClaimMappingEditor } from './claim-mapping-editor'
 import { ClaimAttributeMappingEditor } from './claim-attribute-mapping-editor'
+import { matchingSessionCapture } from './claim-path-input'
 import { useSsoTestSignIn } from '../sso/use-sso-test-sign-in'
 import {
   mergeClaimMapping,
@@ -45,17 +46,15 @@ export function ClaimMappingCard({ provider }: { provider: IdentityProvider }) {
   const [allowMissingEmail, setAllowMissingEmail] = useState(
     provider.claimMapping?.profile?.allowMissingEmail === true
   )
-  const { lastSuccess } = useSsoTestSignIn()
-  // In-session lastSuccess is the test that just completed; the persisted
-  // capture is only reloaded with the provider row. Prefer the session copy
-  // so suggestions and preview update without a refresh.
+  const { lastSuccess, lastCapture } = useSsoTestSignIn()
+  // In-session lastCapture includes mapping failures from this sitting; the
+  // persisted capture is only reloaded with the provider row. Prefer the
+  // session copy so suggestions and preview update without a refresh.
   const capture =
-    lastSuccess && lastSuccess.registrationId === provider.registrationId
-      ? lastSuccess
-      : provider.lastTestCapture &&
-          provider.lastTestCapture.registrationId === provider.registrationId
-        ? provider.lastTestCapture
-        : null
+    matchingSessionCapture(provider.registrationId, lastCapture, lastSuccess) ??
+    (provider.lastTestCapture && provider.lastTestCapture.registrationId === provider.registrationId
+      ? provider.lastTestCapture
+      : null)
 
   const proposed = mergeClaimMapping(provider.claimMapping, {
     role: normalizeRoleMapping(mapping),

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-editor.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-editor.tsx
@@ -23,6 +23,7 @@ import { Autocomplete } from '@/components/ui/autocomplete'
 import { deriveClaimSuggestions } from '@/lib/shared/claim-suggestions'
 import { TestSignInButton } from '../sso/test-sign-in-button'
 import { useSsoTestSignIn } from '../sso/use-sso-test-sign-in'
+import { matchingSessionCapture } from './claim-path-input'
 import { ROLES, type RoleMapping } from './provider-shared'
 
 export function ClaimMappingEditor({
@@ -44,11 +45,9 @@ export function ClaimMappingEditor({
   const current: RoleMapping = mapping ?? { claimPath: 'groups', rules: [] }
   const update = (patch: Partial<RoleMapping>) => onChange({ ...current, ...patch })
 
-  const { lastSuccess } = useSsoTestSignIn()
-  const suggestions =
-    lastSuccess && lastSuccess.registrationId === registrationId
-      ? deriveClaimSuggestions(lastSuccess.claims)
-      : null
+  const { lastSuccess, lastCapture } = useSsoTestSignIn()
+  const session = matchingSessionCapture(registrationId, lastCapture, lastSuccess)
+  const suggestions = session ? deriveClaimSuggestions(session.claims) : null
   const hasSuggestions = (suggestions?.paths.length ?? 0) > 0
   const pathSuggestions = (suggestions?.paths ?? []).map((p) => ({ value: p }))
   const valueSuggestions = (suggestions?.valuesByPath[current.claimPath] ?? []).map((v) => ({

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-editor.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-editor.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/components/ui/select'
 import { Autocomplete } from '@/components/ui/autocomplete'
 import { deriveClaimSuggestions } from '@/lib/shared/claim-suggestions'
+import { captureSuggestionClaims } from '@/lib/shared/sso-test-capture'
 import { TestSignInButton } from '../sso/test-sign-in-button'
 import { useSsoTestSignIn } from '../sso/use-sso-test-sign-in'
 import { matchingSessionCapture } from './claim-path-input'
@@ -47,7 +48,7 @@ export function ClaimMappingEditor({
 
   const { lastSuccess, lastCapture } = useSsoTestSignIn()
   const session = matchingSessionCapture(registrationId, lastCapture, lastSuccess)
-  const suggestions = session ? deriveClaimSuggestions(session.claims) : null
+  const suggestions = session ? deriveClaimSuggestions(captureSuggestionClaims(session)) : null
   const hasSuggestions = (suggestions?.paths.length ?? 0) > 0
   const pathSuggestions = (suggestions?.paths ?? []).map((p) => ({ value: p }))
   const valueSuggestions = (suggestions?.valuesByPath[current.claimPath] ?? []).map((v) => ({

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-path-input.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-path-input.tsx
@@ -18,6 +18,15 @@ function fixtureFor(
   return null
 }
 
+/** Prefer a mapping-failure capture over an earlier success for the same provider. */
+export function matchingSessionCapture(
+  registrationId: string,
+  lastCapture: SsoTestCapture | null | undefined,
+  lastSuccess: SsoTestCapture | null | undefined
+): SsoTestCapture | null {
+  return fixtureFor(registrationId, lastCapture) ?? fixtureFor(registrationId, lastSuccess)
+}
+
 export function ClaimPathInput({
   value,
   onChange,
@@ -36,14 +45,16 @@ export function ClaimPathInput({
   placeholder?: string
   ariaLabel: string
   disabled?: boolean
-  /** Session or persisted fixture. Falls back to the sitting's lastSuccess. */
+  /** Session or persisted fixture. Falls back to the sitting's lastCapture. */
   capture?: SsoTestCapture | null
   /** Role suggestions are array-of-string paths; attribute suggestions are
    *  scalar and array leaves, including profile claims. */
   suggestionsFor?: 'role' | 'attribute'
 }) {
-  const { lastSuccess } = useSsoTestSignIn()
-  const fixture = fixtureFor(registrationId, lastSuccess) ?? fixtureFor(registrationId, capture)
+  const { lastSuccess, lastCapture } = useSsoTestSignIn()
+  const fixture =
+    matchingSessionCapture(registrationId, lastCapture, lastSuccess) ??
+    fixtureFor(registrationId, capture)
   const pathSuggestions = fixture
     ? suggestionsFor === 'attribute'
       ? deriveAttributeClaimPaths(fixture.claims).map((s) => ({
@@ -79,8 +90,10 @@ export function ClaimPathInput({
 }
 
 export function useClaimSuggestions(registrationId: string, capture?: SsoTestCapture | null) {
-  const { lastSuccess } = useSsoTestSignIn()
-  const fixture = fixtureFor(registrationId, lastSuccess) ?? fixtureFor(registrationId, capture)
+  const { lastSuccess, lastCapture } = useSsoTestSignIn()
+  const fixture =
+    matchingSessionCapture(registrationId, lastCapture, lastSuccess) ??
+    fixtureFor(registrationId, capture)
   if (!fixture) return null
   return deriveClaimSuggestions(fixture.claims)
 }

--- a/apps/web/src/components/admin/settings/security/identity-providers/outcome-preview-rail.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/outcome-preview-rail.tsx
@@ -10,7 +10,7 @@ import { MENU_LABEL } from '@/components/ui/menu'
 import { cn } from '@/lib/shared/utils'
 import { getClaimByPath } from '@/lib/shared/oidc-claim-mapping'
 import { resolveSsoRoleMatch } from '@/lib/shared/resolve-sso-role'
-import type { SsoTestCapture } from '../sso/use-sso-test-sign-in'
+import { captureIdentityCaption, type SsoTestCapture } from '@/lib/shared/sso-test-capture'
 import { TestSignInButton } from '../sso/test-sign-in-button'
 import type { IdentityProvider } from '@/lib/server/domains/settings/identity-providers.service'
 import { AttributeWritesPreview } from './attribute-writes-preview'
@@ -63,7 +63,7 @@ export function OutcomePreviewRail({
   const match = resolveSsoRoleMatch(claims, roleMapping ?? undefined)
   const matchedRule = match && roleMapping ? roleMapping.rules[match.ruleIndex] : undefined
 
-  const provenance = formatProvenance(capture.identity.sources)
+  const provenance = formatProvenance(capture.identity?.sources ?? {})
 
   return (
     <aside className="flex flex-col gap-4 border-t border-border/40 bg-muted/20 px-4 py-5 text-[12.5px] lg:border-t-0 lg:border-l">
@@ -71,7 +71,7 @@ export function OutcomePreviewRail({
         <h3 className={cn(MENU_LABEL, 'font-mono')}>Outcome preview</h3>
         <div className="mt-2 font-medium">Last test sign-in</div>
         <div className="mt-0.5 text-muted-foreground">
-          {capture.identity.email ?? capture.identity.id} · <TimeAgo date={capture.capturedAt} /> ·{' '}
+          {captureIdentityCaption(capture)} · <TimeAgo date={capture.capturedAt} /> ·{' '}
           <TestSignInButton
             registrationId={registrationId}
             variant="link"
@@ -158,7 +158,9 @@ function formatValue(value: unknown): string {
   return String(value)
 }
 
-function formatProvenance(sources: SsoTestCapture['identity']['sources']): string | null {
+function formatProvenance(
+  sources: NonNullable<SsoTestCapture['identity']>['sources']
+): string | null {
   const seen: string[] = []
   for (const key of ['id', 'email', 'name'] as const) {
     const src = sources[key]

--- a/apps/web/src/components/admin/settings/security/identity-providers/use-provider-save.ts
+++ b/apps/web/src/components/admin/settings/security/identity-providers/use-provider-save.ts
@@ -14,7 +14,11 @@ import { useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useServerFn } from '@tanstack/react-start'
 import { toast } from 'sonner'
-import { upsertIdentityProviderFn } from '@/lib/server/functions/sso'
+import {
+  saveIdentityProviderClaimMappingFn,
+  upsertIdentityProviderFn,
+} from '@/lib/server/functions/sso'
+import type { ClaimMappingOperation } from '@/lib/shared/sso-claim-mapping-edit'
 import type {
   IdentityProvider,
   UpsertIdentityProviderInput,
@@ -26,6 +30,7 @@ export type ProviderPatch = Partial<Omit<UpsertIdentityProviderInput, 'id' | 're
 export function useProviderSave(provider: IdentityProvider) {
   const queryClient = useQueryClient()
   const upsert = useServerFn(upsertIdentityProviderFn)
+  const saveMappingFn = useServerFn(saveIdentityProviderClaimMappingFn)
   const [saving, setSaving] = useState(false)
 
   /** Returns true when the write landed, so a card can clear its drafts. */
@@ -52,5 +57,35 @@ export function useProviderSave(provider: IdentityProvider) {
     }
   }
 
-  return { saving, save }
+  const saveClaimMapping = async (
+    args: {
+      operations: ClaimMappingOperation[]
+      acknowledgeIdentifierChange?: boolean
+      acknowledgeAdminRules?: boolean
+    },
+    successMessage = 'Claim mapping saved.'
+  ): Promise<boolean> => {
+    setSaving(true)
+    try {
+      await saveMappingFn({
+        data: {
+          id: provider.id,
+          expectedClaimMapping: provider.claimMapping,
+          operations: args.operations,
+          acknowledgeIdentifierChange: args.acknowledgeIdentifierChange,
+          acknowledgeAdminRules: args.acknowledgeAdminRules,
+        },
+      })
+      await queryClient.invalidateQueries({ queryKey: IDENTITY_PROVIDERS_KEY })
+      toast.success(successMessage)
+      return true
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Could not save the identity provider.')
+      return false
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return { saving, save, saveClaimMapping }
 }

--- a/apps/web/src/components/admin/settings/security/sso/__tests__/sso-test-capture-context.test.tsx
+++ b/apps/web/src/components/admin/settings/security/sso/__tests__/sso-test-capture-context.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import { SsoTestSignInProvider, useSsoTestSignIn } from '../use-sso-test-sign-in'
+import { SSO_TEST_POSTMESSAGE_SOURCE } from '@/lib/shared/sso-test-keys'
+
+vi.mock('@tanstack/react-start', () => ({
+  useServerFn: () =>
+    vi.fn(async () => ({ testId: 'ssotest_x', authorizeUrl: 'https://idp.example/auth' })),
+}))
+
+vi.mock('@/lib/server/functions/sso-test', () => ({
+  startSsoTestFn: vi.fn(),
+  getSsoTestResultFn: vi.fn(),
+}))
+
+vi.mock('@/lib/client/hooks/use-auth-broadcast', () => ({
+  openAuthPopup: vi.fn(() => ({ close: vi.fn() })),
+  usePopupTracker: () => ({ trackPopup: vi.fn(), clearPopup: vi.fn() }),
+}))
+
+function Probe() {
+  const { lastSuccess, lastCapture, open } = useSsoTestSignIn()
+  return (
+    <div>
+      <button type="button" onClick={() => open({ registrationId: 'oidc_x' })}>
+        open-test
+      </button>
+      <div data-testid="success-at">{lastSuccess?.capturedAt ?? ''}</div>
+      <div data-testid="capture-at">{lastCapture?.capturedAt ?? ''}</div>
+      <div data-testid="success-id">{lastSuccess?.identity?.id ?? ''}</div>
+      <div data-testid="capture-id">{lastCapture?.identity?.id ?? 'none'}</div>
+    </div>
+  )
+}
+
+const capture = {
+  version: 2 as const,
+  registrationId: 'oidc_x',
+  capturedAt: '2026-09-07T12:00:00.000Z',
+  detailsChangedAtAtStart: null,
+  outcome: 'success' as const,
+  identity: { id: 'person-1', email: 'jane@example.test', sources: { id: 'idToken' } },
+  claims: { sub: 'person-1' },
+  replay: { sources: [{ source: 'idToken' as const, claims: { sub: 'person-1' } }] },
+}
+
+describe('SSO test capture context', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('carries server capture metadata instead of rebuilding it with browser time', async () => {
+    render(
+      <SsoTestSignInProvider>
+        <Probe />
+      </SsoTestSignInProvider>
+    )
+    await act(async () => {
+      screen.getByText('open-test').click()
+    })
+    await act(async () => {
+      screen.getByRole('button', { name: /start test sign-in/i }).click()
+    })
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: window.location.origin,
+          data: {
+            source: SSO_TEST_POSTMESSAGE_SOURCE,
+            result: {
+              ok: true,
+              steps: [],
+              claims: { iss: 'https://idp', sub: 'person-1', aud: 'cid' },
+              tokenInfo: { idTokenAlg: 'RS256', hasAccessToken: true, hasRefreshToken: false },
+              capture,
+            },
+            identityMatched: true,
+          },
+        })
+      )
+    })
+
+    expect(screen.getByTestId('success-at').textContent).toBe('2026-09-07T12:00:00.000Z')
+    expect(screen.getByTestId('capture-at').textContent).toBe('2026-09-07T12:00:00.000Z')
+    expect(screen.getByTestId('success-id').textContent).toBe('person-1')
+  })
+
+  it('keeps mapping-failure captures on lastCapture without treating them as lastSuccess', async () => {
+    render(
+      <SsoTestSignInProvider>
+        <Probe />
+      </SsoTestSignInProvider>
+    )
+    await act(async () => {
+      screen.getByText('open-test').click()
+    })
+    await act(async () => {
+      screen.getByRole('button', { name: /start test sign-in/i }).click()
+    })
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: window.location.origin,
+          data: {
+            source: SSO_TEST_POSTMESSAGE_SOURCE,
+            result: {
+              ok: false,
+              stage: 'claim-check',
+              hint: 'No email address was released',
+              steps: [],
+              capture: { ...capture, outcome: 'mapping_failed', identity: undefined },
+            },
+          },
+        })
+      )
+    })
+
+    expect(screen.getByTestId('success-id').textContent).toBe('')
+    expect(screen.getByTestId('capture-at').textContent).toBe('2026-09-07T12:00:00.000Z')
+    expect(screen.getByTestId('capture-id').textContent).toBe('none')
+  })
+})

--- a/apps/web/src/components/admin/settings/security/sso/use-sso-test-sign-in.tsx
+++ b/apps/web/src/components/admin/settings/security/sso/use-sso-test-sign-in.tsx
@@ -54,7 +54,7 @@ import {
   type WireResult,
   type SsoTestState,
 } from './sso-test-state'
-import type { SsoTestCapture } from '@/lib/shared/sso-test-capture'
+import { isV2Capture, type SsoTestCapture } from '@/lib/shared/sso-test-capture'
 
 export type { SsoTestCapture }
 
@@ -87,6 +87,8 @@ interface SsoTestSignInContextValue {
   /** The most recent successful test sign-in, tagged with the provider it ran
    *  against so a consumer only uses claims from a test of THAT provider. */
   lastSuccess: SsoTestCapture | null
+  /** Latest usable diagnostic capture, including mapping failures. */
+  lastCapture: SsoTestCapture | null
 }
 
 const SsoTestSignInContext = createContext<SsoTestSignInContextValue | null>(null)
@@ -106,6 +108,7 @@ export function SsoTestSignInProvider({ children }: { children: ReactNode }) {
   const [state, dispatch] = useReducer(ssoTestReducer, initialSsoTestState)
   const [applying, setApplying] = useState(false)
   const [lastSuccess, setLastSuccess] = useState<SsoTestCapture | null>(null)
+  const [lastCapture, setLastCapture] = useState<SsoTestCapture | null>(null)
 
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const onSuccessRef = useRef<OnSuccess | null>(null)
@@ -172,7 +175,13 @@ export function SsoTestSignInProvider({ children }: { children: ReactNode }) {
       clearPoll()
       clearPopup()
       dispatch({ type: 'resolved', result, identityMatched })
-      if (result.ok) {
+      const capture = 'capture' in result ? result.capture : undefined
+      if (capture) {
+        setLastCapture(capture)
+        if (!isV2Capture(capture) || capture.outcome === 'success') {
+          setLastSuccess(capture)
+        }
+      } else if (result.ok) {
         setLastSuccess({
           registrationId: registrationIdRef.current,
           capturedAt: new Date().toISOString(),
@@ -184,6 +193,8 @@ export function SsoTestSignInProvider({ children }: { children: ReactNode }) {
           },
           claims: result.allClaims ?? {},
         })
+      }
+      if (result.ok) {
         void runAutoApply()
       }
     },
@@ -283,7 +294,7 @@ export function SsoTestSignInProvider({ children }: { children: ReactNode }) {
   }, [startTest, pollResult, trackPopup, clearPoll, clearPopup, resolveTest])
 
   return (
-    <SsoTestSignInContext.Provider value={{ open, lastSuccess }}>
+    <SsoTestSignInContext.Provider value={{ open, lastSuccess, lastCapture }}>
       {children}
       <SsoTestSignInModal
         state={state}

--- a/apps/web/src/lib/server/auth/__tests__/resolve-identity.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/resolve-identity.test.ts
@@ -359,6 +359,32 @@ describe('resolveIdentity — subject consistency (OIDC Core 5.3.2)', () => {
     expect(result.identity.sources.id).toBe('userinfo')
   })
 
+  it('incomplete subject replacement discards prior subject role and People claims', async () => {
+    const result = await resolveIdentity({
+      tokens: {
+        idToken: fakeJwt({
+          sub: 'from-token',
+          groups: ['eng'],
+          org: { department: 'TokenDept' },
+        }),
+        accessToken: 'at',
+      },
+      fetchUserInfo: async () => ({
+        sub: 'from-userinfo',
+        email: 'e@x.com',
+        name: 'N',
+        groups: ['ops'],
+        org: { department: 'UserinfoDept' },
+      }),
+      requiredClaimPaths: ['groups', 'org.department'],
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.identity.id).toBe('from-userinfo')
+    expect(result.identity.claims.groups).toEqual(['ops'])
+    expect(result.identity.claims.org).toEqual({ department: 'UserinfoDept' })
+  })
+
   it('does NOT apply the rule to the access token, whose subject may differ', async () => {
     // 5.3.2 is scoped to the userinfo response. An access token is
     // audience-scoped and pairwise subjects legitimately differ, so enforcing

--- a/apps/web/src/lib/server/auth/__tests__/sso-mapping-parity.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/sso-mapping-parity.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { SignJWT, exportJWK, generateKeyPair } from 'jose'
+import { buildGenericOAuthConfigs } from '../build-oauth-configs'
+import { runHandshake } from '../sso-test-handshake'
+import { claimMappingFor, identityMappingFor } from '@/lib/shared/oidc-claim-mapping'
+import { finishBinding, replayClaimMapping } from '@/lib/shared/sso-claim-binder'
+import { finalizeProfileOutcome } from '@/lib/shared/sso-profile-outcome'
+import { resolveSsoRoleMatch } from '@/lib/shared/resolve-sso-role'
+import { planClaimAttributeWrites } from '@/lib/shared/plan-claim-attribute-writes'
+import { isReplayableCapture } from '@/lib/shared/sso-test-capture'
+import {
+  MAPPING_WORLDS,
+  type MappingWorld,
+} from '@/lib/shared/__tests__/fixtures/sso-mapping-worlds'
+
+vi.mock('@/lib/server/content/ssrf-guard', async (orig) => {
+  const actual = await orig<typeof import('@/lib/server/content/ssrf-guard')>()
+  return { ...actual, safeFetch: vi.fn() }
+})
+
+import { safeFetch } from '@/lib/server/content/ssrf-guard'
+const safeFetchMock = vi.mocked(safeFetch)
+
+beforeEach(() => {
+  safeFetchMock.mockReset()
+})
+
+function row(over: Record<string, unknown> = {}) {
+  return {
+    id: 'idp_abc',
+    registrationId: 'oidc_abc',
+    enabled: true,
+    autoCreateUsers: true,
+    discoveryUrl: 'https://idp.example/.well-known/openid-configuration',
+    userInfoUrl: 'https://idp.example/userinfo',
+    ...over,
+  }
+}
+
+async function signIdToken(claims: Record<string, unknown>, privateKey: CryptoKey) {
+  const jwt = new SignJWT({ ...claims, nonce: 'nonce789' })
+    .setProtectedHeader({ alg: 'RS256', kid: 'test-key' })
+    .setIssuer('https://idp.example')
+    .setAudience('cid')
+    .setIssuedAt()
+    .setExpirationTime('5m')
+  if (typeof claims.sub === 'string') jwt.setSubject(claims.sub)
+  return jwt.sign(privateKey)
+}
+
+async function productionProfile(world: MappingWorld, idToken: string) {
+  const configs = await buildGenericOAuthConfigs({
+    providers: [row({ claimMapping: world.mapping })] as never,
+    creds: async () => ({ clientId: 'c', clientSecret: 's' }),
+    tierAllowsOidc: true,
+    fetchUserInfo: async () => world.userinfo,
+  })
+  return configs[0].getUserInfo?.({ idToken, accessToken: 'at' })
+}
+
+async function testHandshake(world: MappingWorld, idToken: string, publicJwk: JsonWebKey) {
+  const issuer = 'https://idp.example'
+  safeFetchMock.mockResolvedValueOnce(
+    new Response(
+      JSON.stringify({
+        issuer,
+        token_endpoint: `${issuer}/token`,
+        jwks_uri: `${issuer}/jwks`,
+        userinfo_endpoint: `${issuer}/userinfo`,
+      }),
+      { status: 200 }
+    )
+  )
+  safeFetchMock.mockResolvedValueOnce(
+    new Response(JSON.stringify({ id_token: idToken, access_token: 'at', token_type: 'Bearer' }), {
+      status: 200,
+    })
+  )
+  safeFetchMock.mockResolvedValueOnce(
+    new Response(JSON.stringify({ keys: [publicJwk] }), { status: 200 })
+  )
+  safeFetchMock.mockResolvedValue(new Response(JSON.stringify(world.userinfo), { status: 200 }))
+
+  return runHandshake({
+    state: 'state123',
+    code: 'authcode456',
+    discoveryUrl: `${issuer}/.well-known/openid-configuration`,
+    clientId: 'cid',
+    clientSecret: 'csecret',
+    redirectUri: 'https://qb/api/auth/oauth2/callback/oidc_abc',
+    codeVerifier: 'test-code-verifier',
+    expectedNonce: 'nonce789',
+    expectedState: 'state123',
+    identityMapping: identityMappingFor(world.mapping),
+    claimMapping: claimMappingFor(world.mapping),
+    registrationId: 'oidc_abc',
+  })
+}
+
+describe('production test and preview agree on identity role and People mappings', () => {
+  it.each(MAPPING_WORLDS)('$name', async (world) => {
+    const { publicKey, privateKey } = await generateKeyPair('RS256', { extractable: true })
+    const publicJwk = await exportJWK(publicKey)
+    publicJwk.kid = 'test-key'
+    publicJwk.alg = 'RS256'
+    const idToken = await signIdToken(world.idToken, privateKey)
+
+    const profile = await productionProfile(world, idToken)
+    const handshake = await testHandshake(world, idToken, publicJwk)
+    if (!handshake.ok)
+      throw new Error(`${world.name}: handshake ${handshake.stage}: ${handshake.hint}`)
+    expect(isReplayableCapture(handshake.capture!)).toBe(true)
+
+    const bound = finishBinding(
+      replayClaimMapping(
+        {
+          mapping: identityMappingFor(world.mapping),
+          requiredClaimPaths: [
+            ...(claimMappingFor(world.mapping).attributes?.map ?? []).map((e) => e.claimPath),
+            ...(claimMappingFor(world.mapping).role?.claimPath
+              ? [claimMappingFor(world.mapping).role!.claimPath]
+              : []),
+          ],
+          wantImage: true,
+        },
+        handshake.capture!.replay.sources
+      )
+    )
+    const preview = finalizeProfileOutcome(bound, { allowMissingEmail: false })
+    const mapping = claimMappingFor(world.mapping)
+
+    expect(profile?.id).toBe(world.expect.id)
+    expect(handshake.identity?.id).toBe(world.expect.id)
+    expect(preview.id).toBe(world.expect.id)
+
+    expect(String(profile?.email).toLowerCase()).toBe(world.expect.email)
+    expect(handshake.mappingOutcome?.email).toBe(world.expect.email)
+    expect(preview.email).toBe(world.expect.email)
+
+    expect(profile?.name).toBe(world.expect.name)
+    expect(preview.name).toBe(world.expect.name)
+
+    expect(handshake.identity?.sources.id).toBe(world.expect.idSource)
+    expect(handshake.identity?.sources.email).toBe(world.expect.emailSource)
+    expect(bound.provenance.email?.path).toBe(world.expect.emailPath)
+
+    const accepted = preview.acceptedClaims
+    const roleMatch = resolveSsoRoleMatch(accepted, mapping.role)
+    if (world.expect.role) {
+      expect(roleMatch).toEqual(world.expect.role)
+    } else {
+      expect(roleMatch).toBeNull()
+    }
+
+    if (world.expect.people && mapping.attributes) {
+      const plan = planClaimAttributeWrites({
+        claims: accepted,
+        mapping: mapping.attributes,
+        existing: {},
+        definitions: world.definitions,
+      })
+      expect(plan.valid).toEqual(world.expect.people)
+    }
+  })
+})
+
+describe('parity boundaries', () => {
+  it('new source absent from capture requires retest', () => {
+    const snapshots: import('@/lib/shared/oidc-claim-mapping').SourceSnapshot[] = [
+      { source: 'idToken', claims: { sub: 's', email: 'e@x.com', name: 'N' } },
+    ]
+    expect(snapshots.some((s) => s.source === 'accessTokenJwt')).toBe(false)
+    const bound = finishBinding(
+      replayClaimMapping(
+        { mapping: { sources: ['idToken', 'userinfo', 'accessTokenJwt'] }, exhaustive: true },
+        snapshots
+      )
+    )
+    expect(bound.sourceAvailability.accessTokenJwt).toBe('absent')
+  })
+
+  it('draft mapping fetches recorded userinfo only when production would', () => {
+    const snapshots = [
+      { source: 'idToken' as const, claims: { sub: 's', email: 'e@x.com', name: 'N' } },
+      { source: 'userinfo' as const, claims: { sub: 's', department: 'Eng' } },
+    ]
+    const withoutPath = finishBinding(replayClaimMapping({ mapping: {} }, snapshots))
+    expect(withoutPath.acceptedClaims.department).toBeUndefined()
+    const withPath = finishBinding(
+      replayClaimMapping({ mapping: {}, requiredClaimPaths: ['department'] }, snapshots)
+    )
+    expect(withPath.acceptedClaims.department).toBe('Eng')
+  })
+})

--- a/apps/web/src/lib/server/auth/__tests__/sso-test-callback.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/sso-test-callback.test.ts
@@ -18,7 +18,7 @@ const hoisted = vi.hoisted(() => ({
   userUpdate: vi.fn(),
   markSsoTestSucceeded: vi.fn(),
   listIdentityProviders: vi.fn(),
-  markTestSucceeded: vi.fn(),
+  persistTestResult: vi.fn(),
 }))
 
 vi.mock('@/lib/server/cache', () => ({
@@ -53,7 +53,7 @@ vi.mock('@/lib/server/domains/settings/settings.service', () => ({
 
 vi.mock('@/lib/server/domains/settings/identity-providers.service', () => ({
   listIdentityProviders: hoisted.listIdentityProviders,
-  markTestSucceeded: hoisted.markTestSucceeded,
+  persistTestResult: hoisted.persistTestResult,
 }))
 
 import { handleSsoTestCallback, renderSsoTestCallbackHtml } from '../sso-test-callback'
@@ -85,11 +85,34 @@ const customProviderSession = {
   redirectUri: 'https://qb.test/api/auth/oauth2/callback/oidc_custom',
 }
 
+function v2Capture(over: Record<string, unknown> = {}): {
+  version: 2
+  registrationId: string
+  capturedAt: string
+  detailsChangedAtAtStart: string | null
+  outcome: 'success' | 'mapping_failed'
+  identity?: { id: string; email?: string; name?: string; sources: Record<string, string> }
+  claims: Record<string, unknown>
+  replay: { sources: Array<{ source: 'idToken'; claims: Record<string, unknown> }> }
+} {
+  return {
+    version: 2,
+    registrationId: 'sso',
+    capturedAt: '2026-09-07T12:00:00.000Z',
+    detailsChangedAtAtStart: null,
+    outcome: 'success',
+    identity: { id: 'u1', sources: {} },
+    claims: { sub: 'u1' },
+    replay: { sources: [{ source: 'idToken', claims: { sub: 'u1' } }] },
+    ...over,
+  }
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
   hoisted.markSsoTestSucceeded.mockResolvedValue(undefined)
   hoisted.listIdentityProviders.mockResolvedValue([])
-  hoisted.markTestSucceeded.mockResolvedValue(undefined)
+  hoisted.persistTestResult.mockResolvedValue('stamped')
 })
 
 describe('handleSsoTestCallback', () => {
@@ -143,21 +166,24 @@ describe('handleSsoTestCallback', () => {
       hoisted.runHandshake.mock.invocationCallOrder[0]
     )
 
-    expect(hoisted.runHandshake).toHaveBeenCalledWith({
-      state: 'state-xyz',
-      code: 'authcode',
-      idpError: null,
-      idpErrorDescription: null,
-      expectedState: 'state-xyz',
-      expectedNonce: 'nonce-xyz',
-      discoveryUrl: 'https://idp/.well-known',
-      tokenEndpoint: 'https://idp/token',
-      jwksUri: 'https://idp/jwks',
-      issuer: 'https://idp',
-      clientId: 'cid',
-      clientSecret: 'csecret',
-      redirectUri: 'https://qb.test/api/auth/oauth2/callback/sso',
-    })
+    expect(hoisted.runHandshake).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: 'state-xyz',
+        code: 'authcode',
+        idpError: null,
+        idpErrorDescription: null,
+        expectedState: 'state-xyz',
+        expectedNonce: 'nonce-xyz',
+        discoveryUrl: 'https://idp/.well-known',
+        tokenEndpoint: 'https://idp/token',
+        jwksUri: 'https://idp/jwks',
+        issuer: 'https://idp',
+        clientId: 'cid',
+        clientSecret: 'csecret',
+        redirectUri: 'https://qb.test/api/auth/oauth2/callback/sso',
+        registrationId: 'sso',
+      })
+    )
 
     expect(hoisted.cacheSet).toHaveBeenCalledWith(
       'sso-test:result:ssotest_abc',
@@ -214,6 +240,7 @@ describe('handleSsoTestCallback', () => {
       // case-insensitive trim normalization.
       claims: { iss: 'https://idp', sub: 'u1', aud: 'cid', email: '  Admin@ACME.com  ' },
       tokenInfo: { idTokenAlg: 'RS256', hasAccessToken: true, hasRefreshToken: false },
+      capture: v2Capture(),
     }
     hoisted.listIdentityProviders.mockResolvedValueOnce([
       { id: 'idp_sso', registrationId: 'sso', domains: [] },
@@ -248,6 +275,7 @@ describe('handleSsoTestCallback', () => {
       steps: [],
       claims: { iss: 'https://idp', sub: 'u1', aud: 'cid', email: 'someone-else@acme.com' },
       tokenInfo: { idTokenAlg: 'RS256', hasAccessToken: true, hasRefreshToken: false },
+      capture: v2Capture(),
     }
     hoisted.listIdentityProviders.mockResolvedValueOnce([
       { id: 'idp_sso', registrationId: 'sso', domains: [] },
@@ -287,6 +315,7 @@ describe('handleSsoTestCallback', () => {
         department: 'Engineering',
       },
       tokenInfo: { idTokenAlg: 'RS256', hasAccessToken: true, hasRefreshToken: false },
+      capture: v2Capture(),
     })
     hoisted.userFindFirst.mockResolvedValueOnce({ email: 'alice@example.com' })
 
@@ -307,6 +336,7 @@ describe('handleSsoTestCallback', () => {
       steps: [],
       claims: { iss: 'https://idp', sub: 'u1', aud: 'cid' },
       tokenInfo: { idTokenAlg: 'RS256', hasAccessToken: true, hasRefreshToken: false },
+      capture: v2Capture(),
     }
     hoisted.listIdentityProviders.mockResolvedValueOnce([
       { id: 'idp_sso', registrationId: 'sso', domains: [] },
@@ -338,6 +368,7 @@ describe('handleSsoTestCallback', () => {
       steps: [],
       claims: { iss: 'https://idp', sub: 'u1', aud: 'cid' },
       tokenInfo: { idTokenAlg: 'RS256', hasAccessToken: true, hasRefreshToken: false },
+      capture: v2Capture(),
     })
 
     await handleSsoTestCallback({
@@ -347,16 +378,16 @@ describe('handleSsoTestCallback', () => {
       errorDescription: null,
     })
 
-    expect(hoisted.markTestSucceeded).toHaveBeenCalledTimes(1)
-    expect(hoisted.markTestSucceeded.mock.calls[0]![0]).toBe('idp_sso')
-    const capture = hoisted.markTestSucceeded.mock.calls[0]![1] as {
-      registrationId: string
-      identity: { id: string }
-      claims: Record<string, unknown>
+    expect(hoisted.persistTestResult).toHaveBeenCalledTimes(1)
+    expect(hoisted.persistTestResult.mock.calls[0]![0]).toBe('idp_sso')
+    const persist = hoisted.persistTestResult.mock.calls[0]![1] as {
+      outcome: string
+      capture: { registrationId: string; identity?: { id: string } }
     }
-    expect(capture.registrationId).toBe('sso')
-    expect(capture.identity.id).toBe('u1')
-    // Legacy blob stamp MUST fire for 'sso'.
+    expect(persist.outcome).toBe('success')
+    expect(persist.capture.registrationId).toBe('sso')
+    expect(persist.capture.identity?.id).toBe('u1')
+    // Legacy blob stamp MUST fire for 'sso' only after the provider stamp succeeds.
     expect(hoisted.markSsoTestSucceeded).toHaveBeenCalledTimes(1)
   })
 
@@ -377,11 +408,13 @@ describe('handleSsoTestCallback', () => {
         detailsChangedAt: '2026-06-24T10:05:00.000Z', // edited after the test started
       },
     ])
+    hoisted.persistTestResult.mockResolvedValueOnce('stale')
     hoisted.runHandshake.mockResolvedValueOnce({
       ok: true,
       steps: [],
       claims: { iss: 'https://idp', sub: 'u1', aud: 'cid' },
       tokenInfo: { idTokenAlg: 'RS256', hasAccessToken: true, hasRefreshToken: false },
+      capture: v2Capture({ detailsChangedAtAtStart: '2026-06-24T10:00:00.000Z' }),
     })
 
     await handleSsoTestCallback({
@@ -391,7 +424,13 @@ describe('handleSsoTestCallback', () => {
       errorDescription: null,
     })
 
-    expect(hoisted.markTestSucceeded).not.toHaveBeenCalled()
+    expect(hoisted.persistTestResult).toHaveBeenCalledWith(
+      'idp_sso',
+      expect.objectContaining({
+        expectedDetailsChangedAt: '2026-06-24T10:00:00.000Z',
+        outcome: 'success',
+      })
+    )
     expect(hoisted.markSsoTestSucceeded).not.toHaveBeenCalled()
   })
 
@@ -423,6 +462,20 @@ describe('handleSsoTestCallback', () => {
         sources: { id: 'idToken', email: 'idToken', name: 'userinfo' },
       },
       tokenInfo: { idTokenAlg: 'RS256', hasAccessToken: true, hasRefreshToken: false },
+      capture: v2Capture({
+        identity: {
+          id: 'u1',
+          email: 'jane@acme.com',
+          name: 'Jane Diaz',
+          sources: { id: 'idToken', email: 'idToken', name: 'userinfo' },
+        },
+        claims: {
+          sub: 'u1',
+          email: 'jane@acme.com',
+          name: 'Jane Diaz',
+          groups: ['feedback-admins', 'eng'],
+        },
+      }),
     })
 
     await handleSsoTestCallback({
@@ -432,14 +485,13 @@ describe('handleSsoTestCallback', () => {
       errorDescription: null,
     })
 
-    const capture = hoisted.markTestSucceeded.mock.calls[0]![1] as {
-      identity: { email?: string; name?: string }
-      claims: Record<string, unknown>
+    const persist = hoisted.persistTestResult.mock.calls[0]![1] as {
+      capture: { identity?: { email?: string; name?: string }; claims: Record<string, unknown> }
     }
-    expect(capture.identity.email).toBe('jane@acme.com')
-    expect(capture.identity.name).toBe('Jane Diaz')
-    expect(capture.claims.groups).toEqual(['feedback-admins', 'eng'])
-    expect(capture.claims.email).toBe('jane@acme.com')
+    expect(persist.capture.identity?.email).toBe('jane@acme.com')
+    expect(persist.capture.identity?.name).toBe('Jane Diaz')
+    expect(persist.capture.claims.groups).toEqual(['feedback-admins', 'eng'])
+    expect(persist.capture.claims.email).toBe('jane@acme.com')
   })
 
   it('stamps only the provider row (not the legacy blob) for a non-sso registrationId', async () => {
@@ -455,6 +507,7 @@ describe('handleSsoTestCallback', () => {
       steps: [],
       claims: { iss: 'https://idp', sub: 'u2', aud: 'cid' },
       tokenInfo: { idTokenAlg: 'RS256', hasAccessToken: true, hasRefreshToken: false },
+      capture: v2Capture({ registrationId: 'oidc_custom', identity: { id: 'u2', sources: {} } }),
     })
 
     await handleSsoTestCallback({
@@ -465,8 +518,8 @@ describe('handleSsoTestCallback', () => {
     })
 
     // Only the custom provider's row is stamped.
-    expect(hoisted.markTestSucceeded).toHaveBeenCalledTimes(1)
-    expect(hoisted.markTestSucceeded.mock.calls[0]![0]).toBe('idp_custom')
+    expect(hoisted.persistTestResult).toHaveBeenCalledTimes(1)
+    expect(hoisted.persistTestResult.mock.calls[0]![0]).toBe('idp_custom')
     // Legacy blob stamp must NOT fire for a non-sso provider.
     expect(hoisted.markSsoTestSucceeded).not.toHaveBeenCalled()
   })
@@ -491,9 +544,40 @@ describe('handleSsoTestCallback', () => {
     expect(handled?.identityMatched).toBe(false)
     expect(hoisted.userFindFirst).not.toHaveBeenCalled()
     expect(hoisted.markSsoTestSucceeded).not.toHaveBeenCalled()
-    // Neither stamp may fire on failure (guards the stamp block staying inside
-    // `if (result.ok)` — moving it out would unlock enforcement without a pass).
-    expect(hoisted.markTestSucceeded).not.toHaveBeenCalled()
+    // Handshake validation failures cannot become trusted preview captures.
+    expect(hoisted.persistTestResult).not.toHaveBeenCalled()
+  })
+
+  it('mapping failure captures claims without unlocking enforcement', async () => {
+    hoisted.cacheGet.mockResolvedValueOnce(validSession)
+    hoisted.listIdentityProviders.mockResolvedValueOnce([
+      { id: 'idp_sso', registrationId: 'sso', domains: [] },
+    ])
+    const failedCapture = v2Capture({
+      outcome: 'mapping_failed',
+      identity: { id: 'u1', sources: { id: 'idToken' } },
+      claims: { sub: 'u1', upn: 'jane@acme.com' },
+    })
+    hoisted.runHandshake.mockResolvedValueOnce({
+      ok: false,
+      stage: 'claim-check',
+      hint: 'No email address was released',
+      steps: [],
+      capture: failedCapture,
+    })
+
+    await handleSsoTestCallback({
+      state: 'state-xyz',
+      code: 'authcode',
+      error: null,
+      errorDescription: null,
+    })
+
+    expect(hoisted.persistTestResult).toHaveBeenCalledWith(
+      'idp_sso',
+      expect.objectContaining({ outcome: 'mapping_failed', capture: failedCapture })
+    )
+    expect(hoisted.markSsoTestSucceeded).not.toHaveBeenCalled()
   })
 
   it('forwards IdP-side error params to the handshake', async () => {

--- a/apps/web/src/lib/server/auth/__tests__/sso-test-handshake.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/sso-test-handshake.test.ts
@@ -548,4 +548,132 @@ describe('runHandshake — capture and production replay', () => {
     expect(JSON.stringify(result.capture)).not.toMatch(/id_token|access_token/)
     expect(JSON.stringify(result.capture)).not.toContain(idToken)
   })
+
+  it('stores binder-accepted claims so nested mapped leaves survive source merge', async () => {
+    const { publicKey, privateKey } = await generateKeyPair('RS256', { extractable: true })
+    const publicJwk = await exportJWK(publicKey)
+    publicJwk.kid = 'test-key'
+    publicJwk.alg = 'RS256'
+    const issuer = 'https://idp.example'
+    const idToken = await new SignJWT({
+      nonce: 'nonce789',
+      email: 'from-token@x.com',
+      name: 'From Token',
+      org: { department: 'from-token' },
+    })
+      .setProtectedHeader({ alg: 'RS256', kid: 'test-key' })
+      .setIssuer(issuer)
+      .setAudience('cid')
+      .setSubject('from-token')
+      .setIssuedAt()
+      .setExpirationTime('5m')
+      .sign(privateKey)
+
+    safeFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          issuer,
+          token_endpoint: `${issuer}/token`,
+          jwks_uri: `${issuer}/jwks`,
+          userinfo_endpoint: `${issuer}/userinfo`,
+        }),
+        { status: 200 }
+      )
+    )
+    safeFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ id_token: idToken, access_token: 'at', token_type: 'Bearer' }),
+        { status: 200 }
+      )
+    )
+    safeFetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ keys: [publicJwk] }), { status: 200 })
+    )
+    safeFetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          sub: 'from-token',
+          org: { costCenter: 'cc-9', department: 'from-userinfo' },
+          extra: 'only-userinfo',
+        }),
+        { status: 200 }
+      )
+    )
+
+    const result = await runHandshake({
+      ...baseInput,
+      registrationId: 'oidc_x',
+      claimMapping: {
+        attributes: { map: [{ claimPath: 'org.costCenter', attributeKey: 'cost_center' }] },
+      },
+    })
+    if (!result.ok) throw new Error(`expected success, got ${result.stage}: ${result.hint}`)
+    expect(result.capture?.claims.org).toEqual({ department: 'from-token', costCenter: 'cc-9' })
+    expect(result.allClaims?.org).toEqual({ department: 'from-token' })
+  })
+
+  it('omits userinfo claims the binder discarded for a subject mismatch', async () => {
+    const { publicKey, privateKey } = await generateKeyPair('RS256', { extractable: true })
+    const publicJwk = await exportJWK(publicKey)
+    publicJwk.kid = 'test-key'
+    publicJwk.alg = 'RS256'
+    const issuer = 'https://idp.example'
+    const idToken = await new SignJWT({
+      nonce: 'nonce789',
+      email: 'from-token@x.com',
+      name: 'From Token',
+      org: { department: 'from-token' },
+    })
+      .setProtectedHeader({ alg: 'RS256', kid: 'test-key' })
+      .setIssuer(issuer)
+      .setAudience('cid')
+      .setSubject('from-token')
+      .setIssuedAt()
+      .setExpirationTime('5m')
+      .sign(privateKey)
+
+    safeFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          issuer,
+          token_endpoint: `${issuer}/token`,
+          jwks_uri: `${issuer}/jwks`,
+          userinfo_endpoint: `${issuer}/userinfo`,
+        }),
+        { status: 200 }
+      )
+    )
+    safeFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ id_token: idToken, access_token: 'at', token_type: 'Bearer' }),
+        { status: 200 }
+      )
+    )
+    safeFetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ keys: [publicJwk] }), { status: 200 })
+    )
+    safeFetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          sub: 'other-subject',
+          org: { costCenter: 'cc-9' },
+          extra: 'only-userinfo',
+        }),
+        { status: 200 }
+      )
+    )
+
+    const result = await runHandshake({
+      ...baseInput,
+      registrationId: 'oidc_x',
+      claimMapping: {
+        attributes: { map: [{ claimPath: 'org.costCenter', attributeKey: 'cost_center' }] },
+      },
+    })
+    if (!result.ok) throw new Error(`expected success, got ${result.stage}: ${result.hint}`)
+    expect(result.capture?.claims.org).toEqual({ department: 'from-token' })
+    expect(result.capture?.claims.extra).toBeUndefined()
+    expect(result.allClaims?.extra).toBe('only-userinfo')
+    expect(result.mappingOutcome?.warnings).toContain('subject_mismatch')
+  })
 })

--- a/apps/web/src/lib/server/auth/__tests__/sso-test-handshake.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/sso-test-handshake.test.ts
@@ -305,8 +305,8 @@ describe('runHandshake — provider that releases no email', () => {
   })
 })
 
-describe('runHandshake — default sources still require an id_token', () => {
-  it('fails when there is only an access_token and identity still reads the ID token', async () => {
+describe('runHandshake — source availability without an ID token', () => {
+  it('fails mapping when there is only an opaque access token and no userinfo', async () => {
     safeFetchMock.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
@@ -326,8 +326,71 @@ describe('runHandshake — default sources still require an id_token', () => {
     const result = await runHandshake({ ...baseInput })
     expect(result.ok).toBe(false)
     if (result.ok) return
-    expect(result.stage).toBe('token-exchange')
-    expect(result.hint).toMatch(/id_token/i)
+    expect(result.stage).toBe('claim-check')
+    expect(result.capture?.outcome).toBe('mapping_failed')
+  })
+
+  it('userinfo-only identity without an ID token agrees across all paths', async () => {
+    safeFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          issuer: 'https://idp.example',
+          token_endpoint: 'https://idp.example/token',
+          jwks_uri: 'https://idp.example/jwks',
+          userinfo_endpoint: 'https://idp.example/userinfo',
+        }),
+        { status: 200 }
+      )
+    )
+    safeFetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ access_token: 'opaque', token_type: 'Bearer' }), {
+        status: 200,
+      })
+    )
+    safeFetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ sub: 'from-userinfo', email: 'u@x.com', name: 'Userinfo' }), {
+        status: 200,
+      })
+    )
+
+    const result = await runHandshake({ ...baseInput })
+    if (!result.ok) throw new Error(`expected success, got ${result.stage}: ${result.hint}`)
+    expect(result.identity?.id).toBe('from-userinfo')
+    expect(result.identity?.email).toBe('u@x.com')
+    expect(result.identity?.sources.id).toBe('userinfo')
+    expect(
+      result.capture?.replay.sources.some(
+        (s: { source: string; unavailable?: string }) =>
+          s.source === 'idToken' && Boolean(s.unavailable)
+      )
+    ).toBe(true)
+  })
+
+  it('present invalid ID token still fails handshake validation', async () => {
+    safeFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          issuer: 'https://idp.example',
+          token_endpoint: 'https://idp.example/token',
+          jwks_uri: 'https://idp.example/jwks',
+        }),
+        { status: 200 }
+      )
+    )
+    safeFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ id_token: 'not-a-jwt', access_token: 'opaque', token_type: 'Bearer' }),
+        {
+          status: 200,
+        }
+      )
+    )
+
+    const result = await runHandshake({ ...baseInput })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.stage).toBe('id-token-decode')
+    expect(result.capture).toBeUndefined()
   })
 })
 
@@ -420,5 +483,69 @@ describe('runHandshake — access-token-only IdP', () => {
     if (!result.ok) throw new Error(`expected success, got ${result.stage}: ${result.hint}`)
     expect(safeFetchMock.mock.calls.some((c) => String(c[0]).includes('/jwks'))).toBe(true)
     expect(result.tokenInfo.idTokenAlg).toBe('RS256')
+  })
+})
+
+describe('runHandshake — capture and production replay', () => {
+  it('exhaustive diagnostic capture cannot alter production outcome', async () => {
+    const { publicKey, privateKey } = await generateKeyPair('RS256', { extractable: true })
+    const publicJwk = await exportJWK(publicKey)
+    publicJwk.kid = 'test-key'
+    publicJwk.alg = 'RS256'
+    const issuer = 'https://idp.example'
+    const idToken = await new SignJWT({
+      nonce: 'nonce789',
+      email: 'from-token@x.com',
+      name: 'From Token',
+    })
+      .setProtectedHeader({ alg: 'RS256', kid: 'test-key' })
+      .setIssuer(issuer)
+      .setAudience('cid')
+      .setSubject('from-token')
+      .setIssuedAt()
+      .setExpirationTime('5m')
+      .sign(privateKey)
+
+    safeFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          issuer,
+          token_endpoint: `${issuer}/token`,
+          jwks_uri: `${issuer}/jwks`,
+          userinfo_endpoint: `${issuer}/userinfo`,
+        }),
+        { status: 200 }
+      )
+    )
+    safeFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ id_token: idToken, access_token: 'at', token_type: 'Bearer' }),
+        {
+          status: 200,
+        }
+      )
+    )
+    safeFetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ keys: [publicJwk] }), { status: 200 })
+    )
+    safeFetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          sub: 'from-token',
+          email: 'from-userinfo@x.com',
+          extra: 'only-userinfo',
+        }),
+        { status: 200 }
+      )
+    )
+
+    const result = await runHandshake({ ...baseInput, registrationId: 'oidc_x' })
+    if (!result.ok) throw new Error(`expected success, got ${result.stage}: ${result.hint}`)
+    expect(result.identity?.email).toBe('from-token@x.com')
+    expect(result.mappingOutcome?.email).toBe('from-token@x.com')
+    expect(result.allClaims?.extra).toBe('only-userinfo')
+    expect(result.capture?.claims.extra).toBe('only-userinfo')
+    expect(JSON.stringify(result.capture)).not.toMatch(/id_token|access_token/)
+    expect(JSON.stringify(result.capture)).not.toContain(idToken)
   })
 })

--- a/apps/web/src/lib/server/auth/build-oauth-configs.ts
+++ b/apps/web/src/lib/server/auth/build-oauth-configs.ts
@@ -22,7 +22,7 @@
 import type { IdentityProvider } from '@/lib/server/domains/settings/identity-providers.service'
 import { authorizeRequestFor, supportsPrompt } from '@/lib/shared/oidc-request'
 import { resolveIdentity, pickAvatarUrl } from './resolve-identity'
-import { synthesizeName } from './placeholder-identity'
+import { finalizeProfileOutcome } from '@/lib/shared/sso-profile-outcome'
 import {
   allowsMissingEmail,
   claimMappingFor,
@@ -264,17 +264,27 @@ export async function buildGenericOAuthConfigs({
       // that resolves identity from userinfo or an access token.
       onResolved?.(provider.registrationId, id, claims)
 
+      const outcome = finalizeProfileOutcome(
+        {
+          identity: { id, email, name, emailVerified },
+          acceptedClaims: claims,
+          warnings: warnings ?? [],
+          provenance: {},
+        },
+        { allowMissingEmail: allowsMissingEmail(provider.claimMapping) }
+      )
+
       // Gap-fill runs LAST, after every real source has been tried, so it can
       // never shadow something the provider actually sent.
       //
       // A synthesized name needs no opt-in: it only ever rescues a sign-in that
       // would fail outright, and a display name creates nothing irreversible.
       // A minted address does, so it stays behind `allowMissingEmail`, which is
-      // off unless an admin turned it on.
-      const resolvedName = name ?? synthesizeName(claims, id)
+      // off unless an admin turned it on. Production alone materializes it.
+      const resolvedName = outcome.name
       let resolvedEmail = email
       let resolvedEmailVerified = emailVerified
-      if (!resolvedEmail && allowsMissingEmail(provider.claimMapping) && placeholderEmailFor) {
+      if (outcome.kind === 'placeholder_required' && placeholderEmailFor) {
         resolvedEmail = await placeholderEmailFor(provider.registrationId, id)
         resolvedEmailVerified = false
       }

--- a/apps/web/src/lib/server/auth/placeholder-identity.ts
+++ b/apps/web/src/lib/server/auth/placeholder-identity.ts
@@ -24,6 +24,8 @@
 import { randomBytes } from 'crypto'
 import { ANON_EMAIL_DOMAIN } from '@/lib/shared/anonymous-email'
 
+export { synthesizeName } from '@/lib/shared/sso-profile-outcome'
+
 /**
  * The anonymous plugin owns `temp-` in this domain. A separate prefix keeps the
  * two populations distinguishable: one is a visitor who never signed in, the
@@ -50,44 +52,4 @@ export function mintPlaceholderEmail(registrationId: string): string {
   const provider = sanitiseForLocalPart(registrationId) || 'idp'
   const unique = randomBytes(12).toString('hex')
   return `${SSO_PLACEHOLDER_PREFIX}${provider}-${unique}@${ANON_EMAIL_DOMAIN}`
-}
-
-function usableClaim(value: unknown): string | undefined {
-  if (typeof value !== 'string') return undefined
-  const trimmed = value.trim()
-  return trimmed.length > 0 ? trimmed : undefined
-}
-
-/**
- * Turn a subject into something printable. Subjects are opaque and often
- * structured (`ACCOUNT:REGION:2119123456`), and some providers put an email
- * address there — which must not become a display name, because display names
- * are published on posts and comments.
- */
-function readableFromSubject(subject: string): string {
-  const withoutAddress = subject.includes('@') ? subject.split('@')[0] : subject
-  // Hyphens survive: they are legitimate in handles and names, and turning
-  // `some-handle` into `some handle` is a worse result than the structure it
-  // removes. Everything else separating the parts becomes a space.
-  const cleaned = withoutAddress
-    .replace(/[^\p{L}\p{N}-]+/gu, ' ')
-    .replace(/\s+/g, ' ')
-    .replace(/^[-\s]+|[-\s]+$/g, '')
-    .slice(0, 60)
-  // Never empty: a name is required to create the account, and returning ''
-  // would move the failure to a database constraint at the worst moment.
-  return cleaned || 'Member'
-}
-
-/**
- * A display name from the claims, falling back to the subject. Ordered by how
- * deliberately the person chose it: a handle they set, then a nickname, then
- * whatever can be read out of the identifier.
- */
-export function synthesizeName(claims: Record<string, unknown>, subject: string): string {
-  return (
-    usableClaim(claims.preferred_username) ??
-    usableClaim(claims.nickname) ??
-    readableFromSubject(usableClaim(subject) ?? '')
-  )
 }

--- a/apps/web/src/lib/server/auth/resolve-identity.ts
+++ b/apps/web/src/lib/server/auth/resolve-identity.ts
@@ -10,29 +10,23 @@
  * signed users in successfully while failing the test that gates enforcement.
  * Collapsing them removes that entire class of bug.
  *
- * The cascade is ordered and gap-filling: each source contributes only fields
- * still missing, and an earlier source is never overwritten. That is strictly
- * more capable than all-or-nothing resolution — it can take the subject from
- * the ID token and the address from userinfo, which no previous path could.
+ * Binding rules live in the shared source-aware binder. This module supplies
+ * decoded tokens and lazy userinfo, then adapts the binder result.
  */
 
 import { decodeJwt } from 'jose'
-import { getClaimByPath, isAffirmativeClaim } from '@/lib/shared/oidc-claim-mapping'
+import {
+  advanceBindingState,
+  asHttpUrl,
+  bindingComplete,
+  createBindingState,
+  finishBinding,
+  type BindingState,
+  type IdentityMapping,
+} from '@/lib/shared/sso-claim-binder'
+import type { IdentitySource, SourceUnavailableReason } from '@/lib/shared/oidc-claim-mapping'
 
-/** Sources in the order they are consulted. */
-export type IdentitySource = 'idToken' | 'userinfo' | 'accessTokenJwt'
-
-const DEFAULT_SOURCES: IdentitySource[] = ['idToken', 'userinfo']
-
-export interface IdentityMapping {
-  /** Defaults to ID token then userinfo. `accessTokenJwt` is opt-in. */
-  sources?: IdentitySource[]
-  idClaim?: string
-  nameClaim?: string
-  emailClaim?: string
-  /** Claim holding the avatar URL. Defaults to the OIDC-standard `picture`. */
-  imageClaim?: string
-}
+export type { IdentitySource, IdentityMapping }
 
 export interface ResolvedIdentity {
   id: string
@@ -95,20 +89,6 @@ export interface ResolveIdentityArgs {
   wantImage?: boolean
 }
 
-/**
- * Resolve a claim path. An exact key match is tried first so namespaced claims
- * like `https://acme.com/email`, whose dots are not separators, still work.
- */
-function resolveClaim(claims: Record<string, unknown>, path: string): unknown {
-  if (path in claims) return claims[path]
-  let current: unknown = claims
-  for (const segment of path.split('.')) {
-    if (current === null || typeof current !== 'object') return undefined
-    current = (current as Record<string, unknown>)[segment]
-  }
-  return current
-}
-
 /** Decode a JWT payload without verifying it. Possession is the trust anchor:
  *  the token came first-hand from the token endpoint over TLS. */
 function decodePayload(token: string | undefined): Record<string, unknown> | null {
@@ -121,85 +101,12 @@ function decodePayload(token: string | undefined): Record<string, unknown> | nul
   }
 }
 
-function asNonEmptyString(value: unknown): string | undefined {
-  if (typeof value === 'string' && value !== '') return value
-  if (typeof value === 'number' && Number.isFinite(value)) return String(value)
-  return undefined
-}
-
-/** Same missing-value rule as `planClaimAttributeWrites`. */
-function claimIsMissing(value: unknown): boolean {
-  return value === undefined || value === null || value === ''
-}
-
-function requiredPathsResolved(
-  merged: Record<string, unknown>,
-  paths: string[] | undefined
-): boolean {
-  if (!paths?.length) return true
-  return paths.every((path) => !claimIsMissing(getClaimByPath(merged, path)))
-}
-
-/** Segments that would walk onto or rewrite a prototype rather than a claim. */
-const UNSAFE_SEGMENTS = new Set(['__proto__', 'constructor', 'prototype'])
-
-/**
- * Write a leaf onto `claims` without replacing an already-present parent
- * object. Used to gap-fill required nested paths (e.g. `org.costCenter`)
- * after the shallow earlier-source-wins merge has already taken `org`.
- *
- * The path is admin-configured, so a segment like `__proto__` is refused
- * outright rather than followed: `current['__proto__']` is `Object.prototype`,
- * and assigning the leaf there would pollute every object in the process.
- */
-function setClaimByPath(claims: Record<string, unknown>, path: string, value: unknown): void {
-  const segments = path.split('.')
-  if (segments.some((segment) => UNSAFE_SEGMENTS.has(segment))) return
-  if (Object.hasOwn(claims, path) || path.includes('://') || segments.length === 1) {
-    claims[path] = value
-    return
-  }
-  let current: Record<string, unknown> = claims
-  for (let i = 0; i < segments.length - 1; i++) {
-    const segment = segments[i]
-    const next = Object.hasOwn(current, segment) ? current[segment] : undefined
-    if (next === null || typeof next !== 'object' || Array.isArray(next)) {
-      current[segment] = {}
-    }
-    current = current[segment] as Record<string, unknown>
-  }
-  current[segments[segments.length - 1]] = value
-}
-
-function fillRequiredLeaves(
-  merged: Record<string, unknown>,
-  source: Record<string, unknown>,
-  paths: string[] | undefined
-): void {
-  if (!paths?.length) return
-  for (const path of paths) {
-    if (!claimIsMissing(getClaimByPath(merged, path))) continue
-    const incoming = getClaimByPath(source, path)
-    if (claimIsMissing(incoming)) continue
-    setClaimByPath(merged, path, incoming)
-  }
-}
-
-/**
- * A trimmed absolute `http(s)` URL, or `undefined`. The value is stored verbatim
- * and later rendered as an `<img src>`, so a relative path or a `data:` /
- * `javascript:` string must not pass.
- */
-function asHttpUrl(value: unknown): string | undefined {
-  if (typeof value !== 'string') return undefined
-  const trimmed = value.trim()
-  if (trimmed === '') return undefined
-  try {
-    const url = new URL(trimmed)
-    return url.protocol === 'http:' || url.protocol === 'https:' ? trimmed : undefined
-  } catch {
-    return undefined
-  }
+function decodeSource(
+  token: string | undefined
+): { claims: Record<string, unknown> } | { unavailable: SourceUnavailableReason } {
+  if (!token) return { unavailable: 'absent' }
+  const payload = decodePayload(token)
+  return payload ? { claims: payload } : { unavailable: 'unreadable' }
 }
 
 /**
@@ -215,6 +122,38 @@ export function pickAvatarUrl(claims: Record<string, unknown>): string | undefin
   return asHttpUrl(claims.picture)
 }
 
+function sourcesFrom(state: BindingState): ResolvedIdentity['sources'] {
+  const sources: ResolvedIdentity['sources'] = {}
+  if (state.provenance.id) sources.id = state.provenance.id.source
+  if (state.provenance.email) sources.email = state.provenance.email.source
+  if (state.provenance.name) sources.name = state.provenance.name.source
+  if (state.provenance.image) sources.image = state.provenance.image.source
+  return sources
+}
+
+function toResolveResult(state: BindingState): ResolveResult {
+  const finished = finishBinding(state)
+  if (finished.failed === 'subject_mismatch') {
+    return { ok: false, reason: 'subject_mismatch', claims: finished.acceptedClaims }
+  }
+  if (!finished.identity.id) {
+    return { ok: false, reason: 'no_identity', claims: finished.acceptedClaims }
+  }
+  return {
+    ok: true,
+    identity: {
+      id: finished.identity.id,
+      email: finished.identity.email,
+      name: finished.identity.name,
+      ...(finished.identity.image ? { image: finished.identity.image } : {}),
+      emailVerified: finished.identity.emailVerified,
+      sources: sourcesFrom(finished),
+      claims: finished.acceptedClaims,
+      ...(finished.warnings.length > 0 ? { warnings: finished.warnings } : {}),
+    },
+  }
+}
+
 export async function resolveIdentity({
   tokens,
   fetchUserInfo,
@@ -224,151 +163,37 @@ export async function resolveIdentity({
   exhaustive = false,
   wantImage = false,
 }: ResolveIdentityArgs): Promise<ResolveResult> {
-  const idClaim = mapping?.idClaim ?? 'sub'
-  const nameClaim = mapping?.nameClaim ?? 'name'
-  const emailClaim = mapping?.emailClaim ?? 'email'
-  const imageClaim = mapping?.imageClaim ?? 'picture'
-  const sources = mapping?.sources ?? DEFAULT_SOURCES
+  let state = createBindingState({
+    mapping,
+    requiredClaimPaths,
+    wantImage,
+    exhaustive,
+    subjectMismatch,
+  })
 
-  const merged: Record<string, unknown> = {}
-  const found: ResolvedIdentity['sources'] = {}
-  let id: string | undefined
-  let email: string | undefined
-  let name: string | undefined
-  let image: string | undefined
-  let emailVerified = false
-  const warnings: ResolveWarning[] = []
-
-  const loadSource = async (source: IdentitySource): Promise<Record<string, unknown> | null> => {
-    if (source === 'idToken') return decodePayload(tokens.idToken)
-    if (source === 'accessTokenJwt') return decodePayload(tokens.accessToken)
+  const loadSource = async (
+    source: IdentitySource
+  ): Promise<{ claims: Record<string, unknown> } | { unavailable: SourceUnavailableReason }> => {
+    if (source === 'idToken') return decodeSource(tokens.idToken)
+    if (source === 'accessTokenJwt') return decodeSource(tokens.accessToken)
     try {
-      return await fetchUserInfo()
+      const doc = await fetchUserInfo()
+      return doc ? { claims: doc } : { unavailable: 'absent' }
     } catch {
-      return null
+      return { unavailable: 'fetch_failed' }
     }
   }
 
-  for (const source of sources) {
-    // Fast path: stop before any network call once identity is complete and
-    // every mapped claim is already in `merged`. With `wantImage`, keep going
-    // for the avatar too — its claim commonly lives only at userinfo, past
-    // where id + email + name already stopped us. `exhaustive` disables this
-    // so the connection test walks every source.
-    const identityComplete = Boolean(id && email && name)
-    if (
-      !exhaustive &&
-      identityComplete &&
-      (!wantImage || image) &&
-      requiredPathsResolved(merged, requiredClaimPaths)
-    ) {
-      break
+  for (const source of state.config.sources) {
+    if (!state.config.exhaustive && bindingComplete(state)) break
+    const loaded = await loadSource(source)
+    if ('unavailable' in loaded) {
+      state = advanceBindingState(state, source, null, loaded.unavailable)
+      continue
     }
-
-    const claims = await loadSource(source)
-    if (!claims) continue
-
-    // Reproduce the library's own derivation exactly, or an upgrade re-keys
-    // existing accounts: lookup matches the account identifier first, so a
-    // changed value misses, the email fallback finds the user, and a second
-    // account row appears — or, with no email, the user forks. The `id`
-    // fallback is userinfo-only because that is where the library applies it;
-    // its ID-token path keys on `sub` alone. An explicit idClaim wins over both.
-    const claimedId =
-      asNonEmptyString(resolveClaim(claims, idClaim)) ??
-      (source === 'userinfo' && !mapping?.idClaim
-        ? asNonEmptyString(resolveClaim(claims, 'id'))
-        : undefined)
-
-    // OIDC Core 5.3.2: a userinfo response whose subject differs from the ID
-    // token's must be discarded. Scoped to userinfo deliberately — an access
-    // token is audience-scoped, and with pairwise subjects the same person
-    // legitimately carries a different one there.
-    //
-    // Observed rather than enforced by default. A provider in this state works
-    // TODAY, because the path being replaced discards the ID token and takes
-    // userinfo wholesale; enforcing on the same release as the cascade would
-    // make that a total sign-in outage on an upgrade nobody chose, with no
-    // telemetry to size it first. So the default reproduces today's behaviour
-    // and reports the discrepancy, and a later release flips to enforcing.
-    if (source === 'userinfo' && id && claimedId && claimedId !== id) {
-      if (subjectMismatch === 'enforce') {
-        return { ok: false, reason: 'subject_mismatch', claims: merged }
-      }
-      warnings.push('subject_mismatch')
-      // The legacy re-key below only ever applied when the ID token was
-      // INCOMPLETE, because a complete one never reached userinfo. When this
-      // fetch happened solely for a mapped claim path, the avatar, or the
-      // exhaustive test walk, the account is already keyed by the ID token and
-      // must stay so: enabling a mapping cannot be what links a different account.
-      // Per OIDC Core 5.3.2 the mismatched response is discarded outright.
-      if (identityComplete) continue
-      // Legacy behaviour: userinfo wins wholesale, which means its subject is
-      // what keys the account. Anything already taken from the ID token is
-      // cleared so the two are never mixed.
-      id = undefined
-      email = undefined
-      name = undefined
-      image = undefined
-      emailVerified = false
-      found.id = undefined
-      found.email = undefined
-      found.name = undefined
-      found.image = undefined
-    }
-
-    // Earlier sources win: only fill what is still absent.
-    for (const [key, value] of Object.entries(claims)) {
-      if (!(key in merged)) merged[key] = value
-    }
-    // Nested required paths are not covered by the shallow merge: an ID token
-    // `org` object without `costCenter` would otherwise block userinfo's
-    // `org.costCenter`. Fill those leaves without rewriting earlier keys.
-    fillRequiredLeaves(merged, claims, requiredClaimPaths)
-
-    if (!id && claimedId) {
-      id = claimedId
-      found.id = source
-    }
-    if (!name) {
-      const claimedName = asNonEmptyString(resolveClaim(claims, nameClaim))
-      if (claimedName) {
-        name = claimedName
-        found.name = source
-      }
-    }
-    if (!email) {
-      const claimedEmail = asNonEmptyString(resolveClaim(claims, emailClaim))
-      if (claimedEmail) {
-        email = claimedEmail
-        found.email = source
-        // The verified flag must come from the SAME source as the address; one
-        // asserted in the ID token cannot vouch for a userinfo address.
-        emailVerified = isAffirmativeClaim(resolveClaim(claims, 'email_verified'))
-      }
-    }
-    if (wantImage && !image) {
-      const claimedImage = asHttpUrl(resolveClaim(claims, imageClaim))
-      if (claimedImage) {
-        image = claimedImage
-        found.image = source
-      }
-    }
+    state = advanceBindingState(state, source, loaded.claims)
+    if (state.failed) break
   }
 
-  if (!id) return { ok: false, reason: 'no_identity', claims: merged }
-
-  return {
-    ok: true,
-    identity: {
-      id,
-      email,
-      name,
-      ...(image ? { image } : {}),
-      emailVerified,
-      sources: found,
-      claims: merged,
-      ...(warnings.length > 0 ? { warnings } : {}),
-    },
-  }
+  return toResolveResult(state)
 }

--- a/apps/web/src/lib/server/auth/sso-test-callback.ts
+++ b/apps/web/src/lib/server/auth/sso-test-callback.ts
@@ -5,11 +5,12 @@
  * a miss falls through to a real OAuth sign-in.
  *
  * On a successful handshake this stamps the tested provider's
- * `lastSuccessfulTestAt` (via `markTestSucceeded`) to unlock its enforcement
- * gate. For the legacy `sso` provider it also stamps
- * `ssoOidc.lastSuccessfulTestAt` (via `markSsoTestSucceeded`) for backward
- * compatibility. Reports whether the IdP identity matched the admin —
- * informational only, not a gate.
+ * `lastSuccessfulTestAt` (via `persistTestResult`) to unlock its enforcement
+ * gate. Mapping failures persist diagnostic capture without unlocking
+ * enforcement. For the legacy `sso` provider it also stamps
+ * `ssoOidc.lastSuccessfulTestAt` (via `markSsoTestSucceeded`) after the
+ * provider stamp actually succeeds. Reports whether the IdP identity matched
+ * the admin — informational only, not a gate.
  */
 
 import { runHandshake } from '@/lib/server/auth/sso-test-handshake'
@@ -89,6 +90,9 @@ export async function handleSsoTestCallback(
     requestedPrompt: session.requestedPrompt,
     allowMissingEmail: session.allowMissingEmail,
     identityMapping: session.identityMapping,
+    claimMapping: session.claimMapping,
+    registrationId: session.registrationId,
+    detailsChangedAtAtStart: session.detailsChangedAt,
     clientId: session.clientId,
     clientSecret: session.clientSecret,
     redirectUri: session.redirectUri,
@@ -106,48 +110,35 @@ export async function handleSsoTestCallback(
         errorCode: result.errorCode,
         hint: result.hint,
         steps: result.steps,
+        ...(result.mappingOutcome ? { mappingOutcome: result.mappingOutcome } : {}),
+        ...(result.capture ? { capture: result.capture } : {}),
+        ...(result.allClaims ? { allClaims: result.allClaims } : {}),
       }
 
-  // A successful test sign-in stamps the provider's `lastSuccessfulTestAt`,
-  // which unlocks its enforcement gate. The test ran a real end-to-end OIDC
-  // handshake — that it completed is the meaningful proof the connection
-  // works, regardless of which IdP account signed in. The gate logic compares
-  // the stamp against `detailsChangedAt`, so a stale test (predating the last
-  // discoveryUrl / clientId / secret change) no longer counts.
+  // Persist capture against the configuration the test started with. Success
+  // stamps lastSuccessfulTestAt in the same conditional update; mapping
+  // failure replaces diagnostic capture only. A mid-test edit yields a
+  // zero-row update (stale) and cannot unlock enforcement.
   //
   // `identityMatched` is still computed — purely informational, shown
   // in the result panel as a "you tested as a different account" FYI —
   // but it does not gate anything.
   let identityMatched = false
-  if (result.ok) {
-    const { listIdentityProviders, markTestSucceeded } =
+  const capture = result.capture
+  if (result.ok || capture) {
+    const { listIdentityProviders, persistTestResult } =
       await import('@/lib/server/domains/settings/identity-providers.service')
     const providers = await listIdentityProviders()
     const provider = providers.find((p) => p.registrationId === session.registrationId)
-    // Only stamp when the provider is UNCHANGED since the test started. If its
-    // connection details (clientId/endpoints/secret) were edited mid-test, the
-    // handshake exercised the OLD config — stamping would let a stale test
-    // unlock enforcement (lastSuccessfulTestAt > detailsChangedAt) for an
-    // untested new configuration. The admin must re-test after editing.
-    const unchanged = !!provider && provider.detailsChangedAt === session.detailsChangedAt
-
-    if (provider && unchanged) {
-      const capture = {
-        registrationId: session.registrationId,
-        capturedAt: new Date().toISOString(),
-        identity: result.identity ?? {
-          id: result.claims.sub,
-          email: result.claims.email,
-          name: result.claims.name,
-          sources: {},
-        },
-        claims: result.allClaims ?? {},
-      }
-      await markTestSucceeded(provider.id, capture)
-
-      // For the legacy `sso` provider also stamp the JSON blob that the
-      // old single-provider gate still reads, keeping both paths in sync.
-      if (session.registrationId === 'sso') {
+    let stamped = false
+    if (provider && capture) {
+      const persist = await persistTestResult(provider.id, {
+        expectedDetailsChangedAt: session.detailsChangedAt ?? null,
+        outcome: result.ok ? 'success' : 'mapping_failed',
+        capture,
+      })
+      stamped = persist === 'stamped' && result.ok
+      if (stamped && session.registrationId === 'sso') {
         const { markSsoTestSucceeded } =
           await import('@/lib/server/domains/settings/settings.service')
         await markSsoTestSucceeded()
@@ -158,14 +149,16 @@ export async function handleSsoTestCallback(
       {
         admin_user_id: session.adminUserId,
         registrationId: session.registrationId,
-        stamped: provider ? unchanged : false,
+        stamped,
       },
-      unchanged
+      stamped
         ? 'sso test succeeded; provider gates unlocked'
-        : 'sso test succeeded but provider changed mid-test; not stamping'
+        : result.ok
+          ? 'sso test succeeded but provider changed mid-test; not stamping'
+          : 'sso test mapping failed; capture stored without unlocking enforcement'
     )
 
-    if (result.claims.email) {
+    if (result.ok && result.claims.email) {
       const { db, user, eq } = await import('@/lib/server/db')
       type UserId = `user_${string}`
       const admin = await db.query.user.findFirst({

--- a/apps/web/src/lib/server/auth/sso-test-handshake.ts
+++ b/apps/web/src/lib/server/auth/sso-test-handshake.ts
@@ -14,6 +14,24 @@
 import { jwtVerify, createLocalJWKSet, decodeProtectedHeader, decodeJwt } from 'jose'
 import type { JsonValue } from '@/lib/server/audit/log'
 import { explainAuthorizeError, explainTokenError } from './oidc-error-explain'
+import {
+  DEFAULT_IDENTITY_SOURCES,
+  claimMappingFor,
+  type IdentityProviderClaimMapping,
+  type IdentitySource,
+  type SourceUnavailableReason,
+} from '@/lib/shared/oidc-claim-mapping'
+import {
+  finishBinding,
+  replayClaimMapping,
+  type IdentityMapping,
+} from '@/lib/shared/sso-claim-binder'
+import { finalizeProfileOutcome, type ProfileOutcome } from '@/lib/shared/sso-profile-outcome'
+import type {
+  CapturedIdentity,
+  SourceSnapshot,
+  SsoTestCaptureV2,
+} from '@/lib/shared/sso-test-capture'
 
 export type HandshakeStage =
   | 'state-validation'
@@ -55,7 +73,14 @@ export interface HandshakeInput {
    */
   allowMissingEmail?: boolean
   /** Identity sources and claim paths — the same mapping production uses. */
-  identityMapping?: import('./resolve-identity').IdentityMapping
+  identityMapping?: IdentityMapping
+  /**
+   * Full stored mapping snapshotted at test start. Pre-deploy sessions may omit
+   * this and carry only `identityMapping` for the existing 600-second TTL.
+   */
+  claimMapping?: IdentityProviderClaimMapping
+  registrationId?: string
+  detailsChangedAtAtStart?: string | null
   /** IdP-returned `error` query parameter, if the authorize step failed. */
   idpError?: string | null
   idpErrorDescription?: string | null
@@ -107,6 +132,8 @@ export type HandshakeResult =
         image?: string
         sources: Partial<Record<'id' | 'email' | 'name' | 'image', string>>
       }
+      mappingOutcome?: ProfileOutcome
+      capture?: SsoTestCaptureV2
     }
   | {
       ok: false
@@ -115,6 +142,9 @@ export type HandshakeResult =
       hint: string
       raw?: unknown
       steps: DiagnosticStep[]
+      mappingOutcome?: ProfileOutcome
+      capture?: SsoTestCaptureV2
+      allClaims?: Record<string, JsonValue>
     }
 
 export async function runHandshake(input: HandshakeInput): Promise<HandshakeResult> {
@@ -312,19 +342,7 @@ export async function runHandshake(input: HandshakeInput): Promise<HandshakeResu
   }
   steps.push({ ok: true, stage: 'token-exchange', label: 'Token exchange succeeded' })
 
-  const sources = input.identityMapping?.sources
-  const accessTokenOnly =
-    Array.isArray(sources) && sources.includes('accessTokenJwt') && !sources.includes('idToken')
   const hasIdToken = typeof tokens.id_token === 'string' && tokens.id_token.length > 0
-
-  if (!hasIdToken && !accessTokenOnly) {
-    return {
-      ok: false,
-      stage: 'token-exchange',
-      hint: "No id_token returned. Make sure 'openid' is in the requested scopes and your IdP is configured to issue ID tokens, or set identity sources to access-token JWT only.",
-      steps,
-    }
-  }
 
   let header: ReturnType<typeof decodeProtectedHeader> | undefined
   let verifiedPayload: ReturnType<typeof decodeJwt> | undefined
@@ -406,57 +424,114 @@ export async function runHandshake(input: HandshakeInput): Promise<HandshakeResu
     steps.push({ ok: true, stage: 'claim-check', label: 'Nonce matched' })
   }
 
-  const { resolveIdentity } = await import('./resolve-identity')
-  const resolution = await resolveIdentity({
-    tokens: { idToken: tokens.id_token, accessToken: tokens.access_token },
-    mapping: input.identityMapping,
-    exhaustive: true,
-    // Mirror production, which now resolves the avatar from `picture`.
-    wantImage: true,
-    fetchUserInfo: async () => {
-      if (!discovery.userinfo_endpoint || !tokens.access_token) return null
-      try {
-        const uiRes = await safeFetch(discovery.userinfo_endpoint, {
-          headers: { Authorization: `Bearer ${tokens.access_token}` },
-          timeoutMs: 5000,
-        })
-        if (!uiRes.ok) {
-          steps.push({
-            ok: false,
-            stage: 'userinfo',
-            label: `Userinfo failed (${uiRes.status})`,
-          })
-          return null
-        }
-        steps.push({ ok: true, stage: 'userinfo', label: 'Userinfo endpoint reachable' })
-        const body: unknown = await uiRes.json()
-        return body !== null && typeof body === 'object' ? (body as Record<string, unknown>) : null
-      } catch {
+  const identityMapping = input.identityMapping
+  const storedMapping = claimMappingFor(input.claimMapping)
+  const requiredClaimPaths = [
+    ...(storedMapping.attributes?.map ?? []).map((entry) => entry.claimPath),
+    ...(storedMapping.role?.claimPath ? [storedMapping.role.claimPath] : []),
+  ]
+  const configuredSources = identityMapping?.sources ?? DEFAULT_IDENTITY_SOURCES
+
+  let userinfoMemo:
+    { claims: Record<string, unknown> } | { unavailable: SourceUnavailableReason } | undefined
+  const loadUserinfo = async (): Promise<
+    { claims: Record<string, unknown> } | { unavailable: SourceUnavailableReason }
+  > => {
+    if (userinfoMemo) return userinfoMemo
+    if (!discovery.userinfo_endpoint || !tokens.access_token) {
+      userinfoMemo = { unavailable: 'absent' }
+      return userinfoMemo
+    }
+    try {
+      const uiRes = await safeFetch(discovery.userinfo_endpoint, {
+        headers: { Authorization: `Bearer ${tokens.access_token}` },
+        timeoutMs: 5000,
+      })
+      if (!uiRes.ok) {
         steps.push({
           ok: false,
           stage: 'userinfo',
-          label: 'Userinfo unreachable or unsafe to fetch',
+          label: `Userinfo failed (${uiRes.status})`,
         })
-        return null
+        userinfoMemo = { unavailable: 'fetch_failed' }
+        return userinfoMemo
       }
-    },
-  })
-
-  if (!resolution.ok) {
-    return {
-      ok: false,
-      stage: 'claim-check',
-      hint:
-        resolution.reason === 'subject_mismatch'
-          ? "Your IdP's userinfo endpoint reported a different 'sub' than its ID token. OIDC requires these to match, and mixing them could attach the wrong account, so sign-in is refused."
-          : "Couldn't resolve an account identifier. The IdP must return a stable subject in the ID token, userinfo, or (when configured) the access token.",
-      steps,
+      steps.push({ ok: true, stage: 'userinfo', label: 'Userinfo endpoint reachable' })
+      const body: unknown = await uiRes.json()
+      userinfoMemo =
+        body !== null && typeof body === 'object' && !Array.isArray(body)
+          ? { claims: body as Record<string, unknown> }
+          : { unavailable: 'absent' }
+      return userinfoMemo
+    } catch {
+      steps.push({
+        ok: false,
+        stage: 'userinfo',
+        label: 'Userinfo unreachable or unsafe to fetch',
+      })
+      userinfoMemo = { unavailable: 'fetch_failed' }
+      return userinfoMemo
     }
   }
 
-  const { identity } = resolution
+  const snapshots: SourceSnapshot[] = []
+  for (const source of configuredSources) {
+    snapshots.push(
+      await snapshotForSource(source, { hasIdToken, verifiedPayload, tokens, loadUserinfo })
+    )
+  }
+
+  const bound = finishBinding(
+    replayClaimMapping(
+      {
+        mapping: identityMapping,
+        requiredClaimPaths: requiredClaimPaths.length > 0 ? requiredClaimPaths : undefined,
+        wantImage: true,
+      },
+      snapshots
+    )
+  )
+  const mappingOutcome = finalizeProfileOutcome(bound, {
+    allowMissingEmail: input.allowMissingEmail === true,
+  })
+  const diagnosticClaims = mergeSnapshotClaims(snapshots)
+  const capture = buildTestCapture({
+    registrationId: input.registrationId ?? '',
+    detailsChangedAtAtStart: input.detailsChangedAtAtStart ?? null,
+    snapshots,
+    diagnosticClaims,
+    bound,
+    mappingOutcome,
+  })
+
+  if (bound.failed === 'subject_mismatch') {
+    return {
+      ok: false,
+      stage: 'claim-check',
+      hint: "Your IdP's userinfo endpoint reported a different 'sub' than its ID token. OIDC requires these to match, and mixing them could attach the wrong account, so sign-in is refused.",
+      steps,
+      mappingOutcome,
+      capture,
+      allClaims: diagnosticClaims as Record<string, JsonValue>,
+    }
+  }
+
+  if (mappingOutcome.kind === 'missing_id') {
+    return {
+      ok: false,
+      stage: 'claim-check',
+      hint: "Couldn't resolve an account identifier. The IdP must return a stable subject in the ID token, userinfo, or (when configured) the access token.",
+      steps,
+      mappingOutcome,
+      capture,
+      allClaims: diagnosticClaims as Record<string, JsonValue>,
+    }
+  }
+
+  const identity = capture.identity
+
   for (const field of ['id', 'email', 'name'] as const) {
-    const source = identity.sources[field]
+    const source = bound.provenance[field]?.source
     if (!source) continue
     steps.push({
       ok: true,
@@ -466,17 +541,15 @@ export async function runHandshake(input: HandshakeInput): Promise<HandshakeResu
     })
   }
 
-  // Avatar is optional: report it, but a missing `picture` is informational,
-  // not a failed connection.
-  if (identity.image) {
+  if (bound.identity.image) {
     steps.push({
       ok: true,
       stage: 'claim-check',
       label: 'Avatar resolved',
       detail:
-        identity.sources.image === 'idToken'
+        bound.provenance.image?.source === 'idToken'
           ? 'from the ID token'
-          : `from ${identity.sources.image}`,
+          : `from ${bound.provenance.image?.source}`,
     })
   } else {
     steps.push({
@@ -489,10 +562,7 @@ export async function runHandshake(input: HandshakeInput): Promise<HandshakeResu
     })
   }
 
-  // Observed, not enforced. Surfacing it here is how an admin learns about the
-  // discrepancy while sign-in still works, rather than discovering it on the
-  // release that starts refusing.
-  if (identity.warnings?.includes('subject_mismatch')) {
+  if (bound.warnings.includes('subject_mismatch')) {
     steps.push({
       ok: false,
       stage: 'claim-check',
@@ -502,15 +572,19 @@ export async function runHandshake(input: HandshakeInput): Promise<HandshakeResu
     })
   }
 
-  if (!identity.email) {
-    if (!input.allowMissingEmail) {
-      return {
-        ok: false,
-        stage: 'claim-check',
-        hint: "No email address was released, in the ID token or from the userinfo endpoint. Either configure your IdP's claim mapper to release it, or — if this provider has no email addresses to give — enable the placeholder-address option on the provider.",
-        steps,
-      }
+  if (mappingOutcome.kind === 'missing_email') {
+    return {
+      ok: false,
+      stage: 'claim-check',
+      hint: "No email address was released, in the ID token or from the userinfo endpoint. Either configure your IdP's claim mapper to release it, or — if this provider has no email addresses to give — enable the placeholder-address option on the provider.",
+      steps,
+      mappingOutcome,
+      capture,
+      allClaims: diagnosticClaims as Record<string, JsonValue>,
     }
+  }
+
+  if (mappingOutcome.kind === 'placeholder_required') {
     steps.push({
       ok: true,
       stage: 'claim-check',
@@ -529,14 +603,14 @@ export async function runHandshake(input: HandshakeInput): Promise<HandshakeResu
         (verifiedPayload?.iss as string | undefined) ??
         (accessPayload?.iss as string | undefined) ??
         '',
-      sub: identity.id,
+      sub: bound.identity.id ?? '',
       aud:
         (verifiedPayload?.aud as string | string[] | undefined) ??
         (accessPayload?.aud as string | string[] | undefined) ??
         input.clientId,
-      email: identity.email,
-      email_verified: identity.emailVerified,
-      name: identity.name,
+      email: bound.identity.email,
+      email_verified: bound.identity.emailVerified,
+      name: mappingOutcome.name,
       preferred_username: verifiedPayload?.preferred_username as string | undefined,
     },
     tokenInfo: {
@@ -545,14 +619,18 @@ export async function runHandshake(input: HandshakeInput): Promise<HandshakeResu
       hasRefreshToken: !!tokens.refresh_token,
       expiresIn: tokens.expires_in,
     },
-    allClaims: identity.claims as unknown as Record<string, JsonValue>,
-    identity: {
-      id: identity.id,
-      email: identity.email,
-      name: identity.name,
-      image: identity.image,
-      sources: identity.sources,
-    },
+    allClaims: diagnosticClaims as Record<string, JsonValue>,
+    identity: identity
+      ? {
+          id: identity.id,
+          email: identity.email,
+          name: identity.name,
+          image: identity.image,
+          sources: identity.sources,
+        }
+      : undefined,
+    mappingOutcome,
+    capture,
   }
 }
 
@@ -562,5 +640,97 @@ function decodeJwtSafe(token: string): Record<string, unknown> | null {
     return payload && typeof payload === 'object' ? (payload as Record<string, unknown>) : null
   } catch {
     return null
+  }
+}
+
+function jsonClaims(value: Record<string, unknown>): Record<string, JsonValue> {
+  return JSON.parse(JSON.stringify(value)) as Record<string, JsonValue>
+}
+
+async function snapshotForSource(
+  source: IdentitySource,
+  ctx: {
+    hasIdToken: boolean
+    verifiedPayload: ReturnType<typeof decodeJwt> | undefined
+    tokens: { id_token?: string; access_token?: string }
+    loadUserinfo: () => Promise<
+      { claims: Record<string, unknown> } | { unavailable: SourceUnavailableReason }
+    >
+  }
+): Promise<SourceSnapshot> {
+  if (source === 'idToken') {
+    if (!ctx.hasIdToken) return { source, unavailable: 'absent' }
+    if (!ctx.verifiedPayload) return { source, unavailable: 'unreadable' }
+    return { source, claims: jsonClaims(ctx.verifiedPayload as Record<string, unknown>) }
+  }
+  if (source === 'accessTokenJwt') {
+    if (!ctx.tokens.access_token) return { source, unavailable: 'absent' }
+    const decoded = decodeJwtSafe(ctx.tokens.access_token)
+    if (!decoded) return { source, unavailable: 'unreadable' }
+    return { source, claims: jsonClaims(decoded) }
+  }
+  const loaded = await ctx.loadUserinfo()
+  if ('unavailable' in loaded) return { source, unavailable: loaded.unavailable }
+  return { source, claims: jsonClaims(loaded.claims) }
+}
+
+function mergeSnapshotClaims(snapshots: SourceSnapshot[]): Record<string, unknown> {
+  const merged: Record<string, unknown> = {}
+  for (const snapshot of snapshots) {
+    if (!('claims' in snapshot) || !snapshot.claims) continue
+    for (const [key, value] of Object.entries(snapshot.claims)) {
+      if (!Object.hasOwn(merged, key)) merged[key] = value
+    }
+  }
+  return merged
+}
+
+function buildTestCapture({
+  registrationId,
+  detailsChangedAtAtStart,
+  snapshots,
+  diagnosticClaims,
+  bound,
+  mappingOutcome,
+}: {
+  registrationId: string
+  detailsChangedAtAtStart: string | null
+  snapshots: SourceSnapshot[]
+  diagnosticClaims: Record<string, unknown>
+  bound: ReturnType<typeof finishBinding>
+  mappingOutcome: ProfileOutcome
+}): SsoTestCaptureV2 {
+  const success =
+    mappingOutcome.kind === 'identity' || mappingOutcome.kind === 'placeholder_required'
+  const id = bound.identity.id
+  const identity: CapturedIdentity | undefined = id
+    ? {
+        id,
+        ...(mappingOutcome.email ? { email: mappingOutcome.email } : {}),
+        ...(mappingOutcome.name ? { name: mappingOutcome.name } : {}),
+        ...(bound.identity.image ? { image: bound.identity.image } : {}),
+        sources: {
+          ...(bound.provenance.id ? { id: bound.provenance.id.source } : {}),
+          ...(bound.provenance.email ? { email: bound.provenance.email.source } : {}),
+          ...(bound.provenance.name ? { name: bound.provenance.name.source } : {}),
+          ...(bound.provenance.image ? { image: bound.provenance.image.source } : {}),
+        },
+        paths: {
+          ...(bound.provenance.id ? { id: bound.provenance.id.path } : {}),
+          ...(bound.provenance.email ? { email: bound.provenance.email.path } : {}),
+          ...(bound.provenance.name ? { name: bound.provenance.name.path } : {}),
+          ...(bound.provenance.image ? { image: bound.provenance.image.path } : {}),
+        },
+      }
+    : undefined
+  return {
+    version: 2,
+    registrationId,
+    capturedAt: new Date().toISOString(),
+    detailsChangedAtAtStart,
+    outcome: success && !bound.failed ? 'success' : 'mapping_failed',
+    ...(identity ? { identity } : {}),
+    claims: diagnosticClaims as Record<string, JsonValue>,
+    replay: { sources: snapshots },
   }
 }

--- a/apps/web/src/lib/server/auth/sso-test-handshake.ts
+++ b/apps/web/src/lib/server/auth/sso-test-handshake.ts
@@ -499,7 +499,6 @@ export async function runHandshake(input: HandshakeInput): Promise<HandshakeResu
     registrationId: input.registrationId ?? '',
     detailsChangedAtAtStart: input.detailsChangedAtAtStart ?? null,
     snapshots,
-    diagnosticClaims,
     bound,
     mappingOutcome,
   })
@@ -689,14 +688,12 @@ function buildTestCapture({
   registrationId,
   detailsChangedAtAtStart,
   snapshots,
-  diagnosticClaims,
   bound,
   mappingOutcome,
 }: {
   registrationId: string
   detailsChangedAtAtStart: string | null
   snapshots: SourceSnapshot[]
-  diagnosticClaims: Record<string, unknown>
   bound: ReturnType<typeof finishBinding>
   mappingOutcome: ProfileOutcome
 }): SsoTestCaptureV2 {
@@ -730,7 +727,7 @@ function buildTestCapture({
     detailsChangedAtAtStart,
     outcome: success && !bound.failed ? 'success' : 'mapping_failed',
     ...(identity ? { identity } : {}),
-    claims: diagnosticClaims as Record<string, JsonValue>,
+    claims: bound.acceptedClaims as Record<string, JsonValue>,
     replay: { sources: snapshots },
   }
 }

--- a/apps/web/src/lib/server/domains/settings/__tests__/identity-providers.service.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/identity-providers.service.test.ts
@@ -64,6 +64,27 @@ describe('connectionAffectingChange', () => {
     ).toBe(true)
   })
 
+  it('default Save with Advanced sources mounted does not invalidate a passing connection test', () => {
+    expect(
+      connectionAffectingChange(
+        { claimMapping: { profile: { sources: ['idToken', 'userinfo'] } } },
+        { ...existing, claimMapping: null }
+      )
+    ).toBe(false)
+    expect(
+      connectionAffectingChange(
+        { claimMapping: { profile: { sources: ['userinfo', 'idToken'] } } },
+        { ...existing, claimMapping: { profile: { sources: ['idToken', 'userinfo'] } } }
+      )
+    ).toBe(true)
+    expect(
+      connectionAffectingChange(
+        { claimMapping: { profile: { claims: { id: 'sub' } } } },
+        { ...existing, claimMapping: null }
+      )
+    ).toBe(true)
+  })
+
   it('is false when only claimMapping.role or attributes change', () => {
     expect(
       connectionAffectingChange(

--- a/apps/web/src/lib/server/domains/settings/__tests__/identity-providers.service.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/identity-providers.service.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   connectionAffectingChange,
   deriveVisibility,
+  persistTestResult,
   shouldRenderPublicButton,
   verifiedDomainCount,
 } from '../identity-providers.service'
@@ -113,5 +114,11 @@ describe('identity providers visibility', () => {
         domains: [{ verifiedAt: null }, { verifiedAt: 'x' }, { verifiedAt: 'y' }] as any,
       })
     ).toBe(2)
+  })
+})
+
+describe('persistTestResult', () => {
+  it('is the atomic capture persistence API', () => {
+    expect(typeof persistTestResult).toBe('function')
   })
 })

--- a/apps/web/src/lib/server/domains/settings/__tests__/upsert-identity-provider.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/upsert-identity-provider.test.ts
@@ -335,6 +335,32 @@ describe('upsertIdentityProvider — detailsChangedAt restamp (Fix 6)', () => {
     expect(hoisted.capturedSetPatch!.detailsChangedAt).toBeUndefined()
   })
 
+  it('rejects a typed mapping DTO that would drop nested unknown role extras', async () => {
+    hoisted.txSelectResult = [
+      {
+        ...EXISTING_ROW,
+        claimMapping: {
+          role: {
+            claimPath: 'groups',
+            rules: [{ whenContains: 'admins', role: 'admin', note: 'keep' }],
+            custom: 1,
+          },
+        },
+      },
+    ]
+    await expect(
+      upsertIdentityProvider({
+        ...BASE_INPUT,
+        id: 'idp_existing' as `idp_${string}`,
+        acknowledgeAdminRules: true,
+        claimMapping: {
+          role: { claimPath: 'groups', rules: [{ whenContains: 'admins', role: 'admin' }] },
+        },
+      })
+    ).rejects.toMatchObject({ code: 'MAPPING_UNSUPPORTED_STRIPPED' })
+    expect(hoisted.capturedSetPatch).toBeNull()
+  })
+
   it('does NOT restamp detailsChangedAt when only claimMapping.attributes change', async () => {
     await upsertIdentityProvider({
       ...BASE_INPUT,

--- a/apps/web/src/lib/server/domains/settings/__tests__/upsert-identity-provider.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/upsert-identity-provider.test.ts
@@ -327,6 +327,7 @@ describe('upsertIdentityProvider — detailsChangedAt restamp (Fix 6)', () => {
     await upsertIdentityProvider({
       ...BASE_INPUT,
       id: 'idp_existing' as `idp_${string}`,
+      acknowledgeAdminRules: true,
       claimMapping: {
         role: { claimPath: 'groups', rules: [{ whenContains: 'admins', role: 'admin' }] },
       },

--- a/apps/web/src/lib/server/domains/settings/identity-providers.service.ts
+++ b/apps/web/src/lib/server/domains/settings/identity-providers.service.ts
@@ -18,9 +18,11 @@ import type { Role } from '@/lib/shared/roles'
 import {
   db,
   account,
+  and,
   count,
   eq,
   identityProvider,
+  isNull,
   ssoVerifiedDomain,
   type IdentityProviderClaimMapping,
 } from '@/lib/server/db'
@@ -94,7 +96,7 @@ export interface IdentityProvider {
   detailsChangedAt: string | null
   /** ISO-8601 UTC; null until a test sign-in succeeds. */
   lastSuccessfulTestAt: string | null
-  /** Last successful Test fixture, as captured. Null until a test succeeds. */
+  /** Last usable Test fixture, including mapping failures. Null until a test. */
   lastTestCapture: SsoTestCapture | null
   createdAt: string
   domains: VerifiedDomain[]
@@ -612,20 +614,54 @@ export async function stampDetailsChanged(id: IdentityProviderId): Promise<void>
   }
 }
 
-/** Stamp `last_successful_test_at = now()` and persist the test fixture. */
-export async function markTestSucceeded(
+/**
+ * Persist a test capture against the configuration the test started with.
+ * Success stamps `lastSuccessfulTestAt`; mapping failure replaces diagnostic
+ * capture only. A zero-row conditional update is stale, not success.
+ */
+export async function persistTestResult(
   id: IdentityProviderId,
-  capture?: SsoTestCapture
-): Promise<void> {
-  log.info({ id }, 'mark identity provider test succeeded')
+  args: {
+    expectedDetailsChangedAt: string | null
+    outcome: 'success' | 'mapping_failed'
+    capture: SsoTestCapture
+  }
+): Promise<'stamped' | 'stale'> {
+  const { bumpAuthConfigVersionInTx } = await import('@/lib/server/auth/config-version')
+  const { resetAuth } = await import('@/lib/server/auth')
+
+  log.info({ id, outcome: args.outcome }, 'persist identity provider test result')
   try {
-    await stampTimestamp(id, {
-      lastSuccessfulTestAt: new Date(),
-      ...(capture ? { lastTestCapture: capture } : {}),
+    const detailsMatch =
+      args.expectedDetailsChangedAt === null
+        ? isNull(identityProvider.detailsChangedAt)
+        : eq(identityProvider.detailsChangedAt, new Date(args.expectedDetailsChangedAt))
+
+    const result = await db.transaction(async (tx) => {
+      const [row] = await tx
+        .update(identityProvider)
+        .set({
+          lastTestCapture: args.capture,
+          ...(args.outcome === 'success' ? { lastSuccessfulTestAt: new Date() } : {}),
+        })
+        .where(and(eq(identityProvider.id, id), detailsMatch))
+        .returning({ id: identityProvider.id })
+      if (!row) return 'stale' as const
+      if (args.outcome === 'success') {
+        await bumpAuthConfigVersionInTx(tx)
+      }
+      return 'stamped' as const
     })
+
+    if (result === 'stamped') {
+      if (args.outcome === 'success') resetAuth()
+      await invalidateSettingsCache()
+    }
+    return result
   } catch (error) {
-    log.error({ err: error }, 'mark identity provider test succeeded failed')
-    wrapDbError('mark identity provider test succeeded', error)
+    log.error({ err: error }, 'persist identity provider test result failed')
+    wrapDbError('persist identity provider test result', error)
+    throw error
   }
 }
 

--- a/apps/web/src/lib/server/domains/settings/identity-providers.service.ts
+++ b/apps/web/src/lib/server/domains/settings/identity-providers.service.ts
@@ -28,6 +28,14 @@ import {
 } from '@/lib/server/db'
 import type { IdentityProviderId } from '@quackback/ids'
 import { parseSsoTestCapture, type SsoTestCapture } from '@/lib/shared/sso-test-capture'
+import {
+  applyClaimMappingEdits,
+  effectiveProfileSignature,
+  mappingSaveRisks,
+  mappingWouldStripUnsupported,
+  storedJsonEqual,
+  type ClaimMappingOperation,
+} from '@/lib/shared/sso-claim-mapping-edit'
 import { logger } from '@/lib/server/logger'
 import { getPublicUrlOrNull } from '@/lib/server/storage/s3'
 import { absolutizeOffHostAssetUrl } from '@/lib/server/storage/asset-url'
@@ -41,7 +49,7 @@ import { AUTH_CREDENTIAL_PREFIX } from '@/lib/server/auth/auth-providers'
 import { verifiedDomainCount, shouldRenderPublicButton } from '@/lib/server/auth/provider-ids'
 import type { VerifiedDomain } from './settings.types'
 import { invalidateSettingsCache, wrapDbError } from './settings.helpers'
-import { ValidationError } from '@/lib/shared/errors'
+import { ConflictError, ValidationError } from '@/lib/shared/errors'
 
 const log = logger.child({ component: 'identity-providers' })
 
@@ -132,6 +140,8 @@ export interface UpsertIdentityProviderInput {
   autoProvisionRole?: Role | null
   claimMapping?: IdentityProviderClaimMapping | null
   showButton?: boolean
+  acknowledgeIdentifierChange?: boolean
+  acknowledgeAdminRules?: boolean
 }
 
 // ============================================================================
@@ -199,7 +209,8 @@ export function connectionAffectingChange(
   // missing-email) does, so a prior stamp cannot vouch for it.
   if (input.claimMapping === undefined) return false
   return (
-    JSON.stringify(input.claimMapping?.profile) !== JSON.stringify(existing.claimMapping?.profile)
+    effectiveProfileSignature(input.claimMapping) !==
+    effectiveProfileSignature(existing.claimMapping)
   )
 }
 
@@ -449,7 +460,30 @@ export async function upsertIdentityProvider(
         if (input.enabled !== undefined) patch.enabled = input.enabled
         if (input.autoCreateUsers !== undefined) patch.autoCreateUsers = input.autoCreateUsers
         if (input.autoProvisionRole !== undefined) patch.autoProvisionRole = input.autoProvisionRole
-        if (input.claimMapping !== undefined) patch.claimMapping = input.claimMapping
+        if (input.claimMapping !== undefined) {
+          if (mappingWouldStripUnsupported(existing.claimMapping, input.claimMapping)) {
+            throw new ValidationError(
+              'MAPPING_UNSUPPORTED_STRIPPED',
+              'This save would drop unsupported mapping data. Reload and use the mapping editor.'
+            )
+          }
+          if (!storedJsonEqual(existing.claimMapping, input.claimMapping)) {
+            const risks = mappingSaveRisks(existing.claimMapping, input.claimMapping)
+            if (risks.identifierChanged && !input.acknowledgeIdentifierChange) {
+              throw new ValidationError(
+                'MAPPING_IDENTIFIER_ACK_REQUIRED',
+                'Changing the identifier requires explicit acknowledgement.'
+              )
+            }
+            if (risks.hasAdminRules && !input.acknowledgeAdminRules) {
+              throw new ValidationError(
+                'MAPPING_ADMIN_ACK_REQUIRED',
+                'Saving admin role rules requires explicit acknowledgement.'
+              )
+            }
+          }
+          patch.claimMapping = input.claimMapping
+        }
         if (input.showButton !== undefined) patch.showButton = input.showButton
 
         // Restamp the freshness baseline when a connection-affecting field
@@ -661,6 +695,78 @@ export async function persistTestResult(
   } catch (error) {
     log.error({ err: error }, 'persist identity provider test result failed')
     wrapDbError('persist identity provider test result', error)
+    throw error
+  }
+}
+
+export async function saveIdentityProviderClaimMapping(
+  id: IdentityProviderId,
+  args: {
+    expectedClaimMapping: unknown
+    operations: ClaimMappingOperation[]
+    acknowledgeIdentifierChange?: boolean
+    acknowledgeAdminRules?: boolean
+  }
+): Promise<IdentityProvider> {
+  const { bumpAuthConfigVersionInTx } = await import('@/lib/server/auth/config-version')
+  const { resetAuth } = await import('@/lib/server/auth')
+
+  log.info({ id }, 'save identity provider claim mapping')
+  try {
+    const saved = await db.transaction(async (tx) => {
+      const [existing] = await tx
+        .select()
+        .from(identityProvider)
+        .where(eq(identityProvider.id, id))
+        .for('update')
+      if (!existing) {
+        throw new ValidationError('IDP_NOT_FOUND', 'Identity provider not found.')
+      }
+      if (!storedJsonEqual(existing.claimMapping ?? null, args.expectedClaimMapping ?? null)) {
+        throw new ConflictError(
+          'MAPPING_CONFLICT',
+          'This mapping was updated elsewhere. Reload and try again.'
+        )
+      }
+      const next = applyClaimMappingEdits(existing.claimMapping, args.operations)
+      const risks = mappingSaveRisks(existing.claimMapping, next)
+      if (risks.identifierChanged && !args.acknowledgeIdentifierChange) {
+        throw new ValidationError(
+          'MAPPING_IDENTIFIER_ACK_REQUIRED',
+          'Changing the identifier requires explicit acknowledgement.'
+        )
+      }
+      if (risks.hasAdminRules && args.operations.length > 0 && !args.acknowledgeAdminRules) {
+        throw new ValidationError(
+          'MAPPING_ADMIN_ACK_REQUIRED',
+          'Saving admin role rules requires explicit acknowledgement.'
+        )
+      }
+      const restamp =
+        effectiveProfileSignature(existing.claimMapping) !== effectiveProfileSignature(next)
+      const [row] = await tx
+        .update(identityProvider)
+        .set({
+          claimMapping: next as IdentityProviderClaimMapping | null,
+          ...(restamp ? { detailsChangedAt: new Date() } : {}),
+        })
+        .where(eq(identityProvider.id, id))
+        .returning()
+      await bumpAuthConfigVersionInTx(tx)
+      return row
+    })
+
+    resetAuth()
+    await invalidateSettingsCache()
+    const [domains, configured] = await Promise.all([
+      listDomainsForProvider(saved.id),
+      hasPlatformCredentials(`${AUTH_CREDENTIAL_PREFIX}${saved.registrationId}`),
+    ])
+    return rowToIdentityProvider(saved, domains, configured)
+  } catch (error) {
+    if (error instanceof ValidationError || error instanceof ConflictError) throw error
+    log.error({ err: error }, 'save identity provider claim mapping failed')
+    wrapDbError('save identity provider claim mapping', error)
     throw error
   }
 }

--- a/apps/web/src/lib/server/functions/__tests__/identity-providers.fn.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/identity-providers.fn.test.ts
@@ -57,6 +57,7 @@ vi.mock('@/lib/server/audit/log', () => ({
 vi.mock('@/lib/server/domains/settings/identity-providers.service', () => ({
   listIdentityProviders: hoisted.listIdentityProviders,
   upsertIdentityProvider: hoisted.upsertIdentityProvider,
+  saveIdentityProviderClaimMapping: vi.fn(),
   deleteIdentityProvider: vi.fn(),
   stampDetailsChanged: vi.fn(),
 }))

--- a/apps/web/src/lib/server/functions/__tests__/sso-test.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/sso-test.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { identityMappingFor } from '@/lib/shared/oidc-claim-mapping'
+import { claimMappingFor, identityMappingFor } from '@/lib/shared/oidc-claim-mapping'
 
 type AnyHandler = (args: { data: Record<string, unknown> }) => Promise<unknown>
 
@@ -354,6 +354,7 @@ describe('startSsoTestFn', () => {
           emailClaim?: string
           nameClaim?: string
         }
+        claimMapping?: unknown
       },
     ]
     expect(session.identityMapping).toEqual(identityMappingFor(claimMapping))
@@ -363,6 +364,7 @@ describe('startSsoTestFn', () => {
       emailClaim: 'upn',
       nameClaim: 'preferred_username',
     })
+    expect(session.claimMapping).toEqual(claimMappingFor(claimMapping))
   })
 })
 

--- a/apps/web/src/lib/server/functions/sso-test.ts
+++ b/apps/web/src/lib/server/functions/sso-test.ts
@@ -26,9 +26,16 @@ import { z } from 'zod'
 import { requireAuth } from './auth-helpers'
 import { PERMISSIONS } from '@/lib/shared/permissions'
 import type { DiagnosticStep, HandshakeStage } from '@/lib/server/auth/sso-test-handshake'
+import type { ProfileOutcome } from '@/lib/shared/sso-profile-outcome'
+import type { SsoTestCaptureV2 } from '@/lib/shared/sso-test-capture'
 import type { JsonValue } from '@/lib/server/audit/log'
 import { authorizeRequestFor } from '@/lib/shared/oidc-request'
-import { allowsMissingEmail, identityMappingFor } from '@/lib/shared/oidc-claim-mapping'
+import {
+  allowsMissingEmail,
+  claimMappingFor,
+  identityMappingFor,
+  type IdentityProviderClaimMapping,
+} from '@/lib/shared/oidc-claim-mapping'
 import { ssoTestResultKey, ssoTestSessionKey } from '@/lib/shared/sso-test-keys'
 import type { IdentityMapping } from '@/lib/server/auth/resolve-identity'
 
@@ -65,6 +72,8 @@ type TestSession = {
   requestedPrompt?: string
   /** Identity sources and claim paths — the same mapping production uses. */
   identityMapping?: IdentityMapping
+  /** Full mapping snapshotted at start. Pre-deploy sessions may omit this. */
+  claimMapping?: IdentityProviderClaimMapping
   /** The provider's `detailsChangedAt` at test-start. The callback only stamps
    *  `lastSuccessfulTestAt` when this still matches — so a mid-test edit to the
    *  provider can't let a stale test unlock enforcement for the new config. */
@@ -188,6 +197,7 @@ export const startSsoTestFn = createServerFn({ method: 'POST' })
       tokenAuth: request.tokenAuth,
       requestedPrompt: request.prompt,
       identityMapping: identityMappingFor(provider.claimMapping),
+      claimMapping: claimMappingFor(provider.claimMapping),
       adminUserId: user.id,
       startedAt: Date.now(),
       detailsChangedAt: provider.detailsChangedAt,
@@ -256,6 +266,8 @@ export type SsoTestDiagnostic = {
           image?: string
           sources: Partial<Record<'id' | 'email' | 'name' | 'image', string>>
         }
+        mappingOutcome?: ProfileOutcome
+        capture?: SsoTestCaptureV2
       }
     | {
         ok: false
@@ -263,13 +275,14 @@ export type SsoTestDiagnostic = {
         errorCode?: string
         hint: string
         steps: DiagnosticStep[]
+        mappingOutcome?: ProfileOutcome
+        capture?: SsoTestCaptureV2
+        allClaims?: Record<string, JsonValue>
       }
   /**
-   * Set when result.ok and the IdP-returned `email` claim
-   * case-insensitively matches the admin who started the test.
-   * When true, `principal.last_sso_sign_in_at` has been updated
-   * for that admin and the per-domain SSO enforcement bootstrap
-   * gate is satisfied for the standard 7-day window.
+   * Informational only. True when the IdP-returned email matches the admin
+   * who started the test. It does not write `principal.last_sso_sign_in_at`
+   * and is not a bootstrap or enforcement gate.
    */
   identityMatched?: boolean
 }

--- a/apps/web/src/lib/server/functions/sso.ts
+++ b/apps/web/src/lib/server/functions/sso.ts
@@ -160,7 +160,7 @@ const idpRole = z.enum(['admin', 'member', 'user'])
 /** Mirror of `IdentityProviderClaimMapping`, section by section. */
 const claimRoleSchema = z.object({
   claimPath: z.string(),
-  rules: z.array(z.object({ whenContains: z.string(), role: idpRole })),
+  rules: z.array(z.object({ whenContains: z.string(), role: idpRole }).passthrough()),
   syncOnEverySignIn: z.boolean().optional(),
 })
 

--- a/apps/web/src/lib/server/functions/sso.ts
+++ b/apps/web/src/lib/server/functions/sso.ts
@@ -28,6 +28,7 @@ import { httpsUrl } from '@/lib/shared/schemas/auth'
 import { actorFromAuth, withAuditEvent } from '@/lib/server/audit/log'
 import { PERMISSIONS } from '@/lib/shared/permissions'
 import { diffProviderAudit } from '@/lib/server/auth/idp-audit-diff'
+import { applyClaimMappingEdits } from '@/lib/shared/sso-claim-mapping-edit'
 import { requireAuth } from './auth-helpers'
 
 const verifiedDomainId = z.string().regex(/^domain_/) as z.ZodType<`domain_${string}`>
@@ -163,29 +164,36 @@ const claimRoleSchema = z.object({
   syncOnEverySignIn: z.boolean().optional(),
 })
 
-const claimMappingSchema = z.object({
-  profile: z
-    .object({
-      sources: z.array(z.enum(['idToken', 'userinfo', 'accessTokenJwt'])).optional(),
-      claims: z
-        .object({
-          id: z.string().optional(),
-          email: z.string().optional(),
-          name: z.string().optional(),
-        })
-        .optional(),
-      allowMissingEmail: z.boolean().optional(),
-    })
-    .optional(),
-  role: claimRoleSchema.optional(),
-  attributes: z
-    .object({
-      map: z.array(z.object({ claimPath: z.string(), attributeKey: z.string() })).optional(),
-      overrideExisting: z.boolean().optional(),
-      syncOnSignIn: z.boolean().optional(),
-    })
-    .optional(),
-})
+const claimMappingSchema = z
+  .object({
+    profile: z
+      .object({
+        sources: z.array(z.enum(['idToken', 'userinfo', 'accessTokenJwt'])).optional(),
+        claims: z
+          .object({
+            id: z.string().optional(),
+            email: z.string().optional(),
+            name: z.string().optional(),
+          })
+          .passthrough()
+          .optional(),
+        allowMissingEmail: z.boolean().optional(),
+      })
+      .passthrough()
+      .optional(),
+    role: claimRoleSchema.passthrough().optional(),
+    attributes: z
+      .object({
+        map: z
+          .array(z.object({ claimPath: z.string(), attributeKey: z.string() }).passthrough())
+          .optional(),
+        overrideExisting: z.boolean().optional(),
+        syncOnSignIn: z.boolean().optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough()
 
 /**
  * Identity-provider registrationIds are restricted to the generated `oidc_`
@@ -225,6 +233,8 @@ const upsertIdentityProviderInput = z.object({
   autoProvisionRole: idpRole.nullable().optional(),
   claimMapping: claimMappingSchema.nullable().optional(),
   showButton: z.boolean().optional(),
+  acknowledgeIdentifierChange: z.boolean().optional(),
+  acknowledgeAdminRules: z.boolean().optional(),
 })
 
 /** Read-only listing of every identity provider with its linked domains. */
@@ -299,6 +309,104 @@ export const upsertIdentityProviderFn = createServerFn({ method: 'POST' })
         headers: getRequestHeaders(),
       },
       async () => upsertIdentityProvider(data)
+    )
+  })
+
+const claimMappingOperationSchema = z.discriminatedUnion('op', [
+  z.object({
+    op: z.literal('setProfileClaim'),
+    field: z.enum(['id', 'email', 'name']),
+    path: z.string(),
+  }),
+  z.object({ op: z.literal('resetProfileClaim'), field: z.enum(['id', 'email', 'name']) }),
+  z.object({
+    op: z.literal('setSources'),
+    sources: z.array(z.enum(['idToken', 'userinfo', 'accessTokenJwt'])),
+  }),
+  z.object({ op: z.literal('resetSources') }),
+  z.object({ op: z.literal('setAllowMissingEmail'), allow: z.boolean() }),
+  z.object({ op: z.literal('setRolePath'), claimPath: z.string() }),
+  z.object({
+    op: z.literal('insertRoleRule'),
+    index: z.number().int().nonnegative(),
+    rule: z.object({ whenContains: z.string(), role: idpRole }),
+  }),
+  z.object({
+    op: z.literal('editRoleRule'),
+    index: z.number().int().nonnegative(),
+    rule: z.object({ whenContains: z.string(), role: idpRole }),
+  }),
+  z.object({ op: z.literal('removeRoleRule'), index: z.number().int().nonnegative() }),
+  z.object({
+    op: z.literal('reorderRoleRule'),
+    from: z.number().int().nonnegative(),
+    to: z.number().int().nonnegative(),
+  }),
+  z.object({ op: z.literal('setRoleSync'), syncOnEverySignIn: z.boolean() }),
+  z.object({ op: z.literal('removeRole') }),
+  z.object({
+    op: z.literal('insertPeopleMapping'),
+    index: z.number().int().nonnegative(),
+    entry: z.object({ claimPath: z.string(), attributeKey: z.string() }),
+  }),
+  z.object({
+    op: z.literal('editPeopleMapping'),
+    index: z.number().int().nonnegative(),
+    entry: z.object({ claimPath: z.string(), attributeKey: z.string() }),
+  }),
+  z.object({ op: z.literal('removePeopleMapping'), index: z.number().int().nonnegative() }),
+  z.object({
+    op: z.literal('setPeopleFlags'),
+    overrideExisting: z.boolean().optional(),
+    syncOnSignIn: z.boolean().optional(),
+  }),
+])
+
+const saveClaimMappingInput = z.object({
+  id: identityProviderId,
+  expectedClaimMapping: z.unknown(),
+  operations: z.array(claimMappingOperationSchema),
+  acknowledgeIdentifierChange: z.boolean().optional(),
+  acknowledgeAdminRules: z.boolean().optional(),
+})
+
+export const saveIdentityProviderClaimMappingFn = createServerFn({ method: 'POST' })
+  .validator(saveClaimMappingInput)
+  .handler(async ({ data }) => {
+    const auth = await requireAuth({ permission: PERMISSIONS.AUTH_MANAGE })
+    const { requireEntitlement } = await import('@/lib/server/domains/settings/cloud/entitlements')
+    await requireEntitlement('sso')
+
+    const { listIdentityProviders, saveIdentityProviderClaimMapping } =
+      await import('@/lib/server/domains/settings/identity-providers.service')
+    const existing = await listIdentityProviders()
+    const prior = existing.find((p) => p.id === data.id)
+    if (!prior) {
+      throw new ValidationError('IDP_NOT_FOUND', 'Identity provider not found.')
+    }
+
+    const nextMapping = applyClaimMappingEdits(prior.claimMapping, data.operations)
+    const { before, after } = diffProviderAudit(prior, {
+      ...prior,
+      claimMapping: nextMapping as typeof prior.claimMapping,
+    })
+
+    return withAuditEvent(
+      {
+        event: 'idp.updated',
+        actor: actorFromAuth(auth),
+        target: { type: 'identity_provider', id: data.id },
+        before,
+        after,
+        headers: getRequestHeaders(),
+      },
+      async () =>
+        saveIdentityProviderClaimMapping(data.id, {
+          expectedClaimMapping: data.expectedClaimMapping,
+          operations: data.operations,
+          acknowledgeIdentifierChange: data.acknowledgeIdentifierChange,
+          acknowledgeAdminRules: data.acknowledgeAdminRules,
+        })
     )
   })
 

--- a/apps/web/src/lib/server/policy/authz-matrix/MATRIX.md
+++ b/apps/web/src/lib/server/policy/authz-matrix/MATRIX.md
@@ -100,7 +100,7 @@ Profiles: **Owner** = admin class + an admin-owned full API key (scoped keys hol
 
 ## 2. Surfaces and their enforced authorization
 
-### Server functions (`requireAuth`) — 682 surfaces
+### Server functions (`requireAuth`) — 683 surfaces
 
 | Surface | Enforces |
 | --- | --- |
@@ -622,6 +622,7 @@ Profiles: **Owner** = admin class + an admin-owned full API key (scoped keys hol
 | `lib/server/functions/sso.ts`::getVerifiedDomainsFn | auth.manage |
 | `lib/server/functions/sso.ts`::listIdentityProvidersFn | auth.manage |
 | `lib/server/functions/sso.ts`::upsertIdentityProviderFn | auth.manage |
+| `lib/server/functions/sso.ts`::saveIdentityProviderClaimMappingFn | auth.manage |
 | `lib/server/functions/sso.ts`::deleteIdentityProviderFn | auth.manage |
 | `lib/server/functions/sso.ts`::saveIdentityProviderLogoFn | auth.manage |
 | `lib/server/functions/sso.ts`::deleteIdentityProviderLogoFn | auth.manage |
@@ -993,7 +994,7 @@ Key scopes are enforced: an API key holds exactly its stored scopes (owner permi
 
 ## 4. Entry points without a requireAuth/key gate
 
-192 of 986 entry points hold no `requireAuth` / `withApiKeyAuth` / `requireTeamAuth` gate.
+192 of 987 entry points hold no `requireAuth` / `withApiKeyAuth` / `requireTeamAuth` gate.
 Each is expected to be intentionally public, a pre-auth flow, a signature-verified webhook, or a handler that delegates auth (e.g. the MCP route).
 **Adding a row here is an access-control change** — confirm the new entry point is meant to be reachable without a gate.
 

--- a/apps/web/src/lib/shared/__tests__/fixtures/sso-mapping-worlds.ts
+++ b/apps/web/src/lib/shared/__tests__/fixtures/sso-mapping-worlds.ts
@@ -1,0 +1,162 @@
+/**
+ * Synthetic IdP worlds for production / test / preview parity.
+ * These are fixtures, not certification of those services.
+ */
+
+import type { IdentityProviderClaimMapping } from '../../oidc-claim-mapping'
+import type { UserAttributeType } from '../../db-types'
+
+export type MappingWorld = {
+  name: string
+  mapping: IdentityProviderClaimMapping
+  idToken: Record<string, unknown>
+  userinfo: Record<string, unknown>
+  definitions: Array<{ key: string; type: UserAttributeType; label: string }>
+  expect: {
+    id: string
+    email: string
+    name: string
+    idSource: 'idToken' | 'userinfo'
+    emailSource: 'idToken' | 'userinfo'
+    emailPath: string
+    role?: { role: 'admin' | 'member' | 'user'; ruleIndex: number }
+    people?: Record<string, unknown>
+  }
+}
+
+export const ENTRA_WORLD: MappingWorld = {
+  name: 'Entra upn/oid',
+  mapping: {
+    profile: { claims: { id: 'oid', email: 'upn' } },
+    role: {
+      claimPath: 'groups',
+      rules: [
+        { whenContains: 'platform-admins', role: 'admin' },
+        { whenContains: 'engineering', role: 'member' },
+      ],
+    },
+    attributes: { map: [{ claimPath: 'department', attributeKey: 'department' }] },
+  },
+  idToken: {
+    oid: 'entra-oid-1',
+    upn: 'Jane@Contoso.Example',
+    name: 'Jane Doe',
+    groups: ['engineering'],
+  },
+  userinfo: { oid: 'entra-oid-1', department: 'Engineering' },
+  definitions: [{ key: 'department', type: 'string', label: 'Department' }],
+  expect: {
+    id: 'entra-oid-1',
+    email: 'jane@contoso.example',
+    name: 'Jane Doe',
+    idSource: 'idToken',
+    emailSource: 'idToken',
+    emailPath: 'upn',
+    role: { role: 'member', ruleIndex: 1 },
+    people: { department: 'Engineering' },
+  },
+}
+
+export const OKTA_WORLD: MappingWorld = {
+  name: 'Okta scalar/array groups',
+  mapping: {
+    role: {
+      claimPath: 'groups',
+      rules: [{ whenContains: 'Everyone', role: 'member' }],
+    },
+  },
+  idToken: { sub: 'okta-1', email: 'okta@example.test', name: 'Okta User', groups: 'Everyone' },
+  userinfo: { sub: 'okta-1', groups: ['Everyone', 'Sales'] },
+  definitions: [],
+  expect: {
+    id: 'okta-1',
+    email: 'okta@example.test',
+    name: 'Okta User',
+    idSource: 'idToken',
+    emailSource: 'idToken',
+    emailPath: 'email',
+    role: { role: 'member', ruleIndex: 0 },
+  },
+}
+
+export const AUTH0_WORLD: MappingWorld = {
+  name: 'Auth0 URI keys',
+  mapping: {
+    profile: { claims: { email: 'https://acme.com/email' } },
+    role: {
+      claimPath: 'https://acme.com/roles',
+      rules: [{ whenContains: 'staff', role: 'member' }],
+    },
+  },
+  idToken: {
+    sub: 'auth0|1',
+    'https://acme.com/email': 'uri@example.test',
+    name: 'Auth0 User',
+    'https://acme.com/roles': ['staff'],
+  },
+  userinfo: { sub: 'auth0|1' },
+  definitions: [],
+  expect: {
+    id: 'auth0|1',
+    email: 'uri@example.test',
+    name: 'Auth0 User',
+    idSource: 'idToken',
+    emailSource: 'idToken',
+    emailPath: 'https://acme.com/email',
+    role: { role: 'member', ruleIndex: 0 },
+  },
+}
+
+export const KEYCLOAK_WORLD: MappingWorld = {
+  name: 'Keycloak nested claims',
+  mapping: {
+    role: {
+      claimPath: 'realm_access.roles',
+      rules: [{ whenContains: 'offline_access', role: 'user' }],
+    },
+    attributes: { map: [{ claimPath: 'org.costCenter', attributeKey: 'cost_center' }] },
+  },
+  idToken: {
+    sub: 'kc-1',
+    email: 'kc@example.test',
+    name: 'Keycloak User',
+    realm_access: { roles: ['offline_access'] },
+    org: { department: 'IT' },
+  },
+  userinfo: { sub: 'kc-1', org: { costCenter: 'cc-9', department: 'from-userinfo' } },
+  definitions: [{ key: 'cost_center', type: 'string', label: 'Cost center' }],
+  expect: {
+    id: 'kc-1',
+    email: 'kc@example.test',
+    name: 'Keycloak User',
+    idSource: 'idToken',
+    emailSource: 'idToken',
+    emailPath: 'email',
+    role: { role: 'user', ruleIndex: 0 },
+    people: { cost_center: 'cc-9' },
+  },
+}
+
+export const GOOGLE_WORLD: MappingWorld = {
+  name: 'Google-shaped OIDC',
+  mapping: {},
+  idToken: {
+    sub: 'google-1',
+    email: 'google@example.test',
+    email_verified: true,
+    name: 'Google User',
+    picture: 'https://lh3.googleusercontent.com/a/x',
+  },
+  userinfo: { sub: 'google-1', email: 'google@example.test', name: 'Google User' },
+  definitions: [],
+  expect: {
+    id: 'google-1',
+    email: 'google@example.test',
+    name: 'Google User',
+    idSource: 'idToken',
+    emailSource: 'idToken',
+    emailPath: 'email',
+  },
+}
+
+export const MAPPING_WORLDS = [ENTRA_WORLD, OKTA_WORLD, AUTH0_WORLD, KEYCLOAK_WORLD, GOOGLE_WORLD]

--- a/apps/web/src/lib/shared/__tests__/oidc-claim-mapping.test.ts
+++ b/apps/web/src/lib/shared/__tests__/oidc-claim-mapping.test.ts
@@ -1,13 +1,41 @@
 import { describe, it, expect } from 'vitest'
+import type {
+  ClaimRoleMapping as DbClaimRoleMapping,
+  IdentityProviderClaimMapping as DbIdentityProviderClaimMapping,
+  IdentitySource as DbIdentitySource,
+  ProfileField as DbProfileField,
+} from '@/lib/shared/db-types'
 import {
   DEFAULT_IDENTITY_SOURCES,
+  IDENTITY_SOURCES,
   claimMappingFor,
   profileClaimFor,
   roleMappingFor,
   allowsMissingEmail,
   getClaimByPath,
+  type ClaimRoleMapping,
   type IdentityProviderClaimMapping,
+  type IdentitySource,
+  type ProfileField,
 } from '../oidc-claim-mapping'
+
+type Equal<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false
+type Expect<T extends true> = T
+
+type _MappingTypesAgree = Expect<
+  Equal<DbIdentityProviderClaimMapping, IdentityProviderClaimMapping>
+>
+type _RoleTypesAgree = Expect<Equal<DbClaimRoleMapping, ClaimRoleMapping>>
+type _SourceTypesAgree = Expect<Equal<DbIdentitySource, IdentitySource>>
+type _FieldTypesAgree = Expect<Equal<DbProfileField, ProfileField>>
+type _SourceConstAgrees = Expect<Equal<IdentitySource, (typeof IDENTITY_SOURCES)[number]>>
+
+const _mappingTypesAgree: _MappingTypesAgree = true
+const _roleTypesAgree: _RoleTypesAgree = true
+const _sourceTypesAgree: _SourceTypesAgree = true
+const _fieldTypesAgree: _FieldTypesAgree = true
+const _sourceConstAgrees: _SourceConstAgrees = true
 
 /**
  * The sectioned `claim_mapping` column, read the same way by sign-in and by the
@@ -15,6 +43,16 @@ import {
  * name; it is now the `role` section here, so there is one place a claim is
  * turned into meaning rather than three.
  */
+describe('canonical mapping types', () => {
+  it('keeps the DB and shared exported mapping types assigned to each other', () => {
+    expect(_mappingTypesAgree).toBe(true)
+    expect(_roleTypesAgree).toBe(true)
+    expect(_sourceTypesAgree).toBe(true)
+    expect(_fieldTypesAgree).toBe(true)
+    expect(_sourceConstAgrees).toBe(true)
+  })
+})
+
 describe('claimMappingFor', () => {
   it('treats an absent column as "no configuration", not as an error', () => {
     const m = claimMappingFor(null)

--- a/apps/web/src/lib/shared/__tests__/sso-claim-binder.test.ts
+++ b/apps/web/src/lib/shared/__tests__/sso-claim-binder.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest'
+import {
+  advanceBindingState,
+  bindingComplete,
+  createBindingState,
+  finishBinding,
+  replayClaimMapping,
+  type BindingConfig,
+} from '../sso-claim-binder'
+import type { SourceSnapshot } from '../oidc-claim-mapping'
+
+function replay(config: BindingConfig, snapshots: SourceSnapshot[]) {
+  return finishBinding(replayClaimMapping(config, snapshots))
+}
+
+describe('sso-claim-binder', () => {
+  it('single path uses later valid scalar despite earlier unusable raw value', () => {
+    const unusable = [null, '', ['not-a-scalar']] as const
+    for (const earlier of unusable) {
+      const result = replay({ mapping: { sources: ['idToken', 'userinfo'] } }, [
+        { source: 'idToken', claims: { sub: 's', email: earlier, name: 'N' } },
+        { source: 'userinfo', claims: { sub: 's', email: 'ok@x.com', name: 'N' } },
+      ])
+      expect(result.identity.email).toBe('ok@x.com')
+      expect(result.provenance.email).toEqual({ source: 'userinfo', path: 'email' })
+      expect(result.acceptedClaims.email).toEqual(earlier)
+    }
+
+    const numberResult = replay({ mapping: { sources: ['idToken', 'userinfo'] } }, [
+      { source: 'idToken', claims: { sub: 's', email: 42, name: 'N' } },
+      { source: 'userinfo', claims: { sub: 's', email: 'later@x.com', name: 'N' } },
+    ])
+    expect(numberResult.identity.email).toBe('42')
+    expect(numberResult.provenance.email?.source).toBe('idToken')
+
+    const imageResult = replay({ mapping: { sources: ['idToken', 'userinfo'] }, wantImage: true }, [
+      {
+        source: 'idToken',
+        claims: { sub: 's', email: 'e@x.com', name: 'N', picture: 'not-a-url' },
+      },
+      {
+        source: 'userinfo',
+        claims: { sub: 's', picture: 'https://cdn.example.com/a.png' },
+      },
+    ])
+    expect(imageResult.identity.image).toBe('https://cdn.example.com/a.png')
+    expect(imageResult.provenance.image).toEqual({ source: 'userinfo', path: 'picture' })
+    expect(imageResult.acceptedClaims.picture).toBe('not-a-url')
+  })
+
+  it('default userinfo id fallback differs from explicit sub', () => {
+    const snapshots: SourceSnapshot[] = [
+      { source: 'userinfo', claims: { id: 'legacy-id', email: 'e@x.com', name: 'N' } },
+    ]
+    const implicit = replay({ mapping: { sources: ['userinfo'] } }, snapshots)
+    expect(implicit.identity.id).toBe('legacy-id')
+    expect(implicit.provenance.id).toEqual({ source: 'userinfo', path: 'id' })
+
+    const explicit = replay({ mapping: { sources: ['userinfo'], idClaim: 'sub' } }, snapshots)
+    expect(explicit.identity.id).toBeUndefined()
+    expect(explicit.provenance.id).toBeUndefined()
+  })
+
+  it('incomplete subject replacement discards prior subject role and People claims', () => {
+    const result = replay(
+      {
+        mapping: { sources: ['idToken', 'userinfo'] },
+        requiredClaimPaths: ['groups', 'org.department'],
+      },
+      [
+        {
+          source: 'idToken',
+          claims: { sub: 'from-token', groups: ['eng'], org: { department: 'TokenDept' } },
+        },
+        {
+          source: 'userinfo',
+          claims: {
+            sub: 'from-userinfo',
+            email: 'e@x.com',
+            name: 'N',
+            groups: ['ops'],
+            org: { department: 'UserinfoDept' },
+          },
+        },
+      ]
+    )
+    expect(result.identity.id).toBe('from-userinfo')
+    expect(result.provenance.id?.source).toBe('userinfo')
+    expect(result.acceptedClaims.groups).toEqual(['ops'])
+    expect(result.acceptedClaims.org).toEqual({ department: 'UserinfoDept' })
+    expect(result.warnings).toContain('subject_mismatch')
+  })
+
+  it('complete identity never rekeys for diagnostic or mapped-path userinfo', () => {
+    const snapshots: SourceSnapshot[] = [
+      { source: 'idToken', claims: { sub: 'from-token', email: 'a@x.com', name: 'A' } },
+      {
+        source: 'userinfo',
+        claims: { sub: 'other', email: 'b@x.com', name: 'B', department: 'Eng' },
+      },
+    ]
+    for (const extra of [{ exhaustive: true }, { requiredClaimPaths: ['department'] }] as const) {
+      const result = replay({ mapping: { sources: ['idToken', 'userinfo'] }, ...extra }, snapshots)
+      expect(result.identity.id).toBe('from-token')
+      expect(result.identity.email).toBe('a@x.com')
+      expect(result.provenance.id?.source).toBe('idToken')
+      expect(result.acceptedClaims.department).toBeUndefined()
+      expect(result.warnings).toContain('subject_mismatch')
+    }
+  })
+
+  it('binder does not mutate captured nested claims', () => {
+    const idTokenClaims = {
+      sub: 's',
+      email: 'e@x.com',
+      name: 'N',
+      org: { department: 'from-token' },
+    }
+    const userinfoClaims = { sub: 's', org: { costCenter: 'cc-9', department: 'from-userinfo' } }
+    const idBefore = structuredClone(idTokenClaims)
+    const userinfoBefore = structuredClone(userinfoClaims)
+
+    const result = replay(
+      {
+        mapping: { sources: ['idToken', 'userinfo'] },
+        requiredClaimPaths: ['org.costCenter'],
+      },
+      [
+        { source: 'idToken', claims: idTokenClaims },
+        { source: 'userinfo', claims: userinfoClaims },
+      ]
+    )
+
+    expect(idTokenClaims).toEqual(idBefore)
+    expect(userinfoClaims).toEqual(userinfoBefore)
+    expect(idTokenClaims.org).not.toHaveProperty('costCenter')
+    expect(result.acceptedClaims.org).toEqual({ department: 'from-token', costCenter: 'cc-9' })
+  })
+
+  it('replay stops where production stops', () => {
+    const snapshots: SourceSnapshot[] = [
+      { source: 'idToken', claims: { sub: 's', email: 'e@x.com', name: 'N' } },
+      { source: 'userinfo', claims: { sub: 's', email: 'later@x.com', extra: 'only-userinfo' } },
+    ]
+    const result = replay({ mapping: { sources: ['idToken', 'userinfo'] } }, snapshots)
+    expect(result.identity.email).toBe('e@x.com')
+    expect(result.provenance.email?.source).toBe('idToken')
+    expect(result.acceptedClaims.extra).toBeUndefined()
+    expect(result.sourceAvailability.userinfo).toBeUndefined()
+  })
+
+  it('does not treat a synthesizable name as complete during the source walk', () => {
+    const result = replay({ mapping: { sources: ['idToken', 'userinfo'] } }, [
+      {
+        source: 'idToken',
+        claims: { sub: 's', email: 'e@x.com', preferred_username: 'handle' },
+      },
+      { source: 'userinfo', claims: { sub: 's', name: 'From Userinfo' } },
+    ])
+    expect(result.identity.name).toBe('From Userinfo')
+    expect(result.provenance.name?.source).toBe('userinfo')
+  })
+
+  it('createBindingState and advanceBindingState are immutable', () => {
+    const state = createBindingState({ mapping: { sources: ['idToken', 'userinfo'] } })
+    const next = advanceBindingState(state, 'idToken', {
+      sub: 's',
+      email: 'e@x.com',
+      name: 'N',
+    })
+    expect(state.identity.id).toBeUndefined()
+    expect(next.identity.id).toBe('s')
+    expect(bindingComplete(state)).toBe(false)
+    expect(bindingComplete(next)).toBe(true)
+  })
+
+  it('records required-source availability without inventing claims for an unavailable source', () => {
+    const result = replay({ mapping: { sources: ['idToken', 'userinfo'] } }, [
+      { source: 'idToken', claims: { sub: 's' } },
+      { source: 'userinfo', unavailable: 'fetch_failed' },
+    ])
+    expect(result.identity.id).toBe('s')
+    expect(result.sourceAvailability.idToken).toBe('available')
+    expect(result.sourceAvailability.userinfo).toBe('fetch_failed')
+    expect(result.acceptedClaims).toEqual({ sub: 's' })
+  })
+})

--- a/apps/web/src/lib/shared/__tests__/sso-claim-mapping-edit.test.ts
+++ b/apps/web/src/lib/shared/__tests__/sso-claim-mapping-edit.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyClaimMappingEdits,
+  diffClaimMappingOperations,
+  effectiveProfileSignature,
+  mappingSaveRisks,
+  storedJsonEqual,
+} from '../sso-claim-mapping-edit'
+
+describe('applyClaimMappingEdits', () => {
+  it('editing one mapping preserves all saved rows and unknown siblings', () => {
+    const raw = {
+      profile: {
+        claims: { email: 'upn' },
+        extra: { nested: true },
+        longPath: 'x'.repeat(300),
+      },
+      role: {
+        claimPath: 'groups',
+        rules: [{ whenContains: 'eng', role: 'member', note: 'keep' }],
+        custom: 1,
+      },
+      attributes: {
+        map: [
+          { claimPath: 'dept', attributeKey: 'department', extra: 'row' },
+          { claimPath: 'gone', attributeKey: 'deleted_def' },
+          { claimPath: 'dept', attributeKey: 'department' },
+        ],
+      },
+      unknownSection: { keep: true },
+    }
+    const next = applyClaimMappingEdits(raw, [
+      { op: 'setProfileClaim', field: 'name', path: 'preferred_username' },
+    ]) as Record<string, unknown>
+    expect(next.unknownSection).toEqual({ keep: true })
+    expect((next.profile as Record<string, unknown>).extra).toEqual({ nested: true })
+    expect((next.profile as Record<string, unknown>).longPath).toHaveLength(300)
+    expect((next.role as Record<string, unknown>).custom).toBe(1)
+    expect(((next.role as Record<string, unknown>).rules as object[])[0]).toEqual({
+      whenContains: 'eng',
+      role: 'member',
+      note: 'keep',
+    })
+    expect((next.attributes as { map: unknown[] }).map).toHaveLength(3)
+    expect((next.profile as { claims: { name: string } }).claims.name).toBe('preferred_username')
+  })
+
+  it('no-op save preserves original JSON', () => {
+    const raw = { role: { claimPath: 'groups', rules: [{ whenContains: 'a', role: 'admin' }] } }
+    expect(applyClaimMappingEdits(raw, [])).toEqual(raw)
+  })
+})
+
+describe('effectiveProfileSignature', () => {
+  it('treats explicit default sources and object key reorder as the same as implicit defaults', () => {
+    const implicit = effectiveProfileSignature(null)
+    const explicit = effectiveProfileSignature({
+      profile: { sources: ['idToken', 'userinfo'], allowMissingEmail: false },
+    })
+    const reordered = effectiveProfileSignature({
+      profile: { allowMissingEmail: false, sources: ['idToken', 'userinfo'] },
+    })
+    expect(explicit).toBe(implicit)
+    expect(reordered).toBe(implicit)
+  })
+
+  it('treats explicit id: sub as different from implicit default', () => {
+    expect(effectiveProfileSignature({ profile: { claims: { id: 'sub' } } })).not.toBe(
+      effectiveProfileSignature(null)
+    )
+  })
+
+  it('role-only and People-only edits do not change the profile signature', () => {
+    const before = { profile: { claims: { email: 'upn' } } }
+    const roleOnly = applyClaimMappingEdits(before, [
+      { op: 'setRolePath', claimPath: 'groups' },
+      { op: 'insertRoleRule', index: 0, rule: { whenContains: 'eng', role: 'member' } },
+    ])
+    const peopleOnly = applyClaimMappingEdits(before, [
+      {
+        op: 'insertPeopleMapping',
+        index: 0,
+        entry: { claimPath: 'dept', attributeKey: 'department' },
+      },
+    ])
+    expect(effectiveProfileSignature(roleOnly)).toBe(effectiveProfileSignature(before))
+    expect(effectiveProfileSignature(peopleOnly)).toBe(effectiveProfileSignature(before))
+  })
+})
+
+describe('mappingSaveRisks', () => {
+  it('identifier edit is detected for id path and sources', () => {
+    expect(mappingSaveRisks(null, { profile: { claims: { id: 'oid' } } }).identifierChanged).toBe(
+      true
+    )
+    expect(mappingSaveRisks(null, { profile: { sources: ['userinfo'] } }).identifierChanged).toBe(
+      true
+    )
+  })
+
+  it('admin rule save requires acknowledgement even when tester would be member', () => {
+    const after = {
+      role: {
+        claimPath: 'groups',
+        rules: [
+          { whenContains: 'platform-admins', role: 'admin' },
+          { whenContains: 'engineering', role: 'member' },
+        ],
+      },
+    }
+    const risks = mappingSaveRisks(null, after)
+    expect(risks.hasAdminRules).toBe(true)
+    expect(risks.adminRules).toHaveLength(1)
+  })
+})
+
+describe('diffClaimMappingOperations', () => {
+  it('default Save with Advanced sources mounted does not invent mapping ops', () => {
+    const ops = diffClaimMappingOperations(null, {
+      profile: { sources: ['idToken', 'userinfo'] },
+    })
+    expect(ops).toEqual([])
+    const after = applyClaimMappingEdits(null, ops)
+    expect(effectiveProfileSignature(after)).toBe(effectiveProfileSignature(null))
+  })
+})
+
+describe('storedJsonEqual', () => {
+  it('ignores object key reorder', () => {
+    expect(storedJsonEqual({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true)
+  })
+})

--- a/apps/web/src/lib/shared/__tests__/sso-claim-mapping-edit.test.ts
+++ b/apps/web/src/lib/shared/__tests__/sso-claim-mapping-edit.test.ts
@@ -4,6 +4,7 @@ import {
   diffClaimMappingOperations,
   effectiveProfileSignature,
   mappingSaveRisks,
+  mappingWouldStripUnsupported,
   storedJsonEqual,
 } from '../sso-claim-mapping-edit'
 
@@ -128,5 +129,83 @@ describe('diffClaimMappingOperations', () => {
 describe('storedJsonEqual', () => {
   it('ignores object key reorder', () => {
     expect(storedJsonEqual({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true)
+  })
+})
+
+describe('mappingWouldStripUnsupported', () => {
+  const stored = {
+    profile: { claims: { email: 'upn' }, extra: true },
+    role: {
+      claimPath: 'groups',
+      rules: [{ whenContains: 'eng', role: 'member', note: 'keep' }],
+      custom: 1,
+    },
+    attributes: {
+      map: [{ claimPath: 'dept', attributeKey: 'department', extra: 'row' }],
+      label: 'people',
+    },
+    unknownSection: { keep: true },
+  }
+
+  it('rejects a typed mapping DTO that would drop nested unknown siblings', () => {
+    const typed = {
+      profile: { claims: { email: 'upn' } },
+      role: {
+        claimPath: 'groups',
+        rules: [{ whenContains: 'eng', role: 'member' }],
+      },
+      attributes: {
+        map: [{ claimPath: 'dept', attributeKey: 'department' }],
+      },
+    }
+    expect(mappingWouldStripUnsupported(stored, typed)).toBe(true)
+    expect(
+      mappingWouldStripUnsupported(stored, {
+        ...stored,
+        role: { claimPath: 'groups', rules: stored.role.rules },
+      })
+    ).toBe(true)
+    expect(
+      mappingWouldStripUnsupported(stored, {
+        ...stored,
+        role: { ...stored.role, rules: [{ whenContains: 'eng', role: 'member' }] },
+      })
+    ).toBe(true)
+    expect(
+      mappingWouldStripUnsupported(stored, {
+        ...stored,
+        attributes: { map: stored.attributes.map },
+      })
+    ).toBe(true)
+    expect(
+      mappingWouldStripUnsupported(stored, {
+        ...stored,
+        attributes: {
+          ...stored.attributes,
+          map: [{ claimPath: 'dept', attributeKey: 'department' }],
+        },
+      })
+    ).toBe(true)
+  })
+
+  it('lets an unchanged mapping with extras round-trip', () => {
+    expect(mappingWouldStripUnsupported(stored, { ...stored })).toBe(false)
+    expect(
+      mappingWouldStripUnsupported(stored, {
+        unknownSection: { keep: true },
+        attributes: stored.attributes,
+        role: stored.role,
+        profile: stored.profile,
+      })
+    ).toBe(false)
+  })
+
+  it('does not treat deleting a fully supported section as stripping extras', () => {
+    expect(
+      mappingWouldStripUnsupported(
+        { role: { claimPath: 'groups', rules: [{ whenContains: 'eng', role: 'member' }] } },
+        { profile: { allowMissingEmail: true } }
+      )
+    ).toBe(false)
   })
 })

--- a/apps/web/src/lib/shared/__tests__/sso-profile-outcome.test.ts
+++ b/apps/web/src/lib/shared/__tests__/sso-profile-outcome.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { finishBinding, replayClaimMapping } from '../sso-claim-binder'
+import { finalizeProfileOutcome, normalizeBoundEmail, synthesizeName } from '../sso-profile-outcome'
+
+describe('sso-profile-outcome', () => {
+  it('normalizes email the way genericOAuth consumes it', () => {
+    expect(normalizeBoundEmail('Jane@Example.COM')).toBe('jane@example.com')
+    const bound = finishBinding(
+      replayClaimMapping({ mapping: { sources: ['idToken'] } }, [
+        { source: 'idToken', claims: { sub: 's', email: 'Jane@Example.COM', name: 'Jane' } },
+      ])
+    )
+    expect(bound.identity.email).toBe('Jane@Example.COM')
+    const outcome = finalizeProfileOutcome(bound, { allowMissingEmail: false })
+    expect(outcome.kind).toBe('identity')
+    expect(outcome.email).toBe('jane@example.com')
+    expect(outcome.acceptedClaims.email).toBe('Jane@Example.COM')
+  })
+
+  it('synthesizes a name only at finalization', () => {
+    const bound = finishBinding(
+      replayClaimMapping({ mapping: { sources: ['idToken'] } }, [
+        {
+          source: 'idToken',
+          claims: { sub: 's', email: 'e@x.com', preferred_username: 'SomePilot' },
+        },
+      ])
+    )
+    expect(bound.identity.name).toBeUndefined()
+    const outcome = finalizeProfileOutcome(bound, { allowMissingEmail: false })
+    expect(outcome.kind).toBe('identity')
+    expect(outcome.name).toBe('SomePilot')
+    expect(outcome.nameSynthesized).toBe(true)
+  })
+
+  it('reports placeholder_required without minting an address', () => {
+    const bound = finishBinding(
+      replayClaimMapping({ mapping: { sources: ['idToken'] } }, [
+        { source: 'idToken', claims: { sub: 'steam-1', name: 'Pilot' } },
+      ])
+    )
+    const outcome = finalizeProfileOutcome(bound, { allowMissingEmail: true })
+    expect(outcome.kind).toBe('placeholder_required')
+    expect(outcome.id).toBe('steam-1')
+    expect(outcome.email).toBeUndefined()
+    expect(outcome.placeholderEmail).toBe(true)
+    expect(outcome.emailVerified).toBe(false)
+  })
+
+  it('reports missing_email when placeholders are off', () => {
+    const bound = finishBinding(
+      replayClaimMapping({ mapping: { sources: ['idToken'] } }, [
+        { source: 'idToken', claims: { sub: 's', name: 'N' } },
+      ])
+    )
+    const outcome = finalizeProfileOutcome(bound, { allowMissingEmail: false })
+    expect(outcome.kind).toBe('missing_email')
+    expect(outcome.placeholderEmail).toBe(false)
+    expect(outcome.email).toBeUndefined()
+  })
+
+  it('reports missing_id when nothing yielded a subject', () => {
+    const bound = finishBinding(
+      replayClaimMapping({ mapping: { sources: ['idToken'] } }, [
+        { source: 'idToken', claims: { email: 'e@x.com', name: 'N' } },
+      ])
+    )
+    const outcome = finalizeProfileOutcome(bound, { allowMissingEmail: false })
+    expect(outcome.kind).toBe('missing_id')
+    expect(outcome.id).toBeUndefined()
+  })
+
+  it('synthesizeName prefers a handle, then nickname, then a readable subject', () => {
+    expect(
+      synthesizeName({ preferred_username: 'SomePilot', nickname: 'sp' }, 'CHARACTER:EVE:2119')
+    ).toBe('SomePilot')
+    expect(synthesizeName({ nickname: 'sp' }, 'CHARACTER:EVE:2119')).toBe('sp')
+    const fromSubject = synthesizeName({}, 'ACCOUNT:REGION:2119123456')
+    expect(fromSubject.length).toBeGreaterThan(0)
+    expect(fromSubject).not.toContain(':')
+  })
+})

--- a/apps/web/src/lib/shared/__tests__/sso-test-capture.test.ts
+++ b/apps/web/src/lib/shared/__tests__/sso-test-capture.test.ts
@@ -114,4 +114,29 @@ describe('captureSuggestionClaims', () => {
     expect(claims.groups).toEqual(['engineering'])
     expect(claims.email).toBe('a@x.com')
   })
+
+  it('omits discarded mismatched userinfo from suggestion candidates', () => {
+    const claims = captureSuggestionClaims({
+      version: 2,
+      registrationId: 'oidc_x',
+      capturedAt: '2026-09-07T12:00:00.000Z',
+      detailsChangedAtAtStart: null,
+      outcome: 'success',
+      claims: { sub: 'from-token', email: 'a@x.com', name: 'A', groups: ['eng'] },
+      replay: {
+        sources: [
+          {
+            source: 'idToken',
+            claims: { sub: 'from-token', email: 'a@x.com', name: 'A', groups: ['eng'] },
+          },
+          {
+            source: 'userinfo',
+            claims: { sub: 'other-subject', groups: ['ops'], extra: 'only-userinfo' },
+          },
+        ],
+      },
+    })
+    expect(claims.groups).toEqual(['eng'])
+    expect(claims.extra).toBeUndefined()
+  })
 })

--- a/apps/web/src/lib/shared/__tests__/sso-test-capture.test.ts
+++ b/apps/web/src/lib/shared/__tests__/sso-test-capture.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   captureIdentityCaption,
+  captureSuggestionClaims,
   isReplayableCapture,
   parseSsoTestCapture,
 } from '../sso-test-capture'
@@ -91,5 +92,26 @@ describe('parseSsoTestCapture', () => {
         replay: { sources: [{ source: 'scim', claims: {} }] },
       })
     ).toBeNull()
+  })
+})
+
+describe('captureSuggestionClaims', () => {
+  it('includes later-source claims the binder omitted from capture.claims', () => {
+    const claims = captureSuggestionClaims({
+      version: 2,
+      registrationId: 'oidc_x',
+      capturedAt: '2026-09-07T12:00:00.000Z',
+      detailsChangedAtAtStart: null,
+      outcome: 'success',
+      claims: { sub: 'u1', email: 'a@x.com', name: 'A' },
+      replay: {
+        sources: [
+          { source: 'idToken', claims: { sub: 'u1', email: 'a@x.com', name: 'A' } },
+          { source: 'userinfo', claims: { sub: 'u1', groups: ['engineering'] } },
+        ],
+      },
+    })
+    expect(claims.groups).toEqual(['engineering'])
+    expect(claims.email).toBe('a@x.com')
   })
 })

--- a/apps/web/src/lib/shared/__tests__/sso-test-capture.test.ts
+++ b/apps/web/src/lib/shared/__tests__/sso-test-capture.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { parseSsoTestCapture } from '../sso-test-capture'
+import {
+  captureIdentityCaption,
+  isReplayableCapture,
+  parseSsoTestCapture,
+} from '../sso-test-capture'
 
 describe('parseSsoTestCapture', () => {
   const valid = {
@@ -36,7 +40,7 @@ describe('parseSsoTestCapture', () => {
       ...valid,
       identity: { ...valid.identity, image: 42 },
     })
-    expect(parsed?.identity.image).toBeUndefined()
+    expect(parsed?.identity?.image).toBeUndefined()
   })
 
   it('returns null for missing or malformed payloads', () => {
@@ -44,5 +48,48 @@ describe('parseSsoTestCapture', () => {
     expect(parseSsoTestCapture({})).toBeNull()
     expect(parseSsoTestCapture({ ...valid, identity: { email: 'x' } })).toBeNull()
     expect(parseSsoTestCapture({ ...valid, claims: null })).toBeNull()
+  })
+
+  it('legacy capture remains inspectable but is not exact replay', () => {
+    const parsed = parseSsoTestCapture(valid)
+    expect(parsed).not.toBeNull()
+    expect(isReplayableCapture(parsed!)).toBe(false)
+    expect(captureIdentityCaption(parsed!)).toBe('jane@acme.com')
+  })
+
+  it('parses a V2 capture with optional identity', () => {
+    const v2 = {
+      version: 2,
+      registrationId: 'oidc_x',
+      capturedAt: '2026-09-07T12:00:00.000Z',
+      detailsChangedAtAtStart: null,
+      outcome: 'mapping_failed',
+      claims: { sub: 'u1', upn: 'jane@acme.com' },
+      replay: {
+        sources: [
+          { source: 'idToken', claims: { sub: 'u1' } },
+          { source: 'userinfo', unavailable: 'fetch_failed' },
+        ],
+      },
+    }
+    const parsed = parseSsoTestCapture(v2)
+    expect(parsed).toMatchObject({ version: 2, outcome: 'mapping_failed' })
+    expect(parsed && 'identity' in parsed ? parsed.identity : undefined).toBeUndefined()
+    expect(isReplayableCapture(parsed!)).toBe(true)
+    expect(captureIdentityCaption(parsed!)).toBe('Not supplied')
+  })
+
+  it('rejects a V2 capture with an unknown source', () => {
+    expect(
+      parseSsoTestCapture({
+        version: 2,
+        registrationId: 'oidc_x',
+        capturedAt: '2026-09-07T12:00:00.000Z',
+        detailsChangedAtAtStart: null,
+        outcome: 'success',
+        claims: {},
+        replay: { sources: [{ source: 'scim', claims: {} }] },
+      })
+    ).toBeNull()
   })
 })

--- a/apps/web/src/lib/shared/db-types.ts
+++ b/apps/web/src/lib/shared/db-types.ts
@@ -60,6 +60,12 @@ export type {
   UseCaseType,
   OnboardingOutcome,
   SetupState,
+  IdentitySource,
+  ProfileField,
+  ClaimRoleMapping,
+  IdentityProviderClaimMapping,
+  SourceSnapshot,
+  SourceUnavailableReason,
 } from '@quackback/db/types'
 
 // Schema types needed by client components (type-only = no side effects)

--- a/apps/web/src/lib/shared/db-types.ts
+++ b/apps/web/src/lib/shared/db-types.ts
@@ -66,6 +66,10 @@ export type {
   IdentityProviderClaimMapping,
   SourceSnapshot,
   SourceUnavailableReason,
+  CapturedIdentity,
+  IdentityProviderTestCapture,
+  IdentityProviderTestCaptureV1,
+  IdentityProviderTestCaptureV2,
 } from '@quackback/db/types'
 
 // Schema types needed by client components (type-only = no side effects)

--- a/apps/web/src/lib/shared/oidc-claim-mapping.ts
+++ b/apps/web/src/lib/shared/oidc-claim-mapping.ts
@@ -19,10 +19,26 @@
  */
 
 import type { Role } from './roles'
+import type {
+  ClaimRoleMapping,
+  IdentityProviderClaimMapping,
+  IdentitySource,
+  ProfileField,
+  SourceSnapshot,
+  SourceUnavailableReason,
+} from './db-types'
+
+export type {
+  ClaimRoleMapping,
+  IdentityProviderClaimMapping,
+  IdentitySource,
+  ProfileField,
+  SourceSnapshot,
+  SourceUnavailableReason,
+}
 
 /** Where identity may be read from, in the order the resolver tries them. */
 export const IDENTITY_SOURCES = ['idToken', 'userinfo', 'accessTokenJwt'] as const
-export type IdentitySource = (typeof IDENTITY_SOURCES)[number]
 
 /**
  * The id token first because it is the only source the provider signed, then
@@ -31,35 +47,13 @@ export type IdentitySource = (typeof IDENTITY_SOURCES)[number]
  */
 export const DEFAULT_IDENTITY_SOURCES: IdentitySource[] = ['idToken', 'userinfo']
 
-/** Profile fields a claim can be bound to. */
-export type ProfileField = 'id' | 'email' | 'name'
-
 const KNOWN_ROLES: readonly string[] = ['admin', 'member', 'user']
 
-export interface ClaimRoleMapping {
-  /** Dotted path, or a URL-shaped namespaced claim used as a single key. */
-  claimPath: string
-  /** First-match-wins. */
-  rules: Array<{ whenContains: string; role: Role }>
-  /** Re-apply on every sign-in, so a role can be promoted or demoted. */
-  syncOnEverySignIn?: boolean
-}
+/** Segments that would walk onto or rewrite a prototype rather than a claim. */
+const UNSAFE_SEGMENTS = new Set(['__proto__', 'constructor', 'prototype'])
 
-export interface IdentityProviderClaimMapping {
-  profile?: {
-    sources?: IdentitySource[]
-    claims?: Partial<Record<ProfileField, string>>
-    /** Mint a placeholder address when the provider supplies no email. */
-    allowMissingEmail?: boolean
-  }
-  role?: ClaimRoleMapping
-  attributes?: {
-    map?: Array<{ claimPath: string; attributeKey: string }>
-    /** Off: a claim only fills an attribute that is empty. */
-    overrideExisting?: boolean
-    /** When true, a disappeared claim clears the stored attribute. */
-    syncOnSignIn?: boolean
-  }
+export function claimPathIsUnsafe(path: string): boolean {
+  return path.split('.').some((segment) => UNSAFE_SEGMENTS.has(segment))
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -196,10 +190,12 @@ export function identityMappingFor(stored: unknown): {
  * like `https://acme.com/email`, whose dots are not separators, still work.
  */
 export function getClaimByPath(claims: Record<string, unknown>, path: string): unknown {
-  if (path in claims) return claims[path]
+  if (Object.hasOwn(claims, path)) return claims[path]
+  if (claimPathIsUnsafe(path)) return undefined
   let current: unknown = claims
   for (const segment of path.split('.')) {
     if (current === null || typeof current !== 'object') return undefined
+    if (!Object.hasOwn(current, segment)) return undefined
     current = (current as Record<string, unknown>)[segment]
   }
   return current

--- a/apps/web/src/lib/shared/sso-claim-binder.ts
+++ b/apps/web/src/lib/shared/sso-claim-binder.ts
@@ -1,0 +1,349 @@
+/**
+ * Pure source-aware identity binder. Production, the SSO test, and browser
+ * replay share these transitions; token decoding and userinfo fetch stay on
+ * the server adapter.
+ */
+
+import {
+  DEFAULT_IDENTITY_SOURCES,
+  claimPathIsUnsafe,
+  getClaimByPath,
+  isAffirmativeClaim,
+  type IdentitySource,
+  type SourceSnapshot,
+  type SourceUnavailableReason,
+} from './oidc-claim-mapping'
+
+export type IdentityMapping = {
+  sources?: IdentitySource[]
+  idClaim?: string
+  nameClaim?: string
+  emailClaim?: string
+  imageClaim?: string
+}
+
+export type BindingConfig = {
+  mapping?: IdentityMapping
+  requiredClaimPaths?: readonly string[]
+  wantImage?: boolean
+  exhaustive?: boolean
+  subjectMismatch?: 'observe' | 'enforce'
+}
+
+export type ResolveWarning = 'subject_mismatch'
+
+export type FieldProvenance = { source: IdentitySource; path: string }
+
+export type BindingIdentity = {
+  id?: string
+  email?: string
+  name?: string
+  image?: string
+  emailVerified: boolean
+}
+
+export type BindingState = {
+  config: ResolvedBindingConfig
+  identity: BindingIdentity
+  provenance: Partial<Record<'id' | 'email' | 'name' | 'image', FieldProvenance>>
+  acceptedClaims: Record<string, unknown>
+  warnings: ResolveWarning[]
+  sourceAvailability: Partial<Record<IdentitySource, 'available' | SourceUnavailableReason>>
+  failed?: 'subject_mismatch'
+}
+
+export type ResolvedBindingConfig = {
+  sources: IdentitySource[]
+  idClaim: string
+  emailClaim: string
+  nameClaim: string
+  imageClaim: string
+  explicitIdClaim: boolean
+  requiredClaimPaths?: readonly string[]
+  wantImage: boolean
+  exhaustive: boolean
+  subjectMismatch: 'observe' | 'enforce'
+}
+
+function cloneJson<T>(value: T): T {
+  return structuredClone(value)
+}
+
+export function asNonEmptyString(value: unknown): string | undefined {
+  if (typeof value === 'string' && value !== '') return value
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value)
+  return undefined
+}
+
+/** Same missing-value rule as `planClaimAttributeWrites`. */
+export function claimIsMissing(value: unknown): boolean {
+  return value === undefined || value === null || value === ''
+}
+
+export function asHttpUrl(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  if (trimmed === '') return undefined
+  try {
+    const url = new URL(trimmed)
+    return url.protocol === 'http:' || url.protocol === 'https:' ? trimmed : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function requiredPathsResolved(
+  merged: Record<string, unknown>,
+  paths: readonly string[] | undefined
+): boolean {
+  if (!paths?.length) return true
+  return paths.every((path) => !claimIsMissing(getClaimByPath(merged, path)))
+}
+
+function setClaimByPath(
+  claims: Record<string, unknown>,
+  path: string,
+  value: unknown
+): Record<string, unknown> {
+  const segments = path.split('.')
+  if (claimPathIsUnsafe(path)) return claims
+  if (Object.hasOwn(claims, path) || path.includes('://') || segments.length === 1) {
+    return { ...claims, [path]: value }
+  }
+  const root = { ...claims }
+  let current: Record<string, unknown> = root
+  for (let i = 0; i < segments.length - 1; i++) {
+    const segment = segments[i]
+    const existing = Object.hasOwn(current, segment) ? current[segment] : undefined
+    const child: Record<string, unknown> =
+      existing !== null && typeof existing === 'object' && !Array.isArray(existing)
+        ? { ...(existing as Record<string, unknown>) }
+        : {}
+    current[segment] = child
+    current = child
+  }
+  current[segments[segments.length - 1]] = value
+  return root
+}
+
+function fillRequiredLeaves(
+  merged: Record<string, unknown>,
+  source: Record<string, unknown>,
+  paths: readonly string[] | undefined
+): Record<string, unknown> {
+  if (!paths?.length) return merged
+  let next = merged
+  for (const path of paths) {
+    if (!claimIsMissing(getClaimByPath(next, path))) continue
+    const incoming = getClaimByPath(source, path)
+    if (claimIsMissing(incoming)) continue
+    next = setClaimByPath(next, path, cloneJson(incoming))
+  }
+  return next
+}
+
+function mergeAcceptedClaims(
+  accepted: Record<string, unknown>,
+  incoming: Record<string, unknown>,
+  requiredClaimPaths: readonly string[] | undefined
+): Record<string, unknown> {
+  const next = { ...accepted }
+  for (const [key, value] of Object.entries(incoming)) {
+    if (!Object.hasOwn(next, key)) next[key] = cloneJson(value)
+  }
+  return fillRequiredLeaves(next, incoming, requiredClaimPaths)
+}
+
+function claimedIdForSource(
+  claims: Record<string, unknown>,
+  source: IdentitySource,
+  config: ResolvedBindingConfig
+): { value: string; path: string } | undefined {
+  const mapped = asNonEmptyString(getClaimByPath(claims, config.idClaim))
+  if (mapped) return { value: mapped, path: config.idClaim }
+  if (source === 'userinfo' && !config.explicitIdClaim) {
+    const fallback = asNonEmptyString(getClaimByPath(claims, 'id'))
+    if (fallback) return { value: fallback, path: 'id' }
+  }
+  return undefined
+}
+
+function identityFieldsComplete(identity: BindingIdentity): boolean {
+  return Boolean(identity.id && identity.email && identity.name)
+}
+
+export function createBindingState(config: BindingConfig = {}): BindingState {
+  const mapping = config.mapping
+  return {
+    config: {
+      sources: mapping?.sources ?? DEFAULT_IDENTITY_SOURCES,
+      idClaim: mapping?.idClaim ?? 'sub',
+      emailClaim: mapping?.emailClaim ?? 'email',
+      nameClaim: mapping?.nameClaim ?? 'name',
+      imageClaim: mapping?.imageClaim ?? 'picture',
+      explicitIdClaim: Boolean(mapping?.idClaim),
+      requiredClaimPaths: config.requiredClaimPaths,
+      wantImage: config.wantImage === true,
+      exhaustive: config.exhaustive === true,
+      subjectMismatch: config.subjectMismatch ?? 'observe',
+    },
+    identity: { emailVerified: false },
+    provenance: {},
+    acceptedClaims: {},
+    warnings: [],
+    sourceAvailability: {},
+  }
+}
+
+export function bindingComplete(state: BindingState): boolean {
+  if (state.failed) return false
+  const { identity, config, acceptedClaims } = state
+  return (
+    identityFieldsComplete(identity) &&
+    (!config.wantImage || Boolean(identity.image)) &&
+    requiredPathsResolved(acceptedClaims, config.requiredClaimPaths)
+  )
+}
+
+function emptyIdentity(): BindingIdentity {
+  return { emailVerified: false }
+}
+
+export function advanceBindingState(
+  state: BindingState,
+  source: IdentitySource,
+  claims: Record<string, unknown> | null,
+  unavailable?: SourceUnavailableReason
+): BindingState {
+  if (state.failed) return state
+  if (!claims) {
+    return {
+      ...state,
+      sourceAvailability: {
+        ...state.sourceAvailability,
+        [source]: unavailable ?? 'absent',
+      },
+    }
+  }
+
+  const incoming = cloneJson(claims)
+  const config = state.config
+  const identityComplete = identityFieldsComplete(state.identity)
+  const claimed = claimedIdForSource(incoming, source, config)
+
+  if (
+    source === 'userinfo' &&
+    state.identity.id &&
+    claimed &&
+    claimed.value !== state.identity.id
+  ) {
+    if (config.subjectMismatch === 'enforce') {
+      return {
+        ...state,
+        sourceAvailability: { ...state.sourceAvailability, [source]: 'available' },
+        warnings: state.warnings.includes('subject_mismatch')
+          ? state.warnings
+          : [...state.warnings, 'subject_mismatch'],
+        failed: 'subject_mismatch',
+      }
+    }
+    if (identityComplete) {
+      return {
+        ...state,
+        sourceAvailability: { ...state.sourceAvailability, [source]: 'available' },
+        warnings: state.warnings.includes('subject_mismatch')
+          ? state.warnings
+          : [...state.warnings, 'subject_mismatch'],
+      }
+    }
+    state = {
+      ...state,
+      identity: emptyIdentity(),
+      provenance: {},
+      acceptedClaims: {},
+      warnings: state.warnings.includes('subject_mismatch')
+        ? state.warnings
+        : [...state.warnings, 'subject_mismatch'],
+    }
+  }
+
+  const acceptedClaims = mergeAcceptedClaims(
+    state.acceptedClaims,
+    incoming,
+    config.requiredClaimPaths
+  )
+  const identity = { ...state.identity }
+  const provenance = { ...state.provenance }
+
+  if (!identity.id && claimed) {
+    identity.id = claimed.value
+    provenance.id = { source, path: claimed.path }
+  }
+  if (!identity.name) {
+    const claimedName = asNonEmptyString(getClaimByPath(incoming, config.nameClaim))
+    if (claimedName) {
+      identity.name = claimedName
+      provenance.name = { source, path: config.nameClaim }
+    }
+  }
+  if (!identity.email) {
+    const claimedEmail = asNonEmptyString(getClaimByPath(incoming, config.emailClaim))
+    if (claimedEmail) {
+      identity.email = claimedEmail
+      provenance.email = { source, path: config.emailClaim }
+      identity.emailVerified = isAffirmativeClaim(getClaimByPath(incoming, 'email_verified'))
+    }
+  }
+  if (config.wantImage && !identity.image) {
+    const claimedImage = asHttpUrl(getClaimByPath(incoming, config.imageClaim))
+    if (claimedImage) {
+      identity.image = claimedImage
+      provenance.image = { source, path: config.imageClaim }
+    }
+  }
+
+  return {
+    ...state,
+    identity,
+    provenance,
+    acceptedClaims,
+    sourceAvailability: { ...state.sourceAvailability, [source]: 'available' },
+  }
+}
+
+export function finishBinding(state: BindingState): BindingState {
+  return state
+}
+
+function snapshotUnavailable(snapshot: SourceSnapshot): SourceUnavailableReason | undefined {
+  if ('unavailable' in snapshot && snapshot.unavailable) return snapshot.unavailable
+  return undefined
+}
+
+function snapshotClaims(snapshot: SourceSnapshot): Record<string, unknown> | null {
+  if (snapshotUnavailable(snapshot)) return null
+  return 'claims' in snapshot && snapshot.claims ? snapshot.claims : null
+}
+
+export function replayClaimMapping(
+  config: BindingConfig,
+  snapshots: SourceSnapshot[]
+): BindingState {
+  let state = createBindingState(config)
+  const bySource = new Map<IdentitySource, SourceSnapshot>()
+  for (const snapshot of snapshots) {
+    if (!bySource.has(snapshot.source)) bySource.set(snapshot.source, snapshot)
+  }
+  for (const source of state.config.sources) {
+    if (!state.config.exhaustive && bindingComplete(state)) break
+    if (state.failed) break
+    const snapshot = bySource.get(source)
+    if (!snapshot) {
+      state = advanceBindingState(state, source, null, 'absent')
+      continue
+    }
+    const unavailable = snapshotUnavailable(snapshot)
+    state = advanceBindingState(state, source, snapshotClaims(snapshot), unavailable)
+  }
+  return state
+}

--- a/apps/web/src/lib/shared/sso-claim-mapping-edit.ts
+++ b/apps/web/src/lib/shared/sso-claim-mapping-edit.ts
@@ -482,6 +482,10 @@ export function storedJsonEqual(a: unknown, b: unknown): boolean {
 const SUPPORTED_TOP = new Set(['profile', 'role', 'attributes'])
 const SUPPORTED_PROFILE = new Set(['sources', 'claims', 'allowMissingEmail'])
 const SUPPORTED_CLAIMS = new Set(['id', 'email', 'name'])
+const SUPPORTED_ROLE = new Set(['claimPath', 'rules', 'syncOnEverySignIn'])
+const SUPPORTED_ROLE_RULE = new Set(['whenContains', 'role'])
+const SUPPORTED_ATTRIBUTES = new Set(['map', 'overrideExisting', 'syncOnSignIn'])
+const SUPPORTED_PEOPLE_ROW = new Set(['claimPath', 'attributeKey'])
 
 function hasLostKeys(stored: unknown, submitted: unknown, supported: Set<string>): boolean {
   if (!isRecord(stored)) return false
@@ -493,6 +497,20 @@ function hasLostKeys(stored: unknown, submitted: unknown, supported: Set<string>
   return false
 }
 
+function hasLostRowExtras(
+  storedRows: unknown,
+  submittedRows: unknown,
+  supported: Set<string>
+): boolean {
+  if (!Array.isArray(storedRows)) return false
+  const dest = Array.isArray(submittedRows) ? submittedRows : []
+  const n = Math.min(storedRows.length, dest.length)
+  for (let i = 0; i < n; i++) {
+    if (hasLostKeys(storedRows[i], dest[i], supported)) return true
+  }
+  return false
+}
+
 /** True when a whole-column submit would drop unknown stored JSON. */
 export function mappingWouldStripUnsupported(stored: unknown, submitted: unknown): boolean {
   if (!isRecord(stored)) return false
@@ -500,8 +518,16 @@ export function mappingWouldStripUnsupported(stored: unknown, submitted: unknown
   if (!isRecord(submitted)) return true
   if (hasLostKeys(stored, submitted, SUPPORTED_TOP)) return true
   if (hasLostKeys(stored.profile, submitted.profile, SUPPORTED_PROFILE)) return true
-  const storedClaims = isRecord(stored.profile) ? stored.profile.claims : undefined
-  const submittedClaims = isRecord(submitted.profile) ? submitted.profile.claims : undefined
-  if (hasLostKeys(storedClaims, submittedClaims, SUPPORTED_CLAIMS)) return true
+  const storedProfile = isRecord(stored.profile) ? stored.profile : undefined
+  const submittedProfile = isRecord(submitted.profile) ? submitted.profile : undefined
+  if (hasLostKeys(storedProfile?.claims, submittedProfile?.claims, SUPPORTED_CLAIMS)) return true
+  if (hasLostKeys(stored.role, submitted.role, SUPPORTED_ROLE)) return true
+  const storedRole = isRecord(stored.role) ? stored.role : undefined
+  const submittedRole = isRecord(submitted.role) ? submitted.role : undefined
+  if (hasLostRowExtras(storedRole?.rules, submittedRole?.rules, SUPPORTED_ROLE_RULE)) return true
+  if (hasLostKeys(stored.attributes, submitted.attributes, SUPPORTED_ATTRIBUTES)) return true
+  const storedAttrs = isRecord(stored.attributes) ? stored.attributes : undefined
+  const submittedAttrs = isRecord(submitted.attributes) ? submitted.attributes : undefined
+  if (hasLostRowExtras(storedAttrs?.map, submittedAttrs?.map, SUPPORTED_PEOPLE_ROW)) return true
   return false
 }

--- a/apps/web/src/lib/shared/sso-claim-mapping-edit.ts
+++ b/apps/web/src/lib/shared/sso-claim-mapping-edit.ts
@@ -1,0 +1,507 @@
+/**
+ * Closed operations over stored claim_mapping JSON. Unedited raw keys survive.
+ */
+
+import {
+  DEFAULT_IDENTITY_SOURCES,
+  IDENTITY_SOURCES,
+  allowsMissingEmail,
+  identitySourcesFor,
+  profileClaimFor,
+  type IdentityProviderClaimMapping,
+  type IdentitySource,
+  type ProfileField,
+} from './oidc-claim-mapping'
+import type { Role } from './roles'
+
+export const MAX_CLAIM_PATH_LENGTH = 256
+
+export type RoleRule = { whenContains: string; role: Role }
+export type PeopleEntry = { claimPath: string; attributeKey: string }
+
+export type ClaimMappingOperation =
+  | { op: 'setProfileClaim'; field: ProfileField; path: string }
+  | { op: 'resetProfileClaim'; field: ProfileField }
+  | { op: 'setSources'; sources: IdentitySource[] }
+  | { op: 'resetSources' }
+  | { op: 'setAllowMissingEmail'; allow: boolean }
+  | { op: 'setRolePath'; claimPath: string }
+  | { op: 'insertRoleRule'; index: number; rule: RoleRule }
+  | { op: 'editRoleRule'; index: number; rule: RoleRule }
+  | { op: 'removeRoleRule'; index: number }
+  | { op: 'reorderRoleRule'; from: number; to: number }
+  | { op: 'setRoleSync'; syncOnEverySignIn: boolean }
+  | { op: 'removeRole' }
+  | { op: 'insertPeopleMapping'; index: number; entry: PeopleEntry }
+  | { op: 'editPeopleMapping'; index: number; entry: PeopleEntry }
+  | { op: 'removePeopleMapping'; index: number }
+  | { op: 'setPeopleFlags'; overrideExisting?: boolean; syncOnSignIn?: boolean }
+
+export class ClaimMappingEditError extends Error {
+  readonly code: string
+  constructor(code: string, message: string) {
+    super(message)
+    this.code = code
+    this.name = 'ClaimMappingEditError'
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function cloneRaw(raw: unknown): Record<string, unknown> {
+  if (!isRecord(raw)) return {}
+  return structuredClone(raw)
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {}
+}
+
+function trimPath(path: string, label: string): string {
+  const trimmed = path.trim()
+  if (!trimmed) {
+    throw new ClaimMappingEditError('INVALID_CLAIM_PATH', `${label} is required.`)
+  }
+  if (trimmed.length > MAX_CLAIM_PATH_LENGTH) {
+    throw new ClaimMappingEditError(
+      'INVALID_CLAIM_PATH',
+      `${label} must be at most ${MAX_CLAIM_PATH_LENGTH} characters.`
+    )
+  }
+  return trimmed
+}
+
+function requireRole(role: string): Role {
+  if (role !== 'admin' && role !== 'member' && role !== 'user') {
+    throw new ClaimMappingEditError('INVALID_ROLE', 'Role must be admin, member, or user.')
+  }
+  return role
+}
+
+function profileObject(next: Record<string, unknown>): Record<string, unknown> {
+  const profile = asRecord(next.profile)
+  next.profile = profile
+  return profile
+}
+
+function roleObject(next: Record<string, unknown>): Record<string, unknown> {
+  const role = asRecord(next.role)
+  next.role = role
+  return role
+}
+
+function attributesObject(next: Record<string, unknown>): Record<string, unknown> {
+  const attributes = asRecord(next.attributes)
+  next.attributes = attributes
+  return attributes
+}
+
+function roleRules(role: Record<string, unknown>): unknown[] {
+  return Array.isArray(role.rules) ? role.rules : []
+}
+
+function peopleMap(attributes: Record<string, unknown>): unknown[] {
+  return Array.isArray(attributes.map) ? attributes.map : []
+}
+
+function pruneEmpty(next: Record<string, unknown>): unknown {
+  if (isRecord(next.profile) && Object.keys(next.profile).length === 0) delete next.profile
+  if (isRecord(next.role) && Object.keys(next.role).length === 0) delete next.role
+  if (isRecord(next.attributes)) {
+    if (Array.isArray(next.attributes.map) && next.attributes.map.length === 0) {
+      delete next.attributes.map
+    }
+    if (Object.keys(next.attributes).length === 0) delete next.attributes
+  }
+  return Object.keys(next).length > 0 ? next : null
+}
+
+export function applyClaimMappingEdits(
+  raw: unknown,
+  operations: readonly ClaimMappingOperation[]
+): unknown {
+  const next = cloneRaw(raw)
+  const roleRemoves = operations
+    .filter(
+      (op): op is Extract<ClaimMappingOperation, { op: 'removeRoleRule' }> =>
+        op.op === 'removeRoleRule'
+    )
+    .map((op) => op.index)
+    .sort((a, b) => b - a)
+  const peopleRemoves = operations
+    .filter(
+      (op): op is Extract<ClaimMappingOperation, { op: 'removePeopleMapping' }> =>
+        op.op === 'removePeopleMapping'
+    )
+    .map((op) => op.index)
+    .sort((a, b) => b - a)
+
+  const rest = operations.filter(
+    (op) => op.op !== 'removeRoleRule' && op.op !== 'removePeopleMapping'
+  )
+
+  for (const index of roleRemoves) {
+    const role = roleObject(next)
+    const rules = roleRules(role)
+    if (index < 0 || index >= rules.length) {
+      throw new ClaimMappingEditError('INVALID_OPERATION', 'Role rule index is out of range.')
+    }
+    rules.splice(index, 1)
+    role.rules = rules
+  }
+  for (const index of peopleRemoves) {
+    const attributes = attributesObject(next)
+    const map = peopleMap(attributes)
+    if (index < 0 || index >= map.length) {
+      throw new ClaimMappingEditError('INVALID_OPERATION', 'People mapping index is out of range.')
+    }
+    map.splice(index, 1)
+    attributes.map = map
+  }
+
+  for (const operation of rest) {
+    applyOne(next, operation)
+  }
+  return pruneEmpty(next)
+}
+
+function applyOne(next: Record<string, unknown>, operation: ClaimMappingOperation): void {
+  switch (operation.op) {
+    case 'setProfileClaim': {
+      const profile = profileObject(next)
+      const claims = asRecord(profile.claims)
+      claims[operation.field] = trimPath(operation.path, 'Claim path')
+      profile.claims = claims
+      return
+    }
+    case 'resetProfileClaim': {
+      if (!isRecord(next.profile) || !isRecord(next.profile.claims)) return
+      delete next.profile.claims[operation.field]
+      if (Object.keys(next.profile.claims).length === 0) delete next.profile.claims
+      return
+    }
+    case 'setSources': {
+      if (operation.sources.length === 0) {
+        throw new ClaimMappingEditError(
+          'INVALID_SOURCES',
+          'At least one identity source is required.'
+        )
+      }
+      const sources = operation.sources.filter((source) =>
+        (IDENTITY_SOURCES as readonly string[]).includes(source)
+      )
+      if (sources.length === 0) {
+        throw new ClaimMappingEditError(
+          'INVALID_SOURCES',
+          'At least one identity source is required.'
+        )
+      }
+      profileObject(next).sources = sources
+      return
+    }
+    case 'resetSources': {
+      if (isRecord(next.profile)) delete next.profile.sources
+      return
+    }
+    case 'setAllowMissingEmail': {
+      const profile = profileObject(next)
+      if (operation.allow) profile.allowMissingEmail = true
+      else delete profile.allowMissingEmail
+      return
+    }
+    case 'setRolePath': {
+      roleObject(next).claimPath = trimPath(operation.claimPath, 'Role claim path')
+      if (!Array.isArray(roleObject(next).rules)) roleObject(next).rules = []
+      return
+    }
+    case 'insertRoleRule': {
+      const whenContains = operation.rule.whenContains.trim()
+      if (!whenContains) {
+        throw new ClaimMappingEditError('INVALID_ROLE_RULE', 'A role rule has no value.')
+      }
+      const role = roleObject(next)
+      const rules = roleRules(role)
+      const index = Math.max(0, Math.min(operation.index, rules.length))
+      rules.splice(index, 0, {
+        whenContains,
+        role: requireRole(operation.rule.role),
+      })
+      role.rules = rules
+      if (typeof role.claimPath !== 'string' || !role.claimPath.trim()) {
+        role.claimPath = 'groups'
+      }
+      return
+    }
+    case 'editRoleRule': {
+      const role = roleObject(next)
+      const rules = roleRules(role)
+      if (operation.index < 0 || operation.index >= rules.length) {
+        throw new ClaimMappingEditError('INVALID_OPERATION', 'Role rule index is out of range.')
+      }
+      const existing = asRecord(rules[operation.index])
+      if (!operation.rule.whenContains.trim()) {
+        throw new ClaimMappingEditError('INVALID_ROLE_RULE', 'A role rule has no value.')
+      }
+      rules[operation.index] = {
+        ...existing,
+        whenContains: operation.rule.whenContains.trim(),
+        role: requireRole(operation.rule.role),
+      }
+      role.rules = rules
+      return
+    }
+    case 'reorderRoleRule': {
+      const role = roleObject(next)
+      const rules = roleRules(role)
+      if (operation.from < 0 || operation.from >= rules.length) {
+        throw new ClaimMappingEditError('INVALID_OPERATION', 'Role rule index is out of range.')
+      }
+      const [moved] = rules.splice(operation.from, 1)
+      const to = Math.max(0, Math.min(operation.to, rules.length))
+      rules.splice(to, 0, moved)
+      role.rules = rules
+      return
+    }
+    case 'setRoleSync': {
+      const role = roleObject(next)
+      if (operation.syncOnEverySignIn) role.syncOnEverySignIn = true
+      else delete role.syncOnEverySignIn
+      if (typeof role.claimPath !== 'string') role.claimPath = 'groups'
+      if (!Array.isArray(role.rules)) role.rules = []
+      return
+    }
+    case 'removeRole': {
+      delete next.role
+      return
+    }
+    case 'insertPeopleMapping': {
+      const attributes = attributesObject(next)
+      const map = peopleMap(attributes)
+      const index = Math.max(0, Math.min(operation.index, map.length))
+      map.splice(index, 0, {
+        claimPath: trimPath(operation.entry.claimPath, 'Claim path'),
+        attributeKey: trimPath(operation.entry.attributeKey, 'People attribute'),
+      })
+      attributes.map = map
+      return
+    }
+    case 'editPeopleMapping': {
+      const attributes = attributesObject(next)
+      const map = peopleMap(attributes)
+      if (operation.index < 0 || operation.index >= map.length) {
+        throw new ClaimMappingEditError(
+          'INVALID_OPERATION',
+          'People mapping index is out of range.'
+        )
+      }
+      const existing = asRecord(map[operation.index])
+      map[operation.index] = {
+        ...existing,
+        claimPath: trimPath(operation.entry.claimPath, 'Claim path'),
+        attributeKey: trimPath(operation.entry.attributeKey, 'People attribute'),
+      }
+      attributes.map = map
+      return
+    }
+    case 'setPeopleFlags': {
+      const attributes = attributesObject(next)
+      if (operation.overrideExisting === true) attributes.overrideExisting = true
+      if (operation.overrideExisting === false) delete attributes.overrideExisting
+      if (operation.syncOnSignIn === true) attributes.syncOnSignIn = true
+      if (operation.syncOnSignIn === false) delete attributes.syncOnSignIn
+      return
+    }
+    case 'removeRoleRule':
+    case 'removePeopleMapping':
+      return
+  }
+}
+
+export function explicitIdClaim(raw: unknown): string | undefined {
+  return profileClaimFor(raw, 'id')
+}
+
+export function effectiveProfileSignature(raw: unknown): string {
+  const id = explicitIdClaim(raw)
+  const profile = isRecord(raw) && isRecord(raw.profile) ? raw.profile : {}
+  const unknownProfileKeys = Object.keys(profile)
+    .filter((key) => key !== 'sources' && key !== 'claims' && key !== 'allowMissingEmail')
+    .sort()
+  const claims = isRecord(profile.claims) ? profile.claims : {}
+  const unknownClaimKeys = Object.keys(claims)
+    .filter((key) => key !== 'id' && key !== 'email' && key !== 'name')
+    .sort()
+  return JSON.stringify({
+    sources: identitySourcesFor(raw),
+    id: id === undefined ? { mode: 'default' } : { mode: 'explicit', path: id },
+    email: profileClaimFor(raw, 'email') ?? 'email',
+    name: profileClaimFor(raw, 'name') ?? 'name',
+    allowMissingEmail: allowsMissingEmail(raw),
+    unknownProfileKeys,
+    unknownClaimKeys,
+  })
+}
+
+export function mappingSaveRisks(
+  before: unknown,
+  after: unknown
+): {
+  identifierChanged: boolean
+  hasAdminRules: boolean
+  adminRules: Array<{ index: number; role: Role }>
+} {
+  const beforeId = explicitIdClaim(before)
+  const afterId = explicitIdClaim(after)
+  const sourcesChanged =
+    JSON.stringify(identitySourcesFor(before)) !== JSON.stringify(identitySourcesFor(after))
+  const identifierChanged = beforeId !== afterId || sourcesChanged
+  const role = isRecord(after) && isRecord(after.role) ? after.role : null
+  const rules = role && Array.isArray(role.rules) ? role.rules : []
+  const adminRules: Array<{ index: number; role: Role }> = []
+  rules.forEach((rule, index) => {
+    if (isRecord(rule) && rule.role === 'admin') adminRules.push({ index, role: 'admin' })
+  })
+  return {
+    identifierChanged,
+    hasAdminRules: adminRules.length > 0,
+    adminRules,
+  }
+}
+
+export function sourcesAreDefault(sources: IdentitySource[] | undefined): boolean {
+  if (!sources || sources.length === 0) return true
+  return JSON.stringify(sources) === JSON.stringify(DEFAULT_IDENTITY_SOURCES)
+}
+
+/** Diff supported editor state against stored JSON into closed operations. */
+export function diffClaimMappingOperations(
+  before: unknown,
+  proposed: IdentityProviderClaimMapping | null
+): ClaimMappingOperation[] {
+  const ops: ClaimMappingOperation[] = []
+  const beforeAllow = allowsMissingEmail(before)
+  const afterAllow = proposed?.profile?.allowMissingEmail === true
+  if (beforeAllow !== afterAllow) ops.push({ op: 'setAllowMissingEmail', allow: afterAllow })
+
+  const afterSources = proposed?.profile?.sources
+  const afterEffectiveSources = afterSources?.length ? afterSources : identitySourcesFor(proposed)
+  if (JSON.stringify(identitySourcesFor(before)) !== JSON.stringify(afterEffectiveSources)) {
+    if (sourcesAreDefault(afterEffectiveSources)) ops.push({ op: 'resetSources' })
+    else ops.push({ op: 'setSources', sources: afterEffectiveSources })
+  }
+
+  for (const field of ['id', 'email', 'name'] as const) {
+    const beforePath = profileClaimFor(before, field)
+    const afterPath = proposed?.profile?.claims?.[field]?.trim() || undefined
+    if (beforePath === afterPath) continue
+    if (!afterPath) ops.push({ op: 'resetProfileClaim', field })
+    else ops.push({ op: 'setProfileClaim', field, path: afterPath })
+  }
+
+  const beforeRole = isRecord(before) && isRecord(before.role) ? before.role : null
+  const afterRole = proposed?.role ?? null
+  if (!afterRole) {
+    if (beforeRole) ops.push({ op: 'removeRole' })
+  } else {
+    const beforePath = typeof beforeRole?.claimPath === 'string' ? beforeRole.claimPath : undefined
+    if (beforePath !== afterRole.claimPath)
+      ops.push({ op: 'setRolePath', claimPath: afterRole.claimPath })
+    const beforeSync = beforeRole?.syncOnEverySignIn === true
+    const afterSync = afterRole.syncOnEverySignIn === true
+    if (beforeSync !== afterSync) ops.push({ op: 'setRoleSync', syncOnEverySignIn: afterSync })
+    const beforeRules = Array.isArray(beforeRole?.rules) ? beforeRole.rules : []
+    const afterRules = afterRole.rules ?? []
+    const commonRules = Math.min(beforeRules.length, afterRules.length)
+    for (let i = 0; i < commonRules; i++) {
+      const left = beforeRules[i]
+      const right = afterRules[i]
+      if (!isRecord(left) || left.whenContains !== right.whenContains || left.role !== right.role) {
+        ops.push({ op: 'editRoleRule', index: i, rule: right })
+      }
+    }
+    for (let i = beforeRules.length - 1; i >= commonRules; i--) {
+      ops.push({ op: 'removeRoleRule', index: i })
+    }
+    for (let i = commonRules; i < afterRules.length; i++) {
+      ops.push({ op: 'insertRoleRule', index: i, rule: afterRules[i] })
+    }
+  }
+
+  const beforeAttrs = isRecord(before) && isRecord(before.attributes) ? before.attributes : null
+  const afterAttrs = proposed?.attributes ?? null
+  const beforeMap = Array.isArray(beforeAttrs?.map) ? beforeAttrs.map : []
+  const afterMap = afterAttrs?.map ?? []
+  const commonMap = Math.min(beforeMap.length, afterMap.length)
+  for (let i = 0; i < commonMap; i++) {
+    const left = beforeMap[i]
+    const right = afterMap[i]
+    if (
+      !isRecord(left) ||
+      left.claimPath !== right.claimPath ||
+      left.attributeKey !== right.attributeKey
+    ) {
+      ops.push({ op: 'editPeopleMapping', index: i, entry: right })
+    }
+  }
+  for (let i = beforeMap.length - 1; i >= commonMap; i--) {
+    ops.push({ op: 'removePeopleMapping', index: i })
+  }
+  for (let i = commonMap; i < afterMap.length; i++) {
+    ops.push({ op: 'insertPeopleMapping', index: i, entry: afterMap[i] })
+  }
+  const beforeOverride = beforeAttrs?.overrideExisting === true
+  const afterOverride = afterAttrs?.overrideExisting === true
+  const beforeSync = beforeAttrs?.syncOnSignIn === true
+  const afterSync = afterAttrs?.syncOnSignIn === true
+  if (beforeOverride !== afterOverride || beforeSync !== afterSync) {
+    ops.push({
+      op: 'setPeopleFlags',
+      overrideExisting: afterOverride,
+      syncOnSignIn: afterSync,
+    })
+  }
+
+  return ops
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === undefined) return 'null'
+  if (value === null || typeof value !== 'object') return JSON.stringify(value)
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`
+  const record = value as Record<string, unknown>
+  const keys = Object.keys(record).sort()
+  return `{${keys.map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`).join(',')}}`
+}
+
+export function storedJsonEqual(a: unknown, b: unknown): boolean {
+  return canonicalJson(a ?? null) === canonicalJson(b ?? null)
+}
+
+const SUPPORTED_TOP = new Set(['profile', 'role', 'attributes'])
+const SUPPORTED_PROFILE = new Set(['sources', 'claims', 'allowMissingEmail'])
+const SUPPORTED_CLAIMS = new Set(['id', 'email', 'name'])
+
+function hasLostKeys(stored: unknown, submitted: unknown, supported: Set<string>): boolean {
+  if (!isRecord(stored)) return false
+  const dest = isRecord(submitted) ? submitted : {}
+  for (const key of Object.keys(stored)) {
+    if (supported.has(key)) continue
+    if (!(key in dest) || !storedJsonEqual(stored[key], dest[key])) return true
+  }
+  return false
+}
+
+/** True when a whole-column submit would drop unknown stored JSON. */
+export function mappingWouldStripUnsupported(stored: unknown, submitted: unknown): boolean {
+  if (!isRecord(stored)) return false
+  if (submitted == null) return Object.keys(stored).length > 0
+  if (!isRecord(submitted)) return true
+  if (hasLostKeys(stored, submitted, SUPPORTED_TOP)) return true
+  if (hasLostKeys(stored.profile, submitted.profile, SUPPORTED_PROFILE)) return true
+  const storedClaims = isRecord(stored.profile) ? stored.profile.claims : undefined
+  const submittedClaims = isRecord(submitted.profile) ? submitted.profile.claims : undefined
+  if (hasLostKeys(storedClaims, submittedClaims, SUPPORTED_CLAIMS)) return true
+  return false
+}

--- a/apps/web/src/lib/shared/sso-profile-outcome.ts
+++ b/apps/web/src/lib/shared/sso-profile-outcome.ts
@@ -1,0 +1,111 @@
+/**
+ * Pure finalization of a bound identity: name synthesis, email normalisation,
+ * and the missing-email / placeholder outcome. Random minting stays server-only.
+ */
+
+import type { BindingState, FieldProvenance, ResolveWarning } from './sso-claim-binder'
+
+export type ProfileOutcomeKind =
+  'identity' | 'missing_id' | 'missing_email' | 'placeholder_required'
+
+export type ProfileOutcome = {
+  kind: ProfileOutcomeKind
+  id?: string
+  email?: string
+  name?: string
+  nameSynthesized: boolean
+  emailVerified: boolean
+  placeholderEmail: boolean
+  provenance: Partial<Record<'id' | 'email' | 'name' | 'image', FieldProvenance>>
+  acceptedClaims: Record<string, unknown>
+  warnings: readonly ResolveWarning[]
+}
+
+function usableClaim(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+/**
+ * Turn a subject into something printable. Subjects are opaque and often
+ * structured (`ACCOUNT:REGION:2119123456`), and some providers put an email
+ * address there — which must not become a display name, because display names
+ * are published on posts and comments.
+ */
+function readableFromSubject(subject: string): string {
+  const withoutAddress = subject.includes('@') ? subject.split('@')[0] : subject
+  const cleaned = withoutAddress
+    .replace(/[^\p{L}\p{N}-]+/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .replace(/^[-\s]+|[-\s]+$/g, '')
+    .slice(0, 60)
+  return cleaned || 'Member'
+}
+
+/**
+ * A display name from the claims, falling back to the subject. Ordered by how
+ * deliberately the person chose it: a handle they set, then a nickname, then
+ * whatever can be read out of the identifier.
+ */
+export function synthesizeName(claims: Record<string, unknown>, subject: string): string {
+  return (
+    usableClaim(claims.preferred_username) ??
+    usableClaim(claims.nickname) ??
+    readableFromSubject(usableClaim(subject) ?? '')
+  )
+}
+
+/** Matches Better-Auth genericOAuth's stored-email lowercase. */
+export function normalizeBoundEmail(email: string): string {
+  return email.toLowerCase()
+}
+
+export type ProfileFinalizationInput = Pick<
+  BindingState,
+  'identity' | 'acceptedClaims' | 'warnings' | 'provenance'
+>
+
+export function finalizeProfileOutcome(
+  bound: ProfileFinalizationInput,
+  opts: { allowMissingEmail: boolean }
+): ProfileOutcome {
+  const { identity, acceptedClaims, warnings, provenance } = bound
+  const base = {
+    provenance: provenance ?? {},
+    acceptedClaims,
+    warnings: warnings ?? [],
+  }
+  if (!identity.id) {
+    return {
+      ...base,
+      kind: 'missing_id',
+      nameSynthesized: false,
+      emailVerified: false,
+      placeholderEmail: false,
+    }
+  }
+  const name = identity.name ?? synthesizeName(acceptedClaims, identity.id)
+  const nameSynthesized = identity.name === undefined
+  if (!identity.email) {
+    return {
+      ...base,
+      kind: opts.allowMissingEmail ? 'placeholder_required' : 'missing_email',
+      id: identity.id,
+      name,
+      nameSynthesized,
+      emailVerified: false,
+      placeholderEmail: opts.allowMissingEmail,
+    }
+  }
+  return {
+    ...base,
+    kind: 'identity',
+    id: identity.id,
+    email: normalizeBoundEmail(identity.email),
+    name,
+    nameSynthesized,
+    emailVerified: identity.emailVerified,
+    placeholderEmail: false,
+  }
+}

--- a/apps/web/src/lib/shared/sso-profile-outcome.ts
+++ b/apps/web/src/lib/shared/sso-profile-outcome.ts
@@ -3,6 +3,7 @@
  * and the missing-email / placeholder outcome. Random minting stays server-only.
  */
 
+import type { JsonValue } from './json'
 import type { BindingState, FieldProvenance, ResolveWarning } from './sso-claim-binder'
 
 export type ProfileOutcomeKind =
@@ -17,7 +18,7 @@ export type ProfileOutcome = {
   emailVerified: boolean
   placeholderEmail: boolean
   provenance: Partial<Record<'id' | 'email' | 'name' | 'image', FieldProvenance>>
-  acceptedClaims: Record<string, unknown>
+  acceptedClaims: Record<string, JsonValue>
   warnings: readonly ResolveWarning[]
 }
 
@@ -73,7 +74,7 @@ export function finalizeProfileOutcome(
   const { identity, acceptedClaims, warnings, provenance } = bound
   const base = {
     provenance: provenance ?? {},
-    acceptedClaims,
+    acceptedClaims: acceptedClaims as Record<string, JsonValue>,
     warnings: warnings ?? [],
   }
   if (!identity.id) {

--- a/apps/web/src/lib/shared/sso-test-capture.ts
+++ b/apps/web/src/lib/shared/sso-test-capture.ts
@@ -7,6 +7,7 @@
 import type { JsonValue } from './json'
 import { IDENTITY_SOURCES } from './oidc-claim-mapping'
 import type { CapturedIdentity, IdentitySource, SourceUnavailableReason } from './db-types'
+import { finishBinding, replayClaimMapping } from './sso-claim-binder'
 
 /** Wire-safe snapshot: JSON values only, no token strings. */
 export type SourceSnapshot = {
@@ -83,18 +84,15 @@ export function isReplayableCapture(capture: SsoTestCapture): capture is SsoTest
   return isV2Capture(capture) && capture.detailsChangedAtAtStart !== undefined
 }
 
-/** Union of recorded source claims for editor suggestions. Production-shaped
- *  `capture.claims` can omit later-source keys the binder did not need. */
+/** Claims the binder would accept from this capture, including later sources
+ *  that share the bound subject. Exhaustive replay still discards a userinfo
+ *  document whose `sub` does not match. */
 export function captureSuggestionClaims(capture: SsoTestCapture): Record<string, JsonValue> {
   if (!isV2Capture(capture)) return capture.claims
-  const merged: Record<string, JsonValue> = { ...capture.claims }
-  for (const snapshot of capture.replay.sources) {
-    if (!('claims' in snapshot) || !snapshot.claims) continue
-    for (const [key, value] of Object.entries(snapshot.claims)) {
-      if (!Object.hasOwn(merged, key)) merged[key] = value
-    }
-  }
-  return merged
+  const bound = finishBinding(
+    replayClaimMapping({ exhaustive: true, wantImage: true }, capture.replay.sources)
+  )
+  return bound.acceptedClaims as Record<string, JsonValue>
 }
 
 /** Caption for a capture that may have no resolved identifier. */

--- a/apps/web/src/lib/shared/sso-test-capture.ts
+++ b/apps/web/src/lib/shared/sso-test-capture.ts
@@ -1,26 +1,92 @@
 /**
- * Session- and row-shaped fixture from a successful Test sign-in.
+ * Session- and row-shaped fixture from a Test sign-in.
  * Stored and shown as the admin saw it. Mapping is an administrative
  * choice — this type does not redact claims.
  */
 
 import type { JsonValue } from './json'
+import { IDENTITY_SOURCES } from './oidc-claim-mapping'
+import type { CapturedIdentity, IdentitySource, SourceUnavailableReason } from './db-types'
 
-export interface SsoTestCapture {
+/** Wire-safe snapshot: JSON values only, no token strings. */
+export type SourceSnapshot = {
+  source: IdentitySource
+  claims?: Record<string, JsonValue>
+  unavailable?: SourceUnavailableReason
+}
+
+export type SsoTestCapture = {
+  version?: 2
   registrationId: string
   capturedAt: string
-  identity: {
-    id: string
-    email?: string
-    name?: string
-    image?: string
-    sources: Partial<Record<'id' | 'email' | 'name' | 'image', string>>
-  }
+  detailsChangedAtAtStart?: string | null
+  outcome?: 'success' | 'mapping_failed'
+  identity?: CapturedIdentity
   claims: Record<string, JsonValue>
+  replay?: { sources: SourceSnapshot[] }
 }
+export type SsoTestCaptureV2 = SsoTestCapture & {
+  version: 2
+  detailsChangedAtAtStart: string | null
+  outcome: 'success' | 'mapping_failed'
+  replay: { sources: SourceSnapshot[] }
+}
+export type { CapturedIdentity }
+
+const UNAVAILABLE: readonly SourceUnavailableReason[] = ['absent', 'unreadable', 'fetch_failed']
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function parseIdentity(value: unknown, required: boolean): CapturedIdentity | undefined {
+  if (!isRecord(value) || typeof value.id !== 'string') {
+    return required ? undefined : undefined
+  }
+  const sources = isRecord(value.sources) ? (value.sources as CapturedIdentity['sources']) : {}
+  const paths = isRecord(value.paths) ? (value.paths as CapturedIdentity['paths']) : undefined
+  return {
+    id: value.id,
+    ...(typeof value.email === 'string' ? { email: value.email } : {}),
+    ...(typeof value.name === 'string' ? { name: value.name } : {}),
+    ...(typeof value.image === 'string' ? { image: value.image } : {}),
+    sources,
+    ...(paths ? { paths } : {}),
+  }
+}
+
+function parseSourceSnapshot(value: unknown): SourceSnapshot | null {
+  if (!isRecord(value) || typeof value.source !== 'string') return null
+  if (!(IDENTITY_SOURCES as readonly string[]).includes(value.source)) return null
+  const source = value.source as IdentitySource
+  if (
+    typeof value.unavailable === 'string' &&
+    UNAVAILABLE.includes(value.unavailable as SourceUnavailableReason)
+  ) {
+    return { source, unavailable: value.unavailable as SourceUnavailableReason }
+  }
+  if (isRecord(value.claims)) {
+    return { source, claims: value.claims as Record<string, JsonValue> }
+  }
+  return null
+}
+
+export function isV2Capture(capture: SsoTestCapture): capture is SsoTestCapture & {
+  version: 2
+  replay: { sources: SourceSnapshot[] }
+  outcome: 'success' | 'mapping_failed'
+} {
+  return capture.version === 2 && Array.isArray(capture.replay?.sources)
+}
+
+export function isReplayableCapture(capture: SsoTestCapture): capture is SsoTestCaptureV2 {
+  return isV2Capture(capture) && capture.detailsChangedAtAtStart !== undefined
+}
+
+/** Caption for a capture that may have no resolved identifier. */
+export function captureIdentityCaption(capture: SsoTestCapture): string {
+  const identity = capture.identity
+  return identity?.email ?? identity?.id ?? 'Not supplied'
 }
 
 /** Tolerate a missing or malformed column; never fail a provider list. */
@@ -29,21 +95,42 @@ export function parseSsoTestCapture(value: unknown): SsoTestCapture | null {
   if (typeof value.registrationId !== 'string' || typeof value.capturedAt !== 'string') {
     return null
   }
-  if (!isRecord(value.identity) || typeof value.identity.id !== 'string') return null
   if (!isRecord(value.claims)) return null
-  const sources = isRecord(value.identity.sources)
-    ? (value.identity.sources as SsoTestCapture['identity']['sources'])
-    : {}
+
+  if (value.version === 2) {
+    const identity = value.identity === undefined ? undefined : parseIdentity(value.identity, false)
+    if (value.identity !== undefined && !identity) return null
+    const replay = isRecord(value.replay) ? value.replay : null
+    if (!replay || !Array.isArray(replay.sources)) return null
+    const sources: SourceSnapshot[] = []
+    for (const entry of replay.sources) {
+      const snapshot = parseSourceSnapshot(entry)
+      if (!snapshot) return null
+      sources.push(snapshot)
+    }
+    if (value.outcome !== 'success' && value.outcome !== 'mapping_failed') return null
+    const detailsChangedAtAtStart =
+      value.detailsChangedAtAtStart === null || typeof value.detailsChangedAtAtStart === 'string'
+        ? value.detailsChangedAtAtStart
+        : null
+    return {
+      version: 2,
+      registrationId: value.registrationId,
+      capturedAt: value.capturedAt,
+      detailsChangedAtAtStart,
+      outcome: value.outcome,
+      ...(identity ? { identity } : {}),
+      claims: value.claims as Record<string, JsonValue>,
+      replay: { sources },
+    }
+  }
+
+  const identity = parseIdentity(value.identity, true)
+  if (!identity) return null
   return {
     registrationId: value.registrationId,
     capturedAt: value.capturedAt,
-    identity: {
-      id: value.identity.id,
-      ...(typeof value.identity.email === 'string' ? { email: value.identity.email } : {}),
-      ...(typeof value.identity.name === 'string' ? { name: value.identity.name } : {}),
-      ...(typeof value.identity.image === 'string' ? { image: value.identity.image } : {}),
-      sources,
-    },
+    identity,
     claims: value.claims as Record<string, JsonValue>,
   }
 }

--- a/apps/web/src/lib/shared/sso-test-capture.ts
+++ b/apps/web/src/lib/shared/sso-test-capture.ts
@@ -83,6 +83,20 @@ export function isReplayableCapture(capture: SsoTestCapture): capture is SsoTest
   return isV2Capture(capture) && capture.detailsChangedAtAtStart !== undefined
 }
 
+/** Union of recorded source claims for editor suggestions. Production-shaped
+ *  `capture.claims` can omit later-source keys the binder did not need. */
+export function captureSuggestionClaims(capture: SsoTestCapture): Record<string, JsonValue> {
+  if (!isV2Capture(capture)) return capture.claims
+  const merged: Record<string, JsonValue> = { ...capture.claims }
+  for (const snapshot of capture.replay.sources) {
+    if (!('claims' in snapshot) || !snapshot.claims) continue
+    for (const [key, value] of Object.entries(snapshot.claims)) {
+      if (!Object.hasOwn(merged, key)) merged[key] = value
+    }
+  }
+  return merged
+}
+
 /** Caption for a capture that may have no resolved identifier. */
 export function captureIdentityCaption(capture: SsoTestCapture): string {
   const identity = capture.identity

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -560,6 +560,12 @@ export const settings = pgTable('settings', {
   authConfigVersion: integer('auth_config_version').notNull().default(0),
 })
 
+/** Where identity may be read from, in resolver order. */
+export type IdentitySource = 'idToken' | 'userinfo' | 'accessTokenJwt'
+
+/** Profile fields a claim can be bound to. */
+export type ProfileField = 'id' | 'email' | 'name'
+
 /**
  * Role-mapping rules applied to an OIDC claim at sign-in. Now the `role`
  * section of {@link IdentityProviderClaimMapping}; the shape is unchanged from
@@ -587,7 +593,7 @@ export type ClaimRoleMapping = {
 export type IdentityProviderClaimMapping = {
   /** Which claim carries the account id, the email, the display name. */
   profile?: {
-    sources?: Array<'idToken' | 'userinfo' | 'accessTokenJwt'>
+    sources?: IdentitySource[]
     claims?: { id?: string; email?: string; name?: string }
     /** Mint a placeholder address when the provider supplies no email. */
     allowMissingEmail?: boolean
@@ -601,6 +607,17 @@ export type IdentityProviderClaimMapping = {
     syncOnSignIn?: boolean
   }
 }
+
+/** Why a captured identity source contributed no claims. */
+export type SourceUnavailableReason = 'absent' | 'unreadable' | 'fetch_failed'
+
+/**
+ * JSON-only snapshot of one identity source from an SSO test. Either a decoded
+ * claims object or a closed reason the source could not be loaded.
+ */
+export type SourceSnapshot =
+  | { source: IdentitySource; claims: Record<string, unknown> }
+  | { source: IdentitySource; unavailable: SourceUnavailableReason }
 
 /**
  * Identity provider — the single source of truth for an OIDC IdP.

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -615,9 +615,11 @@ export type SourceUnavailableReason = 'absent' | 'unreadable' | 'fetch_failed'
  * JSON-only snapshot of one identity source from an SSO test. Either a decoded
  * claims object or a closed reason the source could not be loaded.
  */
-export type SourceSnapshot =
-  | { source: IdentitySource; claims: Record<string, unknown> }
-  | { source: IdentitySource; unavailable: SourceUnavailableReason }
+export type SourceSnapshot = {
+  source: IdentitySource
+  claims?: Record<string, unknown>
+  unavailable?: SourceUnavailableReason
+}
 
 /**
  * Identity provider — the single source of truth for an OIDC IdP.
@@ -630,16 +632,41 @@ export type SourceSnapshot =
  * migration. Discovery-doc installs leave the manual endpoint columns
  * null; manual installs leave `discoveryUrl` null.
  */
+export type CapturedIdentity = {
+  id: string
+  email?: string
+  name?: string
+  image?: string
+  sources: Partial<Record<'id' | 'email' | 'name' | 'image', string>>
+  paths?: Partial<Record<'id' | 'email' | 'name' | 'image', string>>
+}
+
+/**
+ * Stored SSO test capture. V1 rows omit `version`/`replay`. V2 rows set
+ * `version: 2` and include source snapshots for exact replay.
+ */
 export type IdentityProviderTestCapture = {
+  version?: 2
   registrationId: string
   capturedAt: string
-  identity: {
-    id: string
-    email?: string
-    name?: string
-    sources: Partial<Record<'id' | 'email' | 'name', string>>
-  }
+  detailsChangedAtAtStart?: string | null
+  outcome?: 'success' | 'mapping_failed'
+  identity?: CapturedIdentity
   claims: Record<string, unknown>
+  replay?: { sources: SourceSnapshot[] }
+}
+
+export type IdentityProviderTestCaptureV1 = IdentityProviderTestCapture & {
+  identity: CapturedIdentity
+  version?: never
+  replay?: never
+}
+
+export type IdentityProviderTestCaptureV2 = IdentityProviderTestCapture & {
+  version: 2
+  detailsChangedAtAtStart: string | null
+  outcome: 'success' | 'mapping_failed'
+  replay: { sources: SourceSnapshot[] }
 }
 
 export const identityProvider = pgTable(

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -27,6 +27,15 @@ import type { ticketTypes } from './schema/ticket-types'
 import type { ticketActivity } from './schema/ticket-activity'
 import type { principal } from './schema/auth'
 
+export type {
+  IdentitySource,
+  ProfileField,
+  ClaimRoleMapping,
+  IdentityProviderClaimMapping,
+  SourceSnapshot,
+  SourceUnavailableReason,
+} from './schema/auth'
+
 // Status categories (defined here to avoid circular imports in tests)
 export const STATUS_CATEGORIES = ['active', 'complete', 'closed'] as const
 export type StatusCategory = (typeof STATUS_CATEGORIES)[number]

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -34,6 +34,10 @@ export type {
   IdentityProviderClaimMapping,
   SourceSnapshot,
   SourceUnavailableReason,
+  CapturedIdentity,
+  IdentityProviderTestCapture,
+  IdentityProviderTestCaptureV1,
+  IdentityProviderTestCaptureV2,
 } from './schema/auth'
 
 // Status categories (defined here to avoid circular imports in tests)


### PR DESCRIPTION
## Summary

Production, the SSO test, and browser replay now evaluate through one source-aware binder. Test captures store per-source snapshots so a draft mapping can be replayed exactly. Mapping saves apply closed operations onto stored JSON without dropping unknown rows.

This is **PR 2 of 3**. Existing editors still render. Depends on #508.

**Stack:** #508 → #509 → #510 ([stack #511](https://github.com/QuackbackIO/quackback/issues/511))
**Plan:** `docs/superpowers/plans/2026-09-07-sso-claim-attribute-mapping.md` (Tasks 3–5)

## What changed

- Canonical mapping types live in `packages/db` and are type-exported to web.
- Shared binder: `createBindingState` / `advanceBindingState` / `bindingComplete` / `finishBinding` / `replayClaimMapping`.
- Incomplete subject replacement clears the accepted claims bag so leftover role/People claims cannot survive.
- V2 capture `{ version: 2, replay.sources[], outcome }`. Handshake collects diagnostic sources exhaustively; the sign-in outcome uses production stopping.
- Mapping failures persist diagnostics without unlocking enforcement. Stamps are conditional on unchanged `detailsChangedAt`.
- Mapping saves: `saveIdentityProviderClaimMappingFn` with optimistic concurrency, identifier/admin acknowledgements, and semantic freshness (`id: 'sub'` is not the implicit default).
- Leftover whole-column upsert rejects destructive stripping of unknown nested keys.

## Test plan

- [x] Binder regressions: later valid scalar, explicit `sub` vs userinfo `id` fallback, mismatch bag clear, no nested mutation, replay stopping
- [x] Parity: production `getUserInfo`, handshake, and `replayClaimMapping` agree (Entra/Okta/Auth0/Keycloak/Google-shaped fixtures)
- [x] Mapping failure capture without success stamp; stale mid-test edit cannot validate
- [x] Default Save with Advanced sources mounted does not restamp a passing test
- [x] Stale mapping save cannot overwrite newer mapping; identifier/admin acks required
- [x] `cd apps/web && bun run typecheck` and `cd packages/db && bun run typecheck`
- [x] No drizzle migrations generated

## Notes

Old captures remain inspectable but are not exact replay. Keep legacy test-session handling for the existing 600-second TTL during mixed-version rollout.