### PR TITLE
feat(sso): ship the attributes and claims table with draft preview

### DIFF
--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/claim-mapping-card.test.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/claim-mapping-card.test.tsx
@@ -19,7 +19,7 @@ beforeAll(() => {
   Element.prototype.releasePointerCapture = vi.fn()
 })
 
-const { mappingSpy, openTest } = vi.hoisted(() => ({
+const { mappingSpy, openTest, ssoTestRef } = vi.hoisted(() => ({
   mappingSpy: vi.fn(
     async (_args: {
       data: {
@@ -31,13 +31,17 @@ const { mappingSpy, openTest } = vi.hoisted(() => ({
     }) => undefined
   ),
   openTest: vi.fn(),
+  ssoTestRef: {
+    lastSuccess: null as null | import('@/lib/shared/sso-test-capture').SsoTestCapture,
+    lastCapture: null as null | import('@/lib/shared/sso-test-capture').SsoTestCapture,
+  },
 }))
 
 vi.mock('../../sso/use-sso-test-sign-in', () => ({
   useSsoTestSignIn: () => ({
     open: openTest,
-    lastSuccess: null,
-    lastCapture: null,
+    lastSuccess: ssoTestRef.lastSuccess,
+    lastCapture: ssoTestRef.lastCapture,
   }),
   SsoTestSignInProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }))
@@ -178,9 +182,56 @@ beforeEach(() => {
   mappingSpy.mockClear()
   mappingSpy.mockResolvedValue(undefined)
   openTest.mockClear()
+  ssoTestRef.lastSuccess = null
+  ssoTestRef.lastCapture = null
 })
 
 describe('ClaimMappingCard save coordination', () => {
+  it('Edit+Apply on the default identifier does not persist claims.id', async () => {
+    renderCard(makeProvider({ claimMapping: null }))
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Unique user identifier mapping' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Apply to draft' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => expect(mappingSpy).toHaveBeenCalled())
+    expect(lastMapping().acknowledgeIdentifierChange).toBeUndefined()
+    expect(lastMapping().operations).toEqual([])
+    const saved = lastSaved() as { profile?: { claims?: { id?: string } } } | null
+    expect(saved?.profile?.claims?.id).toBeUndefined()
+  })
+
+  it('keeps provider A session success when lastCapture is a mapping failure for B', () => {
+    const captureA = {
+      version: 2 as const,
+      registrationId: 'oidc_x',
+      capturedAt: '2026-09-03T00:00:00.000Z',
+      detailsChangedAtAtStart: null,
+      outcome: 'success' as const,
+      identity: {
+        id: 'alice',
+        email: 'alice@a.test',
+        sources: { id: 'idToken' as const, email: 'idToken' as const },
+      },
+      claims: { sub: 'alice', email: 'alice@a.test' },
+      replay: {
+        sources: [{ source: 'idToken' as const, claims: { sub: 'alice', email: 'alice@a.test' } }],
+      },
+    }
+    ssoTestRef.lastSuccess = captureA
+    ssoTestRef.lastCapture = {
+      version: 2,
+      registrationId: 'oidc_b',
+      capturedAt: '2026-09-04T00:00:00.000Z',
+      detailsChangedAtAtStart: null,
+      outcome: 'mapping_failed',
+      claims: { sub: 'bob' },
+      replay: { sources: [{ source: 'idToken', claims: { sub: 'bob' } }] },
+    }
+    renderCard(makeProvider({ lastTestCapture: makeProvider().lastTestCapture }))
+    expect(screen.getAllByText('alice@a.test').length).toBeGreaterThan(0)
+    expect(screen.queryByText('jane@example.test')).not.toBeInTheDocument()
+    expect(screen.queryByText('bob')).not.toBeInTheDocument()
+  })
+
   it('id-path change requires explicit user-facing confirmation', async () => {
     renderCard(makeProvider({ claimMapping: { profile: { claims: { id: 'oid' } } } }))
     fireEvent.click(screen.getByRole('button', { name: 'Edit Unique user identifier mapping' }))

--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/claim-mapping-card.test.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/claim-mapping-card.test.tsx
@@ -368,4 +368,35 @@ describe('ClaimMappingCard save coordination', () => {
     expect(saved.profile?.allowMissingEmail).toBe(true)
     expect(lastMapping().acknowledgeAdminRules).toBe(true)
   })
+
+  it('editing the second duplicate People row updates that row', async () => {
+    renderCard(
+      makeProvider({
+        claimMapping: {
+          attributes: {
+            map: [
+              { claimPath: 'dept', attributeKey: 'department' },
+              { claimPath: 'org.department', attributeKey: 'department' },
+            ],
+          },
+        },
+      })
+    )
+    fireEvent.click(screen.getAllByRole('button', { name: 'Edit Department mapping' })[1])
+    fireEvent.click(screen.getByRole('combobox', { name: 'IdP claim path' }))
+    fireEvent.change(screen.getByPlaceholderText('Search or type…'), {
+      target: { value: 'costCenter' },
+    })
+    fireEvent.click(screen.getByText(/Use ["“]costCenter["”]/))
+    fireEvent.click(screen.getByRole('button', { name: 'Apply to draft' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => expect(mappingSpy).toHaveBeenCalled())
+    expect(
+      (lastSaved() as { attributes?: { map?: Array<{ claimPath: string; attributeKey: string }> } })
+        .attributes?.map
+    ).toEqual([
+      { claimPath: 'dept', attributeKey: 'department' },
+      { claimPath: 'costCenter', attributeKey: 'department' },
+    ])
+  })
 })

--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/claim-mapping-card.test.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/claim-mapping-card.test.tsx
@@ -1,0 +1,371 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { IdentityProviderId } from '@quackback/ids'
+import type { IdentityProvider } from '@/lib/server/domains/settings/identity-providers.service'
+import { ClaimMappingCard } from '../claim-mapping-card'
+import {
+  applyClaimMappingEdits,
+  effectiveProfileSignature,
+} from '@/lib/shared/sso-claim-mapping-edit'
+import { connectionAffectingChange } from '@/lib/server/domains/settings/identity-providers.service'
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.setPointerCapture = vi.fn()
+  Element.prototype.releasePointerCapture = vi.fn()
+})
+
+const { mappingSpy, openTest } = vi.hoisted(() => ({
+  mappingSpy: vi.fn(
+    async (_args: {
+      data: {
+        expectedClaimMapping: unknown
+        operations: unknown[]
+        acknowledgeIdentifierChange?: boolean
+        acknowledgeAdminRules?: boolean
+      }
+    }) => undefined
+  ),
+  openTest: vi.fn(),
+}))
+
+vi.mock('../../sso/use-sso-test-sign-in', () => ({
+  useSsoTestSignIn: () => ({
+    open: openTest,
+    lastSuccess: null,
+    lastCapture: null,
+  }),
+  SsoTestSignInProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('@tanstack/react-start', () => ({ useServerFn: (fn: unknown) => fn }))
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+}))
+
+vi.mock('@/lib/server/functions/sso', () => ({
+  upsertIdentityProviderFn: vi.fn(),
+  saveIdentityProviderClaimMappingFn: mappingSpy,
+}))
+
+vi.mock('@/lib/client/queries/admin', () => ({
+  adminQueries: {
+    userAttributes: () => ({
+      queryKey: ['admin', 'userAttributes'],
+      queryFn: async () => [
+        {
+          id: 'ua_1',
+          key: 'department',
+          label: 'Department',
+          type: 'string',
+          description: null,
+          currencyCode: null,
+          externalKey: null,
+          createdAt: new Date('2026-01-01'),
+          updatedAt: new Date('2026-01-01'),
+        },
+      ],
+      staleTime: Infinity,
+    }),
+  },
+}))
+
+vi.mock('../../sso/test-sign-in-button', () => ({
+  TestSignInButton: ({ children }: { children?: React.ReactNode }) => (
+    <button type="button">{children ?? 'Test sign-in'}</button>
+  ),
+}))
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+function makeProvider(over: Partial<IdentityProvider> = {}): IdentityProvider {
+  return {
+    id: 'idp_x' as IdentityProviderId,
+    registrationId: 'oidc_x',
+    label: 'Acme SSO',
+    kind: null,
+    configured: true,
+    discoveryUrl: 'https://idp.example/.well-known/openid-configuration',
+    authorizationUrl: null,
+    tokenUrl: null,
+    userInfoUrl: null,
+    jwksUri: null,
+    issuer: null,
+    clientId: 'client-id',
+    scopes: null,
+    prompt: null,
+    tokenEndpointAuthMethod: null,
+    enabled: true,
+    autoCreateUsers: true,
+    autoProvisionRole: 'user',
+    claimMapping: null,
+    showButton: false,
+    logoKey: null,
+    logoUrl: null,
+    detailsChangedAt: '2026-08-01T00:00:00.000Z',
+    lastSuccessfulTestAt: '2026-09-01T00:00:00.000Z',
+    createdAt: '2026-05-01T00:00:00.000Z',
+    domains: [],
+    visibility: 'button',
+    lastTestCapture: {
+      version: 2,
+      registrationId: 'oidc_x',
+      capturedAt: '2026-09-01T00:00:00.000Z',
+      detailsChangedAtAtStart: '2026-08-01T00:00:00.000Z',
+      outcome: 'success',
+      identity: {
+        id: 'person-123',
+        email: 'jane@example.test',
+        name: 'Jane',
+        sources: { id: 'idToken', email: 'idToken' },
+      },
+      claims: { sub: 'person-123', email: 'jane@example.test', groups: ['engineering'] },
+      replay: {
+        sources: [
+          {
+            source: 'idToken',
+            claims: { sub: 'person-123', email: 'jane@example.test', groups: ['engineering'] },
+          },
+          { source: 'userinfo', claims: { sub: 'person-123' } },
+        ],
+      },
+    },
+    ...over,
+  }
+}
+
+function renderCard(provider: IdentityProvider, presentation?: 'table' | 'legacy') {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  qc.setQueryData(
+    ['admin', 'userAttributes'],
+    [
+      {
+        id: 'ua_1',
+        key: 'department',
+        label: 'Department',
+        type: 'string',
+        description: null,
+        currencyCode: null,
+        externalKey: null,
+        createdAt: new Date('2026-01-01'),
+        updatedAt: new Date('2026-01-01'),
+      },
+    ]
+  )
+  return render(
+    <QueryClientProvider client={qc}>
+      <ClaimMappingCard provider={provider} presentation={presentation ?? 'table'} />
+    </QueryClientProvider>
+  )
+}
+
+const lastMapping = () => mappingSpy.mock.calls.at(-1)![0].data
+const lastSaved = () =>
+  applyClaimMappingEdits(
+    lastMapping().expectedClaimMapping,
+    lastMapping()
+      .operations as import('@/lib/shared/sso-claim-mapping-edit').ClaimMappingOperation[]
+  )
+
+beforeEach(() => {
+  mappingSpy.mockClear()
+  mappingSpy.mockResolvedValue(undefined)
+  openTest.mockClear()
+})
+
+describe('ClaimMappingCard save coordination', () => {
+  it('id-path change requires explicit user-facing confirmation', async () => {
+    renderCard(makeProvider({ claimMapping: { profile: { claims: { id: 'oid' } } } }))
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Unique user identifier mapping' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Reset to sub' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    expect(screen.getByText(/stop existing account matches/)).toBeInTheDocument()
+    expect(mappingSpy).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: 'Save mappings' }))
+    await waitFor(() => expect(mappingSpy).toHaveBeenCalled())
+    expect(lastMapping().acknowledgeIdentifierChange).toBe(true)
+  })
+
+  it('admin role mapping requires confirmation even when preview is member', async () => {
+    renderCard(
+      makeProvider({
+        claimMapping: {
+          role: {
+            claimPath: 'groups',
+            rules: [
+              { whenContains: 'platform-admins', role: 'admin' },
+              { whenContains: 'engineering', role: 'member' },
+            ],
+          },
+        },
+      })
+    )
+    await userEvent.click(screen.getByLabelText(/allow accounts without an email/i))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    expect(
+      screen.getByText(/grant admin access even when the person's email is outside/)
+    ).toBeInTheDocument()
+    expect(screen.getAllByText(/does not limit this admin rule/).length).toBeGreaterThan(0)
+    expect(mappingSpy).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: 'Save mappings' }))
+    await waitFor(() => expect(mappingSpy).toHaveBeenCalled())
+    expect(lastMapping().acknowledgeAdminRules).toBe(true)
+  })
+
+  it('canceling either confirmation performs no write', async () => {
+    renderCard(makeProvider({ claimMapping: { profile: { claims: { id: 'oid' } } } }))
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Unique user identifier mapping' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Reset to sub' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(mappingSpy).not.toHaveBeenCalled()
+    expect(openTest).not.toHaveBeenCalled()
+  })
+
+  it('editing the draft invalidates previous confirmation', async () => {
+    renderCard(makeProvider({ claimMapping: { profile: { claims: { id: 'oid' } } } }))
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Unique user identifier mapping' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Reset to sub' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    await userEvent.click(screen.getByLabelText(/allow accounts without an email/i))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    expect(screen.getByText(/stop existing account matches/)).toBeInTheDocument()
+    expect(mappingSpy).not.toHaveBeenCalled()
+  })
+
+  it('reset confirms identifier risk and preserves roles People sources and missing-email policy', async () => {
+    renderCard(
+      makeProvider({
+        claimMapping: {
+          profile: {
+            claims: { id: 'oid', email: 'upn' },
+            sources: ['userinfo', 'idToken'],
+            allowMissingEmail: true,
+          },
+          role: { claimPath: 'groups', rules: [{ whenContains: 'eng', role: 'member' }] },
+          attributes: { map: [{ claimPath: 'dept', attributeKey: 'department' }] },
+        },
+      })
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Reset profile claims' }))
+    expect(
+      screen.getByText(/Keep source order, missing-email policy, Role and People mappings/)
+    ).toBeInTheDocument()
+    expect(screen.getByText(/stop existing account matches/)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Reset profile claims' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save mappings' }))
+    await waitFor(() => expect(mappingSpy).toHaveBeenCalled())
+    const saved = lastSaved() as {
+      profile?: {
+        claims?: { id?: string; email?: string }
+        sources?: string[]
+        allowMissingEmail?: boolean
+      }
+      role?: { claimPath?: string }
+      attributes?: { map?: unknown[] }
+    }
+    expect(saved.profile?.claims?.id).toBeUndefined()
+    expect(saved.profile?.claims?.email).toBeUndefined()
+    expect(saved.profile?.sources).toEqual(['userinfo', 'idToken'])
+    expect(saved.profile?.allowMissingEmail).toBe(true)
+    expect(saved.role?.claimPath).toBe('groups')
+    expect(saved.attributes?.map).toEqual([{ claimPath: 'dept', attributeKey: 'department' }])
+  })
+
+  it('default Save with Advanced sources mounted preserves a passing connection test', async () => {
+    const provider = makeProvider({ claimMapping: null })
+    renderCard(provider)
+    expect(screen.getByText('Advanced sources')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => expect(mappingSpy).toHaveBeenCalled())
+    expect(lastMapping().operations).toEqual([])
+    const next = lastSaved()
+    expect(effectiveProfileSignature(next)).toBe(effectiveProfileSignature(null))
+    expect(
+      connectionAffectingChange(
+        { claimMapping: next as IdentityProvider['claimMapping'] },
+        {
+          clientId: provider.clientId,
+          discoveryUrl: provider.discoveryUrl,
+          authorizationUrl: null,
+          tokenUrl: null,
+          userInfoUrl: null,
+          jwksUri: null,
+          issuer: null,
+          scopes: null,
+          prompt: null,
+          tokenEndpointAuthMethod: null,
+          claimMapping: null,
+        }
+      )
+    ).toBe(false)
+  })
+
+  it('Save and test waits for acknowledged persisted mapping', async () => {
+    let resolveSave: (value: undefined) => void = () => undefined
+    mappingSpy.mockImplementationOnce(
+      () =>
+        new Promise<undefined>((resolve) => {
+          resolveSave = resolve
+        })
+    )
+    renderCard(makeProvider({ claimMapping: null }))
+    await userEvent.click(screen.getByLabelText(/allow accounts without an email/i))
+    fireEvent.click(screen.getByRole('button', { name: 'Save and test' }))
+    await waitFor(() => expect(mappingSpy).toHaveBeenCalled())
+    expect(openTest).not.toHaveBeenCalled()
+    resolveSave(undefined)
+    await waitFor(() => expect(openTest).toHaveBeenCalledWith({ registrationId: 'oidc_x' }))
+  })
+
+  it('stale save keeps the draft and does not open test', async () => {
+    mappingSpy.mockRejectedValueOnce(
+      new Error('This mapping was updated elsewhere. Reload and try again.')
+    )
+    renderCard(makeProvider({ claimMapping: null }))
+    await userEvent.click(screen.getByLabelText(/allow accounts without an email/i))
+    fireEvent.click(screen.getByRole('button', { name: 'Save and test' }))
+    await waitFor(() => expect(mappingSpy).toHaveBeenCalled())
+    expect(openTest).not.toHaveBeenCalled()
+    expect(screen.getByLabelText(/allow accounts without an email/i)).toBeChecked()
+  })
+
+  it('legacy presentation preserves mappings and uses the same confirmations', async () => {
+    renderCard(
+      makeProvider({
+        claimMapping: {
+          role: {
+            claimPath: 'groups',
+            rules: [{ whenContains: 'platform-admins', role: 'admin' }],
+          },
+          attributes: { map: [{ claimPath: 'dept', attributeKey: 'department' }] },
+        },
+      }),
+      'legacy'
+    )
+    expect(screen.getByRole('button', { name: /Map roles from claims/ })).toBeInTheDocument()
+    await userEvent.click(screen.getByLabelText(/allow accounts without an email/i))
+    fireEvent.click(screen.getByRole('button', { name: 'Save claim mapping' }))
+    expect(screen.getByText(/grant admin access/)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Save mappings' }))
+    await waitFor(() => expect(mappingSpy).toHaveBeenCalled())
+    const saved = lastSaved() as {
+      role?: { claimPath?: string }
+      attributes?: { map?: unknown[] }
+      profile?: { allowMissingEmail?: boolean }
+    }
+    expect(saved.role?.claimPath).toBe('groups')
+    expect(saved.attributes?.map).toEqual([{ claimPath: 'dept', attributeKey: 'department' }])
+    expect(saved.profile?.allowMissingEmail).toBe(true)
+    expect(lastMapping().acknowledgeAdminRules).toBe(true)
+  })
+})

--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/claim-mapping-card.test.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/claim-mapping-card.test.tsx
@@ -199,6 +199,22 @@ describe('ClaimMappingCard save coordination', () => {
     expect(saved?.profile?.claims?.id).toBeUndefined()
   })
 
+  it('selecting sub from the default identifier dialog persists explicit id and requires acknowledgement', async () => {
+    renderCard(makeProvider({ claimMapping: null }))
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Unique user identifier mapping' }))
+    await userEvent.click(screen.getByRole('combobox', { name: 'IdP claim path' }))
+    await userEvent.click(screen.getByRole('option', { name: /^sub\b/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Apply to draft' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    expect(screen.getByText(/stop existing account matches/)).toBeInTheDocument()
+    expect(mappingSpy).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: 'Save mappings' }))
+    await waitFor(() => expect(mappingSpy).toHaveBeenCalled())
+    expect(lastMapping().acknowledgeIdentifierChange).toBe(true)
+    const saved = lastSaved() as { profile?: { claims?: { id?: string } } }
+    expect(saved.profile?.claims?.id).toBe('sub')
+  })
+
   it('keeps provider A session success when lastCapture is a mapping failure for B', () => {
     const captureA = {
       version: 2 as const,

--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/claim-row-dialog.test.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/claim-row-dialog.test.tsx
@@ -98,6 +98,46 @@ describe('ClaimRowDialog', () => {
     expect(onCommit).toHaveBeenCalledWith({ type: 'profile', field: 'name', path: null })
   })
 
+  it('empty Apply on a default identifier commits path null', async () => {
+    const onCommit = vi.fn()
+    render(
+      <ClaimRowDialog
+        open
+        mode="edit"
+        lockedTarget={{ type: 'profile', field: 'id' }}
+        availableTargets={[]}
+        definitions={DEFS}
+        registrationId="oidc_x"
+        canTest
+        onOpenChange={vi.fn()}
+        onCommit={onCommit}
+      />
+    )
+    await userEvent.click(screen.getByRole('button', { name: 'Apply to draft' }))
+    expect(onCommit).toHaveBeenCalledWith({ type: 'profile', field: 'id', path: null })
+  })
+
+  it('selecting sub from an empty identifier dialog persists explicit sub', async () => {
+    const onCommit = vi.fn()
+    render(
+      <ClaimRowDialog
+        open
+        mode="edit"
+        lockedTarget={{ type: 'profile', field: 'id' }}
+        availableTargets={[]}
+        definitions={DEFS}
+        registrationId="oidc_x"
+        canTest
+        onOpenChange={vi.fn()}
+        onCommit={onCommit}
+      />
+    )
+    await userEvent.click(screen.getByRole('combobox', { name: 'IdP claim path' }))
+    await userEvent.click(screen.getByRole('option', { name: /^sub\b/i }))
+    await userEvent.click(screen.getByRole('button', { name: 'Apply to draft' }))
+    expect(onCommit).toHaveBeenCalledWith({ type: 'profile', field: 'id', path: 'sub' })
+  })
+
   it('locks the target when editing and has no metadata-key field', () => {
     render(
       <ClaimRowDialog

--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/claim-row-dialog.test.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/claim-row-dialog.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment happy-dom
-import { describe, it, expect, vi, beforeAll } from 'vitest'
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ClaimRowDialog } from '../claim-row-dialog'
 import { availableAddTargets } from '../provider-shared'
+import type { SsoTestCapture } from '@/lib/shared/sso-test-capture'
 
 beforeAll(() => {
   Element.prototype.scrollIntoView = vi.fn()
@@ -12,21 +13,25 @@ beforeAll(() => {
   Element.prototype.releasePointerCapture = vi.fn()
 })
 
+const defaultCapture: SsoTestCapture = {
+  registrationId: 'oidc_x',
+  capturedAt: '2026-09-01T00:00:00.000Z',
+  identity: { id: 'sub', sources: {} },
+  claims: { sub: 'person-123', upn: 'jane@example.test', groups: ['engineering'] },
+}
+
+const { ssoTestRef } = vi.hoisted(() => ({
+  ssoTestRef: {
+    lastSuccess: null as null | SsoTestCapture,
+    lastCapture: null as null | SsoTestCapture,
+  },
+}))
+
 vi.mock('../../sso/use-sso-test-sign-in', () => ({
   useSsoTestSignIn: () => ({
     open: vi.fn(),
-    lastSuccess: {
-      registrationId: 'oidc_x',
-      capturedAt: '2026-09-01T00:00:00.000Z',
-      identity: { id: 'sub', sources: {} },
-      claims: { sub: 'person-123', upn: 'jane@example.test', groups: ['engineering'] },
-    },
-    lastCapture: {
-      registrationId: 'oidc_x',
-      capturedAt: '2026-09-01T00:00:00.000Z',
-      identity: { id: 'sub', sources: {} },
-      claims: { sub: 'person-123', upn: 'jane@example.test', groups: ['engineering'] },
-    },
+    lastSuccess: ssoTestRef.lastSuccess,
+    lastCapture: ssoTestRef.lastCapture,
   }),
 }))
 
@@ -44,6 +49,11 @@ const DEFS = [
   { key: 'department', label: 'Department', type: 'string' },
   { key: 'plan', label: 'Plan', type: 'string' },
 ]
+
+beforeEach(() => {
+  ssoTestRef.lastSuccess = defaultCapture
+  ssoTestRef.lastCapture = defaultCapture
+})
 
 describe('ClaimRowDialog', () => {
   it('discards local edits on Cancel without committing', async () => {
@@ -132,6 +142,38 @@ describe('ClaimRowDialog', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Add rule' }))
     expect(screen.getByRole('button', { name: 'Apply to draft' })).toBeDisabled()
     expect(onCommit).not.toHaveBeenCalled()
+  })
+
+  it('prefers the capture prop over lastSuccess for role value suggestions', async () => {
+    ssoTestRef.lastSuccess = {
+      ...defaultCapture,
+      claims: { sub: 'person-123', groups: ['from-success'] },
+    }
+    ssoTestRef.lastCapture = ssoTestRef.lastSuccess
+    render(
+      <ClaimRowDialog
+        open
+        mode="edit"
+        lockedTarget={{ type: 'role' }}
+        availableTargets={[]}
+        definitions={DEFS}
+        initialRole={{
+          claimPath: 'groups',
+          rules: [{ whenContains: 'engineering', role: 'member' }],
+        }}
+        registrationId="oidc_x"
+        canTest
+        capture={{
+          ...defaultCapture,
+          claims: { sub: 'person-123', groups: ['from-capture'] },
+        }}
+        onOpenChange={vi.fn()}
+        onCommit={vi.fn()}
+      />
+    )
+    await userEvent.click(screen.getByRole('combobox', { name: 'Claim value to match (rule 1)' }))
+    expect(screen.getByText('from-capture')).toBeInTheDocument()
+    expect(screen.queryByText('from-success')).not.toBeInTheDocument()
   })
 
   it('offers Role and unused People targets only', async () => {

--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/claim-row-dialog.test.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/claim-row-dialog.test.tsx
@@ -109,6 +109,31 @@ describe('ClaimRowDialog', () => {
     expect(screen.queryByPlaceholderText(/metadata/i)).not.toBeInTheDocument()
   })
 
+  it('disables Apply to draft when a new role rule has no value', async () => {
+    const onCommit = vi.fn()
+    render(
+      <ClaimRowDialog
+        open
+        mode="edit"
+        lockedTarget={{ type: 'role' }}
+        availableTargets={[]}
+        definitions={DEFS}
+        initialRole={{
+          claimPath: 'groups',
+          rules: [{ whenContains: 'engineering', role: 'member' }],
+        }}
+        registrationId="oidc_x"
+        canTest
+        onOpenChange={vi.fn()}
+        onCommit={onCommit}
+      />
+    )
+    expect(screen.getByRole('button', { name: 'Apply to draft' })).not.toBeDisabled()
+    await userEvent.click(screen.getByRole('button', { name: 'Add rule' }))
+    expect(screen.getByRole('button', { name: 'Apply to draft' })).toBeDisabled()
+    expect(onCommit).not.toHaveBeenCalled()
+  })
+
   it('offers Role and unused People targets only', async () => {
     const targets = availableAddTargets({
       mapping: { attributes: { map: [{ claimPath: 'dept', attributeKey: 'department' }] } },

--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/claim-row-dialog.test.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/claim-row-dialog.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeAll } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ClaimRowDialog } from '../claim-row-dialog'
+import { availableAddTargets } from '../provider-shared'
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.setPointerCapture = vi.fn()
+  Element.prototype.releasePointerCapture = vi.fn()
+})
+
+vi.mock('../../sso/use-sso-test-sign-in', () => ({
+  useSsoTestSignIn: () => ({
+    open: vi.fn(),
+    lastSuccess: {
+      registrationId: 'oidc_x',
+      capturedAt: '2026-09-01T00:00:00.000Z',
+      identity: { id: 'sub', sources: {} },
+      claims: { sub: 'person-123', upn: 'jane@example.test', groups: ['engineering'] },
+    },
+    lastCapture: {
+      registrationId: 'oidc_x',
+      capturedAt: '2026-09-01T00:00:00.000Z',
+      identity: { id: 'sub', sources: {} },
+      claims: { sub: 'person-123', upn: 'jane@example.test', groups: ['engineering'] },
+    },
+  }),
+}))
+
+vi.mock('../../sso/test-sign-in-button', () => ({
+  TestSignInButton: () => <button type="button">Test sign-in</button>,
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+}))
+
+const DEFS = [
+  { key: 'department', label: 'Department', type: 'string' },
+  { key: 'plan', label: 'Plan', type: 'string' },
+]
+
+describe('ClaimRowDialog', () => {
+  it('discards local edits on Cancel without committing', async () => {
+    const onCommit = vi.fn()
+    const onOpenChange = vi.fn()
+    render(
+      <ClaimRowDialog
+        open
+        mode="edit"
+        lockedTarget={{ type: 'profile', field: 'email' }}
+        availableTargets={[]}
+        definitions={DEFS}
+        initialPath="upn"
+        registrationId="oidc_x"
+        canTest
+        onOpenChange={onOpenChange}
+        onCommit={onCommit}
+      />
+    )
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(onCommit).not.toHaveBeenCalled()
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('resets Name to the default path through the dialog', async () => {
+    const onCommit = vi.fn()
+    render(
+      <ClaimRowDialog
+        open
+        mode="edit"
+        lockedTarget={{ type: 'profile', field: 'name' }}
+        availableTargets={[]}
+        definitions={DEFS}
+        initialPath="preferred_username"
+        registrationId="oidc_x"
+        canTest
+        onOpenChange={vi.fn()}
+        onCommit={onCommit}
+      />
+    )
+    await userEvent.click(screen.getByRole('button', { name: 'Reset to name' }))
+    expect(onCommit).toHaveBeenCalledWith({ type: 'profile', field: 'name', path: null })
+  })
+
+  it('locks the target when editing and has no metadata-key field', () => {
+    render(
+      <ClaimRowDialog
+        open
+        mode="edit"
+        lockedTarget={{ type: 'profile', field: 'email' }}
+        availableTargets={[]}
+        definitions={DEFS}
+        initialPath="upn"
+        registrationId="oidc_x"
+        canTest
+        onOpenChange={vi.fn()}
+        onCommit={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Email (fixed target)')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Quackback attribute')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/metadata/i)).not.toBeInTheDocument()
+    expect(screen.queryByPlaceholderText(/metadata/i)).not.toBeInTheDocument()
+  })
+
+  it('offers Role and unused People targets only', async () => {
+    const targets = availableAddTargets({
+      mapping: { attributes: { map: [{ claimPath: 'dept', attributeKey: 'department' }] } },
+      definitions: DEFS,
+    })
+    render(
+      <ClaimRowDialog
+        open
+        mode="add"
+        availableTargets={targets}
+        definitions={DEFS}
+        registrationId="oidc_x"
+        canTest
+        onOpenChange={vi.fn()}
+        onCommit={vi.fn()}
+      />
+    )
+    await userEvent.click(screen.getByRole('combobox', { name: 'Quackback attribute' }))
+    expect(screen.getByRole('option', { name: /Role/ })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: /Plan/ })).toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: /Department/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: /Unique user identifier/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: /^Email/ })).not.toBeInTheDocument()
+  })
+
+  it('includes sub in identity suggestions', async () => {
+    render(
+      <ClaimRowDialog
+        open
+        mode="edit"
+        lockedTarget={{ type: 'profile', field: 'id' }}
+        availableTargets={[]}
+        definitions={DEFS}
+        initialPath="sub"
+        registrationId="oidc_x"
+        canTest
+        onOpenChange={vi.fn()}
+        onCommit={vi.fn()}
+      />
+    )
+    await userEvent.click(screen.getByRole('combobox', { name: 'IdP claim path' }))
+    expect(screen.getAllByText('sub').length).toBeGreaterThan(1)
+  })
+})

--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/claim-row-dialog.test.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/claim-row-dialog.test.tsx
@@ -220,6 +220,34 @@ describe('ClaimRowDialog', () => {
     expect(screen.getAllByText('sub').length).toBeGreaterThan(1)
   })
 
+  it('does not let an admin select a non-bindable identity suggestion', async () => {
+    ssoTestRef.lastSuccess = {
+      ...defaultCapture,
+      claims: { sub: 'person-123', email_verified: true, groups: ['engineering'] },
+    }
+    ssoTestRef.lastCapture = ssoTestRef.lastSuccess
+    const onCommit = vi.fn()
+    render(
+      <ClaimRowDialog
+        open
+        mode="edit"
+        lockedTarget={{ type: 'profile', field: 'id' }}
+        availableTargets={[]}
+        definitions={DEFS}
+        initialPath="sub"
+        registrationId="oidc_x"
+        canTest
+        onOpenChange={vi.fn()}
+        onCommit={onCommit}
+      />
+    )
+    await userEvent.click(screen.getByRole('combobox', { name: 'IdP claim path' }))
+    const groups = screen.getByRole('option', { name: /groups/i })
+    expect(groups).toHaveAttribute('aria-disabled', 'true')
+    await userEvent.click(groups)
+    expect(screen.getByRole('combobox', { name: 'IdP claim path' })).toHaveTextContent('sub')
+  })
+
   it('does not reset in-progress edits when the parent re-renders', () => {
     const targets = availableAddTargets({ mapping: null, definitions: DEFS })
     const { rerender } = render(

--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/claim-row-dialog.test.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/claim-row-dialog.test.tsx
@@ -152,4 +152,63 @@ describe('ClaimRowDialog', () => {
     await userEvent.click(screen.getByRole('combobox', { name: 'IdP claim path' }))
     expect(screen.getAllByText('sub').length).toBeGreaterThan(1)
   })
+
+  it('does not reset in-progress edits when the parent re-renders', () => {
+    const targets = availableAddTargets({ mapping: null, definitions: DEFS })
+    const { rerender } = render(
+      <ClaimRowDialog
+        open
+        mode="edit"
+        lockedTarget={{ type: 'profile', field: 'email' }}
+        availableTargets={targets}
+        definitions={DEFS}
+        initialPath="upn"
+        registrationId="oidc_x"
+        canTest
+        onOpenChange={vi.fn()}
+        onCommit={vi.fn()}
+      />
+    )
+    expect(screen.getByRole('combobox', { name: 'IdP claim path' })).toHaveTextContent('upn')
+    rerender(
+      <ClaimRowDialog
+        open
+        mode="edit"
+        lockedTarget={{ type: 'profile', field: 'email' }}
+        availableTargets={[...targets]}
+        definitions={[...DEFS]}
+        initialPath="email"
+        registrationId="oidc_x"
+        canTest
+        onOpenChange={vi.fn()}
+        onCommit={vi.fn()}
+      />
+    )
+    expect(screen.getByRole('combobox', { name: 'IdP claim path' })).toHaveTextContent('upn')
+  })
+
+  it('commits a People edit with the row baseline index', async () => {
+    const onCommit = vi.fn()
+    render(
+      <ClaimRowDialog
+        open
+        mode="edit"
+        lockedTarget={{ type: 'people', attributeKey: 'department', baselineIndex: 1 }}
+        availableTargets={[]}
+        definitions={DEFS}
+        initialPath="org.department"
+        registrationId="oidc_x"
+        canTest
+        onOpenChange={vi.fn()}
+        onCommit={onCommit}
+      />
+    )
+    await userEvent.click(screen.getByRole('button', { name: 'Apply to draft' }))
+    expect(onCommit).toHaveBeenCalledWith({
+      type: 'people',
+      attributeKey: 'department',
+      claimPath: 'org.department',
+      baselineIndex: 1,
+    })
+  })
 })

--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/claims-table.test.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/claims-table.test.tsx
@@ -133,6 +133,15 @@ describe('ClaimsTable', () => {
     expect(screen.queryByRole('textbox', { name: /key/i })).not.toBeInTheDocument()
   })
 
+  it('does not offer Remove on an unsupported saved profile claim', () => {
+    renderTable({
+      profile: { claims: { email: 'upn', locale: 'locale' } },
+    } as IdentityProviderClaimMapping)
+    expect(screen.getByText('locale')).toBeInTheDocument()
+    expect(screen.getByText(/not editable here/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Remove locale/ })).not.toBeInTheDocument()
+  })
+
   it('lists every role target and the off-domain warning', () => {
     renderTable({
       role: {

--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/claims-table.test.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/claims-table.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { AdvancedSourcesEditor, ClaimsTable } from '../claims-table'
+import { buildClaimsTableModel } from '../provider-shared'
+import type { IdentityProviderClaimMapping } from '@/lib/shared/oidc-claim-mapping'
+
+const DEFS = [
+  { key: 'department', label: 'Department', type: 'string' },
+  { key: 'plan', label: 'Plan', type: 'string' },
+]
+
+function renderTable(
+  mapping: IdentityProviderClaimMapping | null,
+  over: Partial<Parameters<typeof ClaimsTable>[0]> = {}
+) {
+  const model = buildClaimsTableModel({ mapping, definitions: DEFS })
+  const onEdit = vi.fn()
+  const onRemove = vi.fn()
+  const onResetName = vi.fn()
+  const onAllow = vi.fn()
+  const onFlags = vi.fn()
+  render(
+    <ClaimsTable
+      requiredRows={model.required}
+      additionalRows={model.additional}
+      allowMissingEmail={mapping?.profile?.allowMissingEmail === true}
+      onAllowMissingEmailChange={onAllow}
+      peopleFlags={{
+        overrideExisting: mapping?.attributes?.overrideExisting === true,
+        syncOnSignIn: mapping?.attributes?.syncOnSignIn === true,
+      }}
+      onPeopleFlagsChange={onFlags}
+      onEdit={onEdit}
+      onRemove={onRemove}
+      onResetName={onResetName}
+      autoCreateUsers
+      autoProvisionRole="user"
+      {...over}
+    />
+  )
+  return { onEdit, onRemove, onResetName, onAllow, onFlags }
+}
+
+describe('ClaimsTable', () => {
+  it('uses Quackback attribute then IdP claim column headers', () => {
+    renderTable(null)
+    const headers = screen.getAllByRole('columnheader')
+    expect(headers[0]).toHaveTextContent('Quackback attribute')
+    expect(headers[1]).toHaveTextContent('IdP claim')
+  })
+
+  it('always shows required identifier/email and default display name', () => {
+    renderTable(null)
+    expect(screen.getByText('Unique user identifier')).toBeInTheDocument()
+    expect(screen.getByText('Email')).toBeInTheDocument()
+    expect(screen.getByText('Display name')).toBeInTheDocument()
+    expect(screen.getAllByText('Default').length).toBeGreaterThanOrEqual(3)
+    expect(screen.getByText('sub')).toBeInTheDocument()
+    expect(screen.getByText('email')).toBeInTheDocument()
+    expect(screen.getByText('name')).toBeInTheDocument()
+  })
+
+  it('pins explicit sub as a custom identifier', () => {
+    renderTable({ profile: { claims: { id: 'sub' } } })
+    expect(screen.getByText('Custom')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Edit Unique user identifier mapping' })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /Remove Unique user identifier/ })
+    ).not.toBeInTheDocument()
+  })
+
+  it('labels edit and delete actions accessibly and never deletes a required row', () => {
+    renderTable({
+      role: {
+        claimPath: 'groups',
+        rules: [{ whenContains: 'engineering', role: 'member' }],
+      },
+      attributes: { map: [{ claimPath: 'org.department', attributeKey: 'department' }] },
+    })
+    expect(
+      screen.getByRole('button', { name: 'Edit Unique user identifier mapping' })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Edit Email mapping' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Edit Display name mapping' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Edit Role mapping' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Remove Role mapping' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Edit Department mapping' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Remove Department mapping' })).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /Remove Unique user identifier/ })
+    ).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Remove Email/ })).not.toBeInTheDocument()
+  })
+
+  it('restores the default name row through Reset mapping', async () => {
+    const { onResetName } = renderTable({
+      profile: { claims: { name: 'preferred_username' } },
+    })
+    await userEvent.click(screen.getByRole('button', { name: 'Reset mapping' }))
+    expect(onResetName).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves orphaned and duplicate People rows', () => {
+    renderTable({
+      attributes: {
+        map: [
+          { claimPath: 'dept', attributeKey: 'department' },
+          { claimPath: 'org.department', attributeKey: 'department' },
+          { claimPath: 'cc', attributeKey: 'cost_center' },
+        ],
+      },
+    })
+    expect(screen.getAllByText('Duplicate mapping')).toHaveLength(2)
+    expect(screen.getByText('attribute no longer exists')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Remove cost_center mapping' })).toBeInTheDocument()
+  })
+
+  it('keeps People flags section-wide and has no metadata-key text field', () => {
+    renderTable({
+      attributes: { map: [{ claimPath: 'dept', attributeKey: 'department' }] },
+    })
+    expect(screen.getByText('Applies to all mapped People attributes')).toBeInTheDocument()
+    expect(screen.getByLabelText('Overwrite values that are already set')).toBeInTheDocument()
+    expect(
+      screen.getByLabelText('Clear an attribute when its claim is missing')
+    ).toBeInTheDocument()
+    expect(screen.queryByLabelText(/metadata/i)).not.toBeInTheDocument()
+    expect(screen.queryByPlaceholderText(/metadata/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('textbox', { name: /key/i })).not.toBeInTheDocument()
+  })
+
+  it('lists every role target and the off-domain warning', () => {
+    renderTable({
+      role: {
+        claimPath: 'groups',
+        rules: [
+          { whenContains: 'platform-admins', role: 'admin' },
+          { whenContains: 'engineering', role: 'member' },
+        ],
+      },
+    })
+    expect(screen.getByText(/platform-admins/)).toBeInTheDocument()
+    expect(screen.getByText(/engineering/)).toBeInTheDocument()
+    expect(screen.getByText(/even outside this provider's verified domains/)).toBeInTheDocument()
+  })
+})
+
+describe('AdvancedSourcesEditor', () => {
+  it('shows default sources and the access-token warning', () => {
+    const onChange = vi.fn()
+    render(<AdvancedSourcesEditor sources={['idToken', 'userinfo']} onChange={onChange} />)
+    const details = screen.getByText('Advanced sources').closest('details')
+    expect(details).toBeTruthy()
+    if (details) details.open = true
+    expect(screen.getByLabelText('ID token')).toBeChecked()
+    expect(screen.getByLabelText('Userinfo')).toBeChecked()
+    expect(screen.getByLabelText('Access-token JWT')).not.toBeChecked()
+    expect(screen.getByText(/audience-scoped and its subject may differ/)).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/outcome-preview-rail.test.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/outcome-preview-rail.test.tsx
@@ -1,0 +1,207 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { OutcomePreviewRail } from '../outcome-preview-rail'
+import type { SsoTestCapture } from '@/lib/shared/sso-test-capture'
+import type { IdentityProviderClaimMapping } from '@/lib/shared/oidc-claim-mapping'
+
+vi.mock('../../sso/use-sso-test-sign-in', () => ({
+  useSsoTestSignIn: () => ({ open: vi.fn(), lastSuccess: null, lastCapture: null }),
+}))
+
+vi.mock('../../sso/test-sign-in-button', () => ({
+  TestSignInButton: ({ children }: { children?: React.ReactNode }) => (
+    <button type="button">{children ?? 'Test sign-in'}</button>
+  ),
+}))
+
+vi.mock('@/lib/client/hooks/use-user-attributes-queries', () => ({
+  useUserAttributes: () => ({
+    data: [{ key: 'department', type: 'string', label: 'Department' }],
+  }),
+}))
+
+const REG = 'oidc_x'
+const defs = [{ key: 'department', type: 'string' as const, label: 'Department' }]
+const policy = {
+  autoCreateUsers: true,
+  autoProvisionRole: null as 'user' | 'member' | 'admin' | null,
+  registrationId: REG,
+}
+
+function v2(over: Partial<SsoTestCapture> = {}): SsoTestCapture {
+  return {
+    version: 2,
+    registrationId: REG,
+    capturedAt: '2026-09-01T00:00:00.000Z',
+    detailsChangedAtAtStart: null,
+    outcome: 'success',
+    identity: {
+      id: 'person-123',
+      email: 'jane@example.test',
+      name: 'Jane',
+      sources: { id: 'idToken' },
+    },
+    claims: {
+      sub: 'person-123',
+      email: 'Jane@Example.TEST',
+      name: 'Jane',
+      groups: ['engineering'],
+    },
+    replay: {
+      sources: [
+        {
+          source: 'idToken',
+          claims: {
+            sub: 'person-123',
+            email: 'Jane@Example.TEST',
+            name: 'Jane',
+            groups: ['engineering'],
+            iss: 'https://idp.example',
+          },
+        },
+        { source: 'userinfo', claims: { sub: 'person-123', department: 'Engineering' } },
+      ],
+    },
+    ...over,
+  }
+}
+
+function renderRail(over: {
+  capture?: SsoTestCapture | null
+  draft?: IdentityProviderClaimMapping | null
+  dirty?: boolean
+  autoCreateUsers?: boolean
+  detailsChangedAt?: string | null
+}) {
+  return render(
+    <OutcomePreviewRail
+      capture={over.capture === undefined ? v2() : over.capture}
+      draft={over.draft ?? null}
+      definitions={defs}
+      providerPolicy={{
+        ...policy,
+        autoCreateUsers: over.autoCreateUsers ?? true,
+        detailsChangedAt: over.detailsChangedAt,
+      }}
+      dirty={over.dirty ?? false}
+      registrationId={REG}
+      canTest
+    />
+  )
+}
+
+describe('OutcomePreviewRail', () => {
+  it('preview uses production binder for unsaved draft', () => {
+    renderRail({
+      dirty: true,
+      draft: { profile: { claims: { email: 'upn' } } },
+      capture: v2({
+        replay: {
+          sources: [
+            {
+              source: 'idToken',
+              claims: {
+                sub: 'person-123',
+                upn: 'Jane@Idp.Example',
+                email: 'other@x.test',
+                name: 'Jane',
+              },
+            },
+            { source: 'userinfo', claims: { sub: 'person-123' } },
+          ],
+        },
+      }),
+    })
+    expect(screen.getByText('Preview of unsaved mappings')).toBeInTheDocument()
+    expect(screen.getByText('jane@idp.example')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Save and test' })).toBeInTheDocument()
+  })
+
+  it('wrong provider capture is ignored', () => {
+    renderRail({ capture: v2({ registrationId: 'oidc_other' }) })
+    expect(screen.getByText(/Run a test sign-in to inspect this IdP's claims/)).toBeInTheDocument()
+  })
+
+  it('legacy capture asks for retest', () => {
+    renderRail({
+      capture: {
+        registrationId: REG,
+        capturedAt: '2026-09-01T00:00:00.000Z',
+        identity: { id: 'person-123', email: 'jane@example.test', sources: { id: 'idToken' } },
+        claims: { sub: 'person-123' },
+      },
+    })
+    expect(screen.getByText(/preview mappings accurately/i)).toBeInTheDocument()
+    expect(screen.queryByText('Identifier')).not.toBeInTheDocument()
+  })
+
+  it('source change never invents provenance', () => {
+    renderRail({
+      draft: { profile: { sources: ['idToken', 'userinfo', 'accessTokenJwt'] } },
+    })
+    expect(screen.getByText(/Access token JWT was not captured/i)).toBeInTheDocument()
+    expect(screen.queryByText('Identifier')).not.toBeInTheDocument()
+  })
+
+  it('role preview warns about off-domain admin rules even if test matches member', () => {
+    renderRail({
+      draft: {
+        role: {
+          claimPath: 'groups',
+          rules: [
+            { whenContains: 'platform-admins', role: 'admin' },
+            { whenContains: 'engineering', role: 'member' },
+          ],
+        },
+      },
+    })
+    expect(screen.getByText(/Rule 2 matched/)).toBeInTheDocument()
+    expect(screen.getByText(/platform-admins/)).toBeInTheDocument()
+    expect(screen.getByText(/even outside this provider's verified domains/)).toBeInTheDocument()
+    expect(screen.getByText(/does not limit this admin rule/)).toBeInTheDocument()
+  })
+
+  it('auto-create off suppresses role application but not People preview', () => {
+    renderRail({
+      autoCreateUsers: false,
+      draft: {
+        role: { claimPath: 'groups', rules: [{ whenContains: 'engineering', role: 'member' }] },
+        attributes: { map: [{ claimPath: 'department', attributeKey: 'department' }] },
+      },
+    })
+    expect(screen.getByText(/Role application is disabled/)).toBeInTheDocument()
+    expect(screen.getByText(/Engineering/)).toBeInTheDocument()
+  })
+
+  it('placeholder preview never generates an address', () => {
+    renderRail({
+      draft: { profile: { allowMissingEmail: true } },
+      capture: v2({
+        replay: {
+          sources: [
+            { source: 'idToken', claims: { sub: 'person-123', name: 'Jane' } },
+            { source: 'userinfo', claims: { sub: 'person-123' } },
+          ],
+        },
+      }),
+    })
+    expect(screen.getByText('A placeholder address will be used.')).toBeInTheDocument()
+    expect(screen.queryByText(/sso-/)).not.toBeInTheDocument()
+  })
+
+  it('metadata preview cannot claim existing values were kept', () => {
+    renderRail({
+      draft: {
+        attributes: { map: [{ claimPath: 'department', attributeKey: 'department' }] },
+      },
+    })
+    expect(screen.queryByText(/kept existing/i)).not.toBeInTheDocument()
+    expect(screen.getByText(/Assumes the person has no attributes yet/)).toBeInTheDocument()
+  })
+
+  it('shows Member (runtime default) when Accounts role is null', () => {
+    renderRail({ draft: { role: { claimPath: 'groups', rules: [] } } })
+    expect(screen.getByText(/Member \(runtime default\)/)).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-detail-page.test.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-detail-page.test.tsx
@@ -21,6 +21,7 @@ import type { IdentityProvider } from '@/lib/server/domains/settings/identity-pr
 import type { VerifiedDomain } from '@/lib/server/domains/settings/settings.types'
 import { ProviderDetailPage } from '../provider-detail-page'
 import { applyClaimMappingEdits } from '@/lib/shared/sso-claim-mapping-edit'
+import type { SsoTestCapture } from '@/lib/shared/sso-test-capture'
 
 beforeAll(() => {
   Element.prototype.scrollIntoView = vi.fn()
@@ -67,17 +68,9 @@ const { discoveryScopesSpy } = vi.hoisted(() => ({
   discoveryScopesSpy: vi.fn(async () => ({ scopesSupported: null as string[] | null })),
 }))
 
-type SessionCapture = {
-  registrationId: string
-  claims: Record<string, unknown>
-  capturedAt?: string
-  identity?: { id: string; email?: string; sources: Record<string, string> }
-}
-
 const { ssoTestRef } = vi.hoisted(() => ({
   ssoTestRef: {
-    current: null as null | SessionCapture,
-    lastCapture: undefined as undefined | null | SessionCapture,
+    current: null as null | import('@/lib/shared/sso-test-capture').SsoTestCapture,
   },
 }))
 
@@ -108,7 +101,7 @@ vi.mock('../../sso/use-sso-test-sign-in', () => ({
   useSsoTestSignIn: () => ({
     open: vi.fn(),
     lastSuccess: ssoTestRef.current,
-    lastCapture: ssoTestRef.lastCapture !== undefined ? ssoTestRef.lastCapture : ssoTestRef.current,
+    lastCapture: ssoTestRef.current,
   }),
   SsoTestSignInProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }))
@@ -279,7 +272,10 @@ function renderPage(provider: IdentityProvider) {
 const saveConnection = () =>
   fireEvent.click(screen.getByRole('button', { name: 'Save connection' }))
 const saveMapping = () => {
-  fireEvent.click(screen.getByRole('button', { name: 'Save claim mapping' }))
+  const save =
+    screen.queryByRole('button', { name: 'Save claim mapping' }) ??
+    screen.getByRole('button', { name: 'Save' })
+  fireEvent.click(save)
   const confirm = screen.queryByRole('button', { name: 'Save mappings' })
   if (confirm) fireEvent.click(confirm)
 }
@@ -300,7 +296,6 @@ beforeEach(() => {
   discoveryScopesSpy.mockClear()
   discoveryScopesSpy.mockResolvedValue({ scopesSupported: null })
   ssoTestRef.current = null
-  ssoTestRef.lastCapture = undefined
   state.userAttributes = []
   state.authConfig = { oauth: { password: true } }
   state.credentialStatus = { _emailConfigured: true }
@@ -316,7 +311,7 @@ describe('<ProviderDetailPage> page shell', () => {
       ['Connection', '#connection'],
       ['Sign-in', '#signin'],
       ['Accounts', '#accounts'],
-      ['Claim mapping', '#mapping'],
+      ['Attributes & Claims', '#mapping'],
       ['Remove', '#danger'],
     ]) {
       expect(within(nav).getByRole('link', { name: label })).toHaveAttribute('href', hash)
@@ -372,29 +367,21 @@ describe('<ProviderDetailPage> enabled toggle', () => {
 })
 
 describe('<ProviderDetailPage> provisioning consolidation', () => {
-  it('shows a single Default role and a collapsed claim-mapping disclosure when no rules', () => {
+  it('shows a single Default role and required mapping rows when no rules', () => {
     renderPage(
       makeProvider({ autoCreateUsers: true, autoProvisionRole: 'user', claimMapping: null })
     )
-    // One default-role control, bound to autoProvisionRole.
     expect(screen.getByLabelText('Default role')).toBeInTheDocument()
-    // The claim-mapping section is present but the rules are collapsed.
-    expect(screen.getByRole('button', { name: /Map roles from claims/ })).toHaveAttribute(
-      'aria-expanded',
-      'false'
-    )
-    // No nested "default role" duplicate inside the mapping.
+    expect(screen.getByText('Unique user identifier')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Add claim' })).toBeInTheDocument()
     expect(screen.queryByText('No rules. Everyone gets the default role.')).not.toBeInTheDocument()
   })
 
   it('keeps claim mapping reachable when auto-create is off', () => {
-    // Only the default role is creation-only. Identity resolution runs on every
-    // sign-in, including for people who already have accounts, so hiding its
-    // configuration behind "create accounts for new people" would hide a live
-    // control from exactly the workspaces most likely to need it.
     renderPage(makeProvider({ autoCreateUsers: false }))
     expect(screen.queryByLabelText('Default role')).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /Map roles from claims/ })).toBeInTheDocument()
+    expect(screen.getByText('Unique user identifier')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Add claim' })).toBeInTheDocument()
   })
 
   it('persists claimMapping=null when saved with no rules and sync off', async () => {
@@ -478,7 +465,11 @@ describe('<ProviderDetailPage> connection-test status', () => {
     // startSsoTestFn resolves the provider by registrationId and stamps that
     // provider's own lastSuccessfulTestAt, so the legacy "sso" id is no
     // different from a generated one.
-    expect(screen.getByRole('button', { name: /test sign-in/i })).not.toBeDisabled()
+    expect(
+      screen
+        .getAllByRole('button', { name: /test sign-in/i })
+        .every((btn) => !btn.hasAttribute('disabled'))
+    ).toBe(true)
   })
 })
 
@@ -555,26 +546,35 @@ describe('<ProviderDetailPage> sign-in card', () => {
 describe('<ProviderDetailPage> claim-mapping autocomplete', () => {
   it('names the observed claims inline and drops the old assist block', () => {
     ssoTestRef.current = {
-      registrationId: 'oidc_x', // matches makeProvider().registrationId
+      registrationId: 'oidc_x',
+      capturedAt: '2026-09-01T00:00:00.000Z',
+      identity: { id: 's', sources: { id: 'idToken' } },
       claims: { groups: ['11111111-2222'], roles: ['admin'] },
     }
     renderPage(makeProvider({ autoCreateUsers: true, claimMapping: null }))
-    // Inline hint names the observed claims (disclosure auto-opens on suggestions).
-    expect(screen.getByText('From your test sign-in: groups, roles')).toBeInTheDocument()
-    // The old batch-add block's caption is gone.
     expect(screen.queryByText(/Run a test as another user/)).not.toBeInTheDocument()
-    // Claim path is now an autocomplete (combobox), not a plain textbox.
-    expect(screen.getByRole('combobox', { name: 'Claim path' })).toBeInTheDocument()
+    expect(screen.getByText('Unique user identifier')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Add claim' })).toBeInTheDocument()
   })
 
-  it('auto-fills the claim path when the test returned exactly one array claim', () => {
-    ssoTestRef.current = { registrationId: 'oidc_x', claims: { roles: ['admin'] } }
+  it('does not auto-write a Role mapping from a test capture', () => {
+    ssoTestRef.current = {
+      registrationId: 'oidc_x',
+      capturedAt: '2026-09-01T00:00:00.000Z',
+      identity: { id: 's', sources: { id: 'idToken' } },
+      claims: { roles: ['admin'] },
+    }
     renderPage(makeProvider({ autoCreateUsers: true, claimMapping: null }))
-    expect(screen.getByRole('combobox', { name: 'Claim path' })).toHaveTextContent('roles')
+    expect(screen.queryByText('Role')).not.toBeInTheDocument()
   })
 
   it('shows no inline suggestions for a test of a different provider', () => {
-    ssoTestRef.current = { registrationId: 'oidc_other', claims: { roles: ['admin'] } }
+    ssoTestRef.current = {
+      registrationId: 'oidc_other',
+      capturedAt: '2026-09-01T00:00:00.000Z',
+      identity: { id: 's', sources: { id: 'idToken' } },
+      claims: { roles: ['admin'] },
+    }
     renderPage(
       makeProvider({
         autoCreateUsers: true,
@@ -862,26 +862,38 @@ const PEOPLE_ATTRS = [
   },
 ]
 
-const matchingCapture = {
+const matchingCapture: SsoTestCapture = {
+  version: 2 as const,
   registrationId: 'oidc_x',
   capturedAt: '2026-09-01T00:00:00.000Z',
+  detailsChangedAtAtStart: null,
+  outcome: 'success' as const,
   identity: { id: 'sub', email: 'alice@example.com', sources: { email: 'idToken' as const } },
-  claims: { department: 'Engineering' },
+  claims: { sub: 's', email: 'alice@example.com', department: 'Engineering' },
+  replay: {
+    sources: [
+      {
+        source: 'idToken' as const,
+        claims: { sub: 's', email: 'alice@example.com', department: 'Engineering' },
+      },
+      { source: 'userinfo' as const, claims: { sub: 's' } as Record<string, string> },
+    ],
+  },
 }
 
 describe('<ProviderDetailPage> claim → person-attribute mapping', () => {
   it('adds a row, picks a claim path and attribute, and saves without touching role/profile', async () => {
     state.userAttributes = PEOPLE_ATTRS
     renderPage(makeProvider({ claimMapping: null }))
-    fireEvent.click(screen.getByRole('button', { name: /Copy claims into person attributes/ }))
-    fireEvent.click(screen.getByRole('button', { name: /Add mapping/ }))
-    fireEvent.click(screen.getByRole('combobox', { name: /Claim path \(mapping 1\)/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Add claim' }))
+    fireEvent.click(screen.getByRole('combobox', { name: 'Quackback attribute' }))
+    fireEvent.click(screen.getByRole('option', { name: /Department/ }))
+    fireEvent.click(screen.getByRole('combobox', { name: 'IdP claim path' }))
     fireEvent.change(screen.getByPlaceholderText('Search or type…'), {
       target: { value: 'department' },
     })
     fireEvent.click(screen.getByText(/Use ["“]department["”]/))
-    fireEvent.click(screen.getByRole('combobox', { name: /Person attribute \(mapping 1\)/ }))
-    fireEvent.click(screen.getByRole('option', { name: /Department/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Add to draft' }))
     saveMapping()
     await waitFor(() => expect(mappingSpy).toHaveBeenCalled())
     const sent = lastSavedMapping() as {
@@ -903,7 +915,8 @@ describe('<ProviderDetailPage> claim → person-attribute mapping', () => {
         },
       })
     )
-    fireEvent.click(screen.getByRole('button', { name: /Remove mapping 1/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Remove Department mapping' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Remove mapping' }))
     saveMapping()
     await waitFor(() => expect(mappingSpy).toHaveBeenCalled())
     expect(lastSavedMapping()).toBeNull()
@@ -940,9 +953,14 @@ describe('<ProviderDetailPage> claim → person-attribute mapping', () => {
 
   it('shows the People empty state and no Add button when there are no definitions', () => {
     state.userAttributes = []
-    renderPage(makeProvider({ claimMapping: null }))
-    fireEvent.click(screen.getByRole('button', { name: /Copy claims into person attributes/ }))
-    expect(screen.getByText(/No person attributes yet/)).toBeInTheDocument()
+    renderPage(
+      makeProvider({
+        claimMapping: {
+          role: { claimPath: 'groups', rules: [{ whenContains: 'eng', role: 'member' }] },
+        },
+      })
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Add claim' }))
     expect(screen.getByRole('link', { name: 'Open People settings' })).toHaveAttribute(
       'href',
       '/admin/settings/people'
@@ -959,12 +977,9 @@ describe('<ProviderDetailPage> claim → person-attribute mapping', () => {
         },
       })
     )
-    // The row, not the empty state: hiding it would leave the stale mapping
-    // unremovable and still forcing a userinfo fetch on every sign-in.
-    expect(screen.queryByText(/No person attributes yet/)).not.toBeInTheDocument()
     expect(screen.getByText('attribute no longer exists')).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /Add mapping/ })).not.toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: /Remove mapping 1/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Remove cost_center mapping' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Remove mapping' }))
     saveMapping()
     await waitFor(() => expect(mappingSpy).toHaveBeenCalled())
     expect(lastSavedMapping()).toBeNull()
@@ -998,29 +1013,26 @@ describe('<ProviderDetailPage> claim → person-attribute mapping', () => {
         },
       })
     )
-    expect(screen.getByText('Attribute writes from your last test sign-in')).toBeInTheDocument()
     expect(screen.getByText(/“Engineering”/)).toBeInTheDocument()
     expect(screen.getByText(/skipped: missing claim/)).toBeInTheDocument()
-
-    fireEvent.click(screen.getByRole('combobox', { name: /Claim path \(mapping 1\)/ }))
-    fireEvent.change(screen.getByPlaceholderText('Search or type…'), {
-      target: { value: 'nope' },
-    })
-    fireEvent.click(screen.getByText(/Use ["“]nope["”]/))
-    await waitFor(() => {
-      expect(screen.queryByText(/“Engineering”/)).not.toBeInTheDocument()
-    })
-    expect(screen.getAllByText(/skipped: missing claim/).length).toBeGreaterThan(0)
   })
 
   it('prefers an in-session test over a persisted capture for the same provider', () => {
     state.userAttributes = PEOPLE_ATTRS
     ssoTestRef.current = {
-      registrationId: 'oidc_x',
+      ...matchingCapture,
       capturedAt: '2026-09-02T00:00:00.000Z',
-      identity: { id: 'sub', email: 'alice@example.com', sources: { email: 'idToken' } },
-      claims: { department: 'From session' },
-    }
+      claims: { sub: 's', email: 'alice@example.com', department: 'From session' },
+      replay: {
+        sources: [
+          {
+            source: 'idToken',
+            claims: { sub: 's', email: 'alice@example.com', department: 'From session' },
+          },
+          { source: 'userinfo', claims: { sub: 's' } },
+        ],
+      },
+    } as SsoTestCapture
     renderPage(
       makeProvider({
         lastTestCapture: matchingCapture,
@@ -1030,32 +1042,6 @@ describe('<ProviderDetailPage> claim → person-attribute mapping', () => {
       })
     )
     expect(screen.getByText(/“From session”/)).toBeInTheDocument()
-    expect(screen.queryByText(/“Engineering”/)).not.toBeInTheDocument()
-  })
-
-  it('feeds a mapping-failure capture into the editor over an earlier success', () => {
-    state.userAttributes = PEOPLE_ATTRS
-    ssoTestRef.current = {
-      registrationId: 'oidc_x',
-      capturedAt: '2026-09-01T00:00:00.000Z',
-      identity: { id: 'sub', email: 'alice@example.com', sources: { email: 'idToken' } },
-      claims: { department: 'From success' },
-    }
-    ssoTestRef.lastCapture = {
-      registrationId: 'oidc_x',
-      capturedAt: '2026-09-03T00:00:00.000Z',
-      claims: { department: 'From failed mapping' },
-    }
-    renderPage(
-      makeProvider({
-        lastTestCapture: matchingCapture,
-        claimMapping: {
-          attributes: { map: [{ claimPath: 'department', attributeKey: 'department' }] },
-        },
-      })
-    )
-    expect(screen.getByText(/“From failed mapping”/)).toBeInTheDocument()
-    expect(screen.queryByText(/“From success”/)).not.toBeInTheDocument()
     expect(screen.queryByText(/“Engineering”/)).not.toBeInTheDocument()
   })
 
@@ -1069,12 +1055,7 @@ describe('<ProviderDetailPage> claim → person-attribute mapping', () => {
         },
       })
     )
-    expect(
-      screen.queryByText('Attribute writes from your last test sign-in')
-    ).not.toBeInTheDocument()
-    expect(
-      screen.getByText(/Run a test sign-in to preview what these mappings would write/)
-    ).toBeInTheDocument()
+    expect(screen.getByText(/Run a test sign-in to inspect this IdP's claims/)).toBeInTheDocument()
   })
 })
 

--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-shared.test.ts
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/provider-shared.test.ts
@@ -7,9 +7,13 @@
  */
 import { describe, it, expect } from 'vitest'
 import {
+  availableAddTargets,
+  buildClaimsTableModel,
+  hasCustomProfileClaims,
   identityMappingIssue,
   mergeClaimMapping,
   normalizeAttributeMapping,
+  normalizeProfileClaims,
   normalizeRoleMapping,
   withAllowMissingEmail,
 } from '../provider-shared'
@@ -159,5 +163,135 @@ describe('identityMappingIssue', () => {
     expect(
       identityMappingIssue({ role: { claimPath: 'groups', rules: [], syncOnEverySignIn: true } })
     ).toMatch(/no rules/i)
+  })
+
+  it('healthy default providers have no mapping warning pill', () => {
+    expect(identityMappingIssue(null)).toBeNull()
+    expect(identityMappingIssue({})).toBeNull()
+    expect(identityMappingIssue({ profile: { claims: { id: 'sub', email: 'email' } } })).toBeNull()
+    expect(identityMappingIssue({ profile: { sources: ['idToken', 'userinfo'] } })).toBeNull()
+    expect(identityMappingIssue({ profile: { allowMissingEmail: true } })).toBeNull()
+  })
+
+  it('flags an explicitly blank supported path', () => {
+    expect(identityMappingIssue({ profile: { claims: { email: '  ' } } })).toMatch(/email/i)
+    expect(identityMappingIssue({ profile: { claims: { id: ' ' } } })).toMatch(/identifier/i)
+  })
+
+  it('flags sources that contain no valid identity source', () => {
+    expect(
+      identityMappingIssue({
+        profile: { sources: ['nope' as unknown as 'idToken'] },
+      })
+    ).toMatch(/sources/i)
+  })
+})
+
+describe('normalizeProfileClaims', () => {
+  it('omits default email, name, and default sources', () => {
+    expect(
+      normalizeProfileClaims({
+        claims: { email: 'email', name: 'name' },
+        sources: ['idToken', 'userinfo'],
+      })
+    ).toBeUndefined()
+  })
+
+  it('keeps explicit id: sub because it disables userinfo id fallback', () => {
+    expect(normalizeProfileClaims({ claims: { id: 'sub' } })).toEqual({
+      claims: { id: 'sub' },
+    })
+  })
+
+  it('keeps a custom email path and missing-email policy', () => {
+    expect(
+      normalizeProfileClaims({
+        allowMissingEmail: true,
+        claims: { email: 'upn' },
+      })
+    ).toEqual({ allowMissingEmail: true, claims: { email: 'upn' } })
+  })
+})
+
+describe('hasCustomProfileClaims', () => {
+  it('is false for missing-email or default display values', () => {
+    expect(hasCustomProfileClaims(null)).toBe(false)
+    expect(hasCustomProfileClaims({ profile: { allowMissingEmail: true } })).toBe(false)
+    expect(hasCustomProfileClaims({ profile: { claims: { email: 'email' } } })).toBe(false)
+  })
+
+  it('is true for explicit identifier or a custom email/name path', () => {
+    expect(hasCustomProfileClaims({ profile: { claims: { id: 'sub' } } })).toBe(true)
+    expect(hasCustomProfileClaims({ profile: { claims: { email: 'upn' } } })).toBe(true)
+  })
+})
+
+describe('buildClaimsTableModel', () => {
+  const defs = [
+    { key: 'department', label: 'Department', type: 'string' },
+    { key: 'plan', label: 'Plan', type: 'string' },
+  ]
+
+  it('always shows required identifier/email and default name rows', () => {
+    const model = buildClaimsTableModel({ mapping: null, definitions: defs })
+    expect(model.required.map((r) => r.field)).toEqual(['id', 'email'])
+    expect(model.required.every((r) => r.isDefault)).toBe(true)
+    const name = model.additional.find((r) => r.kind === 'profile' && r.field === 'name')
+    expect(name).toMatchObject({ path: 'name', isDefault: true })
+  })
+
+  it('pins explicit sub as a custom identifier', () => {
+    const model = buildClaimsTableModel({
+      mapping: { profile: { claims: { id: 'sub' } } },
+      definitions: [],
+    })
+    expect(model.required[0]).toMatchObject({ field: 'id', path: 'sub', isDefault: false })
+  })
+
+  it('preserves orphaned and duplicate People rows by baseline index', () => {
+    const model = buildClaimsTableModel({
+      mapping: {
+        attributes: {
+          map: [
+            { claimPath: 'dept', attributeKey: 'department' },
+            { claimPath: 'org.department', attributeKey: 'department' },
+            { claimPath: 'cc', attributeKey: 'cost_center' },
+          ],
+        },
+      },
+      definitions: defs,
+    })
+    const people = model.additional.filter((r) => r.kind === 'people')
+    expect(people).toHaveLength(3)
+    expect(people[0]).toMatchObject({ baselineIndex: 0, duplicate: true, orphaned: false })
+    expect(people[1]).toMatchObject({ baselineIndex: 1, duplicate: true })
+    expect(people[2]).toMatchObject({
+      baselineIndex: 2,
+      attributeKey: 'cost_center',
+      orphaned: true,
+    })
+  })
+})
+
+describe('availableAddTargets', () => {
+  it('offers Role when absent and unused People keys only', () => {
+    const defs = [
+      { key: 'department', label: 'Department', type: 'string' },
+      { key: 'plan', label: 'Plan', type: 'string' },
+    ]
+    expect(availableAddTargets({ mapping: null, definitions: defs })).toEqual([
+      { kind: 'role' },
+      { kind: 'people', key: 'department', label: 'Department', attrType: 'string' },
+      { kind: 'people', key: 'plan', label: 'Plan', attrType: 'string' },
+    ])
+    expect(
+      availableAddTargets({
+        mapping: {
+          role: { claimPath: 'groups', rules: [{ whenContains: 'eng', role: 'member' }] },
+          attributes: { map: [{ claimPath: 'dept', attributeKey: 'department' }] },
+        },
+        definitions: defs,
+      })
+    ).toEqual([{ kind: 'people', key: 'plan', label: 'Plan', attrType: 'string' }])
   })
 })

--- a/apps/web/src/components/admin/settings/security/identity-providers/attribute-writes-preview.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/attribute-writes-preview.tsx
@@ -22,6 +22,9 @@ export function AttributeWritesPreview({
   overrideExisting,
   syncOnSignIn,
   canTest,
+  claims: claimsOverride,
+  plan: planOverride,
+  hideCaptureChrome,
 }: {
   capture: SsoTestCapture | null
   registrationId: string
@@ -30,6 +33,10 @@ export function AttributeWritesPreview({
   overrideExisting: boolean
   syncOnSignIn: boolean
   canTest: boolean
+  /** Accepted claims from replay. Diagnostic-only bags must not be passed. */
+  claims?: Record<string, unknown>
+  plan?: ReturnType<typeof planClaimAttributeWrites> | null
+  hideCaptureChrome?: boolean
 }) {
   const { data: attributes } = useUserAttributes()
   const defs = (attributes ?? []).map((d) => ({
@@ -53,38 +60,43 @@ export function AttributeWritesPreview({
     !!detailsChangedAt &&
     new Date(detailsChangedAt).getTime() > new Date(capture.capturedAt).getTime()
 
-  const claims = capture.claims as Record<string, unknown>
+  const claims = (claimsOverride ?? capture.claims) as Record<string, unknown>
   const plan =
-    attributeRows.length > 0
-      ? planClaimAttributeWrites({
-          claims,
-          mapping: {
-            map: attributeRows.filter((r) => r.claimPath && r.attributeKey),
-            ...(overrideExisting ? { overrideExisting: true } : {}),
-            ...(syncOnSignIn ? { syncOnSignIn: true } : {}),
-          },
-          existing: {},
-          definitions: defs,
-          explain: true,
-        })
-      : null
+    planOverride !== undefined
+      ? planOverride
+      : attributeRows.length > 0
+        ? planClaimAttributeWrites({
+            claims,
+            mapping: {
+              map: attributeRows.filter((r) => r.claimPath && r.attributeKey),
+              ...(overrideExisting ? { overrideExisting: true } : {}),
+              ...(syncOnSignIn ? { syncOnSignIn: true } : {}),
+            },
+            existing: {},
+            definitions: defs,
+            explain: true,
+          })
+        : null
 
   return (
     <div className="space-y-2 rounded-md border border-border/40 bg-muted/20 px-3 py-3 text-[12.5px]">
-      <div>
-        <div className="font-medium">Attribute writes from your last test sign-in</div>
-        <div className="mt-0.5 text-muted-foreground">
-          {captureIdentityCaption(capture)} · <TimeAgo date={capture.capturedAt} /> ·{' '}
-          <TestSignInButton
-            registrationId={registrationId}
-            variant="link"
-            size="sm"
-            disabled={!canTest}
-          >
-            Re-test
-          </TestSignInButton>
+      {!hideCaptureChrome && (
+        <div>
+          <div className="font-medium">Attribute writes from your last test sign-in</div>
+          <div className="mt-0.5 text-muted-foreground">
+            {captureIdentityCaption(capture)} · <TimeAgo date={capture.capturedAt} /> ·{' '}
+            <TestSignInButton
+              registrationId={registrationId}
+              variant="link"
+              size="sm"
+              disabled={!canTest}
+            >
+              Re-test
+            </TestSignInButton>
+          </div>
         </div>
-      </div>
+      )}
+      {hideCaptureChrome && <div className="font-medium">People attributes</div>}
 
       {plan && (Object.keys(plan.valid).length > 0 || (plan.skips?.length ?? 0) > 0) ? (
         <dl className="grid grid-cols-[6.6em_1fr] gap-x-2.5 gap-y-1 text-[12px]">

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-card.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-card.tsx
@@ -28,6 +28,7 @@ import {
 import { AdvancedSourcesEditor, ClaimsTable } from './claims-table'
 import { OutcomePreviewRail } from './outcome-preview-rail'
 import { useSsoTestSignIn } from '../sso/use-sso-test-sign-in'
+import { selectMappingCapture } from '@/lib/shared/sso-mapping-preview'
 import {
   CLAIMS_TABLE,
   availableAddTargets,
@@ -84,21 +85,21 @@ export function ClaimMappingCard({
   const pendingOps = useRef<typeof operations>([])
   const pendingTest = useRef(false)
   const { data: attributeDefs } = useUserAttributes()
-  const definitions = (attributeDefs ?? []).map((d) => ({
-    key: d.key,
-    label: d.label,
-    type: d.type,
-  }))
+  const definitions = useMemo(
+    () =>
+      (attributeDefs ?? []).map((d) => ({
+        key: d.key,
+        label: d.label,
+        type: d.type,
+      })),
+    [attributeDefs]
+  )
 
-  const capture =
-    lastCapture && lastCapture.registrationId === provider.registrationId
-      ? lastCapture
-      : lastSuccess && lastSuccess.registrationId === provider.registrationId
-        ? lastSuccess
-        : provider.lastTestCapture &&
-            provider.lastTestCapture.registrationId === provider.registrationId
-          ? provider.lastTestCapture
-          : null
+  const capture = selectMappingCapture({
+    registrationId: provider.registrationId,
+    sessionCapture: lastCapture ?? lastSuccess,
+    persistedCapture: provider.lastTestCapture,
+  })
 
   const draftMapping = useMemo(
     () =>
@@ -185,9 +186,15 @@ export function ClaimMappingCard({
     }
     setAttributes((prev) => {
       const map = [...(prev?.map ?? [])]
-      const existing = map.findIndex((row) => row.attributeKey === commit.attributeKey)
-      if (existing >= 0) map[existing] = { ...map[existing], claimPath: commit.claimPath }
-      else map.push({ claimPath: commit.claimPath, attributeKey: commit.attributeKey })
+      if (typeof commit.baselineIndex === 'number' && map[commit.baselineIndex]) {
+        map[commit.baselineIndex] = {
+          ...map[commit.baselineIndex],
+          claimPath: commit.claimPath,
+          attributeKey: commit.attributeKey,
+        }
+      } else {
+        map.push({ claimPath: commit.claimPath, attributeKey: commit.attributeKey })
+      }
       return { ...(prev ?? { map: [] }), map }
     })
   }
@@ -397,7 +404,11 @@ export function ClaimMappingCard({
                 if (row.kind === 'people') {
                   setDialog({
                     mode: 'edit',
-                    target: { type: 'people', attributeKey: row.attributeKey },
+                    target: {
+                      type: 'people',
+                      attributeKey: row.attributeKey,
+                      baselineIndex: row.baselineIndex,
+                    },
                     path: row.claimPath,
                   })
                 }

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-card.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-card.tsx
@@ -13,11 +13,7 @@ import { ConfirmDialog } from '@/components/shared/confirm-dialog'
 import { useUserAttributes } from '@/lib/client/hooks/use-user-attributes-queries'
 import type { IdentityProvider } from '@/lib/server/domains/settings/identity-providers.service'
 import type { IdentitySource } from '@/lib/shared/oidc-claim-mapping'
-import {
-  applyClaimMappingEdits,
-  diffClaimMappingOperations,
-  mappingSaveRisks,
-} from '@/lib/shared/sso-claim-mapping-edit'
+import { diffClaimMappingOperations, mappingSaveRisks } from '@/lib/shared/sso-claim-mapping-edit'
 import { ClaimMappingEditor } from './claim-mapping-editor'
 import { ClaimAttributeMappingEditor } from './claim-attribute-mapping-editor'
 import {
@@ -125,8 +121,7 @@ export function ClaimMappingCard({
     attributes: normalizeAttributeMapping(attributes),
   })
   const operations = diffClaimMappingOperations(provider.claimMapping, proposed)
-  const nextMapping = applyClaimMappingEdits(provider.claimMapping, operations)
-  const risks = mappingSaveRisks(provider.claimMapping, nextMapping)
+  const risks = mappingSaveRisks(provider.claimMapping, proposed)
   const dirty = operations.length > 0
 
   const rebaseFrom = (next: IdentityProvider) => {

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-card.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-card.tsx
@@ -1,40 +1,70 @@
 /**
  * #mapping — how Quackback reads this provider's claims.
  *
- * A card of its own, NOT a section nested under auto-create. Identity
- * resolution runs on every sign-in, including for people who already have
- * accounts, so packaging it under "create accounts for new people" would hide
- * a live control from exactly the workspaces most likely to need it.
- *
- * It diffs the three sections of the shared `claim_mapping` column (`profile`,
- * `role`, and `attributes`) into closed operations and persists through
- * `saveClaimMapping`. `mergeClaimMapping` only builds the proposed editor
- * state for that diff; unedited stored JSON is not rewritten.
+ * Dialogs edit a local draft; Save diffs closed operations against stored JSON.
+ * `CLAIMS_TABLE` selects presentation only. Both branches share this save path.
  */
-import { useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
+import { PlusIcon } from '@heroicons/react/24/solid'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { SettingsCard } from '@/components/admin/settings/settings-card'
 import { ConfirmDialog } from '@/components/shared/confirm-dialog'
+import { useUserAttributes } from '@/lib/client/hooks/use-user-attributes-queries'
 import type { IdentityProvider } from '@/lib/server/domains/settings/identity-providers.service'
+import type { IdentitySource } from '@/lib/shared/oidc-claim-mapping'
+import {
+  applyClaimMappingEdits,
+  diffClaimMappingOperations,
+  mappingSaveRisks,
+} from '@/lib/shared/sso-claim-mapping-edit'
 import { ClaimMappingEditor } from './claim-mapping-editor'
 import { ClaimAttributeMappingEditor } from './claim-attribute-mapping-editor'
-import { matchingSessionCapture } from './claim-path-input'
+import {
+  ClaimRowDialog,
+  type ClaimRowDialogCommit,
+  type ClaimRowDialogTarget,
+} from './claim-row-dialog'
+import { AdvancedSourcesEditor, ClaimsTable } from './claims-table'
+import { OutcomePreviewRail } from './outcome-preview-rail'
 import { useSsoTestSignIn } from '../sso/use-sso-test-sign-in'
 import {
+  CLAIMS_TABLE,
+  availableAddTargets,
+  buildClaimsTableModel,
+  draftSources,
+  hasCustomProfileClaims,
   mergeClaimMapping,
   normalizeAttributeMapping,
+  normalizeProfileClaims,
   normalizeRoleMapping,
   withAllowMissingEmail,
   type AttributeMapping,
+  type ClaimsTableRow,
   type RoleMapping,
 } from './provider-shared'
 import { useProviderSave } from './use-provider-save'
-import { diffClaimMappingOperations, mappingSaveRisks } from '@/lib/shared/sso-claim-mapping-edit'
 
-export function ClaimMappingCard({ provider }: { provider: IdentityProvider }) {
+export { CLAIMS_TABLE }
+
+export function ClaimMappingCard({
+  provider,
+  presentation,
+}: {
+  provider: IdentityProvider
+  presentation?: 'table' | 'legacy'
+}) {
+  const mode = presentation ?? (CLAIMS_TABLE ? 'table' : 'legacy')
   const { saving, saveClaimMapping } = useProviderSave(provider)
   const [confirmOpen, setConfirmOpen] = useState(false)
+  const [resetOpen, setResetOpen] = useState(false)
+  const [removeRow, setRemoveRow] = useState<ClaimsTableRow | null>(null)
+  const [dialog, setDialog] = useState<{
+    mode: 'add' | 'edit'
+    target?: ClaimRowDialogTarget
+    path?: string
+    role?: RoleMapping | null
+  } | null>(null)
   const [mapping, setMapping] = useState<RoleMapping | null>(provider.claimMapping?.role ?? null)
   const [attributes, setAttributes] = useState<AttributeMapping | null>(
     provider.claimMapping?.attributes ?? null
@@ -42,29 +72,77 @@ export function ClaimMappingCard({ provider }: { provider: IdentityProvider }) {
   const [allowMissingEmail, setAllowMissingEmail] = useState(
     provider.claimMapping?.profile?.allowMissingEmail === true
   )
-  const { lastSuccess, lastCapture } = useSsoTestSignIn()
-  // In-session lastCapture includes mapping failures from this sitting; the
-  // persisted capture is only reloaded with the provider row. Prefer the
-  // session copy so suggestions and preview update without a refresh.
+  const [profileClaims, setProfileClaims] = useState<{
+    id?: string
+    email?: string
+    name?: string
+  }>(() => ({ ...(provider.claimMapping?.profile?.claims ?? {}) }))
+  const [sources, setSources] = useState<IdentitySource[]>(() =>
+    draftSources(provider.claimMapping)
+  )
+  const { lastSuccess, lastCapture, open: openTest } = useSsoTestSignIn()
+  const pendingOps = useRef<typeof operations>([])
+  const pendingTest = useRef(false)
+  const { data: attributeDefs } = useUserAttributes()
+  const definitions = (attributeDefs ?? []).map((d) => ({
+    key: d.key,
+    label: d.label,
+    type: d.type,
+  }))
+
   const capture =
-    matchingSessionCapture(provider.registrationId, lastCapture, lastSuccess) ??
-    (provider.lastTestCapture && provider.lastTestCapture.registrationId === provider.registrationId
-      ? provider.lastTestCapture
-      : null)
+    lastCapture && lastCapture.registrationId === provider.registrationId
+      ? lastCapture
+      : lastSuccess && lastSuccess.registrationId === provider.registrationId
+        ? lastSuccess
+        : provider.lastTestCapture &&
+            provider.lastTestCapture.registrationId === provider.registrationId
+          ? provider.lastTestCapture
+          : null
+
+  const draftMapping = useMemo(
+    () =>
+      mergeClaimMapping(provider.claimMapping, {
+        role: mapping ?? undefined,
+        profile: normalizeProfileClaims({
+          ...withAllowMissingEmail({ claims: profileClaims, sources }, allowMissingEmail),
+          claims: profileClaims,
+          sources,
+        }),
+        attributes: attributes ?? undefined,
+      }),
+    [provider.claimMapping, mapping, profileClaims, sources, allowMissingEmail, attributes]
+  )
 
   const proposed = mergeClaimMapping(provider.claimMapping, {
     role: normalizeRoleMapping(mapping),
-    profile: withAllowMissingEmail(provider.claimMapping?.profile, allowMissingEmail),
+    profile: normalizeProfileClaims({
+      ...withAllowMissingEmail({ claims: profileClaims, sources }, allowMissingEmail),
+      claims: profileClaims,
+      sources,
+    }),
     attributes: normalizeAttributeMapping(attributes),
   })
   const operations = diffClaimMappingOperations(provider.claimMapping, proposed)
-  const risks = mappingSaveRisks(provider.claimMapping, proposed)
+  const nextMapping = applyClaimMappingEdits(provider.claimMapping, operations)
+  const risks = mappingSaveRisks(provider.claimMapping, nextMapping)
+  const dirty = operations.length > 0
 
-  const persist = (acks?: {
+  const rebaseFrom = (next: IdentityProvider) => {
+    setMapping(next.claimMapping?.role ?? null)
+    setAttributes(next.claimMapping?.attributes ?? null)
+    setAllowMissingEmail(next.claimMapping?.profile?.allowMissingEmail === true)
+    setProfileClaims({ ...(next.claimMapping?.profile?.claims ?? {}) })
+    setSources(draftSources(next.claimMapping))
+  }
+
+  const persist = async (acks?: {
     acknowledgeIdentifierChange?: boolean
     acknowledgeAdminRules?: boolean
-  }) =>
-    void saveClaimMapping(
+  }) => {
+    const thenTest = pendingTest.current
+    pendingTest.current = false
+    const saved = await saveClaimMapping(
       {
         operations,
         acknowledgeIdentifierChange: acks?.acknowledgeIdentifierChange,
@@ -72,98 +150,354 @@ export function ClaimMappingCard({ provider }: { provider: IdentityProvider }) {
       },
       'Claim mapping saved.'
     )
+    if (!saved) return false
+    if (saved !== provider) rebaseFrom(saved)
+    if (thenTest) openTest({ registrationId: provider.registrationId })
+    return true
+  }
 
-  const handleSave = () => {
+  const requestSave = (thenTest = false) => {
+    pendingTest.current = thenTest
     if (operations.length > 0 && (risks.identifierChanged || risks.hasAdminRules)) {
+      pendingOps.current = operations
       setConfirmOpen(true)
       return
     }
-    persist()
+    void persist()
+  }
+
+  const handleSave = () => requestSave(false)
+  const handleSaveAndTest = () => requestSave(true)
+
+  const commitDialog = (commit: ClaimRowDialogCommit) => {
+    if (commit.type === 'profile') {
+      setProfileClaims((prev) => {
+        const next = { ...prev }
+        if (commit.path == null) delete next[commit.field]
+        else next[commit.field] = commit.path
+        return next
+      })
+      return
+    }
+    if (commit.type === 'role') {
+      setMapping(commit.mapping)
+      return
+    }
+    setAttributes((prev) => {
+      const map = [...(prev?.map ?? [])]
+      const existing = map.findIndex((row) => row.attributeKey === commit.attributeKey)
+      if (existing >= 0) map[existing] = { ...map[existing], claimPath: commit.claimPath }
+      else map.push({ claimPath: commit.claimPath, attributeKey: commit.attributeKey })
+      return { ...(prev ?? { map: [] }), map }
+    })
+  }
+
+  const applyRemove = (row: ClaimsTableRow) => {
+    if (row.kind === 'role') {
+      setMapping(null)
+      return
+    }
+    if (row.kind === 'people') {
+      setAttributes((prev) => {
+        if (!prev) return prev
+        const map = (prev.map ?? []).filter((_, i) => i !== row.baselineIndex)
+        if (map.length === 0) return null
+        return { ...prev, map }
+      })
+    }
+  }
+
+  const resetProfile = () => {
+    setProfileClaims({})
+    setResetOpen(false)
+  }
+
+  const tableModel = buildClaimsTableModel({
+    mapping: {
+      profile: { claims: profileClaims, allowMissingEmail, sources },
+      role: mapping ?? undefined,
+      attributes: attributes ?? undefined,
+    },
+    definitions,
+  })
+  const addTargets = availableAddTargets({
+    mapping: draftMapping,
+    definitions,
+  })
+  const resetEnabled = hasCustomProfileClaims({ profile: { claims: profileClaims } })
+
+  const confirmBody = (
+    <ConfirmDialog
+      open={confirmOpen}
+      onOpenChange={(open) => {
+        setConfirmOpen(open)
+        if (!open) pendingTest.current = false
+      }}
+      title="Confirm mapping changes"
+      confirmLabel="Save mappings"
+      description={
+        <div className="space-y-2 text-sm">
+          {risks.identifierChanged ? (
+            <p>
+              Changing the identifier can stop existing account matches and create another account.
+              Existing accounts will not be migrated. This invalidates the connection test.
+            </p>
+          ) : null}
+          {risks.hasAdminRules ? (
+            <div className="space-y-1">
+              <p>
+                This can grant admin access even when the person&apos;s email is outside this
+                provider&apos;s verified domains.
+              </p>
+              <ul className="list-disc pl-4">
+                {risks.adminRules.map((rule) => (
+                  <li key={rule.index}>
+                    Rule {rule.index + 1} {'->'} admin
+                  </li>
+                ))}
+              </ul>
+              <p>The preview matching member does not limit this admin rule.</p>
+            </div>
+          ) : null}
+        </div>
+      }
+      onConfirm={() => {
+        if (JSON.stringify(operations) !== JSON.stringify(pendingOps.current)) {
+          setConfirmOpen(false)
+          requestSave(pendingTest.current)
+          return
+        }
+        setConfirmOpen(false)
+        void persist({
+          acknowledgeIdentifierChange: risks.identifierChanged,
+          acknowledgeAdminRules: risks.hasAdminRules,
+        })
+      }}
+    />
+  )
+
+  if (mode === 'legacy') {
+    return (
+      <div id="mapping" className="scroll-mt-6">
+        <SettingsCard
+          title="Claim mapping"
+          description="How Quackback reads this provider. Applies on every sign-in, including for people who already have accounts."
+          contentClassName="space-y-4"
+        >
+          <label className="flex items-start gap-2 text-sm">
+            <Checkbox
+              checked={allowMissingEmail}
+              onCheckedChange={(v) => setAllowMissingEmail(v === true)}
+              disabled={saving}
+              aria-label="Allow accounts without an email address"
+              className="mt-0.5"
+            />
+            <span>
+              Allow accounts without an email address
+              <span className="mt-0.5 block text-xs text-muted-foreground">
+                For providers that release no email. Quackback creates a placeholder so people can
+                still sign in, then asks them for a real address afterwards. Placeholders are
+                permanent: turning this off later does not convert accounts that already have one.
+                Off, these people cannot sign in at all.
+              </span>
+            </span>
+          </label>
+
+          <ClaimMappingEditor
+            mapping={mapping}
+            disabled={saving}
+            registrationId={provider.registrationId}
+            canTest
+            onChange={setMapping}
+          />
+
+          <ClaimAttributeMappingEditor
+            mapping={attributes}
+            disabled={saving}
+            registrationId={provider.registrationId}
+            canTest
+            capture={capture}
+            detailsChangedAt={provider.detailsChangedAt}
+            onChange={setAttributes}
+          />
+
+          <div className="flex justify-end border-t border-border/40 pt-5">
+            <Button type="button" size="sm" onClick={handleSave} disabled={saving}>
+              {saving ? 'Saving…' : 'Save claim mapping'}
+            </Button>
+          </div>
+        </SettingsCard>
+        {confirmBody}
+      </div>
+    )
   }
 
   return (
     <div id="mapping" className="scroll-mt-6">
       <SettingsCard
-        title="Claim mapping"
-        description="How Quackback reads this provider. Applies on every sign-in, including for people who already have accounts."
+        title="Attributes & Claims"
+        description="Configure how Quackback identifies accounts and reads this provider's claims. Email and name are set at account creation. Role and People updates depend on the settings below."
         contentClassName="space-y-4"
+        action={
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-8 text-xs"
+              disabled={!resetEnabled || saving}
+              onClick={() => setResetOpen(true)}
+            >
+              Reset profile claims
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              className="h-8 text-xs gap-1.5"
+              onClick={() => setDialog({ mode: 'add' })}
+              disabled={saving}
+            >
+              <PlusIcon className="h-3.5 w-3.5" />
+              Add claim
+            </Button>
+          </div>
+        }
       >
-        {/* Identity fields. Off by default and one-way: minting stores the
-        address permanently, so turning this back off later does not convert
-        accounts that already have one. */}
-        <label className="flex items-start gap-2 text-sm">
-          <Checkbox
-            checked={allowMissingEmail}
-            onCheckedChange={(v) => setAllowMissingEmail(v === true)}
-            disabled={saving}
-            aria-label="Allow accounts without an email address"
-            className="mt-0.5"
-          />
-          <span>
-            Allow accounts without an email address
-            <span className="mt-0.5 block text-xs text-muted-foreground">
-              For providers that release no email. Quackback creates a placeholder so people can
-              still sign in, then asks them for a real address afterwards. Placeholders are
-              permanent: turning this off later does not convert accounts that already have one.
-              Off, these people cannot sign in at all.
-            </span>
-          </span>
-        </label>
-
-        <ClaimMappingEditor
-          mapping={mapping}
-          disabled={saving}
-          registrationId={provider.registrationId}
-          canTest
-          onChange={setMapping}
-        />
-
-        <ClaimAttributeMappingEditor
-          mapping={attributes}
-          disabled={saving}
-          registrationId={provider.registrationId}
-          canTest
-          capture={capture}
-          detailsChangedAt={provider.detailsChangedAt}
-          onChange={setAttributes}
-        />
-
-        <div className="flex justify-end border-t border-border/40 pt-5">
-          <Button type="button" size="sm" onClick={handleSave} disabled={saving}>
-            {saving ? 'Saving…' : 'Save claim mapping'}
-          </Button>
+        <div className="flex flex-col gap-6 lg:flex-row">
+          <div className="min-w-0 flex-1 space-y-4">
+            <ClaimsTable
+              requiredRows={tableModel.required}
+              additionalRows={tableModel.additional}
+              allowMissingEmail={allowMissingEmail}
+              onAllowMissingEmailChange={setAllowMissingEmail}
+              peopleFlags={{
+                overrideExisting: attributes?.overrideExisting === true,
+                syncOnSignIn: attributes?.syncOnSignIn === true,
+              }}
+              onPeopleFlagsChange={(flags) =>
+                setAttributes((prev) => ({
+                  map: prev?.map ?? [],
+                  ...(flags.overrideExisting ? { overrideExisting: true } : {}),
+                  ...(flags.syncOnSignIn ? { syncOnSignIn: true } : {}),
+                }))
+              }
+              onEdit={(row) => {
+                if (row.kind === 'profile') {
+                  setDialog({
+                    mode: 'edit',
+                    target: { type: 'profile', field: row.field },
+                    path: row.isDefault && row.field !== 'id' ? undefined : row.path,
+                  })
+                  return
+                }
+                if (row.kind === 'role') {
+                  setDialog({ mode: 'edit', target: { type: 'role' }, role: mapping })
+                  return
+                }
+                if (row.kind === 'people') {
+                  setDialog({
+                    mode: 'edit',
+                    target: { type: 'people', attributeKey: row.attributeKey },
+                    path: row.claimPath,
+                  })
+                }
+              }}
+              onRemove={setRemoveRow}
+              onResetName={() =>
+                setProfileClaims((prev) => {
+                  const next = { ...prev }
+                  delete next.name
+                  return next
+                })
+              }
+              disabled={saving}
+              autoCreateUsers={provider.autoCreateUsers}
+              autoProvisionRole={provider.autoProvisionRole}
+            />
+            <AdvancedSourcesEditor sources={sources} onChange={setSources} disabled={saving} />
+            <div className="flex justify-end border-t border-border/40 pt-5">
+              <Button type="button" size="sm" onClick={handleSave} disabled={saving}>
+                {saving ? 'Saving…' : 'Save'}
+              </Button>
+            </div>
+          </div>
+          <div className="lg:w-[22rem] lg:shrink-0" data-preview-slot>
+            <OutcomePreviewRail
+              capture={capture}
+              draft={draftMapping}
+              definitions={definitions}
+              providerPolicy={{
+                autoCreateUsers: provider.autoCreateUsers,
+                autoProvisionRole: provider.autoProvisionRole,
+                detailsChangedAt: provider.detailsChangedAt,
+                registrationId: provider.registrationId,
+              }}
+              dirty={dirty}
+              onSaveAndTest={handleSaveAndTest}
+              registrationId={provider.registrationId}
+              canTest
+            />
+          </div>
         </div>
       </SettingsCard>
+
+      <ClaimRowDialog
+        open={dialog != null}
+        mode={dialog?.mode ?? 'add'}
+        lockedTarget={dialog?.mode === 'edit' ? dialog.target : undefined}
+        availableTargets={addTargets}
+        definitions={definitions}
+        initialPath={dialog?.path}
+        initialRole={dialog?.role}
+        registrationId={provider.registrationId}
+        canTest
+        capture={capture}
+        providerKind={provider.kind}
+        autoCreateUsers={provider.autoCreateUsers}
+        onOpenChange={(open) => {
+          if (!open) setDialog(null)
+        }}
+        onCommit={commitDialog}
+      />
+
       <ConfirmDialog
-        open={confirmOpen}
-        onOpenChange={setConfirmOpen}
-        title="Confirm mapping changes"
-        confirmLabel="Save mappings"
+        open={resetOpen}
+        onOpenChange={setResetOpen}
+        title="Reset profile claims"
+        confirmLabel="Reset profile claims"
         description={
           <div className="space-y-2 text-sm">
-            {risks.identifierChanged ? (
+            <p>
+              Restore identifier, email and display-name defaults. Keep source order, missing-email
+              policy, Role and People mappings.
+            </p>
+            {profileClaims.id ? (
               <p>
                 Changing the identifier can stop existing account matches and create another
                 account. Existing accounts will not be migrated. This invalidates the connection
                 test.
               </p>
             ) : null}
-            {risks.hasAdminRules ? (
-              <p>
-                This can grant admin access even when the person&apos;s email is outside this
-                provider&apos;s verified domains.
-              </p>
-            ) : null}
           </div>
         }
+        onConfirm={resetProfile}
+      />
+
+      <ConfirmDialog
+        open={removeRow != null}
+        onOpenChange={(open) => {
+          if (!open) setRemoveRow(null)
+        }}
+        title="Remove mapping"
+        confirmLabel="Remove mapping"
+        variant="destructive"
+        description="This removes the mapping from the draft. It is not saved until you save the card."
         onConfirm={() => {
-          setConfirmOpen(false)
-          persist({
-            acknowledgeIdentifierChange: risks.identifierChanged,
-            acknowledgeAdminRules: risks.hasAdminRules,
-          })
+          if (removeRow) applyRemove(removeRow)
+          setRemoveRow(null)
         }}
       />
+      {confirmBody}
     </div>
   )
 }

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-card.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-card.tsx
@@ -93,7 +93,12 @@ export function ClaimMappingCard({
 
   const capture = selectMappingCapture({
     registrationId: provider.registrationId,
-    sessionCapture: lastCapture ?? lastSuccess,
+    sessionCapture:
+      lastCapture?.registrationId === provider.registrationId
+        ? lastCapture
+        : lastSuccess?.registrationId === provider.registrationId
+          ? lastSuccess
+          : null,
     persistedCapture: provider.lastTestCapture,
   })
 
@@ -388,7 +393,7 @@ export function ClaimMappingCard({
                   setDialog({
                     mode: 'edit',
                     target: { type: 'profile', field: row.field },
-                    path: row.isDefault && row.field !== 'id' ? undefined : row.path,
+                    path: row.isDefault ? undefined : row.path,
                   })
                   return
                 }

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-editor.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-editor.tsx
@@ -51,8 +51,9 @@ export function RoleMappingRulesBody({
   autoCreateUsers?: boolean
   onChange: (mapping: RoleMapping) => void
 }) {
-  const { lastSuccess } = useSsoTestSignIn()
+  const { lastSuccess, lastCapture } = useSsoTestSignIn()
   const fixture =
+    (lastCapture && lastCapture.registrationId === registrationId ? lastCapture : null) ??
     (lastSuccess && lastSuccess.registrationId === registrationId ? lastSuccess : null) ??
     (capture && capture.registrationId === registrationId ? capture : null)
   const suggestions = fixture ? deriveClaimSuggestions(fixture.claims) : null
@@ -229,11 +230,11 @@ export function ClaimMappingEditor({
   const current: RoleMapping = mapping ?? { claimPath: 'groups', rules: [] }
   const update = (patch: Partial<RoleMapping>) => onChange({ ...current, ...patch })
 
-  const { lastSuccess } = useSsoTestSignIn()
-  const suggestions =
-    lastSuccess && lastSuccess.registrationId === registrationId
-      ? deriveClaimSuggestions(lastSuccess.claims)
-      : null
+  const { lastSuccess, lastCapture } = useSsoTestSignIn()
+  const session =
+    (lastCapture && lastCapture.registrationId === registrationId ? lastCapture : null) ??
+    (lastSuccess && lastSuccess.registrationId === registrationId ? lastSuccess : null)
+  const suggestions = session ? deriveClaimSuggestions(session.claims) : null
   const hasSuggestions = (suggestions?.paths.length ?? 0) > 0
   const pathSuggestions = (suggestions?.paths ?? []).map((p) => ({ value: p }))
   const valueSuggestions = (suggestions?.valuesByPath[current.claimPath] ?? []).map((v) => ({

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-editor.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-editor.tsx
@@ -53,9 +53,9 @@ export function RoleMappingRulesBody({
 }) {
   const { lastSuccess, lastCapture } = useSsoTestSignIn()
   const fixture =
+    (capture && capture.registrationId === registrationId ? capture : null) ??
     (lastCapture && lastCapture.registrationId === registrationId ? lastCapture : null) ??
-    (lastSuccess && lastSuccess.registrationId === registrationId ? lastSuccess : null) ??
-    (capture && capture.registrationId === registrationId ? capture : null)
+    (lastSuccess && lastSuccess.registrationId === registrationId ? lastSuccess : null)
   const suggestions = fixture ? deriveClaimSuggestions(captureSuggestionClaims(fixture)) : null
   const valueSuggestions = (suggestions?.valuesByPath[mapping.claimPath] ?? []).map((v) => ({
     value: v,

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-editor.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-editor.tsx
@@ -8,6 +8,7 @@
  */
 import { useEffect, useState } from 'react'
 import { AdjustmentsHorizontalIcon, PlusIcon, TrashIcon } from '@heroicons/react/24/solid'
+import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/outline'
 import type { Role } from '@/lib/shared/roles'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
@@ -21,11 +22,193 @@ import {
 } from '@/components/ui/select'
 import { Autocomplete } from '@/components/ui/autocomplete'
 import { deriveClaimSuggestions } from '@/lib/shared/claim-suggestions'
-import { captureSuggestionClaims } from '@/lib/shared/sso-test-capture'
+import type { SsoTestCapture } from '@/lib/shared/sso-test-capture'
 import { TestSignInButton } from '../sso/test-sign-in-button'
 import { useSsoTestSignIn } from '../sso/use-sso-test-sign-in'
-import { matchingSessionCapture } from './claim-path-input'
+import { ClaimPathInput } from './claim-path-input'
 import { ROLES, type RoleMapping } from './provider-shared'
+
+const ROLE_OPTION_LABEL: Record<Role, string> = {
+  admin: 'Admin',
+  member: 'Member',
+  user: 'User',
+}
+
+export function RoleMappingRulesBody({
+  mapping,
+  disabled,
+  registrationId,
+  canTest,
+  capture,
+  autoCreateUsers,
+  onChange,
+}: {
+  mapping: RoleMapping
+  disabled: boolean
+  registrationId: string
+  canTest: boolean
+  capture?: SsoTestCapture | null
+  autoCreateUsers?: boolean
+  onChange: (mapping: RoleMapping) => void
+}) {
+  const { lastSuccess } = useSsoTestSignIn()
+  const fixture =
+    (lastSuccess && lastSuccess.registrationId === registrationId ? lastSuccess : null) ??
+    (capture && capture.registrationId === registrationId ? capture : null)
+  const suggestions = fixture ? deriveClaimSuggestions(fixture.claims) : null
+  const valueSuggestions = (suggestions?.valuesByPath[mapping.claimPath] ?? []).map((v) => ({
+    value: v,
+  }))
+  const update = (patch: Partial<RoleMapping>) => onChange({ ...mapping, ...patch })
+  const moveRule = (index: number, dir: -1 | 1) => {
+    const target = index + dir
+    if (target < 0 || target >= mapping.rules.length) return
+    const next = [...mapping.rules]
+    const [item] = next.splice(index, 1)
+    next.splice(target, 0, item)
+    update({ rules: next })
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1.5">
+        <Label htmlFor="idp-claim-path">IdP claim path</Label>
+        <ClaimPathInput
+          value={mapping.claimPath}
+          onChange={(claimPath) => update({ claimPath })}
+          registrationId={registrationId}
+          canTest={canTest}
+          placeholder="groups, realm_access.roles, https://acme.com/roles"
+          ariaLabel="Role claim path"
+          disabled={disabled}
+          capture={capture}
+          suggestionsFor="role"
+        />
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        First matching rule wins. Matches are case-insensitive equality. For an array, a rule
+        matches one complete string value.
+      </p>
+
+      <div className="space-y-2">
+        <Label>Rules</Label>
+        {mapping.rules.length === 0 && (
+          <p className="text-xs text-muted-foreground">No rules. Everyone gets the default role.</p>
+        )}
+        {mapping.rules.map((rule, index) => (
+          <div key={index} className="flex items-center gap-2">
+            <Autocomplete
+              value={rule.whenContains}
+              onValueChange={(v) =>
+                update({
+                  rules: mapping.rules.map((r, i) => (i === index ? { ...r, whenContains: v } : r)),
+                })
+              }
+              suggestions={valueSuggestions}
+              ariaLabel={`Claim value to match (rule ${index + 1})`}
+              placeholder="value to match"
+              emptyHint="No values seen yet. Type the value to match."
+              disabled={disabled}
+              className="flex-1"
+            />
+            <Select
+              value={rule.role}
+              onValueChange={(r) =>
+                update({
+                  rules: mapping.rules.map((rr, i) =>
+                    i === index ? { ...rr, role: r as Role } : rr
+                  ),
+                })
+              }
+              disabled={disabled}
+            >
+              <SelectTrigger className="w-32" aria-label={`Quackback role (rule ${index + 1})`}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {ROLES.map((r) => (
+                  <SelectItem key={r} value={r}>
+                    {ROLE_OPTION_LABEL[r]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-9"
+              aria-label={`Move rule ${index + 1} up`}
+              onClick={() => moveRule(index, -1)}
+              disabled={disabled || index === 0}
+            >
+              <ChevronUpIcon className="size-3.5" />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-9"
+              aria-label={`Move rule ${index + 1} down`}
+              onClick={() => moveRule(index, 1)}
+              disabled={disabled || index === mapping.rules.length - 1}
+            >
+              <ChevronDownIcon className="size-3.5" />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-9"
+              aria-label={`Remove rule ${index + 1}`}
+              onClick={() => update({ rules: mapping.rules.filter((_, i) => i !== index) })}
+              disabled={disabled}
+            >
+              <TrashIcon className="size-3.5" />
+            </Button>
+          </div>
+        ))}
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-9"
+          onClick={() =>
+            update({ rules: [...mapping.rules, { whenContains: '', role: 'member' }] })
+          }
+          disabled={disabled}
+        >
+          <PlusIcon className="size-3.5" />
+          Add rule
+        </Button>
+      </div>
+
+      <label className="flex items-start gap-2 text-xs">
+        <Switch
+          checked={mapping.syncOnEverySignIn ?? false}
+          onCheckedChange={(v) => update({ syncOnEverySignIn: v })}
+          className="mt-0.5"
+          disabled={disabled}
+          aria-label="Reapply roles on every sign-in"
+        />
+        <span>
+          <span className="font-medium">Reapply roles on every sign-in.</span> Off: existing admins
+          and members keep their current role.
+          {autoCreateUsers === false
+            ? ' All role application is disabled when auto-create is off.'
+            : null}
+        </span>
+      </label>
+
+      <p className="text-xs text-muted-foreground">
+        A matching rule assigns this role even outside this provider&apos;s verified domains. Saving
+        admin rules requires confirmation. No match: the Accounts default applies only at verified
+        domains.
+      </p>
+    </div>
+  )
+}
 
 export function ClaimMappingEditor({
   mapping,
@@ -46,9 +229,11 @@ export function ClaimMappingEditor({
   const current: RoleMapping = mapping ?? { claimPath: 'groups', rules: [] }
   const update = (patch: Partial<RoleMapping>) => onChange({ ...current, ...patch })
 
-  const { lastSuccess, lastCapture } = useSsoTestSignIn()
-  const session = matchingSessionCapture(registrationId, lastCapture, lastSuccess)
-  const suggestions = session ? deriveClaimSuggestions(captureSuggestionClaims(session)) : null
+  const { lastSuccess } = useSsoTestSignIn()
+  const suggestions =
+    lastSuccess && lastSuccess.registrationId === registrationId
+      ? deriveClaimSuggestions(lastSuccess.claims)
+      : null
   const hasSuggestions = (suggestions?.paths.length ?? 0) > 0
   const pathSuggestions = (suggestions?.paths ?? []).map((p) => ({ value: p }))
   const valueSuggestions = (suggestions?.valuesByPath[current.claimPath] ?? []).map((v) => ({

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-editor.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-editor.tsx
@@ -22,7 +22,7 @@ import {
 } from '@/components/ui/select'
 import { Autocomplete } from '@/components/ui/autocomplete'
 import { deriveClaimSuggestions } from '@/lib/shared/claim-suggestions'
-import type { SsoTestCapture } from '@/lib/shared/sso-test-capture'
+import { captureSuggestionClaims, type SsoTestCapture } from '@/lib/shared/sso-test-capture'
 import { TestSignInButton } from '../sso/test-sign-in-button'
 import { useSsoTestSignIn } from '../sso/use-sso-test-sign-in'
 import { ClaimPathInput } from './claim-path-input'
@@ -56,7 +56,7 @@ export function RoleMappingRulesBody({
     (lastCapture && lastCapture.registrationId === registrationId ? lastCapture : null) ??
     (lastSuccess && lastSuccess.registrationId === registrationId ? lastSuccess : null) ??
     (capture && capture.registrationId === registrationId ? capture : null)
-  const suggestions = fixture ? deriveClaimSuggestions(fixture.claims) : null
+  const suggestions = fixture ? deriveClaimSuggestions(captureSuggestionClaims(fixture)) : null
   const valueSuggestions = (suggestions?.valuesByPath[mapping.claimPath] ?? []).map((v) => ({
     value: v,
   }))
@@ -234,7 +234,7 @@ export function ClaimMappingEditor({
   const session =
     (lastCapture && lastCapture.registrationId === registrationId ? lastCapture : null) ??
     (lastSuccess && lastSuccess.registrationId === registrationId ? lastSuccess : null)
-  const suggestions = session ? deriveClaimSuggestions(session.claims) : null
+  const suggestions = session ? deriveClaimSuggestions(captureSuggestionClaims(session)) : null
   const hasSuggestions = (suggestions?.paths.length ?? 0) > 0
   const pathSuggestions = (suggestions?.paths ?? []).map((p) => ({ value: p }))
   const valueSuggestions = (suggestions?.valuesByPath[current.claimPath] ?? []).map((v) => ({

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-path-input.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-path-input.tsx
@@ -5,7 +5,11 @@
  */
 
 import { Autocomplete } from '@/components/ui/autocomplete'
-import { deriveAttributeClaimPaths, deriveClaimSuggestions } from '@/lib/shared/claim-suggestions'
+import {
+  deriveAttributeClaimPaths,
+  deriveClaimSuggestions,
+  deriveIdentityClaimPaths,
+} from '@/lib/shared/claim-suggestions'
 import type { SsoTestCapture } from '@/lib/shared/sso-test-capture'
 import { TestSignInButton } from '../sso/test-sign-in-button'
 import { useSsoTestSignIn } from '../sso/use-sso-test-sign-in'
@@ -18,15 +22,6 @@ function fixtureFor(
   return null
 }
 
-/** Prefer a mapping-failure capture over an earlier success for the same provider. */
-export function matchingSessionCapture(
-  registrationId: string,
-  lastCapture: SsoTestCapture | null | undefined,
-  lastSuccess: SsoTestCapture | null | undefined
-): SsoTestCapture | null {
-  return fixtureFor(registrationId, lastCapture) ?? fixtureFor(registrationId, lastSuccess)
-}
-
 export function ClaimPathInput({
   value,
   onChange,
@@ -37,6 +32,8 @@ export function ClaimPathInput({
   disabled,
   capture,
   suggestionsFor = 'role',
+  providerKind,
+  identityField,
 }: {
   value: string
   onChange: (next: string) => void
@@ -45,24 +42,42 @@ export function ClaimPathInput({
   placeholder?: string
   ariaLabel: string
   disabled?: boolean
-  /** Session or persisted fixture. Falls back to the sitting's lastCapture. */
+  /** Session or persisted fixture. Shared with the preview rail. */
   capture?: SsoTestCapture | null
   /** Role suggestions are array-of-string paths; attribute suggestions are
-   *  scalar and array leaves, including profile claims. */
-  suggestionsFor?: 'role' | 'attribute'
+   *  scalar and array leaves, including profile claims. Identity includes
+   *  `sub` and may mark array candidates unsuitable. */
+  suggestionsFor?: 'role' | 'attribute' | 'identity'
+  providerKind?: string | null
+  identityField?: 'id' | 'email' | 'name'
 }) {
   const { lastSuccess, lastCapture } = useSsoTestSignIn()
   const fixture =
-    matchingSessionCapture(registrationId, lastCapture, lastSuccess) ??
-    fixtureFor(registrationId, capture)
-  const pathSuggestions = fixture
-    ? suggestionsFor === 'attribute'
-      ? deriveAttributeClaimPaths(fixture.claims).map((s) => ({
-          value: s.path,
-          description: s.description,
-        }))
-      : deriveClaimSuggestions(fixture.claims).paths.map((p) => ({ value: p }))
-    : []
+    fixtureFor(registrationId, capture) ??
+    fixtureFor(registrationId, lastCapture) ??
+    fixtureFor(registrationId, lastSuccess)
+  const pathSuggestions = (() => {
+    if (suggestionsFor === 'identity') {
+      const claims = fixture?.claims ?? {}
+      return deriveIdentityClaimPaths(claims, {
+        kind: providerKind,
+        field: identityField,
+      }).map((s) => ({
+        value: s.path,
+        description: s.unsuitable
+          ? [s.description, 'Not a scalar identity claim'].filter(Boolean).join(' · ')
+          : s.description,
+      }))
+    }
+    if (!fixture) return []
+    if (suggestionsFor === 'attribute') {
+      return deriveAttributeClaimPaths(fixture.claims).map((s) => ({
+        value: s.path,
+        description: s.description,
+      }))
+    }
+    return deriveClaimSuggestions(fixture.claims).paths.map((p) => ({ value: p }))
+  })()
 
   return (
     <Autocomplete
@@ -90,10 +105,8 @@ export function ClaimPathInput({
 }
 
 export function useClaimSuggestions(registrationId: string, capture?: SsoTestCapture | null) {
-  const { lastSuccess, lastCapture } = useSsoTestSignIn()
-  const fixture =
-    matchingSessionCapture(registrationId, lastCapture, lastSuccess) ??
-    fixtureFor(registrationId, capture)
+  const { lastSuccess } = useSsoTestSignIn()
+  const fixture = fixtureFor(registrationId, lastSuccess) ?? fixtureFor(registrationId, capture)
   if (!fixture) return null
   return deriveClaimSuggestions(fixture.claims)
 }

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-path-input.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-path-input.tsx
@@ -105,8 +105,11 @@ export function ClaimPathInput({
 }
 
 export function useClaimSuggestions(registrationId: string, capture?: SsoTestCapture | null) {
-  const { lastSuccess } = useSsoTestSignIn()
-  const fixture = fixtureFor(registrationId, lastSuccess) ?? fixtureFor(registrationId, capture)
+  const { lastSuccess, lastCapture } = useSsoTestSignIn()
+  const fixture =
+    fixtureFor(registrationId, lastCapture) ??
+    fixtureFor(registrationId, lastSuccess) ??
+    fixtureFor(registrationId, capture)
   if (!fixture) return null
   return deriveClaimSuggestions(fixture.claims)
 }

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-path-input.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-path-input.tsx
@@ -10,7 +10,7 @@ import {
   deriveClaimSuggestions,
   deriveIdentityClaimPaths,
 } from '@/lib/shared/claim-suggestions'
-import type { SsoTestCapture } from '@/lib/shared/sso-test-capture'
+import { captureSuggestionClaims, type SsoTestCapture } from '@/lib/shared/sso-test-capture'
 import { TestSignInButton } from '../sso/test-sign-in-button'
 import { useSsoTestSignIn } from '../sso/use-sso-test-sign-in'
 
@@ -58,7 +58,7 @@ export function ClaimPathInput({
     fixtureFor(registrationId, lastSuccess)
   const pathSuggestions = (() => {
     if (suggestionsFor === 'identity') {
-      const claims = fixture?.claims ?? {}
+      const claims = fixture ? captureSuggestionClaims(fixture) : {}
       return deriveIdentityClaimPaths(claims, {
         kind: providerKind,
         field: identityField,
@@ -70,13 +70,14 @@ export function ClaimPathInput({
       }))
     }
     if (!fixture) return []
+    const claims = captureSuggestionClaims(fixture)
     if (suggestionsFor === 'attribute') {
-      return deriveAttributeClaimPaths(fixture.claims).map((s) => ({
+      return deriveAttributeClaimPaths(claims).map((s) => ({
         value: s.path,
         description: s.description,
       }))
     }
-    return deriveClaimSuggestions(fixture.claims).paths.map((p) => ({ value: p }))
+    return deriveClaimSuggestions(claims).paths.map((p) => ({ value: p }))
   })()
 
   return (
@@ -111,5 +112,5 @@ export function useClaimSuggestions(registrationId: string, capture?: SsoTestCap
     fixtureFor(registrationId, lastSuccess) ??
     fixtureFor(registrationId, capture)
   if (!fixture) return null
-  return deriveClaimSuggestions(fixture.claims)
+  return deriveClaimSuggestions(captureSuggestionClaims(fixture))
 }

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-path-input.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-path-input.tsx
@@ -67,6 +67,7 @@ export function ClaimPathInput({
         description: s.unsuitable
           ? [s.description, 'Not a scalar identity claim'].filter(Boolean).join(' · ')
           : s.description,
+        disabled: s.unsuitable === true,
       }))
     }
     if (!fixture) return []

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-row-dialog.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-row-dialog.tsx
@@ -36,12 +36,12 @@ import {
 export type ClaimRowDialogTarget =
   | { type: 'profile'; field: 'id' | 'email' | 'name' }
   | { type: 'role' }
-  | { type: 'people'; attributeKey: string }
+  | { type: 'people'; attributeKey: string; baselineIndex?: number }
 
 export type ClaimRowDialogCommit =
   | { type: 'profile'; field: 'id' | 'email' | 'name'; path: string | null }
   | { type: 'role'; mapping: RoleMapping }
-  | { type: 'people'; attributeKey: string; claimPath: string }
+  | { type: 'people'; attributeKey: string; claimPath: string; baselineIndex?: number }
 
 const PROFILE_FALLBACK_NOTE: Record<'id' | 'email' | 'name', string> = {
   id: 'Default uses sub, then a userinfo id compatibility fallback. An explicit sub path disables that fallback. Preview cannot check account collisions.',
@@ -95,7 +95,8 @@ export function ClaimRowDialog({
     setTarget(lockedTarget ?? firstAvailable(availableTargets[0]))
     setPath(initialPath ?? '')
     setRole(initialRole ?? { claimPath: 'groups', rules: [] })
-  }, [open, lockedTarget, initialPath, initialRole, availableTargets])
+    // Reset only when the dialog opens. Parent re-renders rebuild availableTargets.
+  }, [open])
 
   const resolvedTarget: ClaimRowDialogTarget | null =
     lockedTarget ??
@@ -136,6 +137,7 @@ export function ClaimRowDialog({
         type: 'people',
         attributeKey: resolvedTarget.attributeKey,
         claimPath: path.trim(),
+        baselineIndex: resolvedTarget.baselineIndex,
       })
     }
     onOpenChange(false)

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-row-dialog.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-row-dialog.tsx
@@ -136,11 +136,19 @@ export function ClaimRowDialog({
     if (resolvedTarget.type === 'profile') {
       const trimmed = path.trim()
       const defaultPath = OIDC_PROFILE_DEFAULTS[resolvedTarget.field]
-      const startedBlank = !(initialPath ?? '').trim()
+      // Identifier: empty Apply keeps the implicit default (userinfo `id` fallback).
+      // Explicitly choosing `sub` must persist `id: 'sub'`. Email/name defaults
+      // stay display-only and are not written.
+      const pathToCommit =
+        resolvedTarget.field === 'id'
+          ? trimmed || null
+          : !trimmed || trimmed === defaultPath
+            ? null
+            : trimmed
       onCommit({
         type: 'profile',
         field: resolvedTarget.field,
-        path: !trimmed || (startedBlank && trimmed === defaultPath) ? null : trimmed,
+        path: pathToCommit,
       })
     } else if (resolvedTarget.type === 'role') {
       onCommit({ type: 'role', mapping: role })

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-row-dialog.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-row-dialog.tsx
@@ -1,0 +1,287 @@
+/**
+ * Add/Edit mapping dialog. Edits a local draft; Cancel discards. The card
+ * Save is the only writer.
+ */
+import { useEffect, useState } from 'react'
+import { Link } from '@tanstack/react-router'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import type { SsoTestCapture } from '@/lib/shared/sso-test-capture'
+import { ClaimPathInput } from './claim-path-input'
+import { RoleMappingRulesBody } from './claim-mapping-editor'
+import {
+  OIDC_PROFILE_DEFAULTS,
+  PEOPLE_TYPE_LABEL,
+  PROFILE_ROW_HELPERS,
+  PROFILE_ROW_LABELS,
+  type AddClaimTarget,
+  type PeopleDefinition,
+  type RoleMapping,
+} from './provider-shared'
+
+export type ClaimRowDialogTarget =
+  | { type: 'profile'; field: 'id' | 'email' | 'name' }
+  | { type: 'role' }
+  | { type: 'people'; attributeKey: string }
+
+export type ClaimRowDialogCommit =
+  | { type: 'profile'; field: 'id' | 'email' | 'name'; path: string | null }
+  | { type: 'role'; mapping: RoleMapping }
+  | { type: 'people'; attributeKey: string; claimPath: string }
+
+const PROFILE_FALLBACK_NOTE: Record<'id' | 'email' | 'name', string> = {
+  id: 'Default uses sub, then a userinfo id compatibility fallback. An explicit sub path disables that fallback. Preview cannot check account collisions.',
+  email: 'Preview cannot check account collisions.',
+  name: '',
+}
+
+export function ClaimRowDialog({
+  open,
+  mode,
+  lockedTarget,
+  availableTargets,
+  definitions,
+  initialPath,
+  initialRole,
+  registrationId,
+  canTest,
+  capture,
+  providerKind,
+  autoCreateUsers,
+  onOpenChange,
+  onCommit,
+}: {
+  open: boolean
+  mode: 'add' | 'edit'
+  lockedTarget?: ClaimRowDialogTarget
+  availableTargets: AddClaimTarget[]
+  definitions: PeopleDefinition[]
+  initialPath?: string
+  initialRole?: RoleMapping | null
+  registrationId: string
+  canTest: boolean
+  capture?: SsoTestCapture | null
+  providerKind?: string | null
+  autoCreateUsers?: boolean
+  onOpenChange: (open: boolean) => void
+  onCommit: (commit: ClaimRowDialogCommit) => void
+}) {
+  const [target, setTarget] = useState<ClaimRowDialogTarget | null>(lockedTarget ?? null)
+  const [path, setPath] = useState(initialPath ?? '')
+  const [role, setRole] = useState<RoleMapping>(initialRole ?? { claimPath: 'groups', rules: [] })
+
+  const firstAvailable = (item: AddClaimTarget | undefined): ClaimRowDialogTarget | null => {
+    if (!item) return null
+    if (item.kind === 'role') return { type: 'role' }
+    return { type: 'people', attributeKey: item.key }
+  }
+
+  useEffect(() => {
+    if (!open) return
+    setTarget(lockedTarget ?? firstAvailable(availableTargets[0]))
+    setPath(initialPath ?? '')
+    setRole(initialRole ?? { claimPath: 'groups', rules: [] })
+  }, [open, lockedTarget, initialPath, initialRole, availableTargets])
+
+  const resolvedTarget: ClaimRowDialogTarget | null =
+    lockedTarget ??
+    (target?.type === 'people'
+      ? target
+      : target?.type === 'role'
+        ? target
+        : target?.type === 'profile'
+          ? target
+          : firstAvailable(availableTargets[0]))
+
+  const title =
+    mode === 'add'
+      ? 'Add claim'
+      : resolvedTarget?.type === 'profile'
+        ? `Edit ${PROFILE_ROW_LABELS[resolvedTarget.field]} mapping`
+        : resolvedTarget?.type === 'role'
+          ? 'Edit Role mapping'
+          : 'Edit mapping'
+
+  const canSubmit = (() => {
+    if (!resolvedTarget) return false
+    if (resolvedTarget.type === 'profile') return path.trim().length > 0
+    if (resolvedTarget.type === 'people') {
+      return path.trim().length > 0 && resolvedTarget.attributeKey.trim().length > 0
+    }
+    return role.claimPath.trim().length > 0
+  })()
+
+  const apply = () => {
+    if (!resolvedTarget) return
+    if (resolvedTarget.type === 'profile') {
+      onCommit({ type: 'profile', field: resolvedTarget.field, path: path.trim() })
+    } else if (resolvedTarget.type === 'role') {
+      onCommit({ type: 'role', mapping: role })
+    } else {
+      onCommit({
+        type: 'people',
+        attributeKey: resolvedTarget.attributeKey,
+        claimPath: path.trim(),
+      })
+    }
+    onOpenChange(false)
+  }
+
+  const resetProfile = () => {
+    if (resolvedTarget?.type !== 'profile') return
+    onCommit({ type: 'profile', field: resolvedTarget.field, path: null })
+    onOpenChange(false)
+  }
+
+  const peopleDef =
+    resolvedTarget?.type === 'people'
+      ? definitions.find((d) => d.key === resolvedTarget.attributeKey)
+      : undefined
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label>Quackback attribute</Label>
+            {lockedTarget?.type === 'profile' ? (
+              <p className="text-sm">{PROFILE_ROW_LABELS[lockedTarget.field]} (fixed target)</p>
+            ) : lockedTarget?.type === 'role' ? (
+              <p className="text-sm">Role (fixed target)</p>
+            ) : lockedTarget?.type === 'people' ? (
+              <p className="text-sm">
+                {peopleDef?.label ?? lockedTarget.attributeKey}
+                {peopleDef ? `, ${PEOPLE_TYPE_LABEL[peopleDef.type] ?? peopleDef.type}` : ''}
+              </p>
+            ) : availableTargets.length === 0 ? (
+              <div className="space-y-2 text-sm">
+                <p className="text-muted-foreground">
+                  No remaining targets. Define an attribute under People to map another claim.
+                </p>
+                <Link
+                  to="/admin/settings/people"
+                  className="font-medium text-primary underline-offset-4 hover:underline"
+                >
+                  Open People settings
+                </Link>
+              </div>
+            ) : (
+              <Select
+                value={
+                  resolvedTarget?.type === 'role'
+                    ? 'role'
+                    : resolvedTarget?.type === 'people'
+                      ? `people:${resolvedTarget.attributeKey}`
+                      : ''
+                }
+                onValueChange={(value) => {
+                  if (value === 'role') {
+                    setTarget({ type: 'role' })
+                    return
+                  }
+                  const key = value.replace(/^people:/, '')
+                  setTarget({ type: 'people', attributeKey: key })
+                }}
+              >
+                <SelectTrigger aria-label="Quackback attribute">
+                  <SelectValue placeholder="Choose an attribute" />
+                </SelectTrigger>
+                <SelectContent>
+                  {availableTargets.map((item) =>
+                    item.kind === 'role' ? (
+                      <SelectItem key="role" value="role">
+                        Role
+                      </SelectItem>
+                    ) : (
+                      <SelectItem key={item.key} value={`people:${item.key}`}>
+                        <span className="flex flex-col text-left">
+                          <span>{item.label}</span>
+                          <span className="text-xs font-normal text-muted-foreground">
+                            {item.key}, {PEOPLE_TYPE_LABEL[item.attrType] ?? item.attrType}
+                          </span>
+                        </span>
+                      </SelectItem>
+                    )
+                  )}
+                </SelectContent>
+              </Select>
+            )}
+          </div>
+
+          {resolvedTarget?.type === 'role' ? (
+            <RoleMappingRulesBody
+              mapping={role}
+              disabled={false}
+              registrationId={registrationId}
+              canTest={canTest}
+              capture={capture}
+              autoCreateUsers={autoCreateUsers}
+              onChange={setRole}
+            />
+          ) : resolvedTarget ? (
+            <div className="space-y-1.5">
+              <Label>IdP claim path</Label>
+              <ClaimPathInput
+                value={path}
+                onChange={setPath}
+                registrationId={registrationId}
+                canTest={canTest}
+                placeholder="email, upn, org.department"
+                ariaLabel="IdP claim path"
+                capture={capture}
+                suggestionsFor={resolvedTarget.type === 'profile' ? 'identity' : 'attribute'}
+                providerKind={providerKind}
+                identityField={resolvedTarget.type === 'profile' ? resolvedTarget.field : undefined}
+              />
+              {resolvedTarget.type === 'profile' && (
+                <p className="text-xs text-muted-foreground">
+                  {PROFILE_ROW_HELPERS[resolvedTarget.field]}
+                  {PROFILE_FALLBACK_NOTE[resolvedTarget.field]
+                    ? ` ${PROFILE_FALLBACK_NOTE[resolvedTarget.field]}`
+                    : ''}
+                </p>
+              )}
+              {resolvedTarget.type === 'people' && (
+                <p className="text-xs text-muted-foreground">
+                  The People update switches apply to all People mappings.
+                </p>
+              )}
+            </div>
+          ) : null}
+        </div>
+
+        <DialogFooter>
+          {mode === 'edit' && resolvedTarget?.type === 'profile' && (
+            <Button type="button" variant="outline" className="mr-auto" onClick={resetProfile}>
+              Reset to {OIDC_PROFILE_DEFAULTS[resolvedTarget.field]}
+            </Button>
+          )}
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={apply} disabled={!canSubmit}>
+            {mode === 'add' ? 'Add to draft' : 'Apply to draft'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-row-dialog.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-row-dialog.tsx
@@ -119,7 +119,9 @@ export function ClaimRowDialog({
 
   const canSubmit = (() => {
     if (!resolvedTarget) return false
-    if (resolvedTarget.type === 'profile') return path.trim().length > 0
+    if (resolvedTarget.type === 'profile') {
+      return mode === 'edit' || path.trim().length > 0
+    }
     if (resolvedTarget.type === 'people') {
       return path.trim().length > 0 && resolvedTarget.attributeKey.trim().length > 0
     }
@@ -132,7 +134,14 @@ export function ClaimRowDialog({
   const apply = () => {
     if (!resolvedTarget || !canSubmit) return
     if (resolvedTarget.type === 'profile') {
-      onCommit({ type: 'profile', field: resolvedTarget.field, path: path.trim() })
+      const trimmed = path.trim()
+      const defaultPath = OIDC_PROFILE_DEFAULTS[resolvedTarget.field]
+      const startedBlank = !(initialPath ?? '').trim()
+      onCommit({
+        type: 'profile',
+        field: resolvedTarget.field,
+        path: !trimmed || (startedBlank && trimmed === defaultPath) ? null : trimmed,
+      })
     } else if (resolvedTarget.type === 'role') {
       onCommit({ type: 'role', mapping: role })
     } else {

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-row-dialog.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-row-dialog.tsx
@@ -123,11 +123,14 @@ export function ClaimRowDialog({
     if (resolvedTarget.type === 'people') {
       return path.trim().length > 0 && resolvedTarget.attributeKey.trim().length > 0
     }
-    return role.claimPath.trim().length > 0
+    return (
+      role.claimPath.trim().length > 0 &&
+      role.rules.every((rule) => rule.whenContains.trim().length > 0)
+    )
   })()
 
   const apply = () => {
-    if (!resolvedTarget) return
+    if (!resolvedTarget || !canSubmit) return
     if (resolvedTarget.type === 'profile') {
       onCommit({ type: 'profile', field: resolvedTarget.field, path: path.trim() })
     } else if (resolvedTarget.type === 'role') {

--- a/apps/web/src/components/admin/settings/security/identity-providers/claims-table.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claims-table.tsx
@@ -1,0 +1,598 @@
+/**
+ * Required / additional mapping table. Presentation only: the card owns the
+ * draft and persists through the operations API.
+ */
+import { PencilIcon, TrashIcon } from '@heroicons/react/24/solid'
+import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/outline'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Checkbox } from '@/components/ui/checkbox'
+import { DEFAULT_IDENTITY_SOURCES, type IdentitySource } from '@/lib/shared/oidc-claim-mapping'
+import type { Role } from '@/lib/shared/roles'
+import {
+  SOURCE_LABELS,
+  type ClaimsPeopleRow,
+  type ClaimsProfileRow,
+  type ClaimsRoleRow,
+  type ClaimsTableRow,
+  type ClaimsUnsupportedRow,
+} from './provider-shared'
+
+const ROLE_LABEL: Record<Role, string> = {
+  admin: 'admin',
+  member: 'member',
+  user: 'user',
+}
+
+export function ClaimsTable({
+  requiredRows,
+  additionalRows,
+  allowMissingEmail,
+  onAllowMissingEmailChange,
+  peopleFlags,
+  onPeopleFlagsChange,
+  onEdit,
+  onRemove,
+  onResetName,
+  disabled,
+  autoCreateUsers,
+  autoProvisionRole,
+}: {
+  requiredRows: ClaimsProfileRow[]
+  additionalRows: ClaimsTableRow[]
+  allowMissingEmail: boolean
+  onAllowMissingEmailChange: (next: boolean) => void
+  peopleFlags: { overrideExisting: boolean; syncOnSignIn: boolean }
+  onPeopleFlagsChange: (next: { overrideExisting: boolean; syncOnSignIn: boolean }) => void
+  onEdit: (row: ClaimsTableRow) => void
+  onRemove: (row: ClaimsTableRow) => void
+  onResetName: () => void
+  disabled?: boolean
+  autoCreateUsers: boolean
+  autoProvisionRole: Role | null
+}) {
+  const hasPeople = additionalRows.some((row) => row.kind === 'people')
+  const hasRole = additionalRows.some((row) => row.kind === 'role')
+  const extraHint = !hasRole && !hasPeople
+
+  return (
+    <div className="space-y-6">
+      <section>
+        <h3 className="text-sm font-medium">Required identity</h3>
+        <MappingTable>
+          {requiredRows.map((row) => (
+            <ProfileRow
+              key={row.field}
+              row={row}
+              disabled={disabled}
+              onEdit={() => onEdit(row)}
+              emailConditional={row.field === 'email' && allowMissingEmail}
+            />
+          ))}
+        </MappingTable>
+        <label className="mt-4 flex items-start gap-2 text-sm">
+          <Checkbox
+            checked={allowMissingEmail}
+            onCheckedChange={(v) => onAllowMissingEmailChange(v === true)}
+            disabled={disabled}
+            aria-label="Allow accounts without an email address"
+            className="mt-0.5"
+          />
+          <span>
+            Allow accounts without an email address
+            <span className="mt-0.5 block text-xs text-muted-foreground">
+              For providers that release no email. Quackback creates a placeholder so people can
+              still sign in, then asks them for a real address afterwards. Placeholders are
+              permanent: turning this off later does not convert accounts that already have one.
+              Off, these people cannot sign in at all.
+            </span>
+          </span>
+        </label>
+      </section>
+
+      <section>
+        <h3 className="text-sm font-medium">Additional attributes</h3>
+        <MappingTable>
+          {additionalRows.map((row) => {
+            if (row.kind === 'profile') {
+              return (
+                <ProfileRow
+                  key={row.field}
+                  row={row}
+                  disabled={disabled}
+                  onEdit={() => onEdit(row)}
+                  onResetName={!row.isDefault ? onResetName : undefined}
+                />
+              )
+            }
+            if (row.kind === 'role') {
+              return (
+                <RoleRowView
+                  key="role"
+                  row={row}
+                  disabled={disabled}
+                  autoCreateUsers={autoCreateUsers}
+                  autoProvisionRole={autoProvisionRole}
+                  onEdit={() => onEdit(row)}
+                  onRemove={() => onRemove(row)}
+                />
+              )
+            }
+            if (row.kind === 'people') {
+              return (
+                <PeopleRowView
+                  key={`people-${row.baselineIndex}`}
+                  row={row}
+                  disabled={disabled}
+                  onEdit={() => onEdit(row)}
+                  onRemove={() => onRemove(row)}
+                />
+              )
+            }
+            return (
+              <UnsupportedRowView
+                key={row.id}
+                row={row}
+                disabled={disabled}
+                onRemove={() => onRemove(row)}
+              />
+            )
+          })}
+        </MappingTable>
+        {extraHint && (
+          <p className="mt-3 text-xs text-muted-foreground">
+            Add a Role mapping or map a claim to an attribute defined under People.
+          </p>
+        )}
+      </section>
+
+      {hasPeople && (
+        <section className="space-y-3">
+          <div>
+            <h3 className="text-sm font-medium">People attribute updates</h3>
+            <p className="text-xs text-muted-foreground">Applies to all mapped People attributes</p>
+          </div>
+          <label className="flex items-start gap-2 text-sm">
+            <Checkbox
+              checked={peopleFlags.overrideExisting}
+              onCheckedChange={(v) =>
+                onPeopleFlagsChange({ ...peopleFlags, overrideExisting: v === true })
+              }
+              disabled={disabled}
+              aria-label="Overwrite values that are already set"
+              className="mt-0.5"
+            />
+            <span>
+              Overwrite values that are already set
+              <span className="mt-0.5 block text-xs text-muted-foreground">
+                Off: a claim only fills an attribute that is empty. On: the IdP value wins on every
+                sign-in.
+              </span>
+            </span>
+          </label>
+          <label className="flex items-start gap-2 text-sm">
+            <Checkbox
+              checked={peopleFlags.syncOnSignIn}
+              onCheckedChange={(v) =>
+                onPeopleFlagsChange({ ...peopleFlags, syncOnSignIn: v === true })
+              }
+              disabled={disabled}
+              aria-label="Clear an attribute when its claim is missing"
+              className="mt-0.5"
+            />
+            <span>
+              Clear an attribute when its claim is missing
+              <span className="mt-0.5 block text-xs text-muted-foreground">
+                Clearing on a fresh missing claim is independent of overwrite: a missing value can
+                be removed even with overwrite off.
+              </span>
+            </span>
+          </label>
+        </section>
+      )}
+    </div>
+  )
+}
+
+function MappingTable({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mt-2 overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-border/50 text-left text-xs text-muted-foreground">
+            <th scope="col" className="py-2 pr-3 font-medium">
+              Quackback attribute
+            </th>
+            <th scope="col" className="py-2 pr-3 font-medium">
+              IdP claim
+            </th>
+            <th scope="col" className="py-2 font-medium">
+              <span className="sr-only">Actions</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody>{children}</tbody>
+      </table>
+    </div>
+  )
+}
+
+function StatusBadge({ isDefault }: { isDefault: boolean }) {
+  return (
+    <Badge variant="outline" className="font-normal">
+      {isDefault ? 'Default' : 'Custom'}
+    </Badge>
+  )
+}
+
+function RowActions({ children }: { children: React.ReactNode }) {
+  return <div className="flex items-center justify-end gap-1 shrink-0">{children}</div>
+}
+
+function IconButton({
+  label,
+  onClick,
+  disabled,
+  destructive,
+  children,
+}: {
+  label: string
+  onClick: () => void
+  disabled?: boolean
+  destructive?: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      className={
+        destructive
+          ? 'h-7 px-2 text-muted-foreground hover:text-destructive'
+          : 'h-7 px-2 text-muted-foreground hover:text-foreground'
+      }
+      onClick={onClick}
+      disabled={disabled}
+      title={label}
+      aria-label={label}
+    >
+      {children}
+    </Button>
+  )
+}
+
+function ProfileRow({
+  row,
+  disabled,
+  onEdit,
+  onResetName,
+  emailConditional,
+}: {
+  row: ClaimsProfileRow
+  disabled?: boolean
+  onEdit: () => void
+  onResetName?: () => void
+  emailConditional?: boolean
+}) {
+  return (
+    <tr className="border-b border-border/50 last:border-0 align-top">
+      <td className="py-3 pr-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-medium">{row.label}</span>
+          <StatusBadge isDefault={row.isDefault} />
+          {emailConditional && (
+            <Badge variant="outline" className="font-normal">
+              Required unless placeholder is allowed
+            </Badge>
+          )}
+        </div>
+        <p className="mt-0.5 text-xs text-muted-foreground">{row.helper}</p>
+      </td>
+      <td className="py-3 pr-3">
+        <code className="text-[11px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded font-mono">
+          {row.path}
+        </code>
+      </td>
+      <td className="py-3">
+        <RowActions>
+          <IconButton label={`Edit ${row.label} mapping`} onClick={onEdit} disabled={disabled}>
+            <PencilIcon className="h-3.5 w-3.5" />
+          </IconButton>
+          {onResetName && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-7 px-2 text-xs text-muted-foreground"
+              onClick={onResetName}
+              disabled={disabled}
+            >
+              Reset mapping
+            </Button>
+          )}
+        </RowActions>
+      </td>
+    </tr>
+  )
+}
+
+function RoleRowView({
+  row,
+  disabled,
+  autoCreateUsers,
+  autoProvisionRole,
+  onEdit,
+  onRemove,
+}: {
+  row: ClaimsRoleRow
+  disabled?: boolean
+  autoCreateUsers: boolean
+  autoProvisionRole: Role | null
+  onEdit: () => void
+  onRemove: () => void
+}) {
+  const fallback = autoProvisionRole ?? 'member'
+  const fallbackLabel =
+    autoProvisionRole == null ? 'Member (runtime default)' : ROLE_LABEL[fallback]
+  return (
+    <tr className="border-b border-border/50 last:border-0 align-top">
+      <td className="py-3 pr-3">
+        <div className="font-medium">Role</div>
+        <ol className="mt-1 list-decimal space-y-0.5 pl-4 text-xs text-muted-foreground">
+          {row.rules.map((rule, index) => (
+            <li key={index}>
+              {rule.whenContains} {'->'} {ROLE_LABEL[rule.role]}
+            </li>
+          ))}
+        </ol>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Otherwise: {fallbackLabel}, at verified domains
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          A matching rule assigns this role even outside this provider&apos;s verified domains.
+        </p>
+        {!autoCreateUsers && (
+          <p className="mt-1 text-xs text-muted-foreground">
+            All role application is disabled when auto-create is off.
+          </p>
+        )}
+        {row.syncOnEverySignIn && (
+          <p className="mt-1 text-xs text-muted-foreground">Reapplies on every sign-in.</p>
+        )}
+      </td>
+      <td className="py-3 pr-3">
+        <code className="text-[11px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded font-mono">
+          {row.claimPath}
+        </code>
+      </td>
+      <td className="py-3">
+        <RowActions>
+          <IconButton label="Edit Role mapping" onClick={onEdit} disabled={disabled}>
+            <PencilIcon className="h-3.5 w-3.5" />
+          </IconButton>
+          <IconButton
+            label="Remove Role mapping"
+            onClick={onRemove}
+            disabled={disabled}
+            destructive
+          >
+            <TrashIcon className="h-3.5 w-3.5" />
+          </IconButton>
+        </RowActions>
+      </td>
+    </tr>
+  )
+}
+
+function PeopleRowView({
+  row,
+  disabled,
+  onEdit,
+  onRemove,
+}: {
+  row: ClaimsPeopleRow
+  disabled?: boolean
+  onEdit: () => void
+  onRemove: () => void
+}) {
+  return (
+    <tr className="border-b border-border/50 last:border-0 align-top">
+      <td className="py-3 pr-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-medium">{row.label}</span>
+          {row.typeLabel && (
+            <span className="text-xs text-muted-foreground">
+              {row.attributeKey}, {row.typeLabel}
+            </span>
+          )}
+          {row.orphaned && (
+            <Badge
+              variant="outline"
+              className="border-amber-500/40 text-amber-700 dark:text-amber-400"
+            >
+              attribute no longer exists
+            </Badge>
+          )}
+          {row.duplicate && (
+            <Badge
+              variant="outline"
+              className="border-amber-500/40 text-amber-700 dark:text-amber-400"
+            >
+              Duplicate mapping
+            </Badge>
+          )}
+        </div>
+      </td>
+      <td className="py-3 pr-3">
+        <code className="text-[11px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded font-mono">
+          {row.claimPath}
+        </code>
+      </td>
+      <td className="py-3">
+        <RowActions>
+          <IconButton label={`Edit ${row.label} mapping`} onClick={onEdit} disabled={disabled}>
+            <PencilIcon className="h-3.5 w-3.5" />
+          </IconButton>
+          <IconButton
+            label={`Remove ${row.label} mapping`}
+            onClick={onRemove}
+            disabled={disabled}
+            destructive
+          >
+            <TrashIcon className="h-3.5 w-3.5" />
+          </IconButton>
+        </RowActions>
+      </td>
+    </tr>
+  )
+}
+
+function UnsupportedRowView({
+  row,
+  disabled,
+  onRemove,
+}: {
+  row: ClaimsUnsupportedRow
+  disabled?: boolean
+  onRemove: () => void
+}) {
+  return (
+    <tr className="border-b border-border/50 last:border-0 align-top">
+      <td className="py-3 pr-3">
+        <div className="font-medium">{row.label}</div>
+        <p className="mt-0.5 text-xs text-muted-foreground">{row.detail}</p>
+      </td>
+      <td className="py-3 pr-3 text-xs text-muted-foreground">Unsupported</td>
+      <td className="py-3">
+        <RowActions>
+          <IconButton
+            label={`Remove ${row.label} mapping`}
+            onClick={onRemove}
+            disabled={disabled}
+            destructive
+          >
+            <TrashIcon className="h-3.5 w-3.5" />
+          </IconButton>
+        </RowActions>
+      </td>
+    </tr>
+  )
+}
+
+export function AdvancedSourcesEditor({
+  sources,
+  onChange,
+  disabled,
+}: {
+  sources: IdentitySource[]
+  onChange: (next: IdentitySource[]) => void
+  disabled?: boolean
+}) {
+  const enabled = new Set(sources)
+  const ordered: IdentitySource[] = []
+  for (const source of sources) {
+    if (!ordered.includes(source)) ordered.push(source)
+  }
+  for (const source of DEFAULT_IDENTITY_SOURCES) {
+    if (!ordered.includes(source)) ordered.push(source)
+  }
+  if (!ordered.includes('accessTokenJwt')) ordered.push('accessTokenJwt')
+
+  const toggle = (source: IdentitySource, on: boolean) => {
+    if (on) {
+      if (enabled.has(source)) return
+      onChange([...sources, source])
+      return
+    }
+    const next = sources.filter((s) => s !== source)
+    if (next.length === 0) return
+    onChange(next)
+  }
+
+  const move = (index: number, dir: -1 | 1) => {
+    const next = [...sources]
+    const target = index + dir
+    if (target < 0 || target >= next.length) return
+    const [item] = next.splice(index, 1)
+    next.splice(target, 0, item)
+    onChange(next)
+  }
+
+  return (
+    <div className="rounded-md border border-border/50 bg-muted/10">
+      <details className="group">
+        <summary className="cursor-pointer list-none px-3 py-2 text-sm font-medium">
+          Advanced sources
+        </summary>
+        <div className="space-y-3 border-t border-border/40 px-3 py-3">
+          <p className="text-xs text-muted-foreground">
+            Read identity from enabled sources in this order:
+          </p>
+          <ol className="space-y-2">
+            {ordered.map((source) => {
+              const checked = enabled.has(source)
+              const index = sources.indexOf(source)
+              return (
+                <li key={source} className="flex items-center gap-2 text-sm">
+                  <Checkbox
+                    checked={checked}
+                    onCheckedChange={(v) => toggle(source, v === true)}
+                    disabled={disabled || (checked && sources.length === 1)}
+                    aria-label={SOURCE_LABELS[source]}
+                  />
+                  <span className="flex-1">
+                    {index >= 0 ? `${index + 1}. ` : ''}
+                    {SOURCE_LABELS[source]}
+                  </span>
+                  {checked && (
+                    <>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 px-2"
+                        aria-label={`Move ${SOURCE_LABELS[source]} up`}
+                        disabled={disabled || index <= 0}
+                        onClick={() => move(index, -1)}
+                      >
+                        <ChevronUpIcon className="h-3.5 w-3.5" />
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 px-2"
+                        aria-label={`Move ${SOURCE_LABELS[source]} down`}
+                        disabled={disabled || index < 0 || index >= sources.length - 1}
+                        onClick={() => move(index, 1)}
+                      >
+                        <ChevronDownIcon className="h-3.5 w-3.5" />
+                      </Button>
+                    </>
+                  )}
+                </li>
+              )
+            })}
+          </ol>
+          <p className="text-xs text-muted-foreground">
+            The access token is audience-scoped and its subject may differ from the ID token. Leave
+            this off unless this IdP puts identity only there.
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Changing sources can change account matching and requires a new connection test.
+          </p>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={disabled}
+            onClick={() => onChange([...DEFAULT_IDENTITY_SOURCES])}
+          >
+            Restore default sources
+          </Button>
+        </div>
+      </details>
+    </div>
+  )
+}

--- a/apps/web/src/components/admin/settings/security/identity-providers/claims-table.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claims-table.tsx
@@ -129,14 +129,7 @@ export function ClaimsTable({
                 />
               )
             }
-            return (
-              <UnsupportedRowView
-                key={row.id}
-                row={row}
-                disabled={disabled}
-                onRemove={() => onRemove(row)}
-              />
-            )
+            return <UnsupportedRowView key={row.id} row={row} />
           })}
         </MappingTable>
         {extraHint && (
@@ -448,15 +441,7 @@ function PeopleRowView({
   )
 }
 
-function UnsupportedRowView({
-  row,
-  disabled,
-  onRemove,
-}: {
-  row: ClaimsUnsupportedRow
-  disabled?: boolean
-  onRemove: () => void
-}) {
+function UnsupportedRowView({ row }: { row: ClaimsUnsupportedRow }) {
   return (
     <tr className="border-b border-border/50 last:border-0 align-top">
       <td className="py-3 pr-3">
@@ -464,18 +449,7 @@ function UnsupportedRowView({
         <p className="mt-0.5 text-xs text-muted-foreground">{row.detail}</p>
       </td>
       <td className="py-3 pr-3 text-xs text-muted-foreground">Unsupported</td>
-      <td className="py-3">
-        <RowActions>
-          <IconButton
-            label={`Remove ${row.label} mapping`}
-            onClick={onRemove}
-            disabled={disabled}
-            destructive
-          >
-            <TrashIcon className="h-3.5 w-3.5" />
-          </IconButton>
-        </RowActions>
-      </td>
+      <td className="py-3" />
     </tr>
   )
 }

--- a/apps/web/src/components/admin/settings/security/identity-providers/outcome-preview-rail.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/outcome-preview-rail.tsx
@@ -1,173 +1,366 @@
 /**
- * Session-scoped outcome preview. Renders only when a test capture exists
- * for this provider. Evaluates the current draft against the captured
- * claims with pure functions — no network.
+ * Draft mapping preview. Replays the selected capture through the shared
+ * binder. Diagnostic dump is admin-only and is never logged.
  */
 
+import { useState } from 'react'
 import { TimeAgo } from '@/components/ui/time-ago'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { MENU_LABEL } from '@/components/ui/menu'
 import { cn } from '@/lib/shared/utils'
-import { getClaimByPath } from '@/lib/shared/oidc-claim-mapping'
-import { resolveSsoRoleMatch } from '@/lib/shared/resolve-sso-role'
-import { captureIdentityCaption, type SsoTestCapture } from '@/lib/shared/sso-test-capture'
+import {
+  captureIdentityCaption,
+  isReplayableCapture,
+  type SsoTestCapture,
+} from '@/lib/shared/sso-test-capture'
+import {
+  SOURCE_WORDS,
+  effectiveEmailPath,
+  effectiveIdPath,
+  effectiveNamePath,
+  previewClaimMapping,
+  runtimeFallbackRole,
+  type MappingPreviewPolicy,
+} from '@/lib/shared/sso-mapping-preview'
+import type { IdentityProviderClaimMapping } from '@/lib/shared/oidc-claim-mapping'
+import type { AttributeDefinition } from '@/lib/shared/plan-claim-attribute-writes'
 import { TestSignInButton } from '../sso/test-sign-in-button'
-import type { IdentityProvider } from '@/lib/server/domains/settings/identity-providers.service'
 import { AttributeWritesPreview } from './attribute-writes-preview'
 
-type RoleMapping = NonNullable<NonNullable<IdentityProvider['claimMapping']>['role']>
-
-const SOURCE_WORDS: Record<string, string> = {
-  idToken: 'ID token',
-  userinfo: 'userinfo',
-  accessTokenJwt: 'access token JWT',
-}
+const PROTOCOL_KEYS = new Set([
+  'iss',
+  'aud',
+  'exp',
+  'iat',
+  'nbf',
+  'jti',
+  'nonce',
+  'azp',
+  'at_hash',
+  'c_hash',
+  'sid',
+  'rh',
+  'uti',
+  'aio',
+  'ver',
+  'amr',
+  'acr',
+])
 
 export function OutcomePreviewRail({
   capture,
-  provider,
-  idClaim,
-  emailClaim,
-  nameClaim,
-  roleMapping,
-  attributeRows,
-  overrideExisting,
-  syncOnSignIn,
+  draft,
+  definitions,
+  providerPolicy,
+  dirty,
+  onSaveAndTest,
   registrationId,
+  canTest,
 }: {
-  capture: SsoTestCapture
-  provider: IdentityProvider | null
-  idClaim: string
-  emailClaim: string
-  nameClaim: string
-  roleMapping: RoleMapping | null
-  attributeRows: Array<{ claimPath: string; attributeKey: string }>
-  overrideExisting: boolean
-  syncOnSignIn: boolean
+  capture: SsoTestCapture | null
+  draft: IdentityProviderClaimMapping | null
+  definitions: AttributeDefinition[]
+  providerPolicy: MappingPreviewPolicy
+  dirty: boolean
+  onSaveAndTest?: () => void
   registrationId: string
+  canTest: boolean
 }) {
-  const stale =
-    !!provider?.detailsChangedAt &&
-    new Date(provider.detailsChangedAt).getTime() > new Date(capture.capturedAt).getTime()
+  const preview = previewClaimMapping({
+    draft,
+    capture,
+    definitions,
+    providerPolicy,
+  })
+  const cta = dirty ? 'Save and test' : capture ? 'Re-test' : 'Test sign-in'
 
-  const paths = {
-    id: idClaim.trim() || 'sub',
-    email: emailClaim.trim() || 'email',
-    name: nameClaim.trim() || 'name',
+  if (!preview.capture) {
+    return (
+      <aside className="flex flex-col gap-4 border-t border-border/40 bg-muted/20 px-4 py-5 text-[12.5px] lg:border-t-0 lg:border-l">
+        <h3 className={cn(MENU_LABEL, 'font-mono')}>Preview</h3>
+        <p className="text-xs text-muted-foreground">
+          Run a test sign-in to inspect this IdP&apos;s claims and preview mappings.
+        </p>
+        <TestCta
+          cta={cta}
+          registrationId={registrationId}
+          canTest={canTest}
+          dirty={dirty}
+          onSaveAndTest={onSaveAndTest}
+        />
+      </aside>
+    )
   }
-  const claims = capture.claims as Record<string, unknown>
-  const idValue = getClaimByPath(claims, paths.id)
-  const emailValue = getClaimByPath(claims, paths.email)
-  const nameValue = getClaimByPath(claims, paths.name)
 
-  const match = resolveSsoRoleMatch(claims, roleMapping ?? undefined)
-  const matchedRule = match && roleMapping ? roleMapping.rules[match.ruleIndex] : undefined
-
-  const provenance = formatProvenance(capture.identity?.sources ?? {})
+  const fallback = runtimeFallbackRole(providerPolicy.autoProvisionRole)
+  const roleRules = draft?.role?.rules ?? []
+  const hasAdminRule = roleRules.some((r) => r.role === 'admin')
 
   return (
     <aside className="flex flex-col gap-4 border-t border-border/40 bg-muted/20 px-4 py-5 text-[12.5px] lg:border-t-0 lg:border-l">
       <div>
-        <h3 className={cn(MENU_LABEL, 'font-mono')}>Outcome preview</h3>
-        <div className="mt-2 font-medium">Last test sign-in</div>
+        <h3 className={cn(MENU_LABEL, 'font-mono')}>Last test sign-in</h3>
+        <div className="mt-2 font-medium">{captureIdentityCaption(preview.capture)}</div>
         <div className="mt-0.5 text-muted-foreground">
-          {captureIdentityCaption(capture)} · <TimeAgo date={capture.capturedAt} /> ·{' '}
-          <TestSignInButton
+          <TimeAgo date={preview.capture.capturedAt} />
+        </div>
+        <div className="mt-2">
+          <TestCta
+            cta={cta}
             registrationId={registrationId}
-            variant="link"
-            size="sm"
-            disabled={!provider}
-          >
-            Re-test
-          </TestSignInButton>
+            canTest={canTest}
+            dirty={dirty}
+            onSaveAndTest={onSaveAndTest}
+          />
         </div>
       </div>
 
-      <div className="border-t border-border/40 pt-3">
-        <h3 className={cn(MENU_LABEL, 'mb-2 font-mono')}>Identity</h3>
-        <dl className="grid grid-cols-[4.4em_1fr] gap-x-2.5 gap-y-1 font-mono text-[11.5px]">
-          <dt className="font-sans text-muted-foreground">id</dt>
-          <dd className="break-all">
-            {formatValue(idValue)} <span className="text-muted-foreground">← {paths.id}</span>
-          </dd>
-          <dt className="font-sans text-muted-foreground">email</dt>
-          <dd className="break-all">
-            {formatValue(emailValue)} <span className="text-muted-foreground">← {paths.email}</span>
-          </dd>
-          <dt className="font-sans text-muted-foreground">name</dt>
-          <dd className="break-all">
-            {formatValue(nameValue)} <span className="text-muted-foreground">← {paths.name}</span>
-          </dd>
-        </dl>
-        {provenance && <p className="mt-1.5 text-xs text-muted-foreground">{provenance}</p>}
-      </div>
+      {dirty && <p className="font-medium">Preview of unsaved mappings</p>}
 
-      <div className="border-t border-border/40 pt-3">
-        <h3 className={cn(MENU_LABEL, 'mb-2 font-mono')}>Role</h3>
-        {match && matchedRule ? (
-          <div>
-            <Badge variant="secondary" className="font-mono">
-              {match.role}
-            </Badge>
-            <span className="ml-1.5">
-              rule {match.ruleIndex + 1} matched:{' '}
-              <span className="font-mono">{roleMapping?.claimPath}</span> contains{' '}
-              <span className="font-mono">{matchedRule.whenContains}</span>
-            </span>
-          </div>
-        ) : (
-          <div>no rule matched</div>
-        )}
-        <p className="mt-1 text-xs text-muted-foreground">
-          For a new user at a verified domain. Existing admins and members change only when Mirror
-          the IdP is on.
+      {preview.status === 'mapping_failed' && (
+        <p className="text-amber-700 dark:text-amber-400">Connection test did not pass.</p>
+      )}
+
+      {preview.status === 'needs_retest' && preview.limitations[0] && (
+        <p className="text-amber-700 dark:text-amber-400">{preview.limitations[0]}</p>
+      )}
+
+      {preview.stale && preview.status === 'ready' && (
+        <p className="text-amber-700 dark:text-amber-400">
+          Configuration changed since this test. Re-test to validate it. Preview uses the captured
+          claims with your current draft.
         </p>
-      </div>
+      )}
 
-      <div className="border-t border-border/40 pt-3">
-        <AttributeWritesPreview
-          capture={capture}
-          registrationId={registrationId}
-          detailsChangedAt={provider?.detailsChangedAt}
-          attributeRows={attributeRows}
-          overrideExisting={overrideExisting}
-          syncOnSignIn={syncOnSignIn}
-          canTest={!!provider}
-        />
-      </div>
+      {preview.identity && (
+        <div className="border-t border-border/40 pt-3">
+          <h3 className={cn(MENU_LABEL, 'mb-2 font-mono')}>Identity</h3>
+          <IdentityLines draft={draft} identity={preview.identity} />
+        </div>
+      )}
 
-      <div className="border-t border-border/40 pt-3 text-xs text-muted-foreground">
-        {stale ? (
-          <p className="text-amber-700 dark:text-amber-400">
-            Configuration changed since capture. Re-test.
+      {preview.status !== 'needs_retest' && (
+        <div className="border-t border-border/40 pt-3">
+          <h3 className={cn(MENU_LABEL, 'mb-2 font-mono')}>Role</h3>
+          {providerPolicy.autoCreateUsers === false ? (
+            <p>Role application is disabled because auto-create is off.</p>
+          ) : preview.roleMatch && draft?.role ? (
+            <div>
+              <Badge variant="secondary" className="font-mono">
+                {preview.roleMatch.role}
+              </Badge>
+              <span className="ml-1.5">
+                Rule {preview.roleMatch.ruleIndex + 1} matched:{' '}
+                <span className="font-mono">{draft.role.claimPath}</span> equals an array member{' '}
+                <span className="font-mono">
+                  {draft.role.rules[preview.roleMatch.ruleIndex]?.whenContains}
+                </span>
+              </span>
+            </div>
+          ) : (
+            <div>No match. {fallback.label}, at verified domains.</div>
+          )}
+          {roleRules.length > 0 && (
+            <div className="mt-2">
+              <div className="text-xs text-muted-foreground">All configured targets:</div>
+              <ol className="mt-1 list-decimal pl-4">
+                {roleRules.map((rule, index) => (
+                  <li key={index}>
+                    {rule.whenContains} {'->'} {rule.role}
+                  </li>
+                ))}
+              </ol>
+            </div>
+          )}
+          <p className="mt-1 text-xs text-muted-foreground">
+            A matching rule assigns this role even outside this provider&apos;s verified domains.
+            {hasAdminRule ? ' The preview matching member does not limit this admin rule.' : ''}
+            {providerPolicy.autoCreateUsers
+              ? ' Existing admin and member roles stay unless role sync is on.'
+              : ''}
           </p>
-        ) : (
-          <p>
-            Re-evaluates as you type. Changes to the connection, scopes, or identity settings
-            invalidate this capture and ask for a fresh test.
-          </p>
-        )}
-      </div>
+        </div>
+      )}
+
+      {preview.status !== 'needs_retest' && (
+        <div className="border-t border-border/40 pt-3">
+          <AttributeWritesPreview
+            capture={preview.capture}
+            registrationId={registrationId}
+            detailsChangedAt={providerPolicy.detailsChangedAt}
+            attributeRows={draft?.attributes?.map ?? []}
+            overrideExisting={draft?.attributes?.overrideExisting === true}
+            syncOnSignIn={draft?.attributes?.syncOnSignIn === true}
+            canTest={canTest}
+            claims={preview.identity?.acceptedClaims}
+            plan={preview.peoplePlan}
+            hideCaptureChrome
+          />
+        </div>
+      )}
+
+      <p className="text-xs text-muted-foreground">
+        Name and email show account-creation inputs. Existing profiles are not overwritten on later
+        sign-ins. People preview assumes no existing attributes.
+      </p>
+
+      <ClaimsDisclosure capture={preview.capture} />
     </aside>
   )
 }
 
-function formatValue(value: unknown): string {
-  if (value === undefined || value === null || value === '') return '—'
-  if (Array.isArray(value)) return value.map(String).join(', ')
-  return String(value)
+function IdentityLines({
+  draft,
+  identity,
+}: {
+  draft: IdentityProviderClaimMapping | null
+  identity: NonNullable<ReturnType<typeof previewClaimMapping>['identity']>
+}) {
+  const idPath = effectiveIdPath(draft)
+  const emailPath = effectiveEmailPath(draft)
+  const namePath = effectiveNamePath(draft)
+  return (
+    <dl className="grid grid-cols-[6.2em_1fr] gap-x-2.5 gap-y-1 font-mono text-[11.5px]">
+      <dt className="font-sans text-muted-foreground">Identifier</dt>
+      <dd className="break-all">
+        {identity.id ?? 'Not supplied'}
+        {identity.provenance.id && (
+          <span className="text-muted-foreground">
+            {' '}
+            {'<-'} {identity.provenance.id.path}, {SOURCE_WORDS[identity.provenance.id.source]}
+          </span>
+        )}
+      </dd>
+      <dt className="font-sans text-muted-foreground">Email</dt>
+      <dd className="break-all">
+        {identity.kind === 'placeholder_required'
+          ? 'A placeholder address will be used.'
+          : identity.kind === 'missing_email'
+            ? `Not supplied by the configured path ${emailPath}`
+            : (identity.email ?? 'Not supplied')}
+        {identity.provenance.email && identity.kind === 'identity' && (
+          <span className="text-muted-foreground">
+            {' '}
+            {'<-'} {identity.provenance.email.path},{' '}
+            {SOURCE_WORDS[identity.provenance.email.source]}
+          </span>
+        )}
+      </dd>
+      <dt className="font-sans text-muted-foreground">Name</dt>
+      <dd className="break-all">
+        {identity.name ?? 'Not supplied'}
+        {identity.nameSynthesized
+          ? ' (generated)'
+          : identity.provenance.name
+            ? ` <- ${identity.provenance.name.path}, ${SOURCE_WORDS[identity.provenance.name.source]}`
+            : !identity.name
+              ? ` <- ${namePath}`
+              : ''}
+      </dd>
+      {identity.warnings.includes('subject_mismatch') && (
+        <dd className="col-span-2 font-sans text-xs text-muted-foreground">
+          A mismatched source was kept for diagnostics and is excluded from the sign-in outcome.
+        </dd>
+      )}
+      {identity.id === undefined && (
+        <dd className="col-span-2 font-sans text-xs text-muted-foreground">
+          Not supplied by the configured path {idPath}.
+        </dd>
+      )}
+    </dl>
+  )
 }
 
-function formatProvenance(
-  sources: NonNullable<SsoTestCapture['identity']>['sources']
-): string | null {
-  const seen: string[] = []
-  for (const key of ['id', 'email', 'name'] as const) {
-    const src = sources[key]
-    if (!src) continue
-    const word = SOURCE_WORDS[src] ?? src
-    if (!seen.includes(word)) seen.push(word)
+function TestCta({
+  cta,
+  registrationId,
+  canTest,
+  dirty,
+  onSaveAndTest,
+}: {
+  cta: string
+  registrationId: string
+  canTest: boolean
+  dirty: boolean
+  onSaveAndTest?: () => void
+}) {
+  if (dirty) {
+    return (
+      <Button type="button" size="sm" onClick={onSaveAndTest} disabled={!canTest}>
+        {cta}
+      </Button>
+    )
   }
-  if (seen.length === 0) return null
-  return `Captured via ${seen.join(' + ')}.`
+  return (
+    <TestSignInButton registrationId={registrationId} disabled={!canTest}>
+      {cta}
+    </TestSignInButton>
+  )
+}
+
+function ClaimsDisclosure({ capture }: { capture: SsoTestCapture }) {
+  const [showProtocol, setShowProtocol] = useState(false)
+  const claims = capture.claims
+  const keys = Object.keys(claims).filter(
+    (key) => showProtocol || !PROTOCOL_KEYS.has(key) || key === 'sub'
+  )
+  if (!keys.includes('sub') && Object.prototype.hasOwnProperty.call(claims, 'sub')) {
+    keys.unshift('sub')
+  }
+  const sources = isReplayableCapture(capture) ? capture.replay.sources : []
+
+  return (
+    <details className="border-t border-border/40 pt-3">
+      <summary className="cursor-pointer text-sm font-medium">Claims from test sign-in</summary>
+      <p className="mt-2 text-xs text-muted-foreground">
+        Personal data. Share only with people who should have access.
+      </p>
+      <label className="mt-2 flex items-center gap-2 text-xs">
+        <input
+          type="checkbox"
+          checked={showProtocol}
+          onChange={(e) => setShowProtocol(e.target.checked)}
+        />
+        Show protocol claims
+      </label>
+      <dl className="mt-2 grid grid-cols-[7em_1fr] gap-x-2.5 gap-y-1 font-mono text-[11px]">
+        {keys.map((key) => (
+          <div key={key} className="contents">
+            <dt className="text-muted-foreground break-all">{key}</dt>
+            <dd className="min-w-0 break-all">{escapeClaimValue(claims[key])}</dd>
+          </div>
+        ))}
+      </dl>
+      {sources.length > 0 && (
+        <div className="mt-3 space-y-2">
+          {sources.map((snapshot) => (
+            <div key={snapshot.source}>
+              <div className="text-xs font-medium">{SOURCE_WORDS[snapshot.source]}</div>
+              {snapshot.unavailable ? (
+                <p className="text-xs text-muted-foreground">
+                  Unavailable ({snapshot.unavailable})
+                </p>
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  {Object.keys(snapshot.claims ?? {}).length} claims captured
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </details>
+  )
+}
+
+function escapeClaimValue(value: unknown): string {
+  if (value === undefined || value === null || value === '') return 'Not supplied'
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return 'Not supplied'
+  }
 }

--- a/apps/web/src/components/admin/settings/security/identity-providers/provider-detail-page.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/provider-detail-page.tsx
@@ -47,7 +47,7 @@ const SECTIONS = [
   { id: 'connection', label: 'Connection' },
   { id: 'signin', label: 'Sign-in' },
   { id: 'accounts', label: 'Accounts' },
-  { id: 'mapping', label: 'Claim mapping' },
+  { id: 'mapping', label: 'Attributes & Claims' },
   { id: 'danger', label: 'Remove' },
 ] as const
 

--- a/apps/web/src/components/admin/settings/security/identity-providers/provider-shared.ts
+++ b/apps/web/src/components/admin/settings/security/identity-providers/provider-shared.ts
@@ -11,9 +11,53 @@
  */
 import { toast } from 'sonner'
 import type { Role } from '@/lib/shared/roles'
-import type { IdentityProviderClaimMapping } from '@/lib/shared/oidc-claim-mapping'
+import {
+  DEFAULT_IDENTITY_SOURCES,
+  IDENTITY_SOURCES,
+  type IdentityProviderClaimMapping,
+  type IdentitySource,
+} from '@/lib/shared/oidc-claim-mapping'
 import type { IdentityProvider } from '@/lib/server/domains/settings/identity-providers.service'
 import type { IdpKind } from '../idp-shortcuts'
+import { sourcesAreDefault } from '@/lib/shared/sso-claim-mapping-edit'
+
+/**
+ * Flip to false to render the pre-table disclosures without a revert.
+ * Both presentations share the same save coordinator.
+ */
+export const CLAIMS_TABLE = true
+
+export const OIDC_PROFILE_DEFAULTS = {
+  id: 'sub',
+  email: 'email',
+  name: 'name',
+} as const
+
+export const PROFILE_ROW_LABELS = {
+  id: 'Unique user identifier',
+  email: 'Email',
+  name: 'Display name',
+} as const
+
+export const PROFILE_ROW_HELPERS = {
+  id: "Used to match this person's account on every sign-in. Choose a stable, unique value.",
+  email: 'Set when the account is created. Later sign-ins do not overwrite it.',
+  name: 'If absent, Quackback generates a display name from a username or identifier.',
+} as const
+
+export const PEOPLE_TYPE_LABEL: Record<string, string> = {
+  string: 'Text',
+  number: 'Number',
+  boolean: 'Boolean',
+  date: 'Date',
+  currency: 'Currency',
+}
+
+export const SOURCE_LABELS: Record<IdentitySource, string> = {
+  idToken: 'ID token',
+  userinfo: 'Userinfo',
+  accessTokenJwt: 'Access-token JWT',
+}
 
 export const IDENTITY_PROVIDERS_KEY = ['settings', 'identityProviders'] as const
 
@@ -148,10 +192,36 @@ export function normalizeRoleMapping(mapping: RoleMapping | null): RoleMapping |
  * runs on every sign-in: a rule that can never match is indistinguishable from
  * a working one until someone cannot get the role they were promised.
  */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function blankSupportedPath(value: unknown): boolean {
+  return typeof value === 'string' && value.length > 0 && value.trim() === ''
+}
+
 export function identityMappingIssue(
   claimMapping: IdentityProviderClaimMapping | null | undefined
 ): string | null {
-  const role = claimMapping?.role
+  if (!claimMapping) return null
+  const profile = claimMapping.profile
+  if (profile && isRecord(profile)) {
+    const claims = isRecord(profile.claims) ? profile.claims : null
+    if (claims) {
+      if (blankSupportedPath(claims.id)) return 'Identifier mapping has no claim path'
+      if (blankSupportedPath(claims.email)) return 'Email mapping has no claim path'
+      if (blankSupportedPath(claims.name)) return 'Display name mapping has no claim path'
+    }
+    if (Array.isArray(profile.sources)) {
+      const kept = profile.sources.filter((s) =>
+        (IDENTITY_SOURCES as readonly string[]).includes(s as string)
+      )
+      if (profile.sources.length > 0 && kept.length === 0) {
+        return 'Identity sources are not valid'
+      }
+    }
+  }
+  const role = claimMapping.role
   if (!role) return null
   if (role.rules.some((r) => r.whenContains.trim() === '')) return 'A role rule has no value'
   if (role.claimPath.trim() === '') return 'Role mapping has no claim path'
@@ -159,6 +229,219 @@ export function identityMappingIssue(
     return 'Role sync is on with no rules'
   }
   return null
+}
+
+/**
+ * Drop display-only OIDC defaults so an untouched table Save does not persist
+ * `profile`. Explicit `id: 'sub'` is kept because it disables userinfo `id`
+ * fallback.
+ */
+export function normalizeProfileClaims(
+  profile: IdentityProviderClaimMapping['profile'] | undefined
+): IdentityProviderClaimMapping['profile'] | undefined {
+  if (!profile) return undefined
+  const next: NonNullable<IdentityProviderClaimMapping['profile']> = {}
+  if (profile.allowMissingEmail === true) next.allowMissingEmail = true
+  if (profile.sources && !sourcesAreDefault(profile.sources)) {
+    const sources = profile.sources.filter((s) =>
+      (IDENTITY_SOURCES as readonly string[]).includes(s)
+    )
+    if (sources.length > 0) next.sources = sources
+  }
+  const claims: NonNullable<NonNullable<IdentityProviderClaimMapping['profile']>['claims']> = {}
+  const rawClaims = profile.claims ?? {}
+  const id = typeof rawClaims.id === 'string' ? rawClaims.id.trim() : ''
+  const email = typeof rawClaims.email === 'string' ? rawClaims.email.trim() : ''
+  const name = typeof rawClaims.name === 'string' ? rawClaims.name.trim() : ''
+  if (id) claims.id = id
+  if (email && email !== OIDC_PROFILE_DEFAULTS.email) claims.email = email
+  if (name && name !== OIDC_PROFILE_DEFAULTS.name) claims.name = name
+  if (Object.keys(claims).length > 0) next.claims = claims
+  return Object.keys(next).length > 0 ? next : undefined
+}
+
+export function hasCustomProfileClaims(
+  mapping: IdentityProviderClaimMapping | null | undefined
+): boolean {
+  const claims = mapping?.profile?.claims
+  if (!claims) return false
+  if (claims.id !== undefined && String(claims.id).trim() !== '') return true
+  const email = typeof claims.email === 'string' ? claims.email.trim() : ''
+  const name = typeof claims.name === 'string' ? claims.name.trim() : ''
+  return (
+    (email !== '' && email !== OIDC_PROFILE_DEFAULTS.email) ||
+    (name !== '' && name !== OIDC_PROFILE_DEFAULTS.name)
+  )
+}
+
+export type PeopleDefinition = { key: string; label: string; type: string }
+
+export type ClaimsProfileRow = {
+  kind: 'profile'
+  field: 'id' | 'email' | 'name'
+  label: string
+  path: string
+  isDefault: boolean
+  required: boolean
+  helper: string
+}
+
+export type ClaimsRoleRow = {
+  kind: 'role'
+  claimPath: string
+  rules: Array<{ whenContains: string; role: Role }>
+  syncOnEverySignIn: boolean
+}
+
+export type ClaimsPeopleRow = {
+  kind: 'people'
+  baselineIndex: number
+  claimPath: string
+  attributeKey: string
+  label: string
+  typeLabel: string | null
+  orphaned: boolean
+  duplicate: boolean
+}
+
+export type ClaimsUnsupportedRow = {
+  kind: 'unsupported'
+  id: string
+  label: string
+  detail: string
+}
+
+export type ClaimsTableRow =
+  ClaimsProfileRow | ClaimsRoleRow | ClaimsPeopleRow | ClaimsUnsupportedRow
+
+export type AddClaimTarget =
+  { kind: 'role' } | { kind: 'people'; key: string; label: string; attrType: string }
+
+function profilePath(
+  mapping: IdentityProviderClaimMapping | null | undefined,
+  field: 'id' | 'email' | 'name'
+): string | undefined {
+  const value = mapping?.profile?.claims?.[field]
+  return typeof value === 'string' && value.trim() !== '' ? value.trim() : undefined
+}
+
+export function buildClaimsTableModel({
+  mapping,
+  definitions,
+}: {
+  mapping: IdentityProviderClaimMapping | null | undefined
+  definitions: PeopleDefinition[]
+}): { required: ClaimsProfileRow[]; additional: ClaimsTableRow[] } {
+  const idPath = profilePath(mapping, 'id')
+  const emailPath = profilePath(mapping, 'email')
+  const namePath = profilePath(mapping, 'name')
+  const required: ClaimsProfileRow[] = [
+    {
+      kind: 'profile',
+      field: 'id',
+      label: PROFILE_ROW_LABELS.id,
+      path: idPath ?? OIDC_PROFILE_DEFAULTS.id,
+      isDefault: idPath === undefined,
+      required: true,
+      helper: PROFILE_ROW_HELPERS.id,
+    },
+    {
+      kind: 'profile',
+      field: 'email',
+      label: PROFILE_ROW_LABELS.email,
+      path: emailPath ?? OIDC_PROFILE_DEFAULTS.email,
+      isDefault: emailPath === undefined || emailPath === OIDC_PROFILE_DEFAULTS.email,
+      required: true,
+      helper: PROFILE_ROW_HELPERS.email,
+    },
+  ]
+  const additional: ClaimsTableRow[] = [
+    {
+      kind: 'profile',
+      field: 'name',
+      label: PROFILE_ROW_LABELS.name,
+      path: namePath ?? OIDC_PROFILE_DEFAULTS.name,
+      isDefault: namePath === undefined || namePath === OIDC_PROFILE_DEFAULTS.name,
+      required: false,
+      helper: PROFILE_ROW_HELPERS.name,
+    },
+  ]
+  const role = mapping?.role
+  if (role && (role.claimPath || (role.rules?.length ?? 0) > 0 || role.syncOnEverySignIn)) {
+    additional.push({
+      kind: 'role',
+      claimPath: role.claimPath || 'groups',
+      rules: role.rules ?? [],
+      syncOnEverySignIn: role.syncOnEverySignIn === true,
+    })
+  }
+  const defByKey = new Map(definitions.map((d) => [d.key, d]))
+  const map = mapping?.attributes?.map ?? []
+  const keyCounts = new Map<string, number>()
+  for (const row of map) {
+    if (row.attributeKey)
+      keyCounts.set(row.attributeKey, (keyCounts.get(row.attributeKey) ?? 0) + 1)
+  }
+  map.forEach((row, baselineIndex) => {
+    const def = defByKey.get(row.attributeKey)
+    additional.push({
+      kind: 'people',
+      baselineIndex,
+      claimPath: row.claimPath,
+      attributeKey: row.attributeKey,
+      label: def?.label ?? row.attributeKey,
+      typeLabel: def ? (PEOPLE_TYPE_LABEL[def.type] ?? def.type) : null,
+      orphaned: Boolean(row.attributeKey) && !def,
+      duplicate: Boolean(row.attributeKey) && (keyCounts.get(row.attributeKey) ?? 0) > 1,
+    })
+  })
+  const extraClaims = mapping?.profile?.claims
+    ? Object.keys(mapping.profile.claims).filter(
+        (key) => key !== 'id' && key !== 'email' && key !== 'name'
+      )
+    : []
+  for (const key of extraClaims) {
+    additional.push({
+      kind: 'unsupported',
+      id: `profile.claims.${key}`,
+      label: key,
+      detail: 'This saved mapping is not editable here.',
+    })
+  }
+  return { required, additional }
+}
+
+export function availableAddTargets({
+  mapping,
+  definitions,
+}: {
+  mapping: IdentityProviderClaimMapping | null | undefined
+  definitions: PeopleDefinition[]
+}): AddClaimTarget[] {
+  const targets: AddClaimTarget[] = []
+  const hasRole = Boolean(
+    mapping?.role &&
+    (mapping.role.claimPath ||
+      (mapping.role.rules?.length ?? 0) > 0 ||
+      mapping.role.syncOnEverySignIn)
+  )
+  if (!hasRole) targets.push({ kind: 'role' })
+  const used = new Set(
+    (mapping?.attributes?.map ?? []).map((row) => row.attributeKey).filter(Boolean)
+  )
+  for (const def of definitions) {
+    if (used.has(def.key)) continue
+    targets.push({ kind: 'people', key: def.key, label: def.label, attrType: def.type })
+  }
+  return targets
+}
+
+export function draftSources(
+  mapping: IdentityProviderClaimMapping | null | undefined
+): IdentitySource[] {
+  const sources = mapping?.profile?.sources
+  if (sources && sources.length > 0) return sources
+  return [...DEFAULT_IDENTITY_SOURCES]
 }
 
 /**

--- a/apps/web/src/components/admin/settings/security/identity-providers/provider-shared.ts
+++ b/apps/web/src/components/admin/settings/security/identity-providers/provider-shared.ts
@@ -116,11 +116,10 @@ export function getConnectionTestState(provider: IdentityProvider | null): Conne
  * other section exactly as it was found.
  *
  * `claim_mapping` is a single jsonb column with named sections (`profile`,
- * `role`, `attributes`) but the UI now writes it from two different cards, and
- * `attributes` has no UI at all. A card that rebuilt the whole object would
- * silently drop whatever it does not render — including the parts of `profile`
- * (`sources`, `claims`) that only the mapping reader knows about. So sections
- * are patched, never rebuilt.
+ * `role`, `attributes`). The mapping card now edits all three, but persist is
+ * ops-based so unknown siblings survive. A card that rebuilt the whole object
+ * would still drop whatever it does not render, so sections are patched, never
+ * rebuilt.
  *
  * An empty section is dropped and an empty object becomes `null`, so a
  * provider with nothing configured persists as `null` rather than `{}` — the
@@ -405,7 +404,7 @@ export function buildClaimsTableModel({
       kind: 'unsupported',
       id: `profile.claims.${key}`,
       label: key,
-      detail: 'This saved mapping is not editable here.',
+      detail: 'Stored on this provider and not editable here. Saving other rows keeps it.',
     })
   }
   return { required, additional }

--- a/apps/web/src/components/admin/settings/security/identity-providers/use-provider-save.ts
+++ b/apps/web/src/components/admin/settings/security/identity-providers/use-provider-save.ts
@@ -64,10 +64,10 @@ export function useProviderSave(provider: IdentityProvider) {
       acknowledgeAdminRules?: boolean
     },
     successMessage = 'Claim mapping saved.'
-  ): Promise<boolean> => {
+  ): Promise<IdentityProvider | false> => {
     setSaving(true)
     try {
-      await saveMappingFn({
+      const saved = (await saveMappingFn({
         data: {
           id: provider.id,
           expectedClaimMapping: provider.claimMapping,
@@ -75,10 +75,10 @@ export function useProviderSave(provider: IdentityProvider) {
           acknowledgeIdentifierChange: args.acknowledgeIdentifierChange,
           acknowledgeAdminRules: args.acknowledgeAdminRules,
         },
-      })
+      })) as IdentityProvider | undefined
       await queryClient.invalidateQueries({ queryKey: IDENTITY_PROVIDERS_KEY })
       toast.success(successMessage)
-      return true
+      return saved ?? (provider as IdentityProvider)
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Could not save the identity provider.')
       return false

--- a/apps/web/src/components/ui/autocomplete.tsx
+++ b/apps/web/src/components/ui/autocomplete.tsx
@@ -16,6 +16,8 @@ export interface AutocompleteSuggestion {
   value: string
   label?: string
   description?: string
+  /** Shown but not selectable (e.g. non-bindable identity claims). */
+  disabled?: boolean
 }
 
 interface AutocompleteProps {
@@ -112,7 +114,11 @@ export function Autocomplete({
                     <CommandItem
                       key={s.value}
                       value={[s.value, s.label, s.description].filter(Boolean).join(' ')}
-                      onSelect={() => commit(s.value)}
+                      disabled={s.disabled}
+                      onSelect={() => {
+                        if (s.disabled) return
+                        commit(s.value)
+                      }}
                     >
                       <CheckIcon
                         className={cn(

--- a/apps/web/src/lib/server/auth/__tests__/sso-mapping-parity.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/sso-mapping-parity.test.ts
@@ -8,6 +8,7 @@ import { finalizeProfileOutcome } from '@/lib/shared/sso-profile-outcome'
 import { resolveSsoRoleMatch } from '@/lib/shared/resolve-sso-role'
 import { planClaimAttributeWrites } from '@/lib/shared/plan-claim-attribute-writes'
 import { isReplayableCapture } from '@/lib/shared/sso-test-capture'
+import { previewClaimMapping } from '@/lib/shared/sso-mapping-preview'
 import {
   MAPPING_WORLDS,
   type MappingWorld,
@@ -160,6 +161,24 @@ describe('production test and preview agree on identity role and People mappings
         definitions: world.definitions,
       })
       expect(plan.valid).toEqual(world.expect.people)
+    }
+
+    const helper = previewClaimMapping({
+      draft: world.mapping,
+      capture: handshake.capture!,
+      definitions: world.definitions,
+      providerPolicy: {
+        autoCreateUsers: true,
+        autoProvisionRole: 'member',
+        registrationId: 'oidc_abc',
+      },
+    })
+    expect(helper.status === 'ready' || helper.status === 'mapping_failed').toBe(true)
+    expect(helper.identity?.id).toBe(world.expect.id)
+    expect(helper.identity?.email).toBe(world.expect.email)
+    expect(helper.roleMatch).toEqual(world.expect.role ?? null)
+    if (world.expect.people) {
+      expect(helper.peoplePlan?.valid).toEqual(world.expect.people)
     }
   })
 })

--- a/apps/web/src/lib/shared/__tests__/claim-suggestions.test.ts
+++ b/apps/web/src/lib/shared/__tests__/claim-suggestions.test.ts
@@ -119,6 +119,18 @@ describe('deriveIdentityClaimPaths', () => {
     expect(identity.map((s) => s.path)).not.toContain('groups.0')
   })
 
+  it('marks boolean and null identity leaves as unsuitable', () => {
+    const identity = deriveIdentityClaimPaths({
+      sub: 'person-123',
+      email_verified: true,
+      department: null,
+      employee_id: 42,
+    })
+    expect(identity.find((s) => s.path === 'email_verified')?.unsuitable).toBe(true)
+    expect(identity.find((s) => s.path === 'department')?.unsuitable).toBe(true)
+    expect(identity.find((s) => s.path === 'employee_id')?.unsuitable).toBeUndefined()
+  })
+
   it('offers entra aliases as suggestions without rewriting captured paths', () => {
     const identity = deriveIdentityClaimPaths({ sub: 's-1', email: 'a@b.test' }, { kind: 'entra' })
     const paths = identity.map((s) => s.path)

--- a/apps/web/src/lib/shared/__tests__/claim-suggestions.test.ts
+++ b/apps/web/src/lib/shared/__tests__/claim-suggestions.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { deriveAttributeClaimPaths, deriveClaimSuggestions } from '../claim-suggestions'
+import {
+  deriveAttributeClaimPaths,
+  deriveClaimSuggestions,
+  deriveIdentityClaimPaths,
+  identityClaimHints,
+} from '../claim-suggestions'
 
 describe('deriveClaimSuggestions', () => {
   it('surfaces a top-level string[] claim as a path with its values', () => {
@@ -79,5 +84,46 @@ describe('deriveAttributeClaimPaths', () => {
     expect(paths).not.toContain('sub')
     expect(paths).not.toContain('aud')
     expect(paths).not.toContain('exp')
+  })
+})
+
+describe('deriveIdentityClaimPaths', () => {
+  it('includes sub among identity suggestions even when attribute suggestions exclude it', () => {
+    const claims = {
+      iss: 'https://idp',
+      sub: 'person-123',
+      aud: 'cid',
+      email: 'jane@example.test',
+      groups: ['engineering'],
+    }
+    const identity = deriveIdentityClaimPaths(claims)
+    const attributes = deriveAttributeClaimPaths(claims)
+    expect(identity.map((s) => s.path)).toContain('sub')
+    expect(identity.find((s) => s.path === 'sub')?.description).toBe('person-123')
+    expect(attributes.map((s) => s.path)).not.toContain('sub')
+  })
+
+  it('includes sub when the capture omitted it', () => {
+    const identity = deriveIdentityClaimPaths({ email: 'jane@example.test' })
+    expect(identity.map((s) => s.path)).toContain('sub')
+  })
+
+  it('marks array candidates as unsuitable for identity and does not unwrap them', () => {
+    const identity = deriveIdentityClaimPaths({
+      sub: 'person-123',
+      groups: ['engineering', 'admins'],
+    })
+    const groups = identity.find((s) => s.path === 'groups')
+    expect(groups?.unsuitable).toBe(true)
+    expect(groups?.description).toBe('engineering, admins')
+    expect(identity.map((s) => s.path)).not.toContain('groups.0')
+  })
+
+  it('offers entra aliases as suggestions without rewriting captured paths', () => {
+    const identity = deriveIdentityClaimPaths({ sub: 's-1', email: 'a@b.test' }, { kind: 'entra' })
+    const paths = identity.map((s) => s.path)
+    expect(paths).toEqual(expect.arrayContaining(['sub', 'oid', 'upn', 'email']))
+    expect(identityClaimHints('entra', 'id')).toEqual(['oid', 'sub'])
+    expect(identityClaimHints('entra', 'email')).toEqual(['email', 'upn', 'preferred_username'])
   })
 })

--- a/apps/web/src/lib/shared/__tests__/sso-claim-mapping-edit.test.ts
+++ b/apps/web/src/lib/shared/__tests__/sso-claim-mapping-edit.test.ts
@@ -155,6 +155,31 @@ describe('diffClaimMappingOperations', () => {
       },
     })
   })
+
+  it('deleting a non-tail rule removes that row so extra fields stay with survivors', () => {
+    const stored = {
+      role: {
+        claimPath: 'groups',
+        rules: [
+          { whenContains: 'eng', role: 'member', note: 'eng-note' },
+          { whenContains: 'admins', role: 'admin', note: 'admin-note' },
+        ],
+      },
+    }
+    const ops = diffClaimMappingOperations(stored, {
+      role: {
+        claimPath: 'groups',
+        rules: [{ whenContains: 'admins', role: 'admin' }],
+      },
+    })
+    expect(ops).toEqual([{ op: 'removeRoleRule', index: 0 }])
+    expect(applyClaimMappingEdits(stored, ops)).toEqual({
+      role: {
+        claimPath: 'groups',
+        rules: [{ whenContains: 'admins', role: 'admin', note: 'admin-note' }],
+      },
+    })
+  })
 })
 
 describe('storedJsonEqual', () => {

--- a/apps/web/src/lib/shared/__tests__/sso-claim-mapping-edit.test.ts
+++ b/apps/web/src/lib/shared/__tests__/sso-claim-mapping-edit.test.ts
@@ -180,6 +180,41 @@ describe('diffClaimMappingOperations', () => {
       },
     })
   })
+
+  it('reorder+remove keeps extra fields on the surviving objects', () => {
+    const stored = {
+      role: {
+        claimPath: 'groups',
+        rules: [
+          { whenContains: 'a', role: 'member', note: 'a-note' },
+          { whenContains: 'b', role: 'member', note: 'b-note' },
+          { whenContains: 'c', role: 'admin', note: 'c-note' },
+        ],
+      },
+    }
+    const ops = diffClaimMappingOperations(stored, {
+      role: {
+        claimPath: 'groups',
+        rules: [
+          { whenContains: 'c', role: 'admin' },
+          { whenContains: 'a', role: 'member' },
+        ],
+      },
+    })
+    expect(ops).toEqual([
+      { op: 'removeRoleRule', index: 1 },
+      { op: 'reorderRoleRule', from: 1, to: 0 },
+    ])
+    expect(applyClaimMappingEdits(stored, ops)).toEqual({
+      role: {
+        claimPath: 'groups',
+        rules: [
+          { whenContains: 'c', role: 'admin', note: 'c-note' },
+          { whenContains: 'a', role: 'member', note: 'a-note' },
+        ],
+      },
+    })
+  })
 })
 
 describe('storedJsonEqual', () => {

--- a/apps/web/src/lib/shared/__tests__/sso-claim-mapping-edit.test.ts
+++ b/apps/web/src/lib/shared/__tests__/sso-claim-mapping-edit.test.ts
@@ -124,6 +124,37 @@ describe('diffClaimMappingOperations', () => {
     const after = applyClaimMappingEdits(null, ops)
     expect(effectiveProfileSignature(after)).toBe(effectiveProfileSignature(null))
   })
+
+  it('reordering rules emits reorderRoleRule so extra fields move with the rule', () => {
+    const stored = {
+      role: {
+        claimPath: 'groups',
+        rules: [
+          { whenContains: 'eng', role: 'member', note: 'eng-note' },
+          { whenContains: 'admins', role: 'admin', note: 'admin-note' },
+        ],
+      },
+    }
+    const ops = diffClaimMappingOperations(stored, {
+      role: {
+        claimPath: 'groups',
+        rules: [
+          { whenContains: 'admins', role: 'admin' },
+          { whenContains: 'eng', role: 'member' },
+        ],
+      },
+    })
+    expect(ops).toEqual([{ op: 'reorderRoleRule', from: 1, to: 0 }])
+    expect(applyClaimMappingEdits(stored, ops)).toEqual({
+      role: {
+        claimPath: 'groups',
+        rules: [
+          { whenContains: 'admins', role: 'admin', note: 'admin-note' },
+          { whenContains: 'eng', role: 'member', note: 'eng-note' },
+        ],
+      },
+    })
+  })
 })
 
 describe('storedJsonEqual', () => {

--- a/apps/web/src/lib/shared/__tests__/sso-mapping-preview.test.ts
+++ b/apps/web/src/lib/shared/__tests__/sso-mapping-preview.test.ts
@@ -124,6 +124,35 @@ describe('previewClaimMapping', () => {
     expect(preview.identity).toBeNull()
   })
 
+  it('marks a session capture stale when details changed after the handshake started', () => {
+    const preview = previewClaimMapping({
+      draft: null,
+      capture: v2Capture({
+        detailsChangedAtAtStart: '2026-09-01T00:00:00.000Z',
+        capturedAt: '2026-09-01T00:02:00.000Z',
+      }),
+      definitions: defs,
+      providerPolicy: { ...policy, detailsChangedAt: '2026-09-01T00:01:00.000Z' },
+    })
+    expect(preview.stale).toBe(true)
+    expect(preview.capture).not.toBeNull()
+    expect(preview.limitations.join(' ')).toMatch(/re-test/i)
+  })
+
+  it('does not mark stale when current details match the handshake start', () => {
+    const preview = previewClaimMapping({
+      draft: null,
+      capture: v2Capture({
+        detailsChangedAtAtStart: '2026-09-01T00:00:00.000Z',
+        capturedAt: '2026-09-01T00:02:00.000Z',
+      }),
+      definitions: defs,
+      providerPolicy: { ...policy, detailsChangedAt: '2026-09-01T00:00:00.000Z' },
+    })
+    expect(preview.stale).toBe(false)
+    expect(preview.limitations.join(' ')).not.toMatch(/re-test/i)
+  })
+
   it('legacy capture asks for retest', () => {
     const capture: SsoTestCapture = {
       registrationId: REG,

--- a/apps/web/src/lib/shared/__tests__/sso-mapping-preview.test.ts
+++ b/apps/web/src/lib/shared/__tests__/sso-mapping-preview.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect } from 'vitest'
+import type { IdentityProviderClaimMapping } from '../oidc-claim-mapping'
+import { previewClaimMapping, selectMappingCapture } from '../sso-mapping-preview'
+import type { SsoTestCapture } from '../sso-test-capture'
+
+const REG = 'oidc_x'
+
+function v2Capture(over: Partial<SsoTestCapture> = {}): SsoTestCapture {
+  return {
+    version: 2,
+    registrationId: REG,
+    capturedAt: '2026-09-01T00:00:00.000Z',
+    detailsChangedAtAtStart: null,
+    outcome: 'success',
+    identity: {
+      id: 'person-123',
+      email: 'jane@example.test',
+      name: 'Jane',
+      sources: { id: 'idToken' },
+    },
+    claims: {
+      sub: 'person-123',
+      email: 'Jane@Example.TEST',
+      name: 'Jane',
+      groups: ['engineering'],
+    },
+    replay: {
+      sources: [
+        {
+          source: 'idToken',
+          claims: {
+            sub: 'person-123',
+            email: 'Jane@Example.TEST',
+            name: 'Jane',
+            groups: ['engineering'],
+          },
+        },
+        { source: 'userinfo', claims: { sub: 'person-123', department: 'Engineering' } },
+      ],
+    },
+    ...over,
+  }
+}
+
+const defs = [{ key: 'department', type: 'string' as const, label: 'Department' }]
+const policy = {
+  autoCreateUsers: true,
+  autoProvisionRole: 'user' as const,
+  registrationId: REG,
+}
+
+describe('selectMappingCapture', () => {
+  it('wrong provider capture is ignored', () => {
+    expect(
+      selectMappingCapture({
+        registrationId: REG,
+        sessionCapture: v2Capture({ registrationId: 'oidc_other' }),
+        persistedCapture: v2Capture({ registrationId: 'oidc_other' }),
+      })
+    ).toBeNull()
+  })
+
+  it('newer failed mapping capture supersedes old success for debugging', () => {
+    const olderSuccess = v2Capture({
+      capturedAt: '2026-09-01T00:00:00.000Z',
+      outcome: 'success',
+    })
+    const newerFail = v2Capture({
+      capturedAt: '2026-09-01T01:00:00.000Z',
+      outcome: 'mapping_failed',
+      identity: undefined,
+    })
+    const selected = selectMappingCapture({
+      registrationId: REG,
+      sessionCapture: newerFail,
+      persistedCapture: olderSuccess,
+    })
+    expect(selected?.outcome).toBe('mapping_failed')
+    expect(selected?.capturedAt).toBe('2026-09-01T01:00:00.000Z')
+  })
+})
+
+describe('previewClaimMapping', () => {
+  it('preview uses production binder for unsaved draft', () => {
+    const draft: IdentityProviderClaimMapping = {
+      profile: { claims: { email: 'upn' } },
+    }
+    const capture = v2Capture({
+      replay: {
+        sources: [
+          {
+            source: 'idToken',
+            claims: {
+              sub: 'person-123',
+              upn: 'Jane@Idp.Example',
+              email: 'other@x.test',
+              name: 'Jane',
+            },
+          },
+          { source: 'userinfo', claims: { sub: 'person-123' } },
+        ],
+      },
+    })
+    const preview = previewClaimMapping({
+      draft,
+      capture,
+      definitions: defs,
+      providerPolicy: policy,
+    })
+    expect(preview.status).toBe('ready')
+    expect(preview.identity?.email).toBe('jane@idp.example')
+    expect(preview.identity?.provenance.email?.path).toBe('upn')
+    expect(preview.identity?.id).toBe('person-123')
+  })
+
+  it('wrong provider capture is ignored', () => {
+    const preview = previewClaimMapping({
+      draft: null,
+      capture: v2Capture({ registrationId: 'oidc_other' }),
+      definitions: defs,
+      providerPolicy: policy,
+    })
+    expect(preview.capture).toBeNull()
+    expect(preview.identity).toBeNull()
+  })
+
+  it('legacy capture asks for retest', () => {
+    const capture: SsoTestCapture = {
+      registrationId: REG,
+      capturedAt: '2026-09-01T00:00:00.000Z',
+      identity: { id: 'person-123', email: 'jane@example.test', sources: { id: 'idToken' } },
+      claims: { sub: 'person-123', email: 'jane@example.test' },
+    }
+    const preview = previewClaimMapping({
+      draft: null,
+      capture,
+      definitions: defs,
+      providerPolicy: policy,
+    })
+    expect(preview.status).toBe('needs_retest')
+    expect(preview.limitations.join(' ')).toMatch(/preview mappings accurately/i)
+    expect(preview.identity).toBeNull()
+  })
+
+  it('source change never invents provenance', () => {
+    const draft: IdentityProviderClaimMapping = {
+      profile: { sources: ['idToken', 'userinfo', 'accessTokenJwt'] },
+    }
+    const preview = previewClaimMapping({
+      draft,
+      capture: v2Capture(),
+      definitions: defs,
+      providerPolicy: policy,
+    })
+    expect(preview.status).toBe('needs_retest')
+    expect(preview.missingSource).toBe('accessTokenJwt')
+    expect(preview.identity).toBeNull()
+  })
+
+  it('role preview warns about off-domain admin rules even if test matches member', () => {
+    const draft: IdentityProviderClaimMapping = {
+      role: {
+        claimPath: 'groups',
+        rules: [
+          { whenContains: 'platform-admins', role: 'admin' },
+          { whenContains: 'engineering', role: 'member' },
+        ],
+      },
+    }
+    const preview = previewClaimMapping({
+      draft,
+      capture: v2Capture(),
+      definitions: defs,
+      providerPolicy: policy,
+    })
+    expect(preview.roleMatch).toEqual({ role: 'member', ruleIndex: 1 })
+    expect(draft.role?.rules.some((r) => r.role === 'admin')).toBe(true)
+  })
+
+  it('auto-create off suppresses role application but not People preview', () => {
+    const draft: IdentityProviderClaimMapping = {
+      role: { claimPath: 'groups', rules: [{ whenContains: 'engineering', role: 'member' }] },
+      attributes: { map: [{ claimPath: 'department', attributeKey: 'department' }] },
+    }
+    const preview = previewClaimMapping({
+      draft,
+      capture: v2Capture(),
+      definitions: defs,
+      providerPolicy: { ...policy, autoCreateUsers: false },
+    })
+    expect(preview.roleMatch?.role).toBe('member')
+    expect(preview.peoplePlan?.valid.department).toBe('Engineering')
+  })
+
+  it('placeholder preview never generates an address', () => {
+    const draft: IdentityProviderClaimMapping = {
+      profile: { allowMissingEmail: true },
+    }
+    const capture = v2Capture({
+      replay: {
+        sources: [
+          { source: 'idToken', claims: { sub: 'person-123', name: 'Jane' } },
+          { source: 'userinfo', claims: { sub: 'person-123' } },
+        ],
+      },
+    })
+    const preview = previewClaimMapping({
+      draft,
+      capture,
+      definitions: defs,
+      providerPolicy: policy,
+    })
+    expect(preview.identity?.kind).toBe('placeholder_required')
+    expect(preview.identity?.email).toBeUndefined()
+    expect(preview.identity?.placeholderEmail).toBe(true)
+  })
+
+  it('metadata preview cannot claim existing values were kept', () => {
+    const draft: IdentityProviderClaimMapping = {
+      attributes: {
+        map: [{ claimPath: 'department', attributeKey: 'department' }],
+        overrideExisting: false,
+      },
+    }
+    const preview = previewClaimMapping({
+      draft,
+      capture: v2Capture(),
+      definitions: defs,
+      providerPolicy: policy,
+    })
+    expect(preview.peoplePlan?.skips?.some((s) => s.reason === 'kept_existing')).toBeFalsy()
+    expect(preview.peoplePlan?.valid.department).toBe('Engineering')
+  })
+
+  it('newer failed mapping capture still previews the draft', () => {
+    const capture = v2Capture({
+      outcome: 'mapping_failed',
+      identity: undefined,
+      replay: {
+        sources: [
+          {
+            source: 'idToken',
+            claims: { sub: 'person-123', upn: 'jane@example.test', name: 'Jane' },
+          },
+          { source: 'userinfo', claims: { sub: 'person-123' } },
+        ],
+      },
+    })
+    const preview = previewClaimMapping({
+      draft: { profile: { claims: { email: 'upn' } } },
+      capture,
+      definitions: defs,
+      providerPolicy: policy,
+    })
+    expect(preview.status).toBe('mapping_failed')
+    expect(preview.identity?.email).toBe('jane@example.test')
+  })
+})

--- a/apps/web/src/lib/shared/claim-suggestions.ts
+++ b/apps/web/src/lib/shared/claim-suggestions.ts
@@ -122,6 +122,80 @@ export type AttributeClaimPathSuggestion = {
   description?: string
 }
 
+export type IdentityClaimPathSuggestion = {
+  path: string
+  description?: string
+  /** Array-valued claims cannot bind identity scalars. Shown, never unwrapped. */
+  unsuitable?: boolean
+}
+
+/** Protocol claims that are never identity paths. `sub` is kept. */
+const IDENTITY_PROTOCOL_CLAIMS = new Set([
+  'iss',
+  'aud',
+  'exp',
+  'iat',
+  'nbf',
+  'jti',
+  'nonce',
+  'azp',
+  'at_hash',
+  'c_hash',
+  'sid',
+  'rh',
+  'uti',
+  'aio',
+  'ver',
+  'amr',
+  'acr',
+])
+
+const IDENTITY_KIND_HINTS: Record<string, { id: string[]; email: string[]; name: string[] }> = {
+  entra: {
+    id: ['oid', 'sub'],
+    email: ['email', 'upn', 'preferred_username'],
+    name: ['name'],
+  },
+  okta: {
+    id: ['sub'],
+    email: ['email', 'preferred_username'],
+    name: ['name'],
+  },
+  auth0: {
+    id: ['sub'],
+    email: ['email'],
+    name: ['name'],
+  },
+  keycloak: {
+    id: ['sub'],
+    email: ['email'],
+    name: ['name', 'preferred_username'],
+  },
+  google: {
+    id: ['sub'],
+    email: ['email'],
+    name: ['name'],
+  },
+  other: {
+    id: ['sub'],
+    email: ['email', 'mail', 'upn'],
+    name: ['name', 'preferred_username'],
+  },
+}
+
+/** Kind-specific aliases only. Never written automatically. */
+export function identityClaimHints(
+  kind?: string | null,
+  field?: 'id' | 'email' | 'name'
+): string[] {
+  const hints = IDENTITY_KIND_HINTS[kind ?? ''] ?? IDENTITY_KIND_HINTS.other
+  if (!hints) return field === 'id' || !field ? ['sub'] : []
+  if (field === 'id') return hints.id
+  if (field === 'email') return hints.email
+  if (field === 'name') return hints.name
+  return [...new Set([...hints.id, ...hints.email, ...hints.name])]
+}
+
 function truncatePreview(value: JsonValue, max = 48): string {
   let text: string
   if (Array.isArray(value)) {
@@ -169,6 +243,66 @@ export function deriveAttributeClaimPaths(
         record(`${key}.${childKey}`, childValue as JsonValue)
       }
     }
+  }
+
+  return out
+}
+
+/**
+ * Scalar claim paths for Unique user identifier / Email / Display name.
+ * Always includes `sub` (attribute suggestions exclude it). Array leaves are
+ * returned as unsuitable rather than unwrapped.
+ */
+export function deriveIdentityClaimPaths(
+  allClaims: Record<string, JsonValue>,
+  opts?: { kind?: string | null; field?: 'id' | 'email' | 'name' }
+): IdentityClaimPathSuggestion[] {
+  const out: IdentityClaimPathSuggestion[] = []
+  const seen = new Set<string>()
+
+  const record = (path: string, value: JsonValue | undefined) => {
+    if (seen.has(path)) return
+    seen.add(path)
+    if (value === undefined) {
+      out.push({ path })
+      return
+    }
+    if (Array.isArray(value)) {
+      out.push({
+        path,
+        description: truncatePreview(value),
+        unsuitable: true,
+      })
+      return
+    }
+    if (!isLeaf(value)) return
+    out.push({ path, description: truncatePreview(value) })
+  }
+
+  for (const [key, value] of Object.entries(allClaims)) {
+    if (IDENTITY_PROTOCOL_CLAIMS.has(key)) continue
+    if (key.includes('://')) {
+      record(key, value)
+      continue
+    }
+    if (isLeaf(value)) {
+      record(key, value)
+    } else if (value !== null && typeof value === 'object') {
+      for (const [childKey, childValue] of Object.entries(value)) {
+        if (childKey.includes('://')) continue
+        record(`${key}.${childKey}`, childValue as JsonValue)
+      }
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(allClaims, 'sub')) {
+    record('sub', allClaims.sub)
+  } else {
+    record('sub', undefined)
+  }
+
+  for (const hint of identityClaimHints(opts?.kind, opts?.field)) {
+    if (!seen.has(hint)) record(hint, undefined)
   }
 
   return out

--- a/apps/web/src/lib/shared/claim-suggestions.ts
+++ b/apps/web/src/lib/shared/claim-suggestions.ts
@@ -125,7 +125,7 @@ export type AttributeClaimPathSuggestion = {
 export type IdentityClaimPathSuggestion = {
   path: string
   description?: string
-  /** Array-valued claims cannot bind identity scalars. Shown, never unwrapped. */
+  /** Arrays, booleans, and null cannot bind identity scalars. Shown, never unwrapped. */
   unsuitable?: boolean
 }
 
@@ -276,6 +276,14 @@ export function deriveIdentityClaimPaths(
       return
     }
     if (!isLeaf(value)) return
+    if (typeof value === 'boolean' || value === null) {
+      out.push({
+        path,
+        description: truncatePreview(value),
+        unsuitable: true,
+      })
+      return
+    }
     out.push({ path, description: truncatePreview(value) })
   }
 

--- a/apps/web/src/lib/shared/sso-claim-mapping-edit.ts
+++ b/apps/web/src/lib/shared/sso-claim-mapping-edit.ts
@@ -412,6 +412,30 @@ function reorderRoleRuleOps(
   return ops
 }
 
+/** When after is a subsequence of before, emit whole-row removals instead of index edits. */
+function subsequenceRemoveOps(
+  beforeRows: unknown[],
+  afterRows: unknown[],
+  identity: (row: unknown) => string | null,
+  removeOp: (index: number) => ClaimMappingOperation
+): ClaimMappingOperation[] | null {
+  if (afterRows.length >= beforeRows.length) return null
+  const beforeKeys = beforeRows.map(identity)
+  const afterKeys = afterRows.map(identity)
+  if (beforeKeys.some((key) => key == null) || afterKeys.some((key) => key == null)) return null
+  let afterIndex = 0
+  const removed: number[] = []
+  for (let i = 0; i < beforeKeys.length; i++) {
+    if (afterIndex < afterKeys.length && beforeKeys[i] === afterKeys[afterIndex]) {
+      afterIndex += 1
+    } else {
+      removed.push(i)
+    }
+  }
+  if (afterIndex !== afterKeys.length) return null
+  return removed.reverse().map(removeOp)
+}
+
 /** Diff supported editor state against stored JSON into closed operations. */
 export function diffClaimMappingOperations(
   before: unknown,
@@ -451,8 +475,14 @@ export function diffClaimMappingOperations(
     const beforeRules = Array.isArray(beforeRole?.rules) ? beforeRole.rules : []
     const afterRules = afterRole.rules ?? []
     const reorders = reorderRoleRuleOps(beforeRules, afterRules)
+    const removals = subsequenceRemoveOps(beforeRules, afterRules, roleRuleIdentity, (index) => ({
+      op: 'removeRoleRule',
+      index,
+    }))
     if (reorders) {
       ops.push(...reorders)
+    } else if (removals) {
+      ops.push(...removals)
     } else {
       const commonRules = Math.min(beforeRules.length, afterRules.length)
       for (let i = 0; i < commonRules; i++) {
@@ -479,23 +509,36 @@ export function diffClaimMappingOperations(
   const afterAttrs = proposed?.attributes ?? null
   const beforeMap = Array.isArray(beforeAttrs?.map) ? beforeAttrs.map : []
   const afterMap = afterAttrs?.map ?? []
-  const commonMap = Math.min(beforeMap.length, afterMap.length)
-  for (let i = 0; i < commonMap; i++) {
-    const left = beforeMap[i]
-    const right = afterMap[i]
-    if (
-      !isRecord(left) ||
-      left.claimPath !== right.claimPath ||
-      left.attributeKey !== right.attributeKey
-    ) {
-      ops.push({ op: 'editPeopleMapping', index: i, entry: right })
+  const peopleIdentity = (row: unknown) => {
+    if (!isRecord(row)) return null
+    if (typeof row.claimPath !== 'string' || typeof row.attributeKey !== 'string') return null
+    return `${row.claimPath}\0${row.attributeKey}`
+  }
+  const peopleRemovals = subsequenceRemoveOps(beforeMap, afterMap, peopleIdentity, (index) => ({
+    op: 'removePeopleMapping',
+    index,
+  }))
+  if (peopleRemovals) {
+    ops.push(...peopleRemovals)
+  } else {
+    const commonMap = Math.min(beforeMap.length, afterMap.length)
+    for (let i = 0; i < commonMap; i++) {
+      const left = beforeMap[i]
+      const right = afterMap[i]
+      if (
+        !isRecord(left) ||
+        left.claimPath !== right.claimPath ||
+        left.attributeKey !== right.attributeKey
+      ) {
+        ops.push({ op: 'editPeopleMapping', index: i, entry: right })
+      }
     }
-  }
-  for (let i = beforeMap.length - 1; i >= commonMap; i--) {
-    ops.push({ op: 'removePeopleMapping', index: i })
-  }
-  for (let i = commonMap; i < afterMap.length; i++) {
-    ops.push({ op: 'insertPeopleMapping', index: i, entry: afterMap[i] })
+    for (let i = beforeMap.length - 1; i >= commonMap; i--) {
+      ops.push({ op: 'removePeopleMapping', index: i })
+    }
+    for (let i = commonMap; i < afterMap.length; i++) {
+      ops.push({ op: 'insertPeopleMapping', index: i, entry: afterMap[i] })
+    }
   }
   const beforeOverride = beforeAttrs?.overrideExisting === true
   const afterOverride = afterAttrs?.overrideExisting === true

--- a/apps/web/src/lib/shared/sso-claim-mapping-edit.ts
+++ b/apps/web/src/lib/shared/sso-claim-mapping-edit.ts
@@ -375,6 +375,43 @@ export function sourcesAreDefault(sources: IdentitySource[] | undefined): boolea
   return JSON.stringify(sources) === JSON.stringify(DEFAULT_IDENTITY_SOURCES)
 }
 
+function roleRuleIdentity(rule: unknown): string | null {
+  if (!isRecord(rule)) return null
+  if (typeof rule.whenContains !== 'string' || typeof rule.role !== 'string') return null
+  return `${rule.whenContains}\0${rule.role}`
+}
+
+/** When after is a permutation of before, emit whole-object moves instead of index edits. */
+function reorderRoleRuleOps(
+  beforeRules: unknown[],
+  afterRules: unknown[]
+): ClaimMappingOperation[] | null {
+  if (beforeRules.length === 0 || beforeRules.length !== afterRules.length) return null
+  const beforeKeys = beforeRules.map(roleRuleIdentity)
+  const afterKeys = afterRules.map(roleRuleIdentity)
+  if (beforeKeys.some((key) => key == null) || afterKeys.some((key) => key == null)) return null
+  const remaining = new Map<string, number>()
+  for (const key of beforeKeys) remaining.set(key!, (remaining.get(key!) ?? 0) + 1)
+  for (const key of afterKeys) {
+    const count = remaining.get(key!) ?? 0
+    if (count === 0) return null
+    remaining.set(key!, count - 1)
+  }
+  if (beforeKeys.every((key, i) => key === afterKeys[i])) return []
+  const ops: ClaimMappingOperation[] = []
+  const working = [...beforeKeys] as string[]
+  for (let i = 0; i < afterKeys.length; i++) {
+    const want = afterKeys[i]!
+    if (working[i] === want) continue
+    const from = working.indexOf(want, i)
+    if (from < 0) return null
+    working.splice(from, 1)
+    working.splice(i, 0, want)
+    ops.push({ op: 'reorderRoleRule', from, to: i })
+  }
+  return ops
+}
+
 /** Diff supported editor state against stored JSON into closed operations. */
 export function diffClaimMappingOperations(
   before: unknown,
@@ -413,19 +450,28 @@ export function diffClaimMappingOperations(
     if (beforeSync !== afterSync) ops.push({ op: 'setRoleSync', syncOnEverySignIn: afterSync })
     const beforeRules = Array.isArray(beforeRole?.rules) ? beforeRole.rules : []
     const afterRules = afterRole.rules ?? []
-    const commonRules = Math.min(beforeRules.length, afterRules.length)
-    for (let i = 0; i < commonRules; i++) {
-      const left = beforeRules[i]
-      const right = afterRules[i]
-      if (!isRecord(left) || left.whenContains !== right.whenContains || left.role !== right.role) {
-        ops.push({ op: 'editRoleRule', index: i, rule: right })
+    const reorders = reorderRoleRuleOps(beforeRules, afterRules)
+    if (reorders) {
+      ops.push(...reorders)
+    } else {
+      const commonRules = Math.min(beforeRules.length, afterRules.length)
+      for (let i = 0; i < commonRules; i++) {
+        const left = beforeRules[i]
+        const right = afterRules[i]
+        if (
+          !isRecord(left) ||
+          left.whenContains !== right.whenContains ||
+          left.role !== right.role
+        ) {
+          ops.push({ op: 'editRoleRule', index: i, rule: right })
+        }
       }
-    }
-    for (let i = beforeRules.length - 1; i >= commonRules; i--) {
-      ops.push({ op: 'removeRoleRule', index: i })
-    }
-    for (let i = commonRules; i < afterRules.length; i++) {
-      ops.push({ op: 'insertRoleRule', index: i, rule: afterRules[i] })
+      for (let i = beforeRules.length - 1; i >= commonRules; i--) {
+        ops.push({ op: 'removeRoleRule', index: i })
+      }
+      for (let i = commonRules; i < afterRules.length; i++) {
+        ops.push({ op: 'insertRoleRule', index: i, rule: afterRules[i] })
+      }
     }
   }
 

--- a/apps/web/src/lib/shared/sso-claim-mapping-edit.ts
+++ b/apps/web/src/lib/shared/sso-claim-mapping-edit.ts
@@ -381,25 +381,39 @@ function roleRuleIdentity(rule: unknown): string | null {
   return `${rule.whenContains}\0${rule.role}`
 }
 
-/** When after is a permutation of before, emit whole-object moves instead of index edits. */
-function reorderRoleRuleOps(
-  beforeRules: unknown[],
-  afterRules: unknown[]
+/** After identities are a submultiset of before: remove extras, then permute survivors. */
+function subsetPermuteOps(
+  beforeRows: unknown[],
+  afterRows: unknown[],
+  identity: (row: unknown) => string | null,
+  removeOp: (index: number) => ClaimMappingOperation,
+  reorderOp?: (from: number, to: number) => ClaimMappingOperation
 ): ClaimMappingOperation[] | null {
-  if (beforeRules.length === 0 || beforeRules.length !== afterRules.length) return null
-  const beforeKeys = beforeRules.map(roleRuleIdentity)
-  const afterKeys = afterRules.map(roleRuleIdentity)
+  if (afterRows.length > beforeRows.length) return null
+  const beforeKeys = beforeRows.map(identity)
+  const afterKeys = afterRows.map(identity)
   if (beforeKeys.some((key) => key == null) || afterKeys.some((key) => key == null)) return null
-  const remaining = new Map<string, number>()
-  for (const key of beforeKeys) remaining.set(key!, (remaining.get(key!) ?? 0) + 1)
-  for (const key of afterKeys) {
-    const count = remaining.get(key!) ?? 0
-    if (count === 0) return null
-    remaining.set(key!, count - 1)
+  const need = new Map<string, number>()
+  for (const key of afterKeys) need.set(key!, (need.get(key!) ?? 0) + 1)
+  const have = new Map<string, number>()
+  for (const key of beforeKeys) have.set(key!, (have.get(key!) ?? 0) + 1)
+  for (const [key, count] of need) {
+    if ((have.get(key) ?? 0) < count) return null
   }
-  if (beforeKeys.every((key, i) => key === afterKeys[i])) return []
   const ops: ClaimMappingOperation[] = []
   const working = [...beforeKeys] as string[]
+  for (let i = working.length - 1; i >= 0; i--) {
+    const key = working[i]
+    if ((have.get(key) ?? 0) > (need.get(key) ?? 0)) {
+      ops.push(removeOp(i))
+      working.splice(i, 1)
+      have.set(key, (have.get(key) ?? 1) - 1)
+    }
+  }
+  if (working.length !== afterKeys.length) return null
+  if (!reorderOp) {
+    return working.every((key, i) => key === afterKeys[i]) ? ops : null
+  }
   for (let i = 0; i < afterKeys.length; i++) {
     const want = afterKeys[i]!
     if (working[i] === want) continue
@@ -407,33 +421,9 @@ function reorderRoleRuleOps(
     if (from < 0) return null
     working.splice(from, 1)
     working.splice(i, 0, want)
-    ops.push({ op: 'reorderRoleRule', from, to: i })
+    ops.push(reorderOp(from, i))
   }
   return ops
-}
-
-/** When after is a subsequence of before, emit whole-row removals instead of index edits. */
-function subsequenceRemoveOps(
-  beforeRows: unknown[],
-  afterRows: unknown[],
-  identity: (row: unknown) => string | null,
-  removeOp: (index: number) => ClaimMappingOperation
-): ClaimMappingOperation[] | null {
-  if (afterRows.length >= beforeRows.length) return null
-  const beforeKeys = beforeRows.map(identity)
-  const afterKeys = afterRows.map(identity)
-  if (beforeKeys.some((key) => key == null) || afterKeys.some((key) => key == null)) return null
-  let afterIndex = 0
-  const removed: number[] = []
-  for (let i = 0; i < beforeKeys.length; i++) {
-    if (afterIndex < afterKeys.length && beforeKeys[i] === afterKeys[afterIndex]) {
-      afterIndex += 1
-    } else {
-      removed.push(i)
-    }
-  }
-  if (afterIndex !== afterKeys.length) return null
-  return removed.reverse().map(removeOp)
 }
 
 /** Diff supported editor state against stored JSON into closed operations. */
@@ -474,15 +464,15 @@ export function diffClaimMappingOperations(
     if (beforeSync !== afterSync) ops.push({ op: 'setRoleSync', syncOnEverySignIn: afterSync })
     const beforeRules = Array.isArray(beforeRole?.rules) ? beforeRole.rules : []
     const afterRules = afterRole.rules ?? []
-    const reorders = reorderRoleRuleOps(beforeRules, afterRules)
-    const removals = subsequenceRemoveOps(beforeRules, afterRules, roleRuleIdentity, (index) => ({
-      op: 'removeRoleRule',
-      index,
-    }))
-    if (reorders) {
-      ops.push(...reorders)
-    } else if (removals) {
-      ops.push(...removals)
+    const aligned = subsetPermuteOps(
+      beforeRules,
+      afterRules,
+      roleRuleIdentity,
+      (index) => ({ op: 'removeRoleRule', index }),
+      (from, to) => ({ op: 'reorderRoleRule', from, to })
+    )
+    if (aligned) {
+      ops.push(...aligned)
     } else {
       const commonRules = Math.min(beforeRules.length, afterRules.length)
       for (let i = 0; i < commonRules; i++) {
@@ -514,12 +504,12 @@ export function diffClaimMappingOperations(
     if (typeof row.claimPath !== 'string' || typeof row.attributeKey !== 'string') return null
     return `${row.claimPath}\0${row.attributeKey}`
   }
-  const peopleRemovals = subsequenceRemoveOps(beforeMap, afterMap, peopleIdentity, (index) => ({
+  const peopleAligned = subsetPermuteOps(beforeMap, afterMap, peopleIdentity, (index) => ({
     op: 'removePeopleMapping',
     index,
   }))
-  if (peopleRemovals) {
-    ops.push(...peopleRemovals)
+  if (peopleAligned) {
+    ops.push(...peopleAligned)
   } else {
     const commonMap = Math.min(beforeMap.length, afterMap.length)
     for (let i = 0; i < commonMap; i++) {

--- a/apps/web/src/lib/shared/sso-mapping-preview.ts
+++ b/apps/web/src/lib/shared/sso-mapping-preview.ts
@@ -69,6 +69,23 @@ function requiredClaimPathsFor(stored: unknown): string[] {
   ]
 }
 
+/** True when current provider details are newer than the config the handshake used. */
+export function captureConfigIsStale(
+  detailsChangedAt: string | null | undefined,
+  capture: SsoTestCapture
+): boolean {
+  if (!detailsChangedAt) return false
+  const currentMs = new Date(detailsChangedAt).getTime()
+  if (!Number.isFinite(currentMs)) return false
+  if (isReplayableCapture(capture)) {
+    if (capture.detailsChangedAtAtStart == null) return true
+    const startMs = new Date(capture.detailsChangedAtAtStart).getTime()
+    return Number.isFinite(startMs) && currentMs > startMs
+  }
+  const capturedMs = new Date(capture.capturedAt).getTime()
+  return Number.isFinite(capturedMs) && currentMs > capturedMs
+}
+
 function sourceMissingFromCapture(draft: unknown, capture: SsoTestCapture): IdentitySource | null {
   if (!isReplayableCapture(capture)) return null
   const captured = new Set(capture.replay.sources.map((s) => s.source))
@@ -102,9 +119,7 @@ export function previewClaimMapping({
     }
   }
 
-  const stale =
-    !!providerPolicy.detailsChangedAt &&
-    new Date(providerPolicy.detailsChangedAt).getTime() > new Date(capture.capturedAt).getTime()
+  const stale = captureConfigIsStale(providerPolicy.detailsChangedAt, capture)
 
   if (!isReplayableCapture(capture)) {
     return {

--- a/apps/web/src/lib/shared/sso-mapping-preview.ts
+++ b/apps/web/src/lib/shared/sso-mapping-preview.ts
@@ -1,0 +1,208 @@
+/**
+ * Draft mapping preview. Replays captured source snapshots through the same
+ * binder production uses. No alternate value extraction.
+ */
+
+import {
+  allowsMissingEmail,
+  claimMappingFor,
+  identityMappingFor,
+  identitySourcesFor,
+  profileClaimFor,
+  type IdentityProviderClaimMapping,
+  type IdentitySource,
+} from './oidc-claim-mapping'
+import { planClaimAttributeWrites, type AttributeDefinition } from './plan-claim-attribute-writes'
+import { resolveSsoRoleMatch } from './resolve-sso-role'
+import type { Role } from './roles'
+import { finishBinding, replayClaimMapping } from './sso-claim-binder'
+import { finalizeProfileOutcome, type ProfileOutcome } from './sso-profile-outcome'
+import { isReplayableCapture, type SsoTestCapture } from './sso-test-capture'
+
+export const SOURCE_WORDS: Record<IdentitySource, string> = {
+  idToken: 'ID token',
+  userinfo: 'userinfo',
+  accessTokenJwt: 'access token JWT',
+}
+
+export type MappingPreviewStatus = 'ready' | 'needs_retest' | 'mapping_failed'
+
+export type MappingPreviewPolicy = {
+  autoCreateUsers: boolean
+  autoProvisionRole: Role | null
+  detailsChangedAt?: string | null
+  registrationId: string
+}
+
+export type MappingPreview = {
+  status: MappingPreviewStatus
+  identity: ProfileOutcome | null
+  roleMatch: { role: Role; ruleIndex: number } | null
+  peoplePlan: ReturnType<typeof planClaimAttributeWrites> | null
+  stale: boolean
+  limitations: string[]
+  missingSource: IdentitySource | null
+  capture: SsoTestCapture | null
+}
+
+export function selectMappingCapture(args: {
+  registrationId: string
+  sessionCapture?: SsoTestCapture | null
+  persistedCapture?: SsoTestCapture | null
+}): SsoTestCapture | null {
+  const candidates = [args.sessionCapture, args.persistedCapture].filter(
+    (c): c is SsoTestCapture => !!c && c.registrationId === args.registrationId
+  )
+  if (candidates.length === 0) return null
+  return candidates.reduce((newest, current) =>
+    new Date(current.capturedAt).getTime() > new Date(newest.capturedAt).getTime()
+      ? current
+      : newest
+  )
+}
+
+function requiredClaimPathsFor(stored: unknown): string[] {
+  const mapping = claimMappingFor(stored)
+  return [
+    ...(mapping.attributes?.map ?? []).map((entry) => entry.claimPath),
+    ...(mapping.role?.claimPath ? [mapping.role.claimPath] : []),
+  ]
+}
+
+function sourceMissingFromCapture(draft: unknown, capture: SsoTestCapture): IdentitySource | null {
+  if (!isReplayableCapture(capture)) return null
+  const captured = new Set(capture.replay.sources.map((s) => s.source))
+  for (const source of identitySourcesFor(draft)) {
+    if (!captured.has(source)) return source
+  }
+  return null
+}
+
+export function previewClaimMapping({
+  draft,
+  capture,
+  definitions,
+  providerPolicy,
+}: {
+  draft: IdentityProviderClaimMapping | null
+  capture: SsoTestCapture | null
+  definitions: AttributeDefinition[]
+  providerPolicy: MappingPreviewPolicy
+}): MappingPreview {
+  if (!capture || capture.registrationId !== providerPolicy.registrationId) {
+    return {
+      status: 'needs_retest',
+      identity: null,
+      roleMatch: null,
+      peoplePlan: null,
+      stale: false,
+      limitations: [],
+      missingSource: null,
+      capture: null,
+    }
+  }
+
+  const stale =
+    !!providerPolicy.detailsChangedAt &&
+    new Date(providerPolicy.detailsChangedAt).getTime() > new Date(capture.capturedAt).getTime()
+
+  if (!isReplayableCapture(capture)) {
+    return {
+      status: 'needs_retest',
+      identity: null,
+      roleMatch: null,
+      peoplePlan: null,
+      stale,
+      limitations: ['Run a new test sign-in to preview mappings accurately.'],
+      missingSource: null,
+      capture,
+    }
+  }
+
+  const missingSource = sourceMissingFromCapture(draft, capture)
+  if (missingSource) {
+    return {
+      status: 'needs_retest',
+      identity: null,
+      roleMatch: null,
+      peoplePlan: null,
+      stale,
+      limitations: [
+        `${SOURCE_WORDS[missingSource]} was not captured by this test. Run a new test before relying on this source configuration.`,
+      ],
+      missingSource,
+      capture,
+    }
+  }
+
+  const bound = finishBinding(
+    replayClaimMapping(
+      {
+        mapping: identityMappingFor(draft),
+        requiredClaimPaths: requiredClaimPathsFor(draft),
+        wantImage: true,
+      },
+      capture.replay.sources
+    )
+  )
+  const identity = finalizeProfileOutcome(bound, {
+    allowMissingEmail: allowsMissingEmail(draft),
+  })
+  const mapping = claimMappingFor(draft)
+  const roleMatch = resolveSsoRoleMatch(identity.acceptedClaims, mapping.role)
+  const peoplePlan = mapping.attributes
+    ? planClaimAttributeWrites({
+        claims: identity.acceptedClaims,
+        mapping: mapping.attributes,
+        existing: {},
+        definitions,
+        explain: true,
+      })
+    : null
+
+  const limitations: string[] = [
+    'Name and email show account-creation inputs. Existing profiles are not overwritten on later sign-ins.',
+    'People preview assumes no existing attributes.',
+  ]
+  if (stale) {
+    limitations.unshift(
+      'Configuration changed since this test. Re-test to validate it. Preview uses the captured claims with your current draft.'
+    )
+  }
+
+  return {
+    status: capture.outcome === 'mapping_failed' ? 'mapping_failed' : 'ready',
+    identity,
+    roleMatch,
+    peoplePlan,
+    stale,
+    limitations,
+    missingSource: null,
+    capture,
+  }
+}
+
+export function effectiveIdPath(draft: unknown): string {
+  return profileClaimFor(draft, 'id') ?? 'sub'
+}
+
+export function effectiveEmailPath(draft: unknown): string {
+  return profileClaimFor(draft, 'email') ?? 'email'
+}
+
+export function effectiveNamePath(draft: unknown): string {
+  return profileClaimFor(draft, 'name') ?? 'name'
+}
+
+export function runtimeFallbackRole(autoProvisionRole: Role | null): {
+  role: Role
+  label: string
+} {
+  if (autoProvisionRole == null) return { role: 'member', label: 'Member (runtime default)' }
+  const labels: Record<Role, string> = {
+    admin: 'Admin',
+    member: 'Member',
+    user: 'User',
+  }
+  return { role: autoProvisionRole, label: labels[autoProvisionRole] }
+}


### PR DESCRIPTION
## Summary

Ships the Attributes & Claims table on the identity-provider detail page: required identifier/email rows, additional name/role/People mappings, Advanced sources, scoped Reset, draft preview from V2 source snapshots, and identifier/admin save confirmations.

This is **PR 3 of 3**. Depends on #509. `CLAIMS_TABLE = true` with a `presentation` prop so UI rollback is a reviewed constant flip, not a data migration.

**Stack:** #508 → #509 → #510 ([stack #511](https://github.com/QuackbackIO/quackback/issues/511))
**Plan:** `docs/superpowers/plans/2026-09-07-sso-claim-attribute-mapping.md` (Tasks 6–8)

## What changed

- Named rows using People settings chrome. Dialogs edit a local draft; card Save uses PR 2's operations API.
- Identity suggestions include `sub`. Explicit `id: 'sub'` is Custom (disables userinfo `id` fallback).
- Preview calls `previewClaimMapping` → production binder replay + shared role/People planners. No second mapper.
- Dirty card CTA is **Save and test** (persists first). Clean is Re-test / Test sign-in.
- Identifier and admin risks share one ConfirmDialog. Cancel performs no write. Stale save keeps the draft.
- Section label is Attributes & Claims; `#mapping` and Connection / Sign-in / Accounts / Remove anchors stay.

## Test plan

- [x] Table: always-visible required/default rows, dialog Cancel isolation, duplicate People edit by baseline index, unsupported rows not a no-op Remove
- [x] Preview: unsaved draft via production binder, wrong-provider capture ignored, legacy asks for retest, placeholder never mints
- [x] Confirmations: identifier change, admin rule even when preview is member, default Save does not restamp, Save and test waits for persist
- [x] Parity suite reaches the exported preview helper
- [x] `cd apps/web && bun run typecheck` and `cd packages/db && bun run typecheck`
- [x] oxlint on PR files: 0 warnings

## Limitations

- Manual IdP acceptance did **not** run. No authorized customer test IdP credentials were available. Fixture names are not provider certification.
- Preview cannot prove uniqueness, linking, or overwrite/keep for a returning person.
- Legacy captures require a new test for exact identity replay.