### PR TITLE
fix(sso): stop the test-sign-in preview from squashing the mapping table

### DIFF
--- a/apps/web/src/components/admin/settings/security/identity-providers/__tests__/claim-mapping-card.test.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/__tests__/claim-mapping-card.test.tsx
@@ -187,6 +187,17 @@ beforeEach(() => {
 })
 
 describe('ClaimMappingCard save coordination', () => {
+  it('keeps the mapping table above the test preview instead of a side column', () => {
+    renderCard(makeProvider())
+    const table = screen.getAllByRole('table')[0]
+    const preview = document.querySelector('[data-preview-slot]')
+    expect(preview).toBeTruthy()
+    expect(table.compareDocumentPosition(preview!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(preview!.className).not.toMatch(/lg:w-\[22rem\]/)
+    expect(preview!.parentElement?.className).not.toMatch(/lg:flex-row/)
+    expect(screen.getByRole('heading', { name: 'Last test sign-in' })).toBeInTheDocument()
+  })
+
   it('Edit+Apply on the default identifier does not persist claims.id', async () => {
     renderCard(makeProvider({ claimMapping: null }))
     fireEvent.click(screen.getByRole('button', { name: 'Edit Unique user identifier mapping' }))

--- a/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-card.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claim-mapping-card.tsx
@@ -346,7 +346,7 @@ export function ClaimMappingCard({
         description="Configure how Quackback identifies accounts and reads this provider's claims. Email and name are set at account creation. Role and People updates depend on the settings below."
         contentClassName="space-y-4"
         action={
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center justify-end gap-2">
             <Button
               type="button"
               variant="ghost"
@@ -370,8 +370,8 @@ export function ClaimMappingCard({
           </div>
         }
       >
-        <div className="flex flex-col gap-6 lg:flex-row">
-          <div className="min-w-0 flex-1 space-y-4">
+        <div className="flex flex-col gap-6">
+          <div className="min-w-0 space-y-4">
             <ClaimsTable
               requiredRows={tableModel.required}
               additionalRows={tableModel.additional}
@@ -432,7 +432,7 @@ export function ClaimMappingCard({
               </Button>
             </div>
           </div>
-          <div className="lg:w-[22rem] lg:shrink-0" data-preview-slot>
+          <div className="min-w-0" data-preview-slot>
             <OutcomePreviewRail
               capture={capture}
               draft={draftMapping}

--- a/apps/web/src/components/admin/settings/security/identity-providers/claims-table.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/claims-table.tsx
@@ -193,13 +193,13 @@ function MappingTable({ children }: { children: React.ReactNode }) {
       <table className="w-full text-sm">
         <thead>
           <tr className="border-b border-border/50 text-left text-xs text-muted-foreground">
-            <th scope="col" className="py-2 pr-3 font-medium">
+            <th scope="col" className="py-2 pr-3 font-medium whitespace-nowrap">
               Quackback attribute
             </th>
-            <th scope="col" className="py-2 pr-3 font-medium">
+            <th scope="col" className="min-w-0 py-2 pr-3 font-medium">
               IdP claim
             </th>
-            <th scope="col" className="py-2 font-medium">
+            <th scope="col" className="w-px py-2 font-medium">
               <span className="sr-only">Actions</span>
             </th>
           </tr>

--- a/apps/web/src/components/admin/settings/security/identity-providers/outcome-preview-rail.tsx
+++ b/apps/web/src/components/admin/settings/security/identity-providers/outcome-preview-rail.tsx
@@ -77,7 +77,7 @@ export function OutcomePreviewRail({
 
   if (!preview.capture) {
     return (
-      <aside className="flex flex-col gap-4 border-t border-border/40 bg-muted/20 px-4 py-5 text-[12.5px] lg:border-t-0 lg:border-l">
+      <aside className="flex flex-col gap-4 rounded-lg border border-border/40 bg-muted/20 px-4 py-5 text-[12.5px]">
         <h3 className={cn(MENU_LABEL, 'font-mono')}>Preview</h3>
         <p className="text-xs text-muted-foreground">
           Run a test sign-in to inspect this IdP&apos;s claims and preview mappings.
@@ -98,7 +98,7 @@ export function OutcomePreviewRail({
   const hasAdminRule = roleRules.some((r) => r.role === 'admin')
 
   return (
-    <aside className="flex flex-col gap-4 border-t border-border/40 bg-muted/20 px-4 py-5 text-[12.5px] lg:border-t-0 lg:border-l">
+    <aside className="flex min-w-0 flex-col gap-4 rounded-lg border border-border/40 bg-muted/20 px-4 py-5 text-[12.5px]">
       <div>
         <h3 className={cn(MENU_LABEL, 'font-mono')}>Last test sign-in</h3>
         <div className="mt-2 font-medium">{captureIdentityCaption(preview.capture)}</div>
@@ -221,52 +221,58 @@ function IdentityLines({
   const emailPath = effectiveEmailPath(draft)
   const namePath = effectiveNamePath(draft)
   return (
-    <dl className="grid grid-cols-[6.2em_1fr] gap-x-2.5 gap-y-1 font-mono text-[11.5px]">
-      <dt className="font-sans text-muted-foreground">Identifier</dt>
-      <dd className="break-all">
-        {identity.id ?? 'Not supplied'}
-        {identity.provenance.id && (
-          <span className="text-muted-foreground">
-            {' '}
-            {'<-'} {identity.provenance.id.path}, {SOURCE_WORDS[identity.provenance.id.source]}
-          </span>
-        )}
-      </dd>
-      <dt className="font-sans text-muted-foreground">Email</dt>
-      <dd className="break-all">
-        {identity.kind === 'placeholder_required'
-          ? 'A placeholder address will be used.'
-          : identity.kind === 'missing_email'
-            ? `Not supplied by the configured path ${emailPath}`
-            : (identity.email ?? 'Not supplied')}
-        {identity.provenance.email && identity.kind === 'identity' && (
-          <span className="text-muted-foreground">
-            {' '}
-            {'<-'} {identity.provenance.email.path},{' '}
-            {SOURCE_WORDS[identity.provenance.email.source]}
-          </span>
-        )}
-      </dd>
-      <dt className="font-sans text-muted-foreground">Name</dt>
-      <dd className="break-all">
-        {identity.name ?? 'Not supplied'}
-        {identity.nameSynthesized
-          ? ' (generated)'
-          : identity.provenance.name
-            ? ` <- ${identity.provenance.name.path}, ${SOURCE_WORDS[identity.provenance.name.source]}`
-            : !identity.name
-              ? ` <- ${namePath}`
-              : ''}
-      </dd>
-      {identity.warnings.includes('subject_mismatch') && (
-        <dd className="col-span-2 font-sans text-xs text-muted-foreground">
-          A mismatched source was kept for diagnostics and is excluded from the sign-in outcome.
+    <dl className="space-y-2 text-[12.5px]">
+      <div>
+        <dt className="text-xs text-muted-foreground">Identifier</dt>
+        <dd className="min-w-0 break-all font-mono text-[11.5px]">
+          {identity.id ?? 'Not supplied'}
+          {identity.provenance.id && (
+            <span className="text-muted-foreground">
+              {' '}
+              {'<-'} {identity.provenance.id.path}, {SOURCE_WORDS[identity.provenance.id.source]}
+            </span>
+          )}
         </dd>
+      </div>
+      <div>
+        <dt className="text-xs text-muted-foreground">Email</dt>
+        <dd className="min-w-0 break-all font-mono text-[11.5px]">
+          {identity.kind === 'placeholder_required'
+            ? 'A placeholder address will be used.'
+            : identity.kind === 'missing_email'
+              ? `Not supplied by the configured path ${emailPath}`
+              : (identity.email ?? 'Not supplied')}
+          {identity.provenance.email && identity.kind === 'identity' && (
+            <span className="text-muted-foreground">
+              {' '}
+              {'<-'} {identity.provenance.email.path},{' '}
+              {SOURCE_WORDS[identity.provenance.email.source]}
+            </span>
+          )}
+        </dd>
+      </div>
+      <div>
+        <dt className="text-xs text-muted-foreground">Name</dt>
+        <dd className="min-w-0 break-all font-mono text-[11.5px]">
+          {identity.name ?? 'Not supplied'}
+          {identity.nameSynthesized
+            ? ' (generated)'
+            : identity.provenance.name
+              ? ` <- ${identity.provenance.name.path}, ${SOURCE_WORDS[identity.provenance.name.source]}`
+              : !identity.name
+                ? ` <- ${namePath}`
+                : ''}
+        </dd>
+      </div>
+      {identity.warnings.includes('subject_mismatch') && (
+        <p className="text-xs text-muted-foreground">
+          A mismatched source was kept for diagnostics and is excluded from the sign-in outcome.
+        </p>
       )}
       {identity.id === undefined && (
-        <dd className="col-span-2 font-sans text-xs text-muted-foreground">
+        <p className="text-xs text-muted-foreground">
           Not supplied by the configured path {idPath}.
-        </dd>
+        </p>
       )}
     </dl>
   )
@@ -324,9 +330,9 @@ function ClaimsDisclosure({ capture }: { capture: SsoTestCapture }) {
         />
         Show protocol claims
       </label>
-      <dl className="mt-2 grid grid-cols-[7em_1fr] gap-x-2.5 gap-y-1 font-mono text-[11px]">
+      <dl className="mt-2 space-y-1.5 font-mono text-[11px]">
         {keys.map((key) => (
-          <div key={key} className="contents">
+          <div key={key} className="min-w-0">
             <dt className="text-muted-foreground break-all">{key}</dt>
             <dd className="min-w-0 break-all">{escapeClaimValue(claims[key])}</dd>
           </div>

--- a/apps/web/src/components/admin/settings/settings-card.tsx
+++ b/apps/web/src/components/admin/settings/settings-card.tsx
@@ -25,7 +25,7 @@ export function SettingsCard({
       )}
     >
       {(title || description || action) && (
-        <div className="px-4 py-3 sm:px-6 sm:py-4 border-b border-border/50 flex items-center justify-between">
+        <div className="flex flex-wrap items-start justify-between gap-2 px-4 py-3 sm:px-6 sm:py-4 border-b border-border/50">
           <div>
             {title && (
               <h2


### PR DESCRIPTION
## Summary

The Attributes & Claims card put the test-sign-in preview in a 22rem side column at `lg`, the same breakpoint as the settings sidebar and provider section nav. That left the mapping table too narrow.

Stack the preview under the table, wrap the card header actions, and let identity/claim values wrap instead of a cramped two-column grid.

## Test plan

- [x] `bunx vitest run` claim-mapping-card, outcome-preview-rail, claims-table
- [ ] Open an identity provider on a typical desktop settings width: the table should keep its columns; preview sits below
- [ ] Confirm Reset / Add claim still fit in the card header when the title wraps