### PR TITLE
fix(integrations): connect platform-managed apps without pasting credentials

### DIFF
--- a/apps/web/src/components/admin/settings/integrations/integration-header.tsx
+++ b/apps/web/src/components/admin/settings/integrations/integration-header.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react'
 import { BackLink } from '@/components/ui/back-link'
 import { Badge } from '@/components/ui/badge'
 import { DocsLink } from '@/components/ui/docs-link'
+import { canInstallIntegration } from '@/lib/shared/integration-connect'
 import type { IntegrationCatalogEntry } from '@/lib/shared/integration-types'
 
 interface IntegrationHeaderProps {
@@ -46,12 +47,12 @@ export function IntegrationHeader({
                   Paused
                 </Badge>
               )}
-              {!status && !catalog.available && catalog.configurable && (
+              {!status && !canInstallIntegration(catalog) && catalog.configurable && (
                 <Badge variant="outline" className="text-muted-foreground/60 border-border/40">
                   Not configured
                 </Badge>
               )}
-              {!status && !catalog.available && !catalog.configurable && (
+              {!status && !canInstallIntegration(catalog) && !catalog.configurable && (
                 <Badge variant="outline" className="text-muted-foreground/60 border-border/40">
                   Coming soon
                 </Badge>

--- a/apps/web/src/components/admin/settings/integrations/integration-list.tsx
+++ b/apps/web/src/components/admin/settings/integrations/integration-list.tsx
@@ -9,6 +9,7 @@ import {
   type IntegrationCategory,
   type PlatformCredentialField,
 } from '@/lib/shared/integration-types'
+import { canInstallIntegration } from '@/lib/shared/integration-connect'
 import { cn } from '@/lib/shared/utils'
 
 const PlatformCredentialsDialog = lazy(() =>
@@ -137,14 +138,14 @@ export function IntegrationList({ catalog, integrations }: IntegrationListProps)
             >
               Paused
             </Badge>
-          ) : !entry.available && !entry.configurable ? (
+          ) : !canInstallIntegration(entry) && !entry.configurable ? (
             <Badge
               variant="outline"
               className="text-[11px] px-1.5 py-0 text-muted-foreground/60 border-border/40"
             >
               Coming soon
             </Badge>
-          ) : !entry.available && entry.configurable ? (
+          ) : !canInstallIntegration(entry) && entry.configurable ? (
             <Badge
               variant="outline"
               className="text-[11px] px-1.5 py-0 text-muted-foreground/60 border-border/40"
@@ -153,8 +154,8 @@ export function IntegrationList({ catalog, integrations }: IntegrationListProps)
             </Badge>
           ) : null
 
-          // Available (connected) integration — link to settings
-          if (entry.available) {
+          // Platform-managed or already configured — open the install/settings page
+          if (canInstallIntegration(entry)) {
             return (
               <Link
                 key={entry.id}

--- a/apps/web/src/lib/server/functions/admin.ts
+++ b/apps/web/src/lib/server/functions/admin.ts
@@ -563,13 +563,16 @@ export const fetchIntegrationByType = createServerFn({ method: 'GET' })
 
     const { integrations } = await import('@/lib/server/db')
     const { getIntegration } = await import('@/lib/server/integrations')
-    const { hasPlatformCredentials } =
+    const { hasPlatformCredentials, arePlatformCredentialsManaged } =
       await import('@/lib/server/domains/platform-credentials/platform-credential.service')
 
     const definition = getIntegration(data.type)
     const platformCredentialFields = definition?.platformCredentials ?? []
+    const platformCredentialsManaged = await arePlatformCredentialsManaged(data.type)
     const platformCredentialsConfigured =
-      platformCredentialFields.length === 0 || (await hasPlatformCredentials(data.type))
+      platformCredentialFields.length === 0 ||
+      (await hasPlatformCredentials(data.type)) ||
+      platformCredentialsManaged
 
     const integration = await db.query.integrations.findFirst({
       where: eq(integrations.integrationType, data.type),
@@ -584,6 +587,7 @@ export const fetchIntegrationByType = createServerFn({ method: 'GET' })
         integration: null,
         platformCredentialFields,
         platformCredentialsConfigured,
+        platformCredentialsManaged,
       }
     }
 
@@ -649,6 +653,7 @@ export const fetchIntegrationByType = createServerFn({ method: 'GET' })
       },
       platformCredentialFields,
       platformCredentialsConfigured,
+      platformCredentialsManaged,
     }
   })
 

--- a/apps/web/src/lib/server/integrations/__tests__/catalog-derivation.test.ts
+++ b/apps/web/src/lib/server/integrations/__tests__/catalog-derivation.test.ts
@@ -4,13 +4,19 @@
  * Regression anchor: Monday/Notion historically claimed "Two-way status
  * sync" with no inbound handler.
  */
-import { describe, it, expect, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
+const mockAreManaged = vi.fn().mockResolvedValue(false)
 vi.mock('@/lib/server/domains/platform-credentials/platform-credential.service', () => ({
   getConfiguredIntegrationTypes: vi.fn().mockResolvedValue(new Set<string>()),
+  arePlatformCredentialsManaged: (type: string) => mockAreManaged(type),
 }))
 
 import { getIntegrationCatalog } from '../index'
+
+afterEach(() => {
+  mockAreManaged.mockResolvedValue(false)
+})
 
 describe('getIntegrationCatalog capability derivation', () => {
   it('monday and notion no longer advertise two-way status sync', async () => {
@@ -67,5 +73,16 @@ describe('getIntegrationCatalog capability derivation', () => {
         expect(cap.description.length, entry.id).toBeGreaterThan(0)
       }
     }
+  })
+
+  it('lets tenants connect platform-managed apps without pasting credentials', async () => {
+    mockAreManaged.mockImplementation(async (type: string) => type === 'slack')
+    const catalog = await getIntegrationCatalog()
+    const slack = catalog.find((e) => e.id === 'slack')!
+    expect(slack.managed).toBe(true)
+    expect(slack.available).toBe(true)
+    const github = catalog.find((e) => e.id === 'github')!
+    expect(github.managed).toBe(false)
+    expect(github.available).toBe(false)
   })
 })

--- a/apps/web/src/lib/server/integrations/index.ts
+++ b/apps/web/src/lib/server/integrations/index.ts
@@ -135,19 +135,25 @@ function deriveCapabilities(i: IntegrationDefinition): IntegrationCapability[] {
 }
 
 export async function getIntegrationCatalog(): Promise<IntegrationCatalogEntry[]> {
-  const { getConfiguredIntegrationTypes } =
+  const { getConfiguredIntegrationTypes, arePlatformCredentialsManaged } =
     await import('@/lib/server/domains/platform-credentials/platform-credential.service')
   const configuredTypes = await getConfiguredIntegrationTypes()
-  return Array.from(registry.values()).map((i) => {
-    const derived = deriveCapabilities(i)
-    return {
-      ...i.catalog,
-      capabilities: derived.length > 0 ? derived : (i.catalog.capabilities ?? []),
-      available: i.platformCredentials.length === 0 || configuredTypes.has(i.id),
-      configurable: i.platformCredentials.length > 0,
-      platformCredentialFields: i.platformCredentials,
-    }
-  })
+  return Promise.all(
+    Array.from(registry.values()).map(async (i) => {
+      const derived = deriveCapabilities(i)
+      const managed = await arePlatformCredentialsManaged(i.id)
+      const hasPlatformApp =
+        i.platformCredentials.length === 0 || configuredTypes.has(i.id) || managed
+      return {
+        ...i.catalog,
+        capabilities: derived.length > 0 ? derived : (i.catalog.capabilities ?? []),
+        available: hasPlatformApp,
+        managed,
+        configurable: i.platformCredentials.length > 0,
+        platformCredentialFields: i.platformCredentials,
+      }
+    })
+  )
 }
 
 export function getIntegrationHook(type: string): HookHandler | undefined {

--- a/apps/web/src/lib/server/integrations/types.ts
+++ b/apps/web/src/lib/server/integrations/types.ts
@@ -129,6 +129,11 @@ export interface IntegrationCatalogEntry {
   iconBg: string
   settingsPath: string
   available: boolean
+  /**
+   * Platform (env / control-plane) owns the OAuth app credentials. Tenants
+   * connect the workspace install; they do not paste client secrets.
+   */
+  managed?: boolean
   /** true if the integration requires platform credentials to be configured */
   configurable: boolean
   /** Field definitions for platform credentials. Present in catalog API response, empty array if none needed. */

--- a/apps/web/src/lib/shared/__tests__/integration-connect.test.ts
+++ b/apps/web/src/lib/shared/__tests__/integration-connect.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import {
+  canEditPlatformCredentials,
+  canInstallIntegration,
+  showOAuthConnect,
+} from '../integration-connect'
+
+describe('canInstallIntegration', () => {
+  it('lets a tenant open settings when env/CP already has the app credentials', () => {
+    expect(canInstallIntegration({ available: false, managed: true })).toBe(true)
+    expect(canInstallIntegration({ available: true, managed: true })).toBe(true)
+  })
+
+  it('keeps unconfigured self-hosted apps on the credentials dialog', () => {
+    expect(canInstallIntegration({ available: false, managed: false })).toBe(false)
+    expect(canInstallIntegration({ available: false })).toBe(false)
+  })
+})
+
+describe('showOAuthConnect', () => {
+  it('shows Connect for platform-managed apps even before a workspace install', () => {
+    expect(
+      showOAuthConnect({
+        hasPlatformCredentialFields: true,
+        platformCredentialsConfigured: false,
+        platformCredentialsManaged: true,
+      })
+    ).toBe(true)
+  })
+
+  it('hides Connect until self-hosted credentials are pasted', () => {
+    expect(
+      showOAuthConnect({
+        hasPlatformCredentialFields: true,
+        platformCredentialsConfigured: false,
+        platformCredentialsManaged: false,
+      })
+    ).toBe(false)
+  })
+})
+
+describe('canEditPlatformCredentials', () => {
+  it('locks the paste form when the platform owns the app', () => {
+    expect(canEditPlatformCredentials(true)).toBe(false)
+    expect(canEditPlatformCredentials(false)).toBe(true)
+  })
+})

--- a/apps/web/src/lib/shared/integration-connect.ts
+++ b/apps/web/src/lib/shared/integration-connect.ts
@@ -1,0 +1,20 @@
+/**
+ * When platform OAuth app credentials come from env / the control plane,
+ * tenants skip the paste-credentials dialog and go straight to Connect.
+ */
+export function canInstallIntegration(entry: { available: boolean; managed?: boolean }): boolean {
+  return entry.available || entry.managed === true
+}
+
+export function canEditPlatformCredentials(managed: boolean): boolean {
+  return !managed
+}
+
+export function showOAuthConnect(opts: {
+  hasPlatformCredentialFields: boolean
+  platformCredentialsConfigured: boolean
+  platformCredentialsManaged: boolean
+}): boolean {
+  if (!opts.hasPlatformCredentialFields) return true
+  return opts.platformCredentialsConfigured || opts.platformCredentialsManaged
+}

--- a/apps/web/src/routes/admin/settings/integrations/$type.tsx
+++ b/apps/web/src/routes/admin/settings/integrations/$type.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/admin/settings/integrations/integration-settings-registry'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
+import { canEditPlatformCredentials, showOAuthConnect } from '@/lib/shared/integration-connect'
 
 /** URL segments use hyphens (e.g. `azure-devops`); registry keys use the
  * underscore integration type (`azure_devops`). Every other provider is a
@@ -38,7 +39,11 @@ function IntegrationSettingsPage() {
 
   const { data } = useSuspenseQuery(adminQueries.integrationByType(type))
   const integration = data.integration as IntegrationSettingsData | null
-  const { platformCredentialFields, platformCredentialsConfigured } = data
+  const {
+    platformCredentialFields,
+    platformCredentialsConfigured,
+    platformCredentialsManaged = false,
+  } = data
   const [credentialsOpen, setCredentialsOpen] = useState(false)
 
   const { catalog, Icon, ConnectionActions, setup } = entry
@@ -46,6 +51,12 @@ function IntegrationSettingsPage() {
   const isConnected = status === 'active'
   const isPaused = status === 'paused'
   const hasCredentials = platformCredentialFields.length > 0
+  const canEditCredentials = canEditPlatformCredentials(platformCredentialsManaged)
+  const canConnect = showOAuthConnect({
+    hasPlatformCredentialFields: hasCredentials,
+    platformCredentialsConfigured,
+    platformCredentialsManaged,
+  })
   const workspaceName = integration
     ? (entry.getWorkspaceName?.(integration) ?? integration.workspaceName)
     : undefined
@@ -60,7 +71,7 @@ function IntegrationSettingsPage() {
         actions={
           isConnected || isPaused ? (
             <div className="flex items-center gap-2">
-              {hasCredentials && (
+              {hasCredentials && canEditCredentials && (
                 <Button variant="outline" size="sm" onClick={() => setCredentialsOpen(true)}>
                   Configure credentials
                 </Button>
@@ -102,12 +113,12 @@ function IntegrationSettingsPage() {
           steps={setup.steps}
           connectionForm={
             <div className="flex flex-col items-end gap-2">
-              {hasCredentials && !platformCredentialsConfigured && (
+              {hasCredentials && !canConnect && (
                 <Button onClick={() => setCredentialsOpen(true)}>Configure credentials</Button>
               )}
-              {(!hasCredentials || platformCredentialsConfigured) && (
+              {canConnect && (
                 <div className="flex items-center gap-2">
-                  {hasCredentials && (
+                  {hasCredentials && canEditCredentials && (
                     <Button variant="outline" size="sm" onClick={() => setCredentialsOpen(true)}>
                       Configure credentials
                     </Button>
@@ -122,7 +133,7 @@ function IntegrationSettingsPage() {
         />
       )}
 
-      {hasCredentials && (
+      {hasCredentials && canEditCredentials && (
         <PlatformCredentialsDialog
           integrationType={type}
           integrationName={catalog.name}


### PR DESCRIPTION
When OAuth app credentials come from env / the control plane, the integrations list treated the provider as unconfigured and opened a credentials dialog that only said they could not be edited.

Platform-managed providers now link to the install page and show Connect. Self-hosted apps that still need pasted credentials keep the existing dialog.

No GitHub release. Merge to main and roll the fleet `:main` image.