### PR TITLE
fix(billing): accept custom-domain Origin on Stripe checkout POSTs

### DIFF
--- a/apps/web/src/lib/server/http/__tests__/same-origin-form.test.ts
+++ b/apps/web/src/lib/server/http/__tests__/same-origin-form.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from 'vitest'
-import { originMatchesRequestHost } from '../same-origin-form'
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { signCustomerHost } from '@/lib/server/workspaces/saas-edge-host'
+import { isSameOriginFormPost, originMatchesRequestHost } from '../same-origin-form'
 
 describe('originMatchesRequestHost', () => {
   it('accepts a browser https Origin against the public Host', () => {
@@ -32,5 +34,80 @@ describe('originMatchesRequestHost', () => {
         'south63792f.quackback.co.uk, 127.0.0.1:3000'
       )
     ).toBe(true)
+  })
+})
+
+describe('isSameOriginFormPost', () => {
+  const SECRET = 'test-edge-secret'
+  const RAILWAY = 'app.up.example'
+  const CUSTOMER = 'shop.customer.test'
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  function formPost(headers: Record<string, string>): Request {
+    return new Request('https://app.up.example/api/billing/session', {
+      method: 'POST',
+      headers,
+    })
+  }
+
+  it('accepts a first-party Host that matches Origin', () => {
+    expect(
+      isSameOriginFormPost(
+        formPost({
+          origin: 'https://south63792f.quackback.co.uk',
+          host: 'south63792f.quackback.co.uk',
+        })
+      )
+    ).toBe(true)
+  })
+
+  it('accepts a custom domain whose Host is the Railway hop', () => {
+    vi.stubEnv('QUACKBACK_SAAS_RAILWAY_ORIGIN', RAILWAY)
+    vi.stubEnv('QUACKBACK_SAAS_EDGE_SECRET', SECRET)
+    expect(
+      isSameOriginFormPost(
+        formPost({
+          origin: `https://${CUSTOMER}`,
+          host: RAILWAY,
+          'x-forwarded-host': RAILWAY,
+          'x-quackback-customer-host': CUSTOMER,
+          'x-quackback-customer-host-sig': signCustomerHost(SECRET, CUSTOMER),
+        })
+      )
+    ).toBe(true)
+  })
+
+  it('refuses a custom-domain Origin when the customer-host HMAC is wrong', () => {
+    vi.stubEnv('QUACKBACK_SAAS_RAILWAY_ORIGIN', RAILWAY)
+    vi.stubEnv('QUACKBACK_SAAS_EDGE_SECRET', SECRET)
+    expect(
+      isSameOriginFormPost(
+        formPost({
+          origin: `https://${CUSTOMER}`,
+          host: RAILWAY,
+          'x-forwarded-host': RAILWAY,
+          'x-quackback-customer-host': CUSTOMER,
+          'x-quackback-customer-host-sig': '00'.repeat(32),
+        })
+      )
+    ).toBe(false)
+  })
+
+  it('refuses a foreign Origin even when a signed customer host is present', () => {
+    vi.stubEnv('QUACKBACK_SAAS_RAILWAY_ORIGIN', RAILWAY)
+    vi.stubEnv('QUACKBACK_SAAS_EDGE_SECRET', SECRET)
+    expect(
+      isSameOriginFormPost(
+        formPost({
+          origin: 'https://attacker.test',
+          host: RAILWAY,
+          'x-quackback-customer-host': CUSTOMER,
+          'x-quackback-customer-host-sig': signCustomerHost(SECRET, CUSTOMER),
+        })
+      )
+    ).toBe(false)
   })
 })

--- a/apps/web/src/lib/server/http/same-origin-form.ts
+++ b/apps/web/src/lib/server/http/same-origin-form.ts
@@ -1,10 +1,18 @@
+import { requestWorkspaceHost } from '@/lib/server/workspaces/saas-edge-host'
+
 /**
  * CSRF check for same-origin form POSTs.
  *
- * Compare the browser Origin host to the incoming Host. Do not compare
+ * Compare the browser Origin host to the visitor hostname. Do not compare
  * `new URL(request.url).origin`: TLS-terminating proxies present the app
  * URL as `http://`, while the browser always sends `Origin: https://…`.
+ *
+ * Custom-domain traffic is fetched by the saas-origin Worker against the
+ * Railway origin, so Host / X-Forwarded-Host is the hop, not the browser
+ * origin. The visitor name arrives as the signed customer-host header and
+ * is recovered by `requestWorkspaceHost`.
  */
+
 export function originMatchesRequestHost(
   origin: string | null,
   hostHeader: string | null
@@ -25,8 +33,10 @@ export function originMatchesRequestHost(
 }
 
 export function isSameOriginFormPost(request: Request): boolean {
+  const origin = request.headers.get('origin')
+  if (originMatchesRequestHost(origin, requestWorkspaceHost(request))) return true
   return originMatchesRequestHost(
-    request.headers.get('origin'),
+    origin,
     request.headers.get('x-forwarded-host') ?? request.headers.get('host')
   )
 }

--- a/apps/web/src/routes/api/billing/__tests__/session.test.ts
+++ b/apps/web/src/routes/api/billing/__tests__/session.test.ts
@@ -179,4 +179,25 @@ describe('POST /api/billing/session checkout', () => {
     expect(res.status).toBe(303)
     expect(res.headers.get('location')).toBe('/admin/settings/billing')
   })
+
+  it('rejects a foreign Origin before talking to Stripe', async () => {
+    const res = await POST({
+      request: new Request('https://app.example.com/api/billing/session', {
+        method: 'POST',
+        headers: {
+          origin: 'https://attacker.test',
+          host: 'app.example.com',
+          'content-type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({
+          action: 'checkout',
+          planId: 'pro',
+          billingPeriod: 'monthly',
+        }),
+      }),
+    })
+    expect(res.status).toBe(403)
+    expect(await res.json()).toEqual({ error: 'invalid_origin' })
+    expect(hoisted.createHostedBillingSession).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Summary

Billing form POSTs (plan checkout, portal, top-up, branding, trial) return `{ error: 'invalid_origin' }` from a customer custom domain. The CSRF check compared the browser `Origin` to `Host` / `X-Forwarded-Host`. Custom-domain traffic is fetched by the saas-origin Worker against the Railway origin, so those hop headers are the Railway hostname while `Origin` is the customer host.

Accept Origin when it matches the signed customer-host recovered by `requestWorkspaceHost`. First-party Host matching is unchanged. A forged customer-host header still fails.

## Test plan

- [x] `bunx vitest run` same-origin-form, billing session, trial
- [ ] From a workspace custom domain, start plan checkout / portal / top-up — should 303 to Stripe, not 403 `invalid_origin`
- [ ] From a first-party workspace host, the same forms still work
- [ ] A foreign Origin still 403s before talking to Stripe