### PR TITLE
fix(import): honour CSV author_name and require an author

### DIFF
--- a/apps/web/src/components/admin/settings/imports/__tests__/import-csv.test.tsx
+++ b/apps/web/src/components/admin/settings/imports/__tests__/import-csv.test.tsx
@@ -115,6 +115,12 @@ afterEach(() => {
 })
 
 describe('<ImportCsv>', () => {
+  it('explains how author_email and author_name are applied', () => {
+    renderCsv()
+    expect(screen.getByText(/Every row needs author_email or author_name/)).toBeTruthy()
+    expect(screen.getByText(/name-only contact/)).toBeTruthy()
+  })
+
   it('walks upload -> dry-run review -> commit -> done', async () => {
     const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url

--- a/apps/web/src/components/admin/settings/imports/import-csv.tsx
+++ b/apps/web/src/components/admin/settings/imports/import-csv.tsx
@@ -202,7 +202,8 @@ export function ImportCsv() {
           </span>
           <span className="text-xs text-muted-foreground">
             Must use the template columns — title and content are required. Up to 10MB / 10,000
-            rows.
+            rows. Every row needs author_email or author_name: email matches or creates a person;
+            name without an email creates a name-only contact.
           </span>
           <input
             ref={fileInputRef}

--- a/apps/web/src/lib/server/domains/import/__tests__/import-email-verified.test.ts
+++ b/apps/web/src/lib/server/domains/import/__tests__/import-email-verified.test.ts
@@ -10,6 +10,7 @@ import {
   parseCsvEmailVerified,
   csvRowSchema,
   resolveRows,
+  AUTHOR_REQUIRED_MESSAGE,
   type RowContext,
 } from '../import-row-resolver'
 import type { ImportUserResolver } from '../user-resolver'
@@ -28,7 +29,7 @@ describe('parseCsvEmailVerified', () => {
 })
 
 describe('csvRowSchema email_verified', () => {
-  const baseRow = { title: 'A title', content: 'Some content' }
+  const baseRow = { title: 'A title', content: 'Some content', author_name: 'Ada' }
 
   it('defaults to true when the column is absent', () => {
     const parsed = csvRowSchema.parse(baseRow)
@@ -48,9 +49,39 @@ describe('csvRowSchema email_verified', () => {
   })
 })
 
-describe('resolveRows email_verified plumb', () => {
-  const FALLBACK = 'principal_fallback' as PrincipalId
+describe('csvRowSchema author', () => {
+  it('rejects a row with neither author_name nor author_email', () => {
+    const parsed = csvRowSchema.safeParse({ title: 'A title', content: 'Some content' })
+    expect(parsed.success).toBe(false)
+    if (parsed.success) return
+    expect(parsed.error.issues[0].message).toBe(AUTHOR_REQUIRED_MESSAGE)
+  })
 
+  it('rejects whitespace-only author_name without an email', () => {
+    const parsed = csvRowSchema.safeParse({
+      title: 'A title',
+      content: 'Some content',
+      author_name: '   ',
+    })
+    expect(parsed.success).toBe(false)
+  })
+
+  it('accepts author_name alone or author_email alone', () => {
+    expect(
+      csvRowSchema.safeParse({ title: 'A title', content: 'Some content', author_name: 'Ada' })
+        .success
+    ).toBe(true)
+    expect(
+      csvRowSchema.safeParse({
+        title: 'A title',
+        content: 'Some content',
+        author_email: 'ada@example.com',
+      }).success
+    ).toBe(true)
+  })
+})
+
+describe('resolveRows email_verified plumb', () => {
   function stubCtx(): RowContext {
     return {
       defaultStatusId: 'post_status_default' as PostStatusId,
@@ -87,7 +118,6 @@ describe('resolveRows email_verified plumb', () => {
       'board_1' as never,
       0,
       resolver,
-      FALLBACK,
       stubCtx(),
       new Set(),
       new Map(),
@@ -96,8 +126,8 @@ describe('resolveRows email_verified plumb', () => {
 
     expect(errors).toEqual([])
     expect(validRows).toHaveLength(3)
-    expect(resolve).toHaveBeenNthCalledWith(1, 'a@example.com', null, FALLBACK, true)
-    expect(resolve).toHaveBeenNthCalledWith(2, 'b@example.com', null, FALLBACK, false)
-    expect(resolve).toHaveBeenNthCalledWith(3, 'c@example.com', null, FALLBACK, true)
+    expect(resolve).toHaveBeenNthCalledWith(1, 'a@example.com', null, true)
+    expect(resolve).toHaveBeenNthCalledWith(2, 'b@example.com', null, false)
+    expect(resolve).toHaveBeenNthCalledWith(3, 'c@example.com', null, true)
   })
 })

--- a/apps/web/src/lib/server/domains/import/__tests__/import-preview.test.ts
+++ b/apps/web/src/lib/server/domains/import/__tests__/import-preview.test.ts
@@ -35,20 +35,32 @@ vi.mock('@/lib/server/db', () => ({
 }))
 
 // previewImport constructs its own resolver internally (no injection point),
-// so the resolver itself is faked: a brand-new email increments pendingCount
-// exactly once, mirroring the real class's queue-for-creation behavior.
+// so the resolver itself is faked: a brand-new email or name increments
+// pendingCount exactly once, mirroring the real class's queue-for-creation
+// behavior.
 vi.mock('../user-resolver', () => {
   class FakeImportUserResolver {
     private seen = new Map<string, string>()
     private pending = 0
-    async resolve(email: string | null, _name: string | null, fallback: string) {
-      if (!email) return fallback
-      const key = email.toLowerCase()
-      if (this.seen.has(key)) return this.seen.get(key)!
-      this.pending++
-      const id = `principal_${key}`
-      this.seen.set(key, id)
-      return id
+    async resolve(email: string | null, name: string | null, fallback: string) {
+      const normalizedEmail = email?.toLowerCase().trim() ?? ''
+      if (normalizedEmail) {
+        if (this.seen.has(normalizedEmail)) return this.seen.get(normalizedEmail)!
+        this.pending++
+        const id = `principal_${normalizedEmail}`
+        this.seen.set(normalizedEmail, id)
+        return id
+      }
+      const trimmedName = name?.trim() ?? ''
+      if (trimmedName) {
+        const key = `name:${trimmedName.toLowerCase()}`
+        if (this.seen.has(key)) return this.seen.get(key)!
+        this.pending++
+        const id = `principal_${key}`
+        this.seen.set(key, id)
+        return id
+      }
+      return fallback
     }
     async flushPendingCreates() {
       return 0
@@ -85,7 +97,7 @@ describe('previewImport', () => {
   })
 
   it('never writes to the database', async () => {
-    const csv = 'title,content\nFirst,Body\n'
+    const csv = 'title,content,author_name\nFirst,Body,Jane\n'
     await previewImport({ ...BASE_INPUT, csvContent: csvContent(csv), totalRows: 1 })
     expect(hoisted.insert).not.toHaveBeenCalled()
   })
@@ -132,7 +144,7 @@ describe('previewImport', () => {
   })
 
   it('reports per-row validation errors without throwing', async () => {
-    const csv = 'title,content\n,Body without a title\n'
+    const csv = 'title,content,author_name\n,Body without a title,Jane\n'
     const preview = await previewImport({
       ...BASE_INPUT,
       csvContent: csvContent(csv),
@@ -145,9 +157,9 @@ describe('previewImport', () => {
 
   it('reports to-be-created statuses, boards, and tags without writing them', async () => {
     const csv =
-      'title,content,status,board,tags\n' +
-      'First,Body one,In Progress,Feature Requests,"ui,theme"\n' +
-      'Second,Body two,open,bugs,ui\n'
+      'title,content,status,board,tags,author_name\n' +
+      'First,Body one,In Progress,Feature Requests,"ui,theme",Jane\n' +
+      'Second,Body two,open,bugs,ui,Jane\n'
 
     const preview = await previewImport({
       ...BASE_INPUT,
@@ -173,7 +185,7 @@ describe('previewImport', () => {
     hoisted.findManyPostExternalLinks.mockResolvedValue([
       { externalId: 'ext-1', postId: 'post_existing' },
     ])
-    const csv = 'title,content,source_id\nExisting,Body,ext-1\n'
+    const csv = 'title,content,source_id,author_name\nExisting,Body,ext-1,Jane\n'
 
     const preview = await previewImport({
       ...BASE_INPUT,
@@ -183,5 +195,42 @@ describe('previewImport', () => {
 
     expect(preview.sample[0].action).toBe('update')
     expect(preview.updatedCount).toBe(1)
+  })
+
+  it('treats author_name without email as a new author and reuses it on repeats', async () => {
+    const csv =
+      'title,content,author_name\n' + 'First,Body one,Jane Doe\n' + 'Second,Body two,jane doe\n'
+
+    const preview = await previewImport({
+      ...BASE_INPUT,
+      csvContent: csvContent(csv),
+      totalRows: 2,
+    })
+
+    expect(preview.counts.byAuthor).toEqual({ 'Jane Doe': 1, 'jane doe': 1 })
+    expect(preview.sample[0]).toMatchObject({
+      author: 'Jane Doe',
+      isNewAuthor: true,
+    })
+    expect(preview.sample[1]).toMatchObject({
+      author: 'jane doe',
+      isNewAuthor: false,
+    })
+  })
+
+  it('skips rows with neither author_name nor author_email', async () => {
+    const csv = 'title,content\nFirst,Body\n'
+
+    const preview = await previewImport({
+      ...BASE_INPUT,
+      csvContent: csvContent(csv),
+      totalRows: 1,
+    })
+
+    expect(preview.sample).toEqual([])
+    expect(preview.counts.byAuthor).toEqual({})
+    expect(preview.errors).toEqual([
+      { row: 1, message: 'Author name or email is required', field: 'author_name' },
+    ])
   })
 })

--- a/apps/web/src/lib/server/domains/import/__tests__/import-service.test.ts
+++ b/apps/web/src/lib/server/domains/import/__tests__/import-service.test.ts
@@ -94,6 +94,25 @@ function emailKeyedResolver(fallback: PrincipalId): ImportUserResolver {
   } as unknown as ImportUserResolver
 }
 
+/** Resolves each distinct author name (when email is empty) to its own principal. */
+function nameKeyedResolver(fallback: PrincipalId): ImportUserResolver {
+  const byName = new Map<string, PrincipalId>()
+  return {
+    resolve: vi.fn(async (email: string | null, name: string | null) => {
+      if (email) return fallback
+      const trimmed = name?.trim()
+      if (!trimmed) return fallback
+      const key = trimmed.toLowerCase()
+      if (!byName.has(key)) byName.set(key, `principal_${key}` as PrincipalId)
+      return byName.get(key)!
+    }),
+    flushPendingCreates: vi.fn().mockResolvedValue(0),
+    get pendingCount() {
+      return byName.size
+    },
+  } as unknown as ImportUserResolver
+}
+
 describe('processBatch', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -107,16 +126,47 @@ describe('processBatch', () => {
     hoisted.deleteWhere.mockResolvedValue(undefined)
   })
 
+  describe('name-only authors', () => {
+    it('attributes a name-only row to the resolved author, not the importer', async () => {
+      const rows = [{ title: 'Row one', content: 'Body one', author_name: 'Jane Doe' }]
+
+      await processBatch(
+        rows,
+        'board_1' as never,
+        0,
+        nameKeyedResolver('principal_fallback' as PrincipalId)
+      )
+
+      const postsInsert = hoisted.insertValues.mock.calls[0][0] as { principalId: string }[]
+      expect(postsInsert[0].principalId).toBe('principal_jane doe')
+    })
+
+    it('skips a row with neither author_name nor author_email', async () => {
+      const result = await processBatch(
+        [{ title: 'Row one', content: 'Body one' }],
+        'board_1' as never,
+        0,
+        fakeResolver('principal_fallback' as PrincipalId)
+      )
+
+      expect(result.imported).toBe(0)
+      expect(result.skipped).toBe(1)
+      expect(result.errors).toEqual([
+        { row: 1, message: 'Author name or email is required', field: 'author_name' },
+      ])
+      expect(hoisted.insertValues).not.toHaveBeenCalled()
+    })
+  })
+
   describe('batch auto-tag', () => {
     it('applies the batch tag to every created post alongside its own tags', async () => {
-      const rows = [{ title: 'Row one', content: 'Body one', tags: 'feature' }]
+      const rows = [{ title: 'Row one', content: 'Body one', tags: 'feature', author_name: 'Jane' }]
 
       await processBatch(
         rows,
         'board_1' as never,
         0,
         fakeResolver('principal_fallback' as PrincipalId),
-        'principal_fallback' as PrincipalId,
         'post_tag_batch' as never
       )
 
@@ -132,14 +182,13 @@ describe('processBatch', () => {
     })
 
     it('omits the batch tag entirely when none is passed (dry-run / legacy path)', async () => {
-      const rows = [{ title: 'Row one', content: 'Body one' }]
+      const rows = [{ title: 'Row one', content: 'Body one', author_name: 'Jane' }]
 
       await processBatch(
         rows,
         'board_1' as never,
         0,
-        fakeResolver('principal_fallback' as PrincipalId),
-        'principal_fallback' as PrincipalId
+        fakeResolver('principal_fallback' as PrincipalId)
       )
 
       // No row tags and no batch tag: the assignments insert never runs, so
@@ -159,6 +208,7 @@ describe('processBatch', () => {
           content: 'Body one',
           status: 'In Progress',
           board: 'Feature Requests',
+          author_name: 'Jane',
         },
       ]
 
@@ -166,8 +216,7 @@ describe('processBatch', () => {
         rows,
         'board_default' as never,
         0,
-        fakeResolver('principal_fallback' as PrincipalId),
-        'principal_fallback' as PrincipalId
+        fakeResolver('principal_fallback' as PrincipalId)
       )
 
       expect(result.createdStatuses).toEqual(['In Progress'])
@@ -193,16 +242,15 @@ describe('processBatch', () => {
       ])
       hoisted.findManyBoards.mockResolvedValue([{ id: 'board_bugs', slug: 'bugs', name: 'Bugs' }])
       const rows = [
-        { title: 'A', content: 'Body', status: 'Open', board: 'Bugs' },
-        { title: 'B', content: 'Body', status: 'open', board: 'bugs' },
+        { title: 'A', content: 'Body', status: 'Open', board: 'Bugs', author_name: 'Jane' },
+        { title: 'B', content: 'Body', status: 'open', board: 'bugs', author_name: 'Jane' },
       ]
 
       const result = await processBatch(
         rows,
         'board_bugs' as never,
         0,
-        fakeResolver('principal_fallback' as PrincipalId),
-        'principal_fallback' as PrincipalId
+        fakeResolver('principal_fallback' as PrincipalId)
       )
 
       expect(result.createdStatuses).toEqual([])
@@ -219,14 +267,15 @@ describe('processBatch', () => {
   describe('source-id idempotence', () => {
     it('creates a new post and an external link when the source_id has not been seen before', async () => {
       hoisted.findManyPostExternalLinks.mockResolvedValue([])
-      const rows = [{ title: 'Row one', content: 'Body one', source_id: 'ext-1' }]
+      const rows = [
+        { title: 'Row one', content: 'Body one', source_id: 'ext-1', author_name: 'Jane' },
+      ]
 
       const result = await processBatch(
         rows,
         'board_1' as never,
         0,
-        fakeResolver('principal_fallback' as PrincipalId),
-        'principal_fallback' as PrincipalId
+        fakeResolver('principal_fallback' as PrincipalId)
       )
 
       expect(result.imported).toBe(1)
@@ -245,14 +294,20 @@ describe('processBatch', () => {
       hoisted.findManyPostExternalLinks.mockResolvedValue([
         { externalId: 'ext-1', postId: 'post_existing' },
       ])
-      const rows = [{ title: 'Updated title', content: 'Updated body', source_id: 'ext-1' }]
+      const rows = [
+        {
+          title: 'Updated title',
+          content: 'Updated body',
+          source_id: 'ext-1',
+          author_name: 'Jane',
+        },
+      ]
 
       const result = await processBatch(
         rows,
         'board_1' as never,
         0,
-        fakeResolver('principal_fallback' as PrincipalId),
-        'principal_fallback' as PrincipalId
+        fakeResolver('principal_fallback' as PrincipalId)
       )
 
       expect(result.imported).toBe(0)
@@ -268,7 +323,13 @@ describe('processBatch', () => {
     it('creates real post_votes rows and sets voteCount from the deduped voter count', async () => {
       hoisted.findManyPostExternalLinks.mockResolvedValue([])
       const rows = [
-        { title: 'Dark mode', content: 'Please', source_id: 'idea-1', vote_count: '99' },
+        {
+          title: 'Dark mode',
+          content: 'Please',
+          source_id: 'idea-1',
+          vote_count: '99',
+          author_name: 'Jane',
+        },
       ]
       const voters = {
         'idea-1': [
@@ -283,7 +344,6 @@ describe('processBatch', () => {
         'board_1' as never,
         0,
         emailKeyedResolver('principal_fallback' as PrincipalId),
-        'principal_fallback' as PrincipalId,
         undefined,
         voters
       )
@@ -308,7 +368,13 @@ describe('processBatch', () => {
     it('falls back to vote-count backfill when no voters entry exists for the row', async () => {
       hoisted.findManyPostExternalLinks.mockResolvedValue([])
       const rows = [
-        { title: 'No voters here', content: 'Body', source_id: 'idea-2', vote_count: '5' },
+        {
+          title: 'No voters here',
+          content: 'Body',
+          source_id: 'idea-2',
+          vote_count: '5',
+          author_name: 'Jane',
+        },
       ]
 
       await processBatch(
@@ -316,7 +382,6 @@ describe('processBatch', () => {
         'board_1' as never,
         0,
         emailKeyedResolver('principal_fallback' as PrincipalId),
-        'principal_fallback' as PrincipalId,
         undefined,
         { 'idea-1': [{ email: 'alice@example.com' }] } // keyed to a different row
       )
@@ -332,7 +397,9 @@ describe('processBatch', () => {
       hoisted.findManyPostExternalLinks.mockResolvedValue([
         { externalId: 'idea-1', postId: 'post_existing' },
       ])
-      const rows = [{ title: 'Dark mode v2', content: 'Please', source_id: 'idea-1' }]
+      const rows = [
+        { title: 'Dark mode v2', content: 'Please', source_id: 'idea-1', author_name: 'Jane' },
+      ]
       const voters = { 'idea-1': [{ email: 'carol@example.com' }] }
 
       const result = await processBatch(
@@ -340,7 +407,6 @@ describe('processBatch', () => {
         'board_1' as never,
         0,
         emailKeyedResolver('principal_fallback' as PrincipalId),
-        'principal_fallback' as PrincipalId,
         undefined,
         voters
       )
@@ -353,6 +419,33 @@ describe('processBatch', () => {
         return Array.isArray(arg) && arg[0]?.sourceType === 'import'
       })
       expect(voteInsertCall).toBeDefined()
+    })
+
+    it('skips voters that have neither email nor name rather than attributing them to the importer', async () => {
+      hoisted.findManyPostExternalLinks.mockResolvedValue([])
+      const rows = [
+        { title: 'Dark mode', content: 'Please', source_id: 'idea-1', author_name: 'Jane' },
+      ]
+      const voters = {
+        'idea-1': [{ email: 'alice@example.com' }, { email: '', name: '' }],
+      }
+
+      await processBatch(
+        rows,
+        'board_1' as never,
+        0,
+        emailKeyedResolver('principal_fallback' as PrincipalId),
+        undefined,
+        voters
+      )
+
+      const voteInsertCall = hoisted.insertValues.mock.calls.find((call) => {
+        const arg = call[0] as { sourceType?: string }[]
+        return Array.isArray(arg) && arg[0]?.sourceType === 'import'
+      })
+      const voteRows = voteInsertCall![0] as { principalId: string }[]
+      expect(voteRows).toHaveLength(1)
+      expect(voteRows[0].principalId).toBe('principal_alice@example.com')
     })
   })
 })

--- a/apps/web/src/lib/server/domains/import/__tests__/user-resolver-name.db.test.ts
+++ b/apps/web/src/lib/server/domains/import/__tests__/user-resolver-name.db.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Real-DB coverage for ImportUserResolver name-only authors: a CSV
+ * author_name with no email creates (or reuses) a name-only portal
+ * person, never the importer, and never an identified user who happens
+ * to share the display name.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest'
+import { createId, type PrincipalId, type UserId } from '@quackback/ids'
+import { createDbTestFixture, testDb } from '@/lib/server/__tests__/db-test-fixture'
+import { eq, and, isNull, principal, user } from '@/lib/server/db'
+
+vi.mock('@/lib/server/db', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/server/db')>()),
+  db: (await import('@/lib/server/__tests__/db-test-fixture')).testDb,
+}))
+
+vi.mock('@/lib/server/cache', () => ({
+  cacheDel: vi.fn(),
+  CACHE_KEYS: { PRINCIPAL_BY_USER: (id: string) => `principal:user:${id}` },
+}))
+
+import { ImportUserResolver } from '../user-resolver'
+
+const fixture = await createDbTestFixture({
+  probe: async (db) => {
+    await db
+      .select({ id: user.id, email: user.email, verified: user.emailVerified })
+      .from(user)
+      .limit(0)
+    await db.select({ id: principal.id }).from(principal).limit(0)
+  },
+})
+
+const runSuffix = () => `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+
+async function seedIdentifiedUser(name: string, email: string): Promise<UserId> {
+  const userId = createId('user') as UserId
+  await testDb.insert(user).values({ id: userId, name, email })
+  await testDb.insert(principal).values({
+    id: createId('principal') as PrincipalId,
+    userId,
+    role: 'user',
+    type: 'user',
+    displayName: name,
+    createdAt: new Date(),
+  })
+  return userId
+}
+
+async function seedNameOnlyPerson(name: string, createdAt = new Date()): Promise<PrincipalId> {
+  const userId = createId('user') as UserId
+  const principalId = createId('principal') as PrincipalId
+  await testDb.insert(user).values({ id: userId, name, email: null })
+  await testDb.insert(principal).values({
+    id: principalId,
+    userId,
+    role: 'user',
+    type: 'user',
+    displayName: name,
+    createdAt,
+  })
+  return principalId
+}
+
+describe.skipIf(!fixture.available)('ImportUserResolver name-only authors', () => {
+  beforeEach(() => fixture.begin())
+  afterEach(() => fixture.rollback())
+  afterAll(() => fixture.close())
+
+  it('creates a name-only portal person when email is empty', async () => {
+    const resolver = new ImportUserResolver()
+    const name = `Jane ${runSuffix()}`
+
+    const principalId = await resolver.resolve(null, name)
+    expect(resolver.pendingCount).toBe(1)
+
+    await resolver.flushPendingCreates()
+
+    const [userRow] = await testDb.select().from(user).where(eq(user.name, name))
+    expect(userRow.email).toBeNull()
+    expect(userRow.emailVerified).toBe(false)
+
+    const [principalRow] = await testDb
+      .select()
+      .from(principal)
+      .where(eq(principal.userId, userRow.id))
+    expect(principalRow.id).toBe(principalId)
+    expect(principalRow.displayName).toBe(name)
+    expect(principalRow.role).toBe('user')
+    expect(principalRow.type).toBe('user')
+  })
+
+  it('reuses the same pending create for the same name with different casing or whitespace', async () => {
+    const resolver = new ImportUserResolver()
+    const suffix = runSuffix()
+
+    const first = await resolver.resolve('', `  Jane ${suffix}  `)
+    const second = await resolver.resolve(null, `jane ${suffix}`)
+
+    expect(first).toBe(second)
+    expect(resolver.pendingCount).toBe(1)
+
+    await resolver.flushPendingCreates()
+
+    const rows = await testDb
+      .select()
+      .from(user)
+      .where(and(isNull(user.email), eq(user.name, `Jane ${suffix}`)))
+    expect(rows).toHaveLength(1)
+  })
+
+  it('reuses an existing name-only person with that display name', async () => {
+    const name = `Pat ${runSuffix()}`
+    const existing = await seedNameOnlyPerson(name)
+
+    const resolver = new ImportUserResolver()
+    const resolved = await resolver.resolve(null, name.toUpperCase())
+
+    expect(resolved).toBe(existing)
+    expect(resolver.pendingCount).toBe(0)
+    await resolver.flushPendingCreates()
+
+    const rows = await testDb.select().from(user).where(eq(user.name, name))
+    expect(rows).toHaveLength(1)
+  })
+
+  it('does not reuse an identified user who shares the display name', async () => {
+    const name = `Sam ${runSuffix()}`
+    await seedIdentifiedUser(name, `sam-${runSuffix()}@example.com`)
+
+    const resolver = new ImportUserResolver()
+    const resolved = await resolver.resolve(null, name)
+
+    expect(resolver.pendingCount).toBe(1)
+    await resolver.flushPendingCreates()
+
+    const [principalRow] = await testDb.select().from(principal).where(eq(principal.id, resolved))
+    expect(principalRow.displayName).toBe(name)
+
+    const nameOnly = await testDb
+      .select()
+      .from(user)
+      .where(and(isNull(user.email), eq(user.name, name)))
+    expect(nameOnly).toHaveLength(1)
+  })
+
+  it('throws and queues nothing when email and name are both empty', async () => {
+    const resolver = new ImportUserResolver()
+
+    await expect(resolver.resolve(null, null)).rejects.toThrow(/name or email/)
+    await expect(resolver.resolve('', '   ')).rejects.toThrow(/name or email/)
+    expect(resolver.pendingCount).toBe(0)
+  })
+})

--- a/apps/web/src/lib/server/domains/import/__tests__/user-resolver-verified.db.test.ts
+++ b/apps/web/src/lib/server/domains/import/__tests__/user-resolver-verified.db.test.ts
@@ -32,7 +32,6 @@ const fixture = await createDbTestFixture({
 })
 
 const runSuffix = () => `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
-const FALLBACK = createId('principal') as PrincipalId
 
 async function seedExistingUser(email: string): Promise<UserId> {
   const userId = createId('user') as UserId
@@ -58,8 +57,8 @@ describe.skipIf(!fixture.available)('ImportUserResolver emailVerified', () => {
     const verifiedEmail = `import-v-${runSuffix()}@example.com`
     const plainEmail = `import-p-${runSuffix()}@example.com`
 
-    await resolver.resolve(verifiedEmail, 'Verified Vic', FALLBACK, true)
-    await resolver.resolve(plainEmail, 'Plain Pat', FALLBACK, false)
+    await resolver.resolve(verifiedEmail, 'Verified Vic', true)
+    await resolver.resolve(plainEmail, 'Plain Pat', false)
 
     await resolver.flushPendingCreates()
 
@@ -74,7 +73,7 @@ describe.skipIf(!fixture.available)('ImportUserResolver emailVerified', () => {
     const existingId = await seedExistingUser(email)
 
     const resolver = new ImportUserResolver()
-    await resolver.resolve(email, 'Someone', FALLBACK, true)
+    await resolver.resolve(email, 'Someone', true)
 
     expect(resolver.pendingCount).toBe(0)
     await resolver.flushPendingCreates()
@@ -87,8 +86,8 @@ describe.skipIf(!fixture.available)('ImportUserResolver emailVerified', () => {
     const email = `import-first-${runSuffix()}@example.com`
     const resolver = new ImportUserResolver()
 
-    await resolver.resolve(email, 'First Row', FALLBACK, false)
-    await resolver.resolve(email.toUpperCase(), 'Second Row', FALLBACK, true)
+    await resolver.resolve(email, 'First Row', false)
+    await resolver.resolve(email.toUpperCase(), 'Second Row', true)
 
     expect(resolver.pendingCount).toBe(1)
     await resolver.flushPendingCreates()

--- a/apps/web/src/lib/server/domains/import/import-preview.ts
+++ b/apps/web/src/lib/server/domains/import/import-preview.ts
@@ -47,7 +47,6 @@ export async function previewImport(data: ImportInput): Promise<ImportPreview> {
       data.boardId,
       i,
       userResolver,
-      data.initiatedByPrincipalId,
       ctx,
       tagsToCreate,
       statusesToCreate,
@@ -60,7 +59,7 @@ export async function previewImport(data: ImportInput): Promise<ImportPreview> {
       byBoard[boardKey] = (byBoard[boardKey] ?? 0) + 1
       const statusKey = row.statusLabel ?? 'default'
       byStatus[statusKey] = (byStatus[statusKey] ?? 0) + 1
-      const authorKey = row.authorEmail ?? row.authorName ?? 'Imported user'
+      const authorKey = row.authorEmail ?? row.authorName ?? 'unknown'
       byAuthor[authorKey] = (byAuthor[authorKey] ?? 0) + 1
       if (row.sourceId) {
         allSourceIds.push(row.sourceId)
@@ -73,7 +72,7 @@ export async function previewImport(data: ImportInput): Promise<ImportPreview> {
           title: row.title,
           board: row.boardSlug,
           status: row.statusLabel,
-          author: row.authorEmail ?? row.authorName ?? 'Imported user',
+          author: row.authorEmail ?? row.authorName ?? 'unknown',
           isNewAuthor: row.isNewAuthor,
           voteCount: row.voteCount,
           action: 'create',
@@ -97,8 +96,7 @@ export async function previewImport(data: ImportInput): Promise<ImportPreview> {
   const finalSample = sample.map(({ sourceId, ...rest }) => ({
     ...rest,
     action: (sourceId && matchedSourceIds.has(sourceId) ? 'update' : 'create') as
-      | 'create'
-      | 'update',
+      'create' | 'update',
   }))
 
   return {

--- a/apps/web/src/lib/server/domains/import/import-row-resolver.ts
+++ b/apps/web/src/lib/server/domains/import/import-row-resolver.ts
@@ -39,41 +39,52 @@ export function parseCsvEmailVerified(value: string | undefined): boolean {
 /**
  * CSV row validation schema
  */
-export const csvRowSchema = z.object({
-  title: z.string().min(1, 'Title is required').max(200, 'Title must be 200 characters or less'),
-  content: z.string().max(10000, 'Content must be 10000 characters or less'),
-  status: z.string().optional(),
-  tags: z.string().optional(),
-  board: z.string().optional(),
-  author_name: z.string().optional(),
-  author_email: z.string().email().optional().or(z.literal('')),
-  // Whether the author's email is verified when this row CREATES the user
-  // (default true — claimable shell). Existing users are never flipped.
-  email_verified: z
-    .string()
-    .optional()
-    .transform((val) => parseCsvEmailVerified(val)),
-  vote_count: z
-    .string()
-    .optional()
-    .transform((val) => {
-      if (!val) return 0
-      const num = parseInt(val, 10)
-      return isNaN(num) || num < 0 ? 0 : num
-    }),
-  created_at: z
-    .string()
-    .optional()
-    .transform((val) => {
-      if (!val) return new Date()
-      const date = new Date(val)
-      return isNaN(date.getTime()) ? new Date() : date
-    }),
-  // Optional stable identifier from the source system (§I2). When present,
-  // re-importing the same row updates the post it previously created instead
-  // of creating a duplicate.
-  source_id: z.string().max(200).optional(),
-})
+export const AUTHOR_REQUIRED_MESSAGE = 'Author name or email is required'
+
+export const csvRowSchema = z
+  .object({
+    title: z.string().min(1, 'Title is required').max(200, 'Title must be 200 characters or less'),
+    content: z.string().max(10000, 'Content must be 10000 characters or less'),
+    status: z.string().optional(),
+    tags: z.string().optional(),
+    board: z.string().optional(),
+    author_name: z.string().optional(),
+    author_email: z.string().email().optional().or(z.literal('')),
+    // Whether the author's email is verified when this row CREATES the user
+    // (default true — claimable shell). Existing users are never flipped.
+    email_verified: z
+      .string()
+      .optional()
+      .transform((val) => parseCsvEmailVerified(val)),
+    vote_count: z
+      .string()
+      .optional()
+      .transform((val) => {
+        if (!val) return 0
+        const num = parseInt(val, 10)
+        return isNaN(num) || num < 0 ? 0 : num
+      }),
+    created_at: z
+      .string()
+      .optional()
+      .transform((val) => {
+        if (!val) return new Date()
+        const date = new Date(val)
+        return isNaN(date.getTime()) ? new Date() : date
+      }),
+    // Optional stable identifier from the source system (§I2). When present,
+    // re-importing the same row updates the post it previously created instead
+    // of creating a duplicate.
+    source_id: z.string().max(200).optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.author_name?.trim() || data.author_email?.trim()) return
+    ctx.addIssue({
+      code: 'custom',
+      message: AUTHOR_REQUIRED_MESSAGE,
+      path: ['author_name'],
+    })
+  })
 
 export interface ProcessedRow {
   title: string
@@ -197,7 +208,6 @@ export async function resolveRows(
   defaultBoardId: BoardId,
   startIndex: number,
   userResolver: ImportUserResolver,
-  fallbackPrincipalId: PrincipalId,
   ctx: RowContext,
   tagsToCreate: Set<string>,
   statusesToCreate: Map<string, string>,
@@ -291,7 +301,6 @@ export async function resolveRows(
     const principalId = await userResolver.resolve(
       row.author_email || null,
       row.author_name || null,
-      fallbackPrincipalId,
       row.email_verified
     )
     const isNewAuthor = userResolver.pendingCount > pendingBefore

--- a/apps/web/src/lib/server/domains/import/import-service.ts
+++ b/apps/web/src/lib/server/domains/import/import-service.ts
@@ -118,7 +118,6 @@ export async function processBatch(
   defaultBoardId: BoardId,
   startIndex: number,
   userResolver: ImportUserResolver,
-  fallbackPrincipalId: PrincipalId,
   batchTagId?: PostTagId | null,
   voters?: Record<string, ImportVoterRecord[]>
 ): Promise<BatchResult> {
@@ -142,7 +141,6 @@ export async function processBatch(
     defaultBoardId,
     startIndex,
     userResolver,
-    fallbackPrincipalId,
     ctx,
     tagsToCreate,
     statusesToCreate,
@@ -246,11 +244,8 @@ export async function processBatch(
       const seen = new Set<PrincipalId>()
       const resolved: { principalId: PrincipalId; createdAt: Date | null }[] = []
       for (const voter of rowVoters) {
-        const principalId = await userResolver.resolve(
-          voter.email,
-          voter.name ?? null,
-          fallbackPrincipalId
-        )
+        if (!voter.email?.trim() && !voter.name?.trim()) continue
+        const principalId = await userResolver.resolve(voter.email, voter.name ?? null)
         if (seen.has(principalId)) continue
         seen.add(principalId)
         resolved.push({
@@ -444,7 +439,6 @@ export async function processImport(data: ImportInput): Promise<ImportResult> {
       data.boardId,
       i,
       userResolver,
-      data.initiatedByPrincipalId,
       data.batchTagId,
       data.voters
     )

--- a/apps/web/src/lib/server/domains/import/types.ts
+++ b/apps/web/src/lib/server/domains/import/types.ts
@@ -78,7 +78,7 @@ export interface ImportPreviewRow {
   board: string | null
   /** Resolved status name, or null when the row falls back to the default status */
   status: string | null
-  /** Author email/name, or "Imported user" when unattributed */
+  /** Author email or author name from the CSV. Rows with neither are skipped. */
   author: string
   /** True when this author does not exist yet and would be created on commit */
   isNewAuthor: boolean

--- a/apps/web/src/lib/server/domains/import/user-resolver.ts
+++ b/apps/web/src/lib/server/domains/import/user-resolver.ts
@@ -1,64 +1,87 @@
 /**
  * User resolution for CSV import.
  *
- * Resolves email addresses to existing member IDs,
- * creating new user+member records when needed.
+ * Resolves CSV authors to principal IDs, creating new user+principal
+ * records when needed. Email is the identity when present; a name with
+ * no email creates a name-only portal contact (same shape as
+ * createPortalUser). Rows with neither are rejected — the importer is
+ * never used as the author.
  *
  * Adapted from scripts/import/core/user-resolver.ts for
  * use within the in-app CSV import flow.
  */
 
-import { db, eq, user, principal } from '@/lib/server/db'
+import { db, eq, and, isNull, sql, asc, user, principal } from '@/lib/server/db'
 import { createId, type PrincipalId, type UserId } from '@quackback/ids'
 import { createPrincipals } from '@/lib/server/domains/principals/principal.factory'
 
 interface PendingUser {
   principalId: PrincipalId
   userId: UserId
-  email: string
+  email: string | null
   name: string
   emailVerified: boolean
 }
 
+function nameCacheKey(name: string): string {
+  return `name:${name.toLowerCase()}`
+}
+
 /**
- * Resolves CSV author emails to member IDs.
+ * Resolves CSV authors to principal IDs.
  *
  * - Caches lookups per instance (create once per import job)
- * - Batches user+member creation via flushPendingCreates()
- * - Case-insensitive email matching
+ * - Batches user+principal creation via flushPendingCreates()
+ * - Case-insensitive email matching; case-insensitive name matching for
+ *   name-only contacts (never matches an identified user by display name)
  */
 export class ImportUserResolver {
   private cache = new Map<string, PrincipalId>()
   private pendingCreates: PendingUser[] = []
 
   /**
-   * Resolve an email to a member ID.
+   * Resolve a CSV author to a principal ID.
    *
-   * If the email has an existing user+member, returns the principalId.
-   * If not, queues a new user+member for creation and returns a pre-generated principalId.
-   * If email is null/empty, returns the fallbackPrincipalId.
+   * Email present: existing user+principal by email, else queue a new
+   * claimable shell (`emailVerified` applies only to that create).
+   * Email empty, name present: existing name-only contact by display
+   * name, else queue a name-only portal person.
+   * Both empty: throws — CSV rows without an author are rejected at
+   * schema validation; callers that might see an empty identity (voters)
+   * must skip before calling this.
    *
-   * `emailVerified` applies only when THIS call queues the creation (default
-   * true: import shells must be claimable via SSO). Existing users (and
-   * already-queued creates) are never flipped — an import row can opt out for
-   * a user it introduces, not one that predates it.
+   * `emailVerified` applies only when THIS call queues an email create
+   * (default true: import shells must be claimable via SSO). Existing
+   * users (and already-queued creates) are never flipped. Name-only
+   * creates are always unverified — there is no address to vouch for.
    */
   async resolve(
     email: string | null | undefined,
     name: string | null | undefined,
-    fallbackPrincipalId: PrincipalId,
     emailVerified = true
   ): Promise<PrincipalId> {
-    if (!email) return fallbackPrincipalId
+    const normalizedEmail = email?.toLowerCase().trim() ?? ''
+    if (normalizedEmail) {
+      return this.resolveByEmail(normalizedEmail, name, emailVerified)
+    }
 
-    const normalizedEmail = email.toLowerCase().trim()
-    if (!normalizedEmail) return fallbackPrincipalId
+    const trimmedName = name?.trim() ?? ''
+    if (trimmedName) {
+      return this.resolveByName(trimmedName)
+    }
 
+    throw new Error('Import author requires a name or email')
+  }
+
+  private async resolveByEmail(
+    normalizedEmail: string,
+    name: string | null | undefined,
+    emailVerified: boolean
+  ): Promise<PrincipalId> {
     if (this.cache.has(normalizedEmail)) {
       return this.cache.get(normalizedEmail)!
     }
 
-    // Look up existing principal by email
     const existing = await db
       .select({ principalId: principal.id })
       .from(user)
@@ -72,7 +95,6 @@ export class ImportUserResolver {
       return principalId
     }
 
-    // Queue for creation
     const userId = createId('user')
     const principalId = createId('principal')
     const displayName = name?.trim() || normalizedEmail.split('@')[0]
@@ -85,6 +107,41 @@ export class ImportUserResolver {
       emailVerified,
     })
     this.cache.set(normalizedEmail, principalId)
+    return principalId
+  }
+
+  private async resolveByName(trimmedName: string): Promise<PrincipalId> {
+    const cacheKey = nameCacheKey(trimmedName)
+    if (this.cache.has(cacheKey)) {
+      return this.cache.get(cacheKey)!
+    }
+
+    const existing = await db
+      .select({ principalId: principal.id })
+      .from(user)
+      .innerJoin(principal, eq(principal.userId, user.id))
+      .where(
+        and(isNull(user.email), sql`lower(${principal.displayName}) = ${trimmedName.toLowerCase()}`)
+      )
+      .orderBy(asc(principal.createdAt))
+      .limit(1)
+
+    if (existing.length > 0) {
+      const principalId = existing[0].principalId as PrincipalId
+      this.cache.set(cacheKey, principalId)
+      return principalId
+    }
+
+    const userId = createId('user')
+    const principalId = createId('principal')
+    this.pendingCreates.push({
+      principalId,
+      userId,
+      email: null,
+      name: trimmedName,
+      emailVerified: false,
+    })
+    this.cache.set(cacheKey, principalId)
     return principalId
   }
 
@@ -116,7 +173,12 @@ export class ImportUserResolver {
 
       // Create principal records (single multi-row insert, no N+1)
       await createPrincipals(
-        chunk.map((u) => ({ id: u.principalId, userId: u.userId, role: 'user' as const }))
+        chunk.map((u) => ({
+          id: u.principalId,
+          userId: u.userId,
+          role: 'user' as const,
+          displayName: u.name,
+        }))
       )
     }
 

--- a/apps/web/src/lib/shared/schemas/import.ts
+++ b/apps/web/src/lib/shared/schemas/import.ts
@@ -15,5 +15,5 @@ export const REQUIRED_HEADERS = ['title', 'content'] as const
  */
 export const CSV_TEMPLATE = `title,content,status,tags,board,author_name,author_email,email_verified,vote_count,created_at,source_id
 "Add dark mode support","It would be great to have a dark mode option for the app. Many users prefer working in low-light environments.","open","feature,ui","","John Doe","john@example.com","false","5","2024-01-15T10:30:00Z",""
-"Fix login timeout","Users are being logged out too quickly. The session timeout seems too aggressive.","under_review","bug","","","","","2","",""
+"Fix login timeout","Users are being logged out too quickly. The session timeout seems too aggressive.","under_review","bug","","Jane Doe","","","2","",""
 `

--- a/packages/db/src/generate-sample-csv.ts
+++ b/packages/db/src/generate-sample-csv.ts
@@ -358,22 +358,17 @@ function escapeCSV(value: string): string {
 // ============================================================================
 
 function generateRow(): string[] {
-  // Author: 75% have author, 25% anonymous
-  const hasAuthor = Math.random() > 0.25
-  let authorName = ''
-  let authorEmail = ''
-
-  if (hasAuthor) {
-    if (Math.random() < 0.6) {
-      const persona = pick(userPersonas)
-      authorName = `${persona.firstName} ${persona.lastName}`
-      authorEmail = `${persona.firstName.toLowerCase()}.${persona.lastName.toLowerCase()}@example.com`
-    } else {
-      const firstName = faker.person.firstName()
-      const lastName = faker.person.lastName()
-      authorName = `${firstName} ${lastName}`
-      authorEmail = faker.internet.email({ firstName, lastName }).toLowerCase()
-    }
+  let authorName: string
+  let authorEmail: string
+  if (Math.random() < 0.6) {
+    const persona = pick(userPersonas)
+    authorName = `${persona.firstName} ${persona.lastName}`
+    authorEmail = `${persona.firstName.toLowerCase()}.${persona.lastName.toLowerCase()}@example.com`
+  } else {
+    const firstName = faker.person.firstName()
+    const lastName = faker.person.lastName()
+    authorName = `${firstName} ${lastName}`
+    authorEmail = faker.internet.email({ firstName, lastName }).toLowerCase()
   }
 
   // Tags: 0-3 with weighted selection

--- a/scripts/import/README.md
+++ b/scripts/import/README.md
@@ -27,6 +27,9 @@ Generic CSV files (posts, comments, votes, notes)
 To migrate from another tool (Canny, UserVoice, ...), export your data there and
 map it onto the intermediate CSV columns below. If you only need posts, the
 in-app CSV import under **Admin → Settings → Imports & exports** is simpler.
+There, every row needs `author_name` or `author_email` (`author_name` without
+an email creates a name-only contact). The CLI path below still identifies
+authors by email.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

In-app CSV import advertised `author_name` as a first-class column, then attributed every row without `author_email` to the admin who uploaded the file. Preview showed the CSV names anyway, so the dry-run looked correct.

- **Name-only authors** (`author_name`, no email) now create or reuse a portal contact with `email = null`, same shape as AuthorSelector / New person. Identified users who happen to share the display name are not reused.
- **Author is required.** A row with neither `author_name` nor `author_email` is skipped with `Author name or email is required`. The uploader is never used as the post author. Voters with neither name nor email are dropped rather than counted as the importer.
- Preview, downloadable template, drop-zone copy, and the CLI README follow that contract.

## Test plan

- [x] `user-resolver-name.db.test.ts` — name-only create, case/whitespace reuse, existing name-only reuse, no match against identified users, throw when both empty
- [x] Preview — name-only `isNewAuthor` on first occurrence; missing author is a row error, not the importer
- [x] `processBatch` — name-only `principal_id`; missing author skipped; empty voters skipped
- [x] Import UI copy
- [ ] Dry-run a CSV with only `author_name` and confirm the review table matches the people created on commit
- [ ] Dry-run a CSV with neither author column and confirm those rows are skipped