### PR TITLE
feat(tags): per-tag portal visibility ("Show on portal")

### DIFF
--- a/apps/web/e2e/tests/admin/settings-tags.spec.ts
+++ b/apps/web/e2e/tests/admin/settings-tags.spec.ts
@@ -73,6 +73,11 @@ test.describe('Admin Tags Settings', () => {
     // Color section label
     await expect(dialog.getByText('Color')).toBeVisible()
 
+    // Portal visibility switch, on by default for new tags
+    const portalSwitch = dialog.getByRole('switch', { name: /show on portal/i })
+    await expect(portalSwitch).toBeVisible()
+    await expect(portalSwitch).toHaveAttribute('aria-checked', 'true')
+
     // Create and Cancel buttons
     await expect(dialog.getByRole('button', { name: /cancel/i })).toBeVisible()
     await expect(dialog.getByRole('button', { name: /create tag/i })).toBeVisible()

--- a/apps/web/src/components/admin/settings/tags/__tests__/tag-list.test.tsx
+++ b/apps/web/src/components/admin/settings/tags/__tests__/tag-list.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment happy-dom
+/**
+ * Tag settings — "Show on portal" visibility control.
+ *
+ * Covers the admin-facing half of tag portal visibility: the create/edit
+ * dialog exposes a switch that defaults to public for new tags, mirrors the
+ * saved flag when editing, and sends `isPublic` on save; internal tags are
+ * marked in the list so the state is visible without opening the dialog.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+import type { PostTag } from '@/lib/shared/db-types'
+
+const mockCreate = vi.fn()
+const mockUpdate = vi.fn()
+vi.mock('@/lib/server/functions/post-tags', () => ({
+  createPostTagFn: (...args: unknown[]) => mockCreate(...args),
+  updatePostTagFn: (...args: unknown[]) => mockUpdate(...args),
+  deletePostTagFn: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useRouter: () => ({ invalidate: vi.fn() }),
+}))
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+import { TagList } from '../tag-list'
+
+const PUBLIC_TAG = {
+  id: 'post_tag_public',
+  name: 'Bug',
+  color: '#ef4444',
+  description: 'Broken behaviour',
+  aiPrompt: null,
+  isPublic: true,
+  createdAt: new Date('2026-01-01'),
+  deletedAt: null,
+} as PostTag
+
+const INTERNAL_TAG = {
+  ...PUBLIC_TAG,
+  id: 'post_tag_internal',
+  name: 'Churn risk',
+  description: null,
+  isPublic: false,
+} as PostTag
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockCreate.mockImplementation(async ({ data }) => ({
+    ...PUBLIC_TAG,
+    id: 'post_tag_new',
+    ...data,
+  }))
+  mockUpdate.mockImplementation(async ({ data }) => ({ ...PUBLIC_TAG, ...data }))
+})
+
+function portalSwitch() {
+  return screen.getByRole('switch', { name: /show on portal/i })
+}
+
+describe('<TagList> — portal visibility', () => {
+  it('marks internal tags in the list and leaves public tags unmarked', () => {
+    render(<TagList initialTags={[PUBLIC_TAG, INTERNAL_TAG]} />)
+
+    const internalRow = screen.getByText('Churn risk').closest('div')!
+    expect(within(internalRow).getByText('Internal')).toBeTruthy()
+
+    const publicRow = screen.getByText('Bug').closest('div')!
+    expect(within(publicRow).queryByText('Internal')).toBeNull()
+  })
+
+  it('defaults a new tag to public and sends isPublic on create', async () => {
+    render(<TagList initialTags={[]} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /add new tag/i }))
+    expect(portalSwitch()).toHaveAttribute('aria-checked', 'true')
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Design' } })
+    fireEvent.click(screen.getByRole('button', { name: /create tag/i }))
+
+    await waitFor(() =>
+      expect(mockCreate).toHaveBeenCalledWith({
+        data: expect.objectContaining({ name: 'Design', isPublic: true }),
+      })
+    )
+  })
+
+  it('lets an admin create an internal tag by turning the switch off', async () => {
+    render(<TagList initialTags={[]} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /add new tag/i }))
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Churn risk' } })
+    fireEvent.click(portalSwitch())
+    expect(portalSwitch()).toHaveAttribute('aria-checked', 'false')
+
+    fireEvent.click(screen.getByRole('button', { name: /create tag/i }))
+
+    await waitFor(() =>
+      expect(mockCreate).toHaveBeenCalledWith({
+        data: expect.objectContaining({ name: 'Churn risk', isPublic: false }),
+      })
+    )
+  })
+
+  it('reflects the saved flag when editing and sends the toggled value', async () => {
+    render(<TagList initialTags={[INTERNAL_TAG]} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /edit tag/i }))
+    expect(portalSwitch()).toHaveAttribute('aria-checked', 'false')
+
+    fireEvent.click(portalSwitch())
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }))
+
+    await waitFor(() =>
+      expect(mockUpdate).toHaveBeenCalledWith({
+        data: expect.objectContaining({ id: 'post_tag_internal', isPublic: true }),
+      })
+    )
+  })
+})

--- a/apps/web/src/components/admin/settings/tags/tag-list.tsx
+++ b/apps/web/src/components/admin/settings/tags/tag-list.tsx
@@ -1,9 +1,16 @@
 import { useState, useEffect, useTransition } from 'react'
 import { useRouter } from '@tanstack/react-router'
 import { toast } from 'sonner'
-import { PlusIcon, TrashIcon, PencilSquareIcon, ArrowPathIcon } from '@heroicons/react/24/solid'
+import {
+  PlusIcon,
+  TrashIcon,
+  PencilSquareIcon,
+  ArrowPathIcon,
+  EyeSlashIcon,
+} from '@heroicons/react/24/solid'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Switch } from '@/components/ui/switch'
 import {
   Dialog,
   DialogContent,
@@ -164,6 +171,7 @@ function TagDialog({ open, onOpenChange, tag, onSaved }: TagDialogProps) {
   const [name, setName] = useState('')
   const [description, setDescription] = useState('')
   const [color, setColor] = useState('#6b7280')
+  const [isPublic, setIsPublic] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [isSaving, setIsSaving] = useState(false)
 
@@ -175,10 +183,12 @@ function TagDialog({ open, onOpenChange, tag, onSaved }: TagDialogProps) {
         setName(tag.name)
         setDescription(tag.description ?? '')
         setColor(tag.color)
+        setIsPublic(tag.isPublic)
       } else {
         setName('')
         setDescription('')
         setColor(randomColor())
+        setIsPublic(true)
       }
       setError(null)
     }
@@ -211,6 +221,7 @@ function TagDialog({ open, onOpenChange, tag, onSaved }: TagDialogProps) {
             name: trimmedName,
             color,
             description: description.trim() || null,
+            isPublic,
           },
         })
       } else {
@@ -219,6 +230,7 @@ function TagDialog({ open, onOpenChange, tag, onSaved }: TagDialogProps) {
             name: trimmedName,
             color,
             description: description.trim() || undefined,
+            isPublic,
           },
         })
       }
@@ -278,6 +290,17 @@ function TagDialog({ open, onOpenChange, tag, onSaved }: TagDialogProps) {
           <Label>Color</Label>
           <ColorPickerGrid selectedColor={color} onColorChange={setColor} />
           <ColorHexInput color={color} onColorChange={setColor} />
+        </div>
+
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <Label htmlFor="tag-is-public">Show on portal</Label>
+            <p className="text-xs text-muted-foreground">
+              Customers can see this tag on posts and filter by it in the public portal. Turn off to
+              keep it internal to your team.
+            </p>
+          </div>
+          <Switch id="tag-is-public" checked={isPublic} onCheckedChange={setIsPublic} />
         </div>
 
         {error && <p className="text-sm text-destructive">{error}</p>}
@@ -365,7 +388,7 @@ export function TagList({ initialTags }: TagListProps) {
     <div className="space-y-8">
       <SettingsCard
         title="Tags"
-        description="Label posts across boards for filtering and organization. Tags appear as colored badges throughout the app."
+        description="Label posts across boards for filtering and organization. Tags appear as colored badges throughout the app, and on the public portal unless marked internal."
         contentClassName="p-4"
       >
         <div className="space-y-1">
@@ -402,6 +425,16 @@ export function TagList({ initialTags }: TagListProps) {
 
               {/* Name */}
               <span className="text-sm font-medium">{tag.name}</span>
+
+              {!tag.isPublic && (
+                <span
+                  className="inline-flex items-center gap-1 rounded-md bg-muted px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground shrink-0"
+                  title="Hidden from the public portal"
+                >
+                  <EyeSlashIcon className="h-3 w-3" />
+                  Internal
+                </span>
+              )}
 
               {/* Description */}
               <span className="text-xs text-muted-foreground truncate flex-1">

--- a/apps/web/src/components/portal/__tests__/portal-access-gate.intl.test.tsx
+++ b/apps/web/src/components/portal/__tests__/portal-access-gate.intl.test.tsx
@@ -9,7 +9,7 @@ vi.mock('@tanstack/react-router', () => ({
 
 // GateCard invalidates portal queries on sign-out.
 vi.mock('@tanstack/react-query', () => ({
-  useQueryClient: () => ({ invalidateQueries: vi.fn(), resetQueries: vi.fn() }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn(), removeQueries: vi.fn() }),
 }))
 
 // GateCard listens for cross-tab auth broadcasts.

--- a/apps/web/src/components/portal/__tests__/portal-access-gate.intl.test.tsx
+++ b/apps/web/src/components/portal/__tests__/portal-access-gate.intl.test.tsx
@@ -9,7 +9,7 @@ vi.mock('@tanstack/react-router', () => ({
 
 // GateCard invalidates portal queries on sign-out.
 vi.mock('@tanstack/react-query', () => ({
-  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn(), resetQueries: vi.fn() }),
 }))
 
 // GateCard listens for cross-tab auth broadcasts.

--- a/apps/web/src/components/portal/__tests__/portal-access-gate.signin-bridge.test.tsx
+++ b/apps/web/src/components/portal/__tests__/portal-access-gate.signin-bridge.test.tsx
@@ -20,7 +20,7 @@ vi.mock('@tanstack/react-router', () => ({
 }))
 
 vi.mock('@tanstack/react-query', () => ({
-  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn(), resetQueries: vi.fn() }),
 }))
 
 // GateCard subscribes without an `enabled` flag.

--- a/apps/web/src/components/portal/__tests__/portal-access-gate.signin-bridge.test.tsx
+++ b/apps/web/src/components/portal/__tests__/portal-access-gate.signin-bridge.test.tsx
@@ -20,7 +20,7 @@ vi.mock('@tanstack/react-router', () => ({
 }))
 
 vi.mock('@tanstack/react-query', () => ({
-  useQueryClient: () => ({ invalidateQueries: vi.fn(), resetQueries: vi.fn() }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn(), removeQueries: vi.fn() }),
 }))
 
 // GateCard subscribes without an `enabled` flag.

--- a/apps/web/src/components/portal/__tests__/portal-access-gate.test.tsx
+++ b/apps/web/src/components/portal/__tests__/portal-access-gate.test.tsx
@@ -19,7 +19,7 @@ vi.mock('@/lib/client/hooks/use-auth-broadcast', () => ({
 }))
 
 vi.mock('@tanstack/react-query', () => ({
-  useQueryClient: () => ({ invalidateQueries: vi.fn(), resetQueries: vi.fn() }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn(), removeQueries: vi.fn() }),
 }))
 
 vi.mock('@/lib/client/auth-client', () => ({ signOut: vi.fn() }))

--- a/apps/web/src/components/portal/__tests__/portal-access-gate.test.tsx
+++ b/apps/web/src/components/portal/__tests__/portal-access-gate.test.tsx
@@ -19,7 +19,7 @@ vi.mock('@/lib/client/hooks/use-auth-broadcast', () => ({
 }))
 
 vi.mock('@tanstack/react-query', () => ({
-  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn(), resetQueries: vi.fn() }),
 }))
 
 vi.mock('@/lib/client/auth-client', () => ({ signOut: vi.fn() }))

--- a/apps/web/src/components/portal/__tests__/portal-access-gate.two-factor-abandon.test.tsx
+++ b/apps/web/src/components/portal/__tests__/portal-access-gate.two-factor-abandon.test.tsx
@@ -10,7 +10,7 @@ vi.mock('@tanstack/react-router', async (orig) => ({
 }))
 
 vi.mock('@tanstack/react-query', () => ({
-  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn(), resetQueries: vi.fn() }),
 }))
 
 // Hoisted so the spy exists when the (hoisted) mock factory runs.

--- a/apps/web/src/components/portal/__tests__/portal-access-gate.two-factor-abandon.test.tsx
+++ b/apps/web/src/components/portal/__tests__/portal-access-gate.two-factor-abandon.test.tsx
@@ -10,7 +10,7 @@ vi.mock('@tanstack/react-router', async (orig) => ({
 }))
 
 vi.mock('@tanstack/react-query', () => ({
-  useQueryClient: () => ({ invalidateQueries: vi.fn(), resetQueries: vi.fn() }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn(), removeQueries: vi.fn() }),
 }))
 
 // Hoisted so the spy exists when the (hoisted) mock factory runs.

--- a/apps/web/src/components/portal/portal-access-gate.tsx
+++ b/apps/web/src/components/portal/portal-access-gate.tsx
@@ -18,7 +18,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { FormattedMessage } from 'react-intl'
 import { toast } from 'sonner'
 import { escapeInlineStyle } from '@/lib/shared/safe-inline-content'
-import { resetViewerScopedPortalQueries } from '@/lib/client/queries/portal'
+import { removeViewerScopedPortalQueries } from '@/lib/client/queries/portal'
 import {
   ArrowPathIcon,
   ChevronUpIcon,
@@ -409,7 +409,7 @@ function GateCard({
     onSuccess: () => {
       setSigningIn(true)
       // Anything cached while gated was fetched as the previous viewer.
-      void resetViewerScopedPortalQueries(queryClient)
+      removeViewerScopedPortalQueries(queryClient)
       if (safeCallback) {
         // Team surfaces full-navigate (re-bootstrap the admin shell); a
         // portal-local destination invalidates so the gate clears, then routes.
@@ -439,9 +439,9 @@ function GateCard({
     setSigningOut(true)
     try {
       await signOut()
+      removeViewerScopedPortalQueries(queryClient)
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['votedPosts'] }),
-        resetViewerScopedPortalQueries(queryClient),
         router.invalidate(),
       ])
     } catch (err) {

--- a/apps/web/src/components/portal/portal-access-gate.tsx
+++ b/apps/web/src/components/portal/portal-access-gate.tsx
@@ -18,6 +18,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { FormattedMessage } from 'react-intl'
 import { toast } from 'sonner'
 import { escapeInlineStyle } from '@/lib/shared/safe-inline-content'
+import { invalidateViewerScopedPortalQueries } from '@/lib/client/queries/portal'
 import {
   ArrowPathIcon,
   ChevronUpIcon,
@@ -439,6 +440,7 @@ function GateCard({
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['portal', 'post'] }),
         queryClient.invalidateQueries({ queryKey: ['votedPosts'] }),
+        invalidateViewerScopedPortalQueries(queryClient),
         router.invalidate(),
       ])
     } catch (err) {

--- a/apps/web/src/components/portal/portal-access-gate.tsx
+++ b/apps/web/src/components/portal/portal-access-gate.tsx
@@ -18,7 +18,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { FormattedMessage } from 'react-intl'
 import { toast } from 'sonner'
 import { escapeInlineStyle } from '@/lib/shared/safe-inline-content'
-import { invalidateViewerScopedPortalQueries } from '@/lib/client/queries/portal'
+import { resetViewerScopedPortalQueries } from '@/lib/client/queries/portal'
 import {
   ArrowPathIcon,
   ChevronUpIcon,
@@ -408,6 +408,8 @@ function GateCard({
   useAuthBroadcast({
     onSuccess: () => {
       setSigningIn(true)
+      // Anything cached while gated was fetched as the previous viewer.
+      void resetViewerScopedPortalQueries(queryClient)
       if (safeCallback) {
         // Team surfaces full-navigate (re-bootstrap the admin shell); a
         // portal-local destination invalidates so the gate clears, then routes.
@@ -438,9 +440,8 @@ function GateCard({
     try {
       await signOut()
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['portal', 'post'] }),
         queryClient.invalidateQueries({ queryKey: ['votedPosts'] }),
-        invalidateViewerScopedPortalQueries(queryClient),
+        resetViewerScopedPortalQueries(queryClient),
         router.invalidate(),
       ])
     } catch (err) {

--- a/apps/web/src/components/public/__tests__/portal-header-help-links.test.tsx
+++ b/apps/web/src/components/public/__tests__/portal-header-help-links.test.tsx
@@ -46,7 +46,7 @@ vi.mock('@/components/auth/oauth-buttons', () => ({
 
 vi.mock('@tanstack/react-query', () => ({
   useQuery: () => ({ data: null }),
-  useQueryClient: () => ({ invalidateQueries: vi.fn(), resetQueries: vi.fn() }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn(), removeQueries: vi.fn() }),
 }))
 
 vi.mock('@/lib/server/functions/conversation', () => ({

--- a/apps/web/src/components/public/__tests__/portal-header-help-links.test.tsx
+++ b/apps/web/src/components/public/__tests__/portal-header-help-links.test.tsx
@@ -46,7 +46,7 @@ vi.mock('@/components/auth/oauth-buttons', () => ({
 
 vi.mock('@tanstack/react-query', () => ({
   useQuery: () => ({ data: null }),
-  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn(), resetQueries: vi.fn() }),
 }))
 
 vi.mock('@/lib/server/functions/conversation', () => ({

--- a/apps/web/src/components/public/__tests__/portal-header.test.tsx
+++ b/apps/web/src/components/public/__tests__/portal-header.test.tsx
@@ -13,7 +13,7 @@ const {
   mockHasAny,
   mockHasDistinctSignup,
   mockInvalidateQueries,
-  mockResetQueries,
+  mockRemoveQueries,
   mockSignOut,
 } = vi.hoisted(() => ({
   mockGetRouteContext: vi.fn(),
@@ -23,7 +23,7 @@ const {
   mockHasAny: vi.fn((): boolean => false),
   mockHasDistinctSignup: vi.fn((): boolean => true),
   mockInvalidateQueries: vi.fn(() => Promise.resolve()),
-  mockResetQueries: vi.fn(() => Promise.resolve()),
+  mockRemoveQueries: vi.fn(() => Promise.resolve()),
   mockSignOut: vi.fn(() => Promise.resolve()),
 }))
 
@@ -67,7 +67,7 @@ vi.mock('@tanstack/react-query', () => ({
   useQuery: () => ({ data: null }),
   useQueryClient: () => ({
     invalidateQueries: mockInvalidateQueries,
-    resetQueries: mockResetQueries,
+    removeQueries: mockRemoveQueries,
   }),
 }))
 
@@ -154,24 +154,25 @@ describe('PortalHeader — Admin dropdown item', () => {
 describe('PortalHeader — sign-out cache hygiene', () => {
   beforeEach(() => {
     mockInvalidateQueries.mockClear()
-    mockResetQueries.mockClear()
+    mockRemoveQueries.mockClear()
     mockSignOut.mockClear()
   })
   afterEach(() => cleanup())
 
-  it('resets (not merely invalidates) every viewer-scoped cache so internal tags do not outlive a team session', async () => {
+  it('removes (not merely invalidates) every viewer-scoped cache so internal tags do not outlive a team session', async () => {
     renderHeader({ userRole: 'admin', isLoggedIn: true })
     fireEvent.pointerDown(screen.getByRole('button'), { button: 0, ctrlKey: false })
     fireEvent.click(await screen.findByRole('menuitem', { name: /log out|sign out/i }))
     await vi.waitFor(() => expect(mockSignOut).toHaveBeenCalled())
 
     // Loaders read through ensureQueryData, which serves retained-but-stale
-    // data; only a reset actually drops the team-scoped payloads.
+    // data, and a reset would restore initialData; only removal actually
+    // drops the team-scoped payloads.
     await vi.waitFor(() => {
-      const resetKeys = mockResetQueries.mock.calls.map(
+      const removedKeys = mockRemoveQueries.mock.calls.map(
         (call) => (call as unknown as [{ queryKey: unknown[] }])[0].queryKey
       )
-      expect(resetKeys).toEqual(expect.arrayContaining([...VIEWER_SCOPED_PORTAL_QUERY_KEYS]))
+      expect(removedKeys).toEqual(expect.arrayContaining([...VIEWER_SCOPED_PORTAL_QUERY_KEYS]))
     })
     expect(VIEWER_SCOPED_PORTAL_QUERY_KEYS).toEqual(
       expect.arrayContaining([

--- a/apps/web/src/components/public/__tests__/portal-header.test.tsx
+++ b/apps/web/src/components/public/__tests__/portal-header.test.tsx
@@ -178,6 +178,7 @@ describe('PortalHeader — sign-out cache hygiene', () => {
         ['portal', 'tags'],
         ['portal', 'data'],
         ['portal', 'post'],
+        ['portal', 'roadmaps'],
         ['portal', 'roadmapPosts'],
       ])
     )

--- a/apps/web/src/components/public/__tests__/portal-header.test.tsx
+++ b/apps/web/src/components/public/__tests__/portal-header.test.tsx
@@ -180,6 +180,7 @@ describe('PortalHeader — sign-out cache hygiene', () => {
         ['portal', 'post'],
         ['portal', 'roadmaps'],
         ['portal', 'roadmapPosts'],
+        ['publicPosts'],
       ])
     )
   })

--- a/apps/web/src/components/public/__tests__/portal-header.test.tsx
+++ b/apps/web/src/components/public/__tests__/portal-header.test.tsx
@@ -13,6 +13,7 @@ const {
   mockHasAny,
   mockHasDistinctSignup,
   mockInvalidateQueries,
+  mockResetQueries,
   mockSignOut,
 } = vi.hoisted(() => ({
   mockGetRouteContext: vi.fn(),
@@ -22,6 +23,7 @@ const {
   mockHasAny: vi.fn((): boolean => false),
   mockHasDistinctSignup: vi.fn((): boolean => true),
   mockInvalidateQueries: vi.fn(() => Promise.resolve()),
+  mockResetQueries: vi.fn(() => Promise.resolve()),
   mockSignOut: vi.fn(() => Promise.resolve()),
 }))
 
@@ -63,7 +65,10 @@ vi.mock('@/components/auth/oauth-buttons', () => ({
 
 vi.mock('@tanstack/react-query', () => ({
   useQuery: () => ({ data: null }),
-  useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries }),
+  useQueryClient: () => ({
+    invalidateQueries: mockInvalidateQueries,
+    resetQueries: mockResetQueries,
+  }),
 }))
 
 vi.mock('@/lib/server/functions/conversation', () => ({
@@ -88,6 +93,7 @@ vi.mock('@/components/shared/user-stats', () => ({
 }))
 
 import { PortalHeader } from '../portal-header'
+import { VIEWER_SCOPED_PORTAL_QUERY_KEYS } from '@/lib/client/queries/portal'
 
 const loggedInSession = {
   user: {
@@ -148,27 +154,33 @@ describe('PortalHeader — Admin dropdown item', () => {
 describe('PortalHeader — sign-out cache hygiene', () => {
   beforeEach(() => {
     mockInvalidateQueries.mockClear()
+    mockResetQueries.mockClear()
     mockSignOut.mockClear()
   })
   afterEach(() => cleanup())
 
-  it('drops the viewer-scoped tag catalog so internal tags do not outlive a team session', async () => {
+  it('resets (not merely invalidates) every viewer-scoped cache so internal tags do not outlive a team session', async () => {
     renderHeader({ userRole: 'admin', isLoggedIn: true })
     fireEvent.pointerDown(screen.getByRole('button'), { button: 0, ctrlKey: false })
     fireEvent.click(await screen.findByRole('menuitem', { name: /log out|sign out/i }))
     await vi.waitFor(() => expect(mockSignOut).toHaveBeenCalled())
 
+    // Loaders read through ensureQueryData, which serves retained-but-stale
+    // data; only a reset actually drops the team-scoped payloads.
     await vi.waitFor(() => {
-      const keys = mockInvalidateQueries.mock.calls.map(
+      const resetKeys = mockResetQueries.mock.calls.map(
         (call) => (call as unknown as [{ queryKey: unknown[] }])[0].queryKey
       )
-      expect(keys).toEqual(
-        expect.arrayContaining([
-          ['portal', 'tags'],
-          ['portal', 'data'],
-        ])
-      )
+      expect(resetKeys).toEqual(expect.arrayContaining([...VIEWER_SCOPED_PORTAL_QUERY_KEYS]))
     })
+    expect(VIEWER_SCOPED_PORTAL_QUERY_KEYS).toEqual(
+      expect.arrayContaining([
+        ['portal', 'tags'],
+        ['portal', 'data'],
+        ['portal', 'post'],
+        ['portal', 'roadmapPosts'],
+      ])
+    )
   })
 })
 

--- a/apps/web/src/components/public/__tests__/portal-header.test.tsx
+++ b/apps/web/src/components/public/__tests__/portal-header.test.tsx
@@ -12,6 +12,8 @@ const {
   mockResolveSole,
   mockHasAny,
   mockHasDistinctSignup,
+  mockInvalidateQueries,
+  mockSignOut,
 } = vi.hoisted(() => ({
   mockGetRouteContext: vi.fn(),
   mockOpenAuthPopover: vi.fn(),
@@ -19,6 +21,8 @@ const {
   mockResolveSole: vi.fn((): string | null => null),
   mockHasAny: vi.fn((): boolean => false),
   mockHasDistinctSignup: vi.fn((): boolean => true),
+  mockInvalidateQueries: vi.fn(() => Promise.resolve()),
+  mockSignOut: vi.fn(() => Promise.resolve()),
 }))
 
 vi.mock('@tanstack/react-router', () => ({
@@ -59,7 +63,7 @@ vi.mock('@/components/auth/oauth-buttons', () => ({
 
 vi.mock('@tanstack/react-query', () => ({
   useQuery: () => ({ data: null }),
-  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+  useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries }),
 }))
 
 vi.mock('@/lib/server/functions/conversation', () => ({
@@ -71,7 +75,7 @@ vi.mock('@/lib/client/hooks/use-auth-broadcast', () => ({
 }))
 
 vi.mock('@/lib/client/auth-client', () => ({
-  signOut: vi.fn(),
+  signOut: mockSignOut,
   authClient: { signIn: { oauth2: mockOauth2 } },
 }))
 
@@ -138,6 +142,33 @@ describe('PortalHeader — Admin dropdown item', () => {
     // no Admin menuitem is present.
     await screen.findByRole('menuitem', { name: /settings/i })
     expect(screen.queryByRole('menuitem', { name: /admin/i })).toBeNull()
+  })
+})
+
+describe('PortalHeader — sign-out cache hygiene', () => {
+  beforeEach(() => {
+    mockInvalidateQueries.mockClear()
+    mockSignOut.mockClear()
+  })
+  afterEach(() => cleanup())
+
+  it('drops the viewer-scoped tag catalog so internal tags do not outlive a team session', async () => {
+    renderHeader({ userRole: 'admin', isLoggedIn: true })
+    fireEvent.pointerDown(screen.getByRole('button'), { button: 0, ctrlKey: false })
+    fireEvent.click(await screen.findByRole('menuitem', { name: /log out|sign out/i }))
+    await vi.waitFor(() => expect(mockSignOut).toHaveBeenCalled())
+
+    await vi.waitFor(() => {
+      const keys = mockInvalidateQueries.mock.calls.map(
+        (call) => (call as unknown as [{ queryKey: unknown[] }])[0].queryKey
+      )
+      expect(keys).toEqual(
+        expect.arrayContaining([
+          ['portal', 'tags'],
+          ['portal', 'data'],
+        ])
+      )
+    })
   })
 })
 

--- a/apps/web/src/components/public/comment-form.tsx
+++ b/apps/web/src/components/public/comment-form.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { useForm } from 'react-hook-form'
-import type { UseMutationResult } from '@tanstack/react-query'
+import { useQueryClient, type UseMutationResult } from '@tanstack/react-query'
 import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
 import { commentSchema, type CommentInput } from '@/lib/shared/schemas/comments'
 import { Button } from '@/components/ui/button'
@@ -18,6 +18,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { StatusBadge } from '@/components/ui/status-badge'
 import { CheckIcon, LockClosedIcon } from '@heroicons/react/24/solid'
 import { signOut } from '@/lib/client/auth-client'
+import { resetViewerScopedPortalQueries } from '@/lib/client/queries/portal'
 import { useRouter, useRouteContext } from '@tanstack/react-router'
 import { useAuthBroadcast } from '@/lib/client/hooks/use-auth-broadcast'
 import { cn } from '@/lib/shared/utils'
@@ -77,6 +78,7 @@ export function CommentForm({
 }: CommentFormProps) {
   const intl = useIntl()
   const router = useRouter()
+  const queryClient = useQueryClient()
   const { session } = useRouteContext({ from: '__root__' })
   const [error, setError] = useState<string | null>(null)
   const [selectedStatusId, setSelectedStatusId] = useState<string | null>(null)
@@ -505,6 +507,7 @@ export function CommentForm({
                     signOut({
                       fetchOptions: {
                         onSuccess: () => {
+                          void resetViewerScopedPortalQueries(queryClient)
                           router.invalidate()
                         },
                       },

--- a/apps/web/src/components/public/comment-form.tsx
+++ b/apps/web/src/components/public/comment-form.tsx
@@ -18,7 +18,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { StatusBadge } from '@/components/ui/status-badge'
 import { CheckIcon, LockClosedIcon } from '@heroicons/react/24/solid'
 import { signOut } from '@/lib/client/auth-client'
-import { resetViewerScopedPortalQueries } from '@/lib/client/queries/portal'
+import { removeViewerScopedPortalQueries } from '@/lib/client/queries/portal'
 import { useRouter, useRouteContext } from '@tanstack/react-router'
 import { useAuthBroadcast } from '@/lib/client/hooks/use-auth-broadcast'
 import { cn } from '@/lib/shared/utils'
@@ -507,7 +507,7 @@ export function CommentForm({
                     signOut({
                       fetchOptions: {
                         onSuccess: () => {
-                          void resetViewerScopedPortalQueries(queryClient)
+                          removeViewerScopedPortalQueries(queryClient)
                           router.invalidate()
                         },
                       },

--- a/apps/web/src/components/public/feedback/feedback-header-animated.tsx
+++ b/apps/web/src/components/public/feedback/feedback-header-animated.tsx
@@ -21,7 +21,7 @@ import { PostingToBoard } from '@/components/public/feedback/posting-to-board'
 import { validatePostCustomFieldValues } from '@/lib/shared/post-custom-fields'
 import type { BoardSettings } from '@/lib/shared/db-types'
 import { signOut } from '@/lib/client/auth-client'
-import { resetViewerScopedPortalQueries } from '@/lib/client/queries/portal'
+import { removeViewerScopedPortalQueries } from '@/lib/client/queries/portal'
 import { resolveSubmitState } from '@/components/public/feedback/submit-permission'
 import type { JSONContent } from '@tiptap/react'
 
@@ -442,7 +442,7 @@ export function FeedbackHeaderAnimated({
                     className="text-primary hover:underline"
                     onClick={async () => {
                       await signOut()
-                      void resetViewerScopedPortalQueries(queryClient)
+                      removeViewerScopedPortalQueries(queryClient)
                       router.invalidate()
                     }}
                   >

--- a/apps/web/src/components/public/feedback/feedback-header-animated.tsx
+++ b/apps/web/src/components/public/feedback/feedback-header-animated.tsx
@@ -3,6 +3,7 @@ import { useState, useCallback, useEffect, useRef } from 'react'
 import { useIntl, FormattedMessage } from 'react-intl'
 import { useKeyboardSubmit } from '@/lib/client/hooks/use-keyboard-submit'
 import { useRouter, useRouteContext } from '@tanstack/react-router'
+import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { motion, AnimatePresence } from 'framer-motion'
 import { PencilIcon } from '@heroicons/react/24/solid'
@@ -20,6 +21,7 @@ import { PostingToBoard } from '@/components/public/feedback/posting-to-board'
 import { validatePostCustomFieldValues } from '@/lib/shared/post-custom-fields'
 import type { BoardSettings } from '@/lib/shared/db-types'
 import { signOut } from '@/lib/client/auth-client'
+import { resetViewerScopedPortalQueries } from '@/lib/client/queries/portal'
 import { resolveSubmitState } from '@/components/public/feedback/submit-permission'
 import type { JSONContent } from '@tiptap/react'
 
@@ -60,6 +62,7 @@ export function FeedbackHeaderAnimated({
 }: FeedbackHeaderProps) {
   const intl = useIntl()
   const router = useRouter()
+  const queryClient = useQueryClient()
   const { session } = useRouteContext({ from: '__root__' })
   const [expanded, setExpanded] = useState(false)
   const [error, setError] = useState('')
@@ -439,6 +442,7 @@ export function FeedbackHeaderAnimated({
                     className="text-primary hover:underline"
                     onClick={async () => {
                       await signOut()
+                      void resetViewerScopedPortalQueries(queryClient)
                       router.invalidate()
                     }}
                   >

--- a/apps/web/src/components/public/portal-header.tsx
+++ b/apps/web/src/components/public/portal-header.tsx
@@ -40,6 +40,7 @@ import {
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { getMyConversationsFn } from '@/lib/server/functions/conversation'
 import { PORTAL_MY_CONVERSATIONS_QUERY_KEY } from '@/lib/client/queries/portal-support'
+import { invalidateViewerScopedPortalQueries } from '@/lib/client/queries/portal'
 import { useAuthBroadcast } from '@/lib/client/hooks/use-auth-broadcast'
 import { NotificationBell } from '@/components/notifications'
 
@@ -149,6 +150,8 @@ export function PortalHeader({
       // Invalidate user-scoped queries so reaction highlights and vote data refresh
       queryClient.invalidateQueries({ queryKey: ['portal', 'post'] })
       queryClient.invalidateQueries({ queryKey: ['votedPosts'] })
+      // A team sign-in must gain internal tags in the filter catalog.
+      void invalidateViewerScopedPortalQueries(queryClient)
       // Refetch loaders (includes session and userRole) for the new session.
       void router.invalidate()
     },
@@ -204,6 +207,9 @@ export function PortalHeader({
     // Clear user-scoped caches so stale reaction/vote highlights don't persist
     queryClient.invalidateQueries({ queryKey: ['portal', 'post'] })
     queryClient.invalidateQueries({ queryKey: ['votedPosts'] })
+    // A team member's cached tag catalog (incl. internal tags) must not
+    // outlive their session.
+    void invalidateViewerScopedPortalQueries(queryClient)
     router.invalidate() // Refetch session
     router.navigate({ to: '/' })
   }

--- a/apps/web/src/components/public/portal-header.tsx
+++ b/apps/web/src/components/public/portal-header.tsx
@@ -40,7 +40,7 @@ import {
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { getMyConversationsFn } from '@/lib/server/functions/conversation'
 import { PORTAL_MY_CONVERSATIONS_QUERY_KEY } from '@/lib/client/queries/portal-support'
-import { resetViewerScopedPortalQueries } from '@/lib/client/queries/portal'
+import { removeViewerScopedPortalQueries } from '@/lib/client/queries/portal'
 import { useAuthBroadcast } from '@/lib/client/hooks/use-auth-broadcast'
 import { NotificationBell } from '@/components/notifications'
 
@@ -150,7 +150,7 @@ export function PortalHeader({
       // Refresh vote highlights and drop viewer-scoped data (post detail,
       // feed, tag catalog) so a team sign-in gains internal tags.
       queryClient.invalidateQueries({ queryKey: ['votedPosts'] })
-      void resetViewerScopedPortalQueries(queryClient)
+      removeViewerScopedPortalQueries(queryClient)
       // Refetch loaders (includes session and userRole) for the new session.
       void router.invalidate()
     },
@@ -206,7 +206,7 @@ export function PortalHeader({
     // Clear user-scoped caches: vote highlights, and every viewer-scoped
     // payload (a team member's internal tags must not outlive their session).
     queryClient.invalidateQueries({ queryKey: ['votedPosts'] })
-    void resetViewerScopedPortalQueries(queryClient)
+    removeViewerScopedPortalQueries(queryClient)
     router.invalidate() // Refetch session
     router.navigate({ to: '/' })
   }

--- a/apps/web/src/components/public/portal-header.tsx
+++ b/apps/web/src/components/public/portal-header.tsx
@@ -40,7 +40,7 @@ import {
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { getMyConversationsFn } from '@/lib/server/functions/conversation'
 import { PORTAL_MY_CONVERSATIONS_QUERY_KEY } from '@/lib/client/queries/portal-support'
-import { invalidateViewerScopedPortalQueries } from '@/lib/client/queries/portal'
+import { resetViewerScopedPortalQueries } from '@/lib/client/queries/portal'
 import { useAuthBroadcast } from '@/lib/client/hooks/use-auth-broadcast'
 import { NotificationBell } from '@/components/notifications'
 
@@ -147,11 +147,10 @@ export function PortalHeader({
   // Listen for auth success to refetch session and role via router invalidation
   useAuthBroadcast({
     onSuccess: () => {
-      // Invalidate user-scoped queries so reaction highlights and vote data refresh
-      queryClient.invalidateQueries({ queryKey: ['portal', 'post'] })
+      // Refresh vote highlights and drop viewer-scoped data (post detail,
+      // feed, tag catalog) so a team sign-in gains internal tags.
       queryClient.invalidateQueries({ queryKey: ['votedPosts'] })
-      // A team sign-in must gain internal tags in the filter catalog.
-      void invalidateViewerScopedPortalQueries(queryClient)
+      void resetViewerScopedPortalQueries(queryClient)
       // Refetch loaders (includes session and userRole) for the new session.
       void router.invalidate()
     },
@@ -204,12 +203,10 @@ export function PortalHeader({
 
   const handleSignOut = async () => {
     await signOut()
-    // Clear user-scoped caches so stale reaction/vote highlights don't persist
-    queryClient.invalidateQueries({ queryKey: ['portal', 'post'] })
+    // Clear user-scoped caches: vote highlights, and every viewer-scoped
+    // payload (a team member's internal tags must not outlive their session).
     queryClient.invalidateQueries({ queryKey: ['votedPosts'] })
-    // A team member's cached tag catalog (incl. internal tags) must not
-    // outlive their session.
-    void invalidateViewerScopedPortalQueries(queryClient)
+    void resetViewerScopedPortalQueries(queryClient)
     router.invalidate() // Refetch session
     router.navigate({ to: '/' })
   }

--- a/apps/web/src/lib/client/queries/portal-viewer-scope.test.ts
+++ b/apps/web/src/lib/client/queries/portal-viewer-scope.test.ts
@@ -30,6 +30,10 @@ describe('resetViewerScopedPortalQueries', () => {
       }
     )
     queryClient.setQueryData(['portal', 'post', 'post_1'], { tags: teamCatalog })
+    queryClient.setQueryData(
+      ['portal', 'roadmaps'],
+      [{ id: 'rm_1', baseFilter: { tagIds: ['tag_internal'] } }]
+    )
 
     await resetViewerScopedPortalQueries(queryClient)
 
@@ -65,6 +69,7 @@ describe('resetViewerScopedPortalQueries', () => {
         ['portal', 'data'],
         ['portal', 'posts'],
         ['portal', 'post'],
+        ['portal', 'roadmaps'],
         ['portal', 'roadmapPosts'],
       ])
     )

--- a/apps/web/src/lib/client/queries/portal-viewer-scope.test.ts
+++ b/apps/web/src/lib/client/queries/portal-viewer-scope.test.ts
@@ -34,6 +34,10 @@ describe('resetViewerScopedPortalQueries', () => {
       ['portal', 'roadmaps'],
       [{ id: 'rm_1', baseFilter: { tagIds: ['tag_internal'] } }]
     )
+    queryClient.setQueryData(['publicPosts', 'list', { sort: 'trending' }], {
+      pages: [{ items: [{ id: 'post_1', tags: teamCatalog }] }],
+      pageParams: [1],
+    })
 
     await resetViewerScopedPortalQueries(queryClient)
 
@@ -71,6 +75,7 @@ describe('resetViewerScopedPortalQueries', () => {
         ['portal', 'post'],
         ['portal', 'roadmaps'],
         ['portal', 'roadmapPosts'],
+        ['publicPosts'],
       ])
     )
   })

--- a/apps/web/src/lib/client/queries/portal-viewer-scope.test.ts
+++ b/apps/web/src/lib/client/queries/portal-viewer-scope.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest'
+import { QueryClient } from '@tanstack/react-query'
+
+vi.mock('@/lib/server/functions/portal', () => ({
+  fetchPublicBoards: vi.fn(),
+  fetchPublicPosts: vi.fn(),
+  fetchPublicStatuses: vi.fn(),
+  fetchPublicTags: vi.fn(),
+  fetchAvatars: vi.fn(),
+  fetchPublicRoadmaps: vi.fn(),
+  fetchPublicRoadmapPosts: vi.fn(),
+  fetchPortalData: vi.fn(),
+}))
+
+import { resetViewerScopedPortalQueries, VIEWER_SCOPED_PORTAL_QUERY_KEYS } from './portal'
+
+const teamCatalog = [{ id: 'tag_internal', name: 'Churn risk', isPublic: false }]
+const anonymousCatalog: unknown[] = []
+
+describe('resetViewerScopedPortalQueries', () => {
+  it('drops retained data so a later ensureQueryData refetches as the new viewer', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    // Team member loaded the roadmap: tag catalog (with an internal tag) and a
+    // roadmap column filtered by that tag are cached, then become inactive.
+    queryClient.setQueryData(['portal', 'tags'], teamCatalog)
+    queryClient.setQueryData(
+      ['portal', 'roadmapPosts', 'rm_1', 'st_1', { tags: ['tag_internal'] }],
+      {
+        items: [{ id: 'post_1' }],
+      }
+    )
+    queryClient.setQueryData(['portal', 'post', 'post_1'], { tags: teamCatalog })
+
+    await resetViewerScopedPortalQueries(queryClient)
+
+    for (const key of VIEWER_SCOPED_PORTAL_QUERY_KEYS) {
+      for (const query of queryClient.getQueryCache().findAll({ queryKey: key })) {
+        expect(query.state.data, `${key.join('/')} still holds data`).toBeUndefined()
+      }
+    }
+
+    // The next loader read goes to the network instead of serving the team copy.
+    const queryFn = vi.fn(async () => anonymousCatalog)
+    const served = await queryClient.ensureQueryData({ queryKey: ['portal', 'tags'], queryFn })
+    expect(queryFn).toHaveBeenCalledTimes(1)
+    expect(served).toBe(anonymousCatalog)
+  })
+
+  it('invalidateQueries alone would have left the team catalog servable (the bug being guarded)', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    queryClient.setQueryData(['portal', 'tags'], teamCatalog)
+
+    await queryClient.invalidateQueries({ queryKey: ['portal', 'tags'] })
+
+    const queryFn = vi.fn(async () => anonymousCatalog)
+    const served = await queryClient.ensureQueryData({ queryKey: ['portal', 'tags'], queryFn })
+    expect(served).toBe(teamCatalog)
+    expect(queryFn).not.toHaveBeenCalled()
+  })
+
+  it('covers every family whose payload depends on the viewer', () => {
+    expect(VIEWER_SCOPED_PORTAL_QUERY_KEYS).toEqual(
+      expect.arrayContaining([
+        ['portal', 'tags'],
+        ['portal', 'data'],
+        ['portal', 'posts'],
+        ['portal', 'post'],
+        ['portal', 'roadmapPosts'],
+      ])
+    )
+  })
+})

--- a/apps/web/src/lib/client/queries/portal-viewer-scope.test.ts
+++ b/apps/web/src/lib/client/queries/portal-viewer-scope.test.ts
@@ -12,39 +12,49 @@ vi.mock('@/lib/server/functions/portal', () => ({
   fetchPortalData: vi.fn(),
 }))
 
-import { resetViewerScopedPortalQueries, VIEWER_SCOPED_PORTAL_QUERY_KEYS } from './portal'
+import { removeViewerScopedPortalQueries, VIEWER_SCOPED_PORTAL_QUERY_KEYS } from './portal'
 
 const teamCatalog = [{ id: 'tag_internal', name: 'Churn risk', isPublic: false }]
 const anonymousCatalog: unknown[] = []
+const teamFeedPage = { pages: [{ items: [{ id: 'post_1', tags: teamCatalog }] }], pageParams: [1] }
+const feedKey = ['publicPosts', 'list', { sort: 'trending' }]
 
-describe('resetViewerScopedPortalQueries', () => {
+function newClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } })
+}
+
+/** Mirrors usePublicPosts seeding an inactive feed query from the SSR payload. */
+function buildFeedQueryWithInitialData(queryClient: QueryClient) {
+  return queryClient
+    .getQueryCache()
+    .build(queryClient, { queryKey: feedKey, initialData: teamFeedPage, queryFn: async () => null })
+}
+
+describe('removeViewerScopedPortalQueries', () => {
   it('drops retained data so a later ensureQueryData refetches as the new viewer', async () => {
-    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-    // Team member loaded the roadmap: tag catalog (with an internal tag) and a
-    // roadmap column filtered by that tag are cached, then become inactive.
+    const queryClient = newClient()
+    // Team member loaded the portal: tag catalog (with an internal tag), the
+    // feed, a roadmap column filtered by that tag and a post detail are cached,
+    // then become inactive.
     queryClient.setQueryData(['portal', 'tags'], teamCatalog)
     queryClient.setQueryData(
       ['portal', 'roadmapPosts', 'rm_1', 'st_1', { tags: ['tag_internal'] }],
-      {
-        items: [{ id: 'post_1' }],
-      }
+      { items: [{ id: 'post_1' }] }
     )
     queryClient.setQueryData(['portal', 'post', 'post_1'], { tags: teamCatalog })
     queryClient.setQueryData(
       ['portal', 'roadmaps'],
       [{ id: 'rm_1', baseFilter: { tagIds: ['tag_internal'] } }]
     )
-    queryClient.setQueryData(['publicPosts', 'list', { sort: 'trending' }], {
-      pages: [{ items: [{ id: 'post_1', tags: teamCatalog }] }],
-      pageParams: [1],
-    })
+    buildFeedQueryWithInitialData(queryClient)
 
-    await resetViewerScopedPortalQueries(queryClient)
+    removeViewerScopedPortalQueries(queryClient)
 
     for (const key of VIEWER_SCOPED_PORTAL_QUERY_KEYS) {
-      for (const query of queryClient.getQueryCache().findAll({ queryKey: key })) {
-        expect(query.state.data, `${key.join('/')} still holds data`).toBeUndefined()
-      }
+      expect(
+        queryClient.getQueryCache().findAll({ queryKey: key }),
+        `${key.join('/')} still cached`
+      ).toEqual([])
     }
 
     // The next loader read goes to the network instead of serving the team copy.
@@ -54,8 +64,8 @@ describe('resetViewerScopedPortalQueries', () => {
     expect(served).toBe(anonymousCatalog)
   })
 
-  it('invalidateQueries alone would have left the team catalog servable (the bug being guarded)', async () => {
-    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  it('guards against invalidateQueries, which leaves the team catalog servable', async () => {
+    const queryClient = newClient()
     queryClient.setQueryData(['portal', 'tags'], teamCatalog)
 
     await queryClient.invalidateQueries({ queryKey: ['portal', 'tags'] })
@@ -64,6 +74,18 @@ describe('resetViewerScopedPortalQueries', () => {
     const served = await queryClient.ensureQueryData({ queryKey: ['portal', 'tags'], queryFn })
     expect(served).toBe(teamCatalog)
     expect(queryFn).not.toHaveBeenCalled()
+  })
+
+  it('guards against resetQueries, which restores a feed page seeded via initialData', async () => {
+    const queryClient = newClient()
+    const query = buildFeedQueryWithInitialData(queryClient)
+    expect(query.state.data).toEqual(teamFeedPage)
+
+    await queryClient.resetQueries({ queryKey: ['publicPosts'] })
+    expect(queryClient.getQueryData(feedKey)).toEqual(teamFeedPage)
+
+    removeViewerScopedPortalQueries(queryClient)
+    expect(queryClient.getQueryData(feedKey)).toBeUndefined()
   })
 
   it('covers every family whose payload depends on the viewer', () => {

--- a/apps/web/src/lib/client/queries/portal.ts
+++ b/apps/web/src/lib/client/queries/portal.ts
@@ -13,18 +13,37 @@ import {
 } from '@/lib/server/functions/portal'
 
 /**
- * Drop portal caches whose payload depends on who the viewer is. The tag
- * catalog (`['portal','tags']`) hides internal tags from non-team viewers, and
- * `['portal','data']` embeds that same catalog, so neither may survive an auth
- * transition: a team member signing out must not keep seeing internal tags,
- * and a team member signing in must gain them. Call on every portal sign-in
- * success and sign-out alongside the existing user-scoped invalidations.
+ * Query families whose payload depends on who the viewer is: the tag catalog
+ * hides internal tags from non-team viewers; portal data, post lists and post
+ * detail embed that filtered catalog; public roadmap results honour the same
+ * guard for caller-supplied tag filters.
  */
-export function invalidateViewerScopedPortalQueries(queryClient: QueryClient): Promise<void[]> {
-  return Promise.all([
-    queryClient.invalidateQueries({ queryKey: ['portal', 'tags'] }),
-    queryClient.invalidateQueries({ queryKey: ['portal', 'data'] }),
-  ])
+export const VIEWER_SCOPED_PORTAL_QUERY_KEYS: readonly (readonly string[])[] = [
+  ['portal', 'tags'],
+  ['portal', 'data'],
+  ['portal', 'posts'],
+  ['portal', 'post'],
+  ['portal', 'roadmapPosts'],
+]
+
+/**
+ * Drop every viewer-scoped portal cache entry on an auth transition, so a team
+ * member signing out does not keep seeing internal tags and a team member
+ * signing in gains them.
+ *
+ * This must *reset*, not invalidate: `invalidateQueries` only marks entries
+ * stale and keeps their data, and route loaders read through
+ * `ensureQueryData`, which returns retained data without waiting for a refetch
+ * — so a stale team-scoped catalog would still render for the next anonymous
+ * view. `resetQueries` clears the data (inactive entries are fetched fresh on
+ * next use; active observers refetch immediately).
+ *
+ * Call from every portal sign-out control and sign-in success handler.
+ */
+export function resetViewerScopedPortalQueries(queryClient: QueryClient): Promise<void[]> {
+  return Promise.all(
+    VIEWER_SCOPED_PORTAL_QUERY_KEYS.map((queryKey) => queryClient.resetQueries({ queryKey }))
+  )
 }
 
 /**

--- a/apps/web/src/lib/client/queries/portal.ts
+++ b/apps/web/src/lib/client/queries/portal.ts
@@ -14,10 +14,11 @@ import {
 
 /**
  * Query families whose payload depends on who the viewer is: the tag catalog
- * hides internal tags from non-team viewers; portal data, post lists and post
- * detail embed that filtered catalog; public roadmap results honour the same
- * guard for caller-supplied tag filters; and the roadmap catalog's
- * `baseFilter` has internal tag ids redacted for non-team viewers.
+ * hides internal tags from non-team viewers; portal data, the infinite feed
+ * (`publicPostsKeys`, see use-portal-posts-query), post lists and post detail
+ * embed that filtered catalog; public roadmap results honour the same guard
+ * for caller-supplied tag filters; and the roadmap catalog's `baseFilter` has
+ * internal tag ids redacted for non-team viewers.
  */
 export const VIEWER_SCOPED_PORTAL_QUERY_KEYS: readonly (readonly string[])[] = [
   ['portal', 'tags'],
@@ -26,6 +27,7 @@ export const VIEWER_SCOPED_PORTAL_QUERY_KEYS: readonly (readonly string[])[] = [
   ['portal', 'post'],
   ['portal', 'roadmaps'],
   ['portal', 'roadmapPosts'],
+  ['publicPosts'],
 ]
 
 /**

--- a/apps/web/src/lib/client/queries/portal.ts
+++ b/apps/web/src/lib/client/queries/portal.ts
@@ -1,4 +1,4 @@
-import { queryOptions } from '@tanstack/react-query'
+import { queryOptions, type QueryClient } from '@tanstack/react-query'
 import type { PrincipalId, RoadmapId, PostStatusId, BoardId } from '@quackback/ids'
 import type { RespondedFilter } from '@/lib/shared/types/filters'
 import {
@@ -11,6 +11,21 @@ import {
   fetchPublicRoadmapPosts,
   fetchPortalData,
 } from '@/lib/server/functions/portal'
+
+/**
+ * Drop portal caches whose payload depends on who the viewer is. The tag
+ * catalog (`['portal','tags']`) hides internal tags from non-team viewers, and
+ * `['portal','data']` embeds that same catalog, so neither may survive an auth
+ * transition: a team member signing out must not keep seeing internal tags,
+ * and a team member signing in must gain them. Call on every portal sign-in
+ * success and sign-out alongside the existing user-scoped invalidations.
+ */
+export function invalidateViewerScopedPortalQueries(queryClient: QueryClient): Promise<void[]> {
+  return Promise.all([
+    queryClient.invalidateQueries({ queryKey: ['portal', 'tags'] }),
+    queryClient.invalidateQueries({ queryKey: ['portal', 'data'] }),
+  ])
+}
 
 /**
  * Query options factory for portal/public routes.

--- a/apps/web/src/lib/client/queries/portal.ts
+++ b/apps/web/src/lib/client/queries/portal.ts
@@ -31,23 +31,25 @@ export const VIEWER_SCOPED_PORTAL_QUERY_KEYS: readonly (readonly string[])[] = [
 ]
 
 /**
- * Drop every viewer-scoped portal cache entry on an auth transition, so a team
- * member signing out does not keep seeing internal tags and a team member
+ * Remove every viewer-scoped portal cache entry on an auth transition, so a
+ * team member signing out does not keep seeing internal tags and a team member
  * signing in gains them.
  *
- * This must *reset*, not invalidate: `invalidateQueries` only marks entries
- * stale and keeps their data, and route loaders read through
- * `ensureQueryData`, which returns retained data without waiting for a refetch
- * — so a stale team-scoped catalog would still render for the next anonymous
- * view. `resetQueries` clears the data (inactive entries are fetched fresh on
- * next use; active observers refetch immediately).
+ * This must *remove*, not invalidate or reset: `invalidateQueries` keeps the
+ * data and route loaders read it back through `ensureQueryData` without
+ * waiting for a refetch; `resetQueries` restores a query's `initialData`, and
+ * the feed (`usePublicPosts`) seeds its pages from the SSR payload that way, so
+ * a reset would put the team-scoped page straight back. `removeQueries` drops
+ * the entries outright. Callers follow up with `router.invalidate()`, which
+ * re-runs loaders and re-renders observers so they rebuild against fresh
+ * queries as the new viewer.
  *
  * Call from every portal sign-out control and sign-in success handler.
  */
-export function resetViewerScopedPortalQueries(queryClient: QueryClient): Promise<void[]> {
-  return Promise.all(
-    VIEWER_SCOPED_PORTAL_QUERY_KEYS.map((queryKey) => queryClient.resetQueries({ queryKey }))
-  )
+export function removeViewerScopedPortalQueries(queryClient: QueryClient): void {
+  for (const queryKey of VIEWER_SCOPED_PORTAL_QUERY_KEYS) {
+    queryClient.removeQueries({ queryKey })
+  }
 }
 
 /**

--- a/apps/web/src/lib/client/queries/portal.ts
+++ b/apps/web/src/lib/client/queries/portal.ts
@@ -16,13 +16,15 @@ import {
  * Query families whose payload depends on who the viewer is: the tag catalog
  * hides internal tags from non-team viewers; portal data, post lists and post
  * detail embed that filtered catalog; public roadmap results honour the same
- * guard for caller-supplied tag filters.
+ * guard for caller-supplied tag filters; and the roadmap catalog's
+ * `baseFilter` has internal tag ids redacted for non-team viewers.
  */
 export const VIEWER_SCOPED_PORTAL_QUERY_KEYS: readonly (readonly string[])[] = [
   ['portal', 'tags'],
   ['portal', 'data'],
   ['portal', 'posts'],
   ['portal', 'post'],
+  ['portal', 'roadmaps'],
   ['portal', 'roadmapPosts'],
 ]
 

--- a/apps/web/src/lib/server/domains/api/schemas/tags.ts
+++ b/apps/web/src/lib/server/domains/api/schemas/tags.ts
@@ -19,10 +19,17 @@ import {
 } from './common'
 
 // PostTag schema
+const IsPublicSchema = z.boolean().meta({
+  description:
+    'Whether customers can see this tag on the public portal. False keeps the tag internal to your team.',
+  example: true,
+})
+
 const TagSchema = z.object({
   id: TypeIdSchema.meta({ example: 'post_tag_01h455vb4pex5vsknk084sn02q' }),
   name: z.string().meta({ example: 'Bug' }),
   color: HexColorSchema.meta({ example: '#ef4444' }),
+  isPublic: IsPublicSchema,
   createdAt: TimestampSchema,
 })
 
@@ -31,6 +38,7 @@ const CreateTagSchema = z
   .object({
     name: z.string().min(1).max(50).meta({ description: 'PostTag name', example: 'Bug' }),
     color: HexColorSchema.optional().meta({ description: 'PostTag color', default: '#6b7280' }),
+    isPublic: IsPublicSchema.optional().meta({ default: true }),
   })
   .meta({ description: 'Create tag request body' })
 
@@ -38,6 +46,7 @@ const UpdateTagSchema = z
   .object({
     name: z.string().min(1).max(50).optional(),
     color: HexColorSchema.optional(),
+    isPublic: IsPublicSchema.optional(),
   })
   .meta({ description: 'Update tag request body' })
 

--- a/apps/web/src/lib/server/domains/export/entities/taxonomy.ts
+++ b/apps/web/src/lib/server/domains/export/entities/taxonomy.ts
@@ -80,7 +80,7 @@ async function fetchTags(offset: number, limit: number) {
     orderBy: asc(postTags.createdAt),
     offset,
     limit,
-    columns: { id: true, name: true, color: true, description: true },
+    columns: { id: true, name: true, color: true, description: true, isPublic: true },
   })
 }
 type TagRow = Awaited<ReturnType<typeof fetchTags>>[number]
@@ -89,7 +89,10 @@ export const tagsExporter: EntityExporter<TagRow> = {
   key: 'tags',
   fileName: 'tags.csv',
   pageSize: 5000,
-  header: 'id,name,color,description',
+  header: 'id,name,color,description,is_public',
   fetchPage: fetchTags,
-  serialize: (t) => [t.id, escapeCSV(t.name), t.color, escapeCSV(t.description ?? '')].join(','),
+  serialize: (t) =>
+    [t.id, escapeCSV(t.name), t.color, escapeCSV(t.description ?? ''), String(t.isPublic)].join(
+      ','
+    ),
 }

--- a/apps/web/src/lib/server/domains/post-tags/__tests__/post-tag.service.test.ts
+++ b/apps/web/src/lib/server/domains/post-tags/__tests__/post-tag.service.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tag portal visibility at the service layer.
+ *
+ * `listPublicPostTags` is the portal's tag catalog. Non-team viewers must only
+ * receive tags marked public; team actors get everything (they assign internal
+ * tags from the portal too). Create/update persist the flag, defaulting new
+ * tags to public so behaviour is unchanged for admins who never touch it.
+ *
+ * Pure unit test — the db module is stubbed with tagging operators so the
+ * `where` shape can be asserted without a database.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { PostTagId, PrincipalId } from '@quackback/ids'
+import type { Actor } from '@/lib/server/policy'
+
+const mockEq = vi.fn((col, val) => ({ _tag: 'eq', col, val }))
+const mockAnd = vi.fn((...args) => ({ _tag: 'and', args }))
+const mockIsNull = vi.fn((col) => ({ _tag: 'isNull', col }))
+const mockAsc = vi.fn((col) => ({ _tag: 'asc', col }))
+
+const mockPostTags = {
+  id: Symbol('postTags.id'),
+  name: Symbol('postTags.name'),
+  isPublic: Symbol('postTags.isPublic'),
+  deletedAt: Symbol('postTags.deletedAt'),
+}
+
+const mockFindMany = vi.fn()
+const mockFindFirst = vi.fn()
+const mockInsertReturning = vi.fn()
+const mockInsertValues = vi.fn(() => ({ returning: mockInsertReturning }))
+const mockUpdateReturning = vi.fn()
+const mockUpdateWhere = vi.fn(() => ({ returning: mockUpdateReturning }))
+const mockUpdateSet = vi.fn(() => ({ where: mockUpdateWhere }))
+
+vi.mock('@/lib/server/db', () => ({
+  db: {
+    query: { postTags: { findMany: mockFindMany, findFirst: mockFindFirst } },
+    insert: vi.fn(() => ({ values: mockInsertValues })),
+    update: vi.fn(() => ({ set: mockUpdateSet })),
+  },
+  eq: mockEq,
+  and: mockAnd,
+  isNull: mockIsNull,
+  asc: mockAsc,
+  postTags: mockPostTags,
+  boards: {},
+  postTagAssignments: {},
+  posts: {},
+}))
+
+const TEAM_ACTOR: Actor = {
+  principalId: 'principal_team' as PrincipalId,
+  role: 'admin',
+  principalType: 'user',
+  segmentIds: new Set(),
+  permissions: new Set(),
+}
+
+const CUSTOMER_ACTOR: Actor = {
+  principalId: 'principal_customer' as PrincipalId,
+  role: 'user',
+  principalType: 'user',
+  segmentIds: new Set(),
+  permissions: new Set(),
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockFindMany.mockResolvedValue([])
+})
+
+describe('listPublicPostTags — portal visibility', () => {
+  it('restricts to public, non-deleted tags for an anonymous viewer (default actor)', async () => {
+    const { listPublicPostTags } = await import('../post-tag.service')
+
+    await listPublicPostTags()
+
+    const { where } = mockFindMany.mock.calls[0][0]
+    expect(where).toEqual({
+      _tag: 'and',
+      args: [
+        { _tag: 'isNull', col: mockPostTags.deletedAt },
+        { _tag: 'eq', col: mockPostTags.isPublic, val: true },
+      ],
+    })
+  })
+
+  it('restricts to public tags for a signed-in customer', async () => {
+    const { listPublicPostTags } = await import('../post-tag.service')
+
+    await listPublicPostTags(CUSTOMER_ACTOR)
+
+    expect(mockEq).toHaveBeenCalledWith(mockPostTags.isPublic, true)
+  })
+
+  it('returns every non-deleted tag for a team actor', async () => {
+    const { listPublicPostTags } = await import('../post-tag.service')
+
+    await listPublicPostTags(TEAM_ACTOR)
+
+    const { where } = mockFindMany.mock.calls[0][0]
+    expect(where).toEqual({ _tag: 'isNull', col: mockPostTags.deletedAt })
+    expect(mockEq).not.toHaveBeenCalledWith(mockPostTags.isPublic, true)
+  })
+})
+
+describe('createPostTag — isPublic', () => {
+  it('defaults new tags to public when the flag is omitted', async () => {
+    mockInsertReturning.mockResolvedValue([{ id: 'post_tag_1', isPublic: true }])
+    const { createPostTag } = await import('../post-tag.service')
+
+    await createPostTag({ name: 'Bug' })
+
+    expect(mockInsertValues).toHaveBeenCalledWith(expect.objectContaining({ isPublic: true }))
+  })
+
+  it('persists an explicit internal flag', async () => {
+    mockInsertReturning.mockResolvedValue([{ id: 'post_tag_1', isPublic: false }])
+    const { createPostTag } = await import('../post-tag.service')
+
+    await createPostTag({ name: 'Churn risk', isPublic: false })
+
+    expect(mockInsertValues).toHaveBeenCalledWith(expect.objectContaining({ isPublic: false }))
+  })
+})
+
+describe('updatePostTag — isPublic', () => {
+  beforeEach(() => {
+    mockFindFirst.mockResolvedValue({ id: 'post_tag_1', name: 'Bug', isPublic: true })
+    mockUpdateReturning.mockResolvedValue([{ id: 'post_tag_1', isPublic: false }])
+  })
+
+  it('writes isPublic when provided', async () => {
+    const { updatePostTag } = await import('../post-tag.service')
+
+    await updatePostTag('post_tag_1' as PostTagId, { isPublic: false })
+
+    expect(mockUpdateSet).toHaveBeenCalledWith({ isPublic: false })
+  })
+
+  it('leaves isPublic untouched when omitted', async () => {
+    const { updatePostTag } = await import('../post-tag.service')
+
+    await updatePostTag('post_tag_1' as PostTagId, { color: '#ef4444' })
+
+    expect(mockUpdateSet).toHaveBeenCalledWith({ color: '#ef4444' })
+  })
+})

--- a/apps/web/src/lib/server/domains/post-tags/post-tag.service.ts
+++ b/apps/web/src/lib/server/domains/post-tags/post-tag.service.ts
@@ -25,6 +25,7 @@ import {
 import type { PostTagId, BoardId } from '@quackback/ids'
 import { NotFoundError, ValidationError, ConflictError, InternalError } from '@/lib/shared/errors'
 import type { CreateTagInput, UpdateTagInput } from './post-tag.types'
+import { isTeamActor, ANONYMOUS_ACTOR, type Actor } from '@/lib/server/policy'
 import { logger } from '@/lib/server/logger'
 
 const log = logger.child({ component: 'tags' })
@@ -76,6 +77,7 @@ export async function createPostTag(input: CreateTagInput): Promise<PostTag> {
       color,
       description: input.description?.trim() || null,
       aiPrompt: input.aiPrompt?.trim() || null,
+      isPublic: input.isPublic ?? true,
     })
     .returning()
 
@@ -141,6 +143,7 @@ export async function updatePostTag(id: PostTagId, input: UpdateTagInput): Promi
   if (input.color !== undefined) updateData.color = input.color
   if (input.description !== undefined) updateData.description = input.description?.trim() || null
   if (input.aiPrompt !== undefined) updateData.aiPrompt = input.aiPrompt?.trim() || null
+  if (input.isPublic !== undefined) updateData.isPublic = input.isPublic
 
   // Update the tag
   const [updatedTag] = await db
@@ -245,16 +248,19 @@ export async function getPostTagsByBoard(boardId: BoardId): Promise<PostTag[]> {
 }
 
 /**
- * List all tags (public, no authentication required)
+ * List tags visible to a portal viewer.
  *
- * Returns tags ordered by name.
- * This method is used for public endpoints like feedback portal filtering.
+ * Team actors see every non-deleted tag (they assign internal tags from the
+ * portal too); everyone else only sees tags marked `isPublic`. Ordered by name.
+ * Used for public endpoints like feedback portal filtering.
  */
-export async function listPublicPostTags(): Promise<PostTag[]> {
+export async function listPublicPostTags(actor: Actor = ANONYMOUS_ACTOR): Promise<PostTag[]> {
   log.debug('list public tags')
   try {
     return await db.query.postTags.findMany({
-      where: isNull(postTags.deletedAt),
+      where: isTeamActor(actor)
+        ? isNull(postTags.deletedAt)
+        : and(isNull(postTags.deletedAt), eq(postTags.isPublic, true)),
       orderBy: [asc(postTags.name)],
     })
   } catch (error) {

--- a/apps/web/src/lib/server/domains/post-tags/post-tag.types.ts
+++ b/apps/web/src/lib/server/domains/post-tags/post-tag.types.ts
@@ -11,6 +11,8 @@ export interface CreateTagInput {
   description?: string
   /** Matching rule for AI auto-tagging of new posts; unset disables it. */
   aiPrompt?: string
+  /** Show on the public portal (default true). False = internal, team-only. */
+  isPublic?: boolean
 }
 
 /**
@@ -21,4 +23,5 @@ export interface UpdateTagInput {
   color?: string
   description?: string | null
   aiPrompt?: string | null
+  isPublic?: boolean
 }

--- a/apps/web/src/lib/server/domains/posts/__tests__/post-public.test.ts
+++ b/apps/web/src/lib/server/domains/posts/__tests__/post-public.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { PostStatusId } from '@quackback/ids'
+import type { PostStatusId, PostTagId, PrincipalId } from '@quackback/ids'
+import type { Actor } from '@/lib/server/policy'
 
 const mockEq = vi.fn((col, val) => ({ _tag: 'eq', col, val }))
 const mockOr = vi.fn((...args) => ({ _tag: 'or', args }))
@@ -48,6 +49,23 @@ const mockMainOrderBy = vi.fn().mockReturnValue({ limit: mockMainLimit })
 const mockMainWhere = vi.fn().mockReturnValue({ orderBy: mockMainOrderBy })
 const mockMainInnerJoin = vi.fn().mockReturnValue({ where: mockMainWhere })
 
+const mockPostTagAssignments = {
+  postId: Symbol('postTagAssignments.postId'),
+  tagId: Symbol('postTagAssignments.tagId'),
+}
+
+const mockPostTags = {
+  id: Symbol('postTags.id'),
+  name: Symbol('postTags.name'),
+  color: Symbol('postTags.color'),
+  isPublic: Symbol('postTags.isPublic'),
+}
+
+// tagIds filter subquery: selectDistinct(...).from(postTagAssignments).innerJoin(postTags).where(...)
+const TAG_SUBQUERY_MARKER = Symbol('tag_subquery')
+const mockTagSubWhere = vi.fn().mockReturnValue(TAG_SUBQUERY_MARKER)
+const mockTagSubInnerJoin = vi.fn().mockReturnValue({ where: mockTagSubWhere })
+
 // Route based on which table is passed to .from(): postStatuses = subquery chain, posts = main chain
 const mockDbSelect = vi.fn().mockImplementation(() => ({
   from: vi.fn().mockImplementation((table) => {
@@ -58,8 +76,17 @@ const mockDbSelect = vi.fn().mockImplementation(() => ({
   }),
 }))
 
+const mockDbSelectDistinct = vi.fn().mockImplementation(() => ({
+  from: vi.fn().mockImplementation((table) => {
+    if (table === mockPostTagAssignments) {
+      return { innerJoin: mockTagSubInnerJoin }
+    }
+    throw new Error('unexpected selectDistinct table')
+  }),
+}))
+
 vi.mock('@/lib/server/db', () => ({
-  db: { select: mockDbSelect },
+  db: { select: mockDbSelect, selectDistinct: mockDbSelectDistinct },
   eq: mockEq,
   and: mockAnd,
   or: mockOr,
@@ -71,15 +98,8 @@ vi.mock('@/lib/server/db', () => ({
   posts: mockPosts,
   boards: mockBoards,
   postStatuses: mockPostStatuses,
-  postTagAssignments: {
-    postId: Symbol('postTagAssignments.postId'),
-    tagId: Symbol('postTagAssignments.tagId'),
-  },
-  postTags: {
-    id: Symbol('postTags.id'),
-    name: Symbol('postTags.name'),
-    color: Symbol('postTags.color'),
-  },
+  postTagAssignments: mockPostTagAssignments,
+  postTags: mockPostTags,
   postVotes: { postId: Symbol('postVotes.postId'), principalId: Symbol('postVotes.principalId') },
   principal: { id: Symbol('principal.id') },
 }))
@@ -260,5 +280,107 @@ describe('listPublicPostsWithVotesAndAvatars — pinned posts lead every sort', 
 
     const args = mockMainOrderBy.mock.calls[0]
     expect(args[1]).toEqual({ _tag: 'desc', col: mockPosts.createdAt })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tag portal visibility — internal (is_public=false) tags never reach a
+// non-team viewer, neither as a filter nor attached to a post.
+// ---------------------------------------------------------------------------
+
+const TEAM_ACTOR: Actor = {
+  principalId: 'principal_team' as PrincipalId,
+  role: 'member',
+  principalType: 'user',
+  segmentIds: new Set(),
+  permissions: new Set(),
+}
+
+function isPublicFilterApplied() {
+  return mockEq.mock.calls.some(([col, val]) => col === mockPostTags.isPublic && val === true)
+}
+
+/** Whether any raw-SQL template contains the `t.is_public` guard. */
+function isPublicSqlFragmentEmitted() {
+  return mockSql.mock.calls.some((call) => {
+    const [fragments] = call as unknown as [TemplateStringsArray | undefined]
+    return fragments ? fragments.join('?').includes('t.is_public = true') : false
+  })
+}
+
+describe('tag portal visibility — tagIds filter subquery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSubWhere.mockReturnValue(SUBQUERY_MARKER)
+    mockTagSubWhere.mockReturnValue(TAG_SUBQUERY_MARKER)
+    mockTagSubInnerJoin.mockReturnValue({ where: mockTagSubWhere })
+    mockMainOffset.mockResolvedValue([])
+    mockMainLimit.mockReturnValue({ offset: mockMainOffset })
+    mockMainOrderBy.mockReturnValue({ limit: mockMainLimit })
+    mockMainWhere.mockReturnValue({ orderBy: mockMainOrderBy })
+    mockMainInnerJoin.mockReturnValue({ where: mockMainWhere })
+  })
+
+  it('joins the tag catalog and requires is_public for an anonymous viewer', async () => {
+    const { listPublicPostsWithVotesAndAvatars } = await import('../post.public')
+
+    await listPublicPostsWithVotesAndAvatars({ tagIds: ['post_tag_1' as PostTagId] })
+
+    expect(mockTagSubInnerJoin).toHaveBeenCalledWith(mockPostTags, expect.anything())
+    expect(mockInArray).toHaveBeenCalledWith(mockPostTagAssignments.tagId, ['post_tag_1'])
+    expect(isPublicFilterApplied()).toBe(true)
+    expect(mockInArray).toHaveBeenCalledWith(mockPosts.id, TAG_SUBQUERY_MARKER)
+  })
+
+  it('does not restrict the tag filter for a team viewer', async () => {
+    const { listPublicPostsWithVotesAndAvatars } = await import('../post.public')
+
+    await listPublicPostsWithVotesAndAvatars({
+      tagIds: ['post_tag_1' as PostTagId],
+      actor: TEAM_ACTOR,
+    })
+
+    expect(mockInArray).toHaveBeenCalledWith(mockPostTagAssignments.tagId, ['post_tag_1'])
+    expect(isPublicFilterApplied()).toBe(false)
+  })
+})
+
+describe('tag portal visibility — tags embedded on listed posts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSubWhere.mockReturnValue(SUBQUERY_MARKER)
+    mockMainOffset.mockResolvedValue([])
+    mockMainLimit.mockReturnValue({ offset: mockMainOffset })
+    mockMainOrderBy.mockReturnValue({ limit: mockMainLimit })
+    mockMainWhere.mockReturnValue({ orderBy: mockMainOrderBy })
+    mockMainInnerJoin.mockReturnValue({ where: mockMainWhere })
+  })
+
+  it('listPublicPosts guards the json_agg tag subquery with is_public for an anonymous viewer', async () => {
+    const { listPublicPosts } = await import('../post.public')
+
+    await listPublicPosts({})
+
+    expect(isPublicSqlFragmentEmitted()).toBe(true)
+  })
+
+  it('listPublicPosts leaves the json_agg tag subquery unguarded for a team viewer', async () => {
+    const { listPublicPosts } = await import('../post.public')
+
+    await listPublicPosts({ actor: TEAM_ACTOR })
+
+    expect(isPublicSqlFragmentEmitted()).toBe(false)
+  })
+
+  it('publicTagCondition is undefined for team actors and an is_public predicate otherwise', async () => {
+    const { publicTagCondition } = await import('../post.public')
+    const { ANONYMOUS_ACTOR } = await import('@/lib/server/policy')
+
+    expect(publicTagCondition(TEAM_ACTOR)).toBeUndefined()
+    expect(publicTagCondition(ANONYMOUS_ACTOR)).toEqual({
+      _tag: 'eq',
+      col: mockPostTags.isPublic,
+      val: true,
+    })
   })
 })

--- a/apps/web/src/lib/server/domains/posts/post.public.detail.ts
+++ b/apps/web/src/lib/server/domains/posts/post.public.detail.ts
@@ -18,7 +18,7 @@ import { toUuid, fromUuid, type PostId, type PostCommentId, type PrincipalId } f
 import { buildCommentTree, toStatusChange } from '@/lib/shared'
 import type { PublicPostDetail, PublicComment, PinnedComment } from './post.types'
 import { DEFAULT_COMMENT_PAGE_SIZE, encodeCommentCursor, decodeCommentCursor } from './comment-page'
-import { resolveAvatarUrl, parseJson } from './post.public'
+import { resolveAvatarUrl, parseJson, publicTagSqlFilter } from './post.public'
 import { getExecuteRows } from '@/lib/server/utils'
 import {
   canViewPost,
@@ -149,7 +149,7 @@ export async function getPublicPostDetail(
           (SELECT json_agg(json_build_object('id', t.id, 'name', t.name, 'color', t.color))
            FROM ${postTagAssignments} pt
            INNER JOIN ${postTags} t ON t.id = pt.tag_id
-           WHERE pt.post_id = ${posts.id}),
+           WHERE pt.post_id = ${posts.id} ${publicTagSqlFilter(actor)}),
           '[]'
         )`.as('tags_json'),
         authorName: sql<string | null>`(

--- a/apps/web/src/lib/server/domains/posts/post.public.ts
+++ b/apps/web/src/lib/server/domains/posts/post.public.ts
@@ -28,9 +28,28 @@ import {
 } from '@quackback/ids'
 import type { PublicPostListResult } from './post.types'
 import type { RespondedFilter } from '@/lib/shared/types/filters'
-import { postViewFilter, ANONYMOUS_ACTOR, type Actor } from '@/lib/server/policy'
+import { postViewFilter, isTeamActor, ANONYMOUS_ACTOR, type Actor } from '@/lib/server/policy'
 
 import { resolveUserAvatarUrl } from '@/lib/server/domains/principals/principal-display'
+
+/**
+ * Portal tag visibility. Non-team viewers only see tags marked public —
+ * both in filter lists and attached to posts — so an internal tag never
+ * reaches a customer. Team actors see every tag (they assign internal tags
+ * from the portal too). Returns undefined for team actors so it can be
+ * dropped into `and(...)` without a branch.
+ */
+export function publicTagCondition(actor: Actor) {
+  return isTeamActor(actor) ? undefined : eq(postTags.isPublic, true)
+}
+
+/**
+ * Raw-SQL twin of {@link publicTagCondition} for the `json_agg` tag
+ * subqueries, which alias `post_tags` as `t`. Empty for team actors.
+ */
+export function publicTagSqlFilter(actor: Actor) {
+  return isTeamActor(actor) ? sql`` : sql`AND t.is_public = true`
+}
 
 /** Resolve avatar URL — uploaded key first, then OAuth/external URL. */
 export function resolveAvatarUrl(source: {
@@ -156,10 +175,14 @@ function buildPostFilterConditions(params: PostListParams, actor: Actor) {
   }
 
   if (tagIds && tagIds.length > 0) {
+    // Join the tag catalog so an internal tag id in a crafted URL is inert
+    // for non-team callers — otherwise the filter would reveal which posts
+    // carry a tag the viewer is never shown.
     const postIdsWithTagsSubquery = db
       .selectDistinct({ postId: postTagAssignments.postId })
       .from(postTagAssignments)
-      .where(inArray(postTagAssignments.tagId, tagIds))
+      .innerJoin(postTags, eq(postTags.id, postTagAssignments.tagId))
+      .where(and(inArray(postTagAssignments.tagId, tagIds), publicTagCondition(actor)))
     conditions.push(inArray(posts.id, postIdsWithTagsSubquery))
   }
 
@@ -277,7 +300,7 @@ export async function listPublicPostsWithVotesAndAvatars(
           })
           .from(postTagAssignments)
           .innerJoin(postTags, eq(postTags.id, postTagAssignments.tagId))
-          .where(inArray(postTagAssignments.postId, pagePostIds))
+          .where(and(inArray(postTagAssignments.postId, pagePostIds), publicTagCondition(actor)))
       : Promise.resolve([]),
     pageAuthorIds.length > 0
       ? db
@@ -359,7 +382,7 @@ export async function listPublicPosts(
         (SELECT json_agg(json_build_object('id', t.id, 'name', t.name, 'color', t.color))
          FROM ${postTagAssignments} pt
          INNER JOIN ${postTags} t ON t.id = pt.tag_id
-         WHERE pt.post_id = ${posts.id}),
+         WHERE pt.post_id = ${posts.id} ${publicTagSqlFilter(actor)}),
         '[]'
       )`.as('tags_json'),
       authorName: sql<string | null>`(

--- a/apps/web/src/lib/server/domains/roadmaps/__tests__/roadmap-derived-query.test.ts
+++ b/apps/web/src/lib/server/domains/roadmaps/__tests__/roadmap-derived-query.test.ts
@@ -33,6 +33,7 @@ import {
 import { DEFAULT_BOARD_ACCESS, type BoardAccess } from '@/lib/shared/db-types'
 import { ANONYMOUS_ACTOR, type Actor } from '@/lib/server/policy'
 import { getPublicRoadmapPosts, getRoadmapPosts } from '../roadmap.query'
+import { listPublicRoadmaps } from '../roadmap.service'
 
 const fixture = await createDbTestFixture({
   probe: async (db) => {
@@ -352,6 +353,41 @@ describe.skipIf(!fixture.available)('roadmap derived membership (real DB)', () =
       ANONYMOUS_ACTOR
     )
     expect(viaBase.items.map((post) => post.id)).toEqual([tagged])
+  })
+
+  it('redacts internal tag ids from public roadmap base filters for non-team viewers', async () => {
+    const seeded = await seedBase()
+    const [internalTag] = await testDb
+      .insert(postTags)
+      .values({ name: `Internal curation tag ${suffix()}`, isPublic: false })
+      .returning()
+    const mixed = await seedRoadmap(seeded, {
+      baseFilter: { boardIds: [seeded.boardA], tagIds: [seeded.tagA, internalTag.id] },
+    })
+    const onlyInternal = await seedRoadmap(seeded, { baseFilter: { tagIds: [internalTag.id] } })
+    const tagged = await seedPost(seeded)
+    await testDb.insert(postTagAssignments).values({ postId: tagged, tagId: internalTag.id })
+
+    const anonymous = await listPublicRoadmaps(ANONYMOUS_ACTOR)
+    const anonMixed = anonymous.find((r) => r.id === mixed)!
+    const anonOnlyInternal = anonymous.find((r) => r.id === onlyInternal)!
+    expect(anonMixed.baseFilter).toEqual({ boardIds: [seeded.boardA], tagIds: [seeded.tagA] })
+    expect(anonOnlyInternal.baseFilter).toEqual({})
+    expect(JSON.stringify(anonymous)).not.toContain(internalTag.id)
+
+    // Redaction is payload-only: the curation still defines membership.
+    const posts = await getPublicRoadmapPosts(
+      onlyInternal,
+      { statusId: seeded.statusA },
+      ANONYMOUS_ACTOR
+    )
+    expect(posts.items.map((post) => post.id)).toEqual([tagged])
+
+    const team = await listPublicRoadmaps(actor({ role: 'member', principalId: seeded.authorA }))
+    expect(team.find((r) => r.id === mixed)!.baseFilter.tagIds).toEqual([
+      seeded.tagA,
+      internalTag.id,
+    ])
   })
 
   it('enforces public, team, and matching-segment roadmap visibility', async () => {

--- a/apps/web/src/lib/server/domains/roadmaps/__tests__/roadmap-derived-query.test.ts
+++ b/apps/web/src/lib/server/domains/roadmaps/__tests__/roadmap-derived-query.test.ts
@@ -303,6 +303,57 @@ describe.skipIf(!fixture.available)('roadmap derived membership (real DB)', () =
     expect(admin.items.some((post) => post.id === merged)).toBe(false)
   })
 
+  it('makes an internal tag inert in caller-supplied public roadmap filters, but not for team', async () => {
+    const seeded = await seedBase()
+    const roadmapId = await seedRoadmap(seeded, {})
+    const [internalTag] = await testDb
+      .insert(postTags)
+      .values({ name: `Internal roadmap tag ${suffix()}`, isPublic: false })
+      .returning()
+    const tagged = await seedPost(seeded)
+    await seedPost(seeded)
+    await testDb.insert(postTagAssignments).values({ postId: tagged, tagId: internalTag.id })
+
+    // A non-team viewer filtering by the internal tag's id must not learn
+    // which posts carry it: the filter matches nothing rather than leaking.
+    const anonymous = await getPublicRoadmapPosts(
+      roadmapId,
+      { statusId: seeded.statusA, tagIds: [internalTag.id] },
+      ANONYMOUS_ACTOR
+    )
+    expect(anonymous.items).toEqual([])
+    expect(anonymous.total).toBe(0)
+
+    // Public tags still filter normally for the same viewer.
+    await testDb.insert(postTagAssignments).values({ postId: tagged, tagId: seeded.tagA })
+    const byPublicTag = await getPublicRoadmapPosts(
+      roadmapId,
+      { statusId: seeded.statusA, tagIds: [seeded.tagA] },
+      ANONYMOUS_ACTOR
+    )
+    expect(byPublicTag.items.map((post) => post.id)).toEqual([tagged])
+
+    // Team viewers see and filter by internal tags.
+    const team = await getPublicRoadmapPosts(
+      roadmapId,
+      { statusId: seeded.statusA, tagIds: [internalTag.id] },
+      actor({ role: 'member', principalId: seeded.authorA })
+    )
+    expect(team.items.map((post) => post.id)).toEqual([tagged])
+
+    // The admin-configured base filter is not caller-controlled and keeps
+    // defining membership even when it names an internal tag.
+    const internalBaseRoadmap = await seedRoadmap(seeded, {
+      baseFilter: { tagIds: [internalTag.id] },
+    })
+    const viaBase = await getPublicRoadmapPosts(
+      internalBaseRoadmap,
+      { statusId: seeded.statusA },
+      ANONYMOUS_ACTOR
+    )
+    expect(viaBase.items.map((post) => post.id)).toEqual([tagged])
+  })
+
   it('enforces public, team, and matching-segment roadmap visibility', async () => {
     const seeded = await seedBase()
     const publicRoadmap = await seedRoadmap(seeded, { visibility: 'public' })

--- a/apps/web/src/lib/server/domains/roadmaps/roadmap.query.ts
+++ b/apps/web/src/lib/server/domains/roadmaps/roadmap.query.ts
@@ -13,6 +13,7 @@ import {
   roadmapColumns,
   posts,
   postTagAssignments,
+  postTags,
   boards,
   userSegments,
   type Roadmap,
@@ -20,6 +21,7 @@ import {
 import { type RoadmapId } from '@quackback/ids'
 import { NotFoundError, ValidationError } from '@/lib/shared/errors'
 import { ANONYMOUS_ACTOR, boardViewFilter, canViewRoadmap, type Actor } from '@/lib/server/policy'
+import { publicTagCondition } from '@/lib/server/domains/posts/post.public'
 import {
   parseRoadmapDateBucket,
   roadmapBaseFilterSchema,
@@ -42,19 +44,32 @@ function parseBaseFilter(roadmap: Roadmap): RoadmapBaseFilter {
   return parsed.data as RoadmapBaseFilter
 }
 
-function addDimensionConditions(conditions: SQL[], filter: RoadmapBaseFilter): void {
+/**
+ * `viewer` is set only for caller-supplied (runtime) filters on the public
+ * roadmap: an internal tag id in a crafted URL must then be inert for
+ * non-team viewers, or the filter would reveal which posts carry a tag they
+ * are never shown. Admin-configured base filters define the roadmap's
+ * membership and are not caller-controlled, so they pass no viewer.
+ */
+function addDimensionConditions(
+  conditions: SQL[],
+  filter: RoadmapBaseFilter,
+  viewer?: Actor
+): void {
   if (filter.statusIds?.length) conditions.push(inArray(posts.statusId, filter.statusIds))
   if (filter.boardIds?.length) conditions.push(inArray(posts.boardId, filter.boardIds))
   if (filter.tagIds?.length) {
-    conditions.push(
-      inArray(
-        posts.id,
-        db
+    const tagSubquery = viewer
+      ? db
+          .selectDistinct({ postId: postTagAssignments.postId })
+          .from(postTagAssignments)
+          .innerJoin(postTags, eq(postTags.id, postTagAssignments.tagId))
+          .where(and(inArray(postTagAssignments.tagId, filter.tagIds), publicTagCondition(viewer)))
+      : db
           .selectDistinct({ postId: postTagAssignments.postId })
           .from(postTagAssignments)
           .where(inArray(postTagAssignments.tagId, filter.tagIds))
-      )
-    )
+    conditions.push(inArray(posts.id, tagSubquery))
   }
   if (filter.segmentIds?.length) {
     conditions.push(
@@ -105,18 +120,22 @@ function membershipConditions(
   return conditions
 }
 
-function runtimeFilterConditions(options: RoadmapPostsQueryOptions): SQL[] {
+function runtimeFilterConditions(options: RoadmapPostsQueryOptions, viewer?: Actor): SQL[] {
   const conditions: SQL[] = []
   if (options.search) {
     conditions.push(
       sql`${posts.searchVector} @@ websearch_to_tsquery('english', ${options.search})`
     )
   }
-  addDimensionConditions(conditions, {
-    boardIds: options.boardIds,
-    tagIds: options.tagIds,
-    segmentIds: options.segmentIds,
-  })
+  addDimensionConditions(
+    conditions,
+    {
+      boardIds: options.boardIds,
+      tagIds: options.tagIds,
+      segmentIds: options.segmentIds,
+    },
+    viewer
+  )
   return conditions
 }
 
@@ -149,7 +168,10 @@ async function queryRoadmapPosts(
   } else {
     conditions.push(isNull(boards.deletedAt))
   }
-  conditions.push(...membershipConditions(roadmap, options), ...runtimeFilterConditions(options))
+  conditions.push(
+    ...membershipConditions(roadmap, options),
+    ...runtimeFilterConditions(options, publicActor)
+  )
   const orderBy = sortFor(options)
 
   const [results, countResult] = await Promise.all([

--- a/apps/web/src/lib/server/domains/roadmaps/roadmap.service.ts
+++ b/apps/web/src/lib/server/domains/roadmaps/roadmap.service.ts
@@ -9,15 +9,16 @@ import {
   roadmaps,
   roadmapColumns,
   postStatuses,
+  postTags,
   type Roadmap,
   type RoadmapColumn,
   type Transaction,
 } from '@/lib/server/db'
-import type { RoadmapId, RoadmapColumnId } from '@quackback/ids'
+import type { PostTagId, RoadmapId, RoadmapColumnId } from '@quackback/ids'
 import { positionCaseSql } from '@/lib/server/utils'
 import { NotFoundError, ValidationError, ConflictError } from '@/lib/shared/errors'
 import { roadmapBaseFilterSchema } from '@/lib/shared/roadmap-config'
-import { roadmapViewFilter, type Actor, ANONYMOUS_ACTOR } from '@/lib/server/policy'
+import { roadmapViewFilter, isTeamActor, type Actor, ANONYMOUS_ACTOR } from '@/lib/server/policy'
 import type {
   CreateRoadmapColumnInput,
   CreateRoadmapInput,
@@ -281,13 +282,53 @@ export async function listRoadmaps(): Promise<RoadmapWithColumns[]> {
   })
 }
 
+/**
+ * Roadmaps visible to `actor`, with internal tag ids redacted from each
+ * `baseFilter` for non-team viewers.
+ *
+ * An admin may curate a public roadmap by an internal tag; the curation still
+ * applies (membership is admin-defined, see roadmap.query), but the tag id
+ * itself must not reach the portal payload, or a viewer could correlate it
+ * with the returned posts and learn which of them carry a tag they are never
+ * shown. Team actors receive the filter unredacted.
+ */
 export async function listPublicRoadmaps(
   actor: Actor = ANONYMOUS_ACTOR
 ): Promise<RoadmapWithColumns[]> {
-  return db.query.roadmaps.findMany({
+  const result = await db.query.roadmaps.findMany({
     where: roadmapViewFilter(actor),
     orderBy: [asc(roadmaps.position)],
     with: { columns: { orderBy: [asc(roadmapColumns.position)] } },
+  })
+  if (isTeamActor(actor)) return result
+
+  const referenced = new Set<PostTagId>()
+  for (const roadmap of result) {
+    for (const tagId of roadmap.baseFilter.tagIds ?? []) referenced.add(tagId)
+  }
+  if (referenced.size === 0) return result
+
+  const publicRows = await db
+    .select({ id: postTags.id })
+    .from(postTags)
+    .where(
+      and(
+        inArray(postTags.id, [...referenced]),
+        eq(postTags.isPublic, true),
+        isNull(postTags.deletedAt)
+      )
+    )
+  const publicIds = new Set<PostTagId>(publicRows.map((row) => row.id))
+
+  return result.map((roadmap) => {
+    const tagIds = roadmap.baseFilter.tagIds
+    if (!tagIds?.length) return roadmap
+    const visible = tagIds.filter((id) => publicIds.has(id))
+    if (visible.length === tagIds.length) return roadmap
+    const baseFilter = { ...roadmap.baseFilter }
+    if (visible.length) baseFilter.tagIds = visible
+    else delete baseFilter.tagIds
+    return { ...roadmap, baseFilter }
   })
 }
 

--- a/apps/web/src/lib/server/fleet/__tests__/migrator-gate.test.ts
+++ b/apps/web/src/lib/server/fleet/__tests__/migrator-gate.test.ts
@@ -350,6 +350,7 @@ describe('replayGateVerdict', () => {
       '0273_identity_provider_logo_key',
       '0274_slack_agent_gateway',
       '0275_slack_thread_sessions',
+      '0276_post_tags_is_public',
     ])
     const verdict = replayGateVerdict(before, verdictsFor(replaySetFor(before)), false)
     expect(verdict.ok).toBe(false)

--- a/apps/web/src/lib/server/functions/__tests__/portal-gate-extended.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/portal-gate-extended.test.ts
@@ -40,6 +40,7 @@
  *   8  topViewedChangelogsFn
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { policyActorFromAuth } from '@/lib/server/functions/auth-helpers'
 
 // ---------------------------------------------------------------------------
 // Shared handler registry
@@ -335,6 +336,22 @@ describe('portal.ts fetchPortalData — portal-visibility gate', () => {
     await h[FETCH_PORTAL_DATA]({ data: { sort: 'top' } })
     expect(mockListPublicBoardsWithStats).toHaveBeenCalledTimes(1)
   })
+
+  it('scopes the tag list to the resolved actor so internal tags stay team-only', async () => {
+    mockResolvePortalAccess.mockResolvedValue({ granted: true, reason: 'public' })
+    mockListPublicBoardsWithStats.mockResolvedValue([])
+    mockListPublicPostsWithVotesAndAvatars.mockResolvedValue({ items: [], hasMore: false })
+    mockListPublicStatuses.mockResolvedValue([])
+    mockListPublicTags.mockResolvedValue([])
+    mockGetVotedPostIdsByUserId.mockResolvedValue(new Set())
+    const actor = { principalId: null, role: null, principalType: 'anonymous' }
+    vi.mocked(policyActorFromAuth).mockResolvedValueOnce(actor as never)
+
+    const h = await loadModule(PORTAL)
+    await h[FETCH_PORTAL_DATA]({ data: { sort: 'top' } })
+    expect(mockListPublicTags).toHaveBeenCalledTimes(1)
+    expect(mockListPublicTags).toHaveBeenCalledWith(actor)
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -582,6 +599,17 @@ describe('portal.ts fetchPublicTags — portal-visibility gate', () => {
     const result = (await h[FETCH_PUBLIC_TAGS]({ data: {} })) as { id: string }[]
     expect(result).toHaveLength(1)
     expect(result[0].id).toBe('tag_1')
+  })
+
+  it('passes the resolved actor so the service can hide internal tags from non-team viewers', async () => {
+    mockResolvePortalAccess.mockResolvedValue({ granted: true, reason: 'public' })
+    mockListPublicTags.mockResolvedValue([])
+    const actor = { principalId: 'principal_1', role: 'member', principalType: 'user' }
+    vi.mocked(policyActorFromAuth).mockResolvedValueOnce(actor as never)
+
+    const h = await loadModule(PORTAL)
+    await h[FETCH_PUBLIC_TAGS]({ data: {} })
+    expect(mockListPublicTags).toHaveBeenCalledWith(actor)
   })
 })
 

--- a/apps/web/src/lib/server/functions/portal.ts
+++ b/apps/web/src/lib/server/functions/portal.ts
@@ -202,7 +202,8 @@ export const fetchPortalData = createServerFn({ method: 'GET' })
           segmentIds,
         }),
         listPublicStatuses(),
-        listPublicPostTags(),
+        // Actor-scoped: internal tags are only listed for team viewers.
+        listPublicPostTags(actor),
         // Get ALL voted post IDs for this user (runs in parallel, we'll filter to displayed posts)
         data.userId
           ? getVotedPostIdsByUserId(data.userId as UserId)
@@ -449,7 +450,12 @@ export const fetchPublicTags = createServerFn({ method: 'GET' }).handler(async (
     log.debug('portal access denied, returning empty')
     return []
   }
-  return await listPublicPostTags()
+
+  // Team viewers assign tags from the portal, so they need the full catalog;
+  // everyone else only gets tags marked public.
+  const auth = await getOptionalAuth()
+  const actor = await policyActorFromAuth(auth)
+  return await listPublicPostTags(actor)
 })
 
 export const fetchUserAvatar = createServerFn({ method: 'GET' })

--- a/apps/web/src/lib/server/functions/post-tags.ts
+++ b/apps/web/src/lib/server/functions/post-tags.ts
@@ -31,6 +31,7 @@ const createTagSchema = z.object({
     .default('#6b7280'),
   description: z.string().max(200).optional(),
   aiPrompt: z.string().max(500).optional(),
+  isPublic: z.boolean().optional(),
 })
 
 const getTagSchema = z.object({
@@ -46,6 +47,7 @@ const updateTagSchema = z.object({
     .optional(),
   description: z.string().max(200).optional().nullable(),
   aiPrompt: z.string().max(500).optional().nullable(),
+  isPublic: z.boolean().optional(),
 })
 
 const deleteTagSchema = z.object({
@@ -114,6 +116,7 @@ export const createPostTagFn = createServerFn({ method: 'POST' })
       color: data.color,
       description: data.description,
       aiPrompt: data.aiPrompt,
+      isPublic: data.isPublic,
     })
     log.info({ tag_id: tag.id }, 'tag created')
     return tag
@@ -134,6 +137,7 @@ export const updatePostTagFn = createServerFn({ method: 'POST' })
       color: data.color,
       description: data.description,
       aiPrompt: data.aiPrompt,
+      isPublic: data.isPublic,
     })
     log.info({ tag_id: tag.id }, 'tag updated')
 

--- a/apps/web/src/lib/server/policy/dep-graph/GRAPH.md
+++ b/apps/web/src/lib/server/policy/dep-graph/GRAPH.md
@@ -57,7 +57,7 @@ Edges (26):
 ## 3. Server domains (lib/server/domains)
 
 Nodes (49): activity, ai, analytics, api, api-keys, assistant, billing, boards, changelog, channel-accounts, channels, comments, companies, company-attributes, conversation, conversation-attributes, conversation-views, embeddings, export, help-center, import, inbox, macros, merge-suggestions, moderation, notifications, office-hours, platform-credentials, post-tags, post-views, posts, principals, push-devices, roadmaps, roles, segments, sentiment, settings, sla, status, statuses, subscriptions, summary, teams, tickets, user-attributes, users, webhooks, workflows
-Edges (118):
+Edges (119):
 
 - analytics -> api
 - analytics -> assistant
@@ -146,6 +146,7 @@ Edges (118):
 - principals -> roles
 - principals -> settings
 - principals -> teams
+- roadmaps -> posts
 - roles -> settings
 - sentiment -> ai
 - sentiment -> settings

--- a/apps/web/src/lib/server/policy/migration-contract/CONTRACT.md
+++ b/apps/web/src/lib/server/policy/migration-contract/CONTRACT.md
@@ -6,7 +6,7 @@ Regenerate with `bunx vitest run apps/web/src/lib/server/policy/migration-contra
 
 ## Summary
 
-Migrations scanned: 253. Migrations with destructive DDL: 34.
+Migrations scanned: 254. Migrations with destructive DDL: 34.
 
 | Kind | Occurrences |
 | --- | --- |

--- a/apps/web/src/routes/api/v1/tags/$tagId.ts
+++ b/apps/web/src/routes/api/v1/tags/$tagId.ts
@@ -19,6 +19,7 @@ const updateTagSchema = z.object({
     .regex(/^#[0-9A-Fa-f]{6}$/, 'Color must be a valid hex color')
     .optional(),
   description: z.string().max(200).optional().nullable(),
+  isPublic: z.boolean().optional(),
 })
 
 export const Route = createFileRoute('/api/v1/tags/$tagId')({
@@ -43,6 +44,7 @@ export const Route = createFileRoute('/api/v1/tags/$tagId')({
             name: tag.name,
             color: tag.color,
             description: tag.description,
+            isPublic: tag.isPublic,
             createdAt: tag.createdAt.toISOString(),
           })
         } catch (error) {
@@ -75,6 +77,7 @@ export const Route = createFileRoute('/api/v1/tags/$tagId')({
             name: parsed.data.name,
             color: parsed.data.color,
             description: parsed.data.description,
+            isPublic: parsed.data.isPublic,
           })
 
           return successResponse({
@@ -82,6 +85,7 @@ export const Route = createFileRoute('/api/v1/tags/$tagId')({
             name: tag.name,
             color: tag.color,
             description: tag.description,
+            isPublic: tag.isPublic,
             createdAt: tag.createdAt.toISOString(),
           })
         } catch (error) {

--- a/apps/web/src/routes/api/v1/tags/index.ts
+++ b/apps/web/src/routes/api/v1/tags/index.ts
@@ -18,6 +18,7 @@ const createTagSchema = z.object({
     .optional()
     .default('#6b7280'),
   description: z.string().max(200).optional(),
+  isPublic: z.boolean().optional(),
 })
 
 export const Route = createFileRoute('/api/v1/tags/')({
@@ -42,6 +43,7 @@ export const Route = createFileRoute('/api/v1/tags/')({
               name: tag.name,
               color: tag.color,
               description: tag.description,
+              isPublic: tag.isPublic,
               createdAt: tag.createdAt.toISOString(),
             }))
           )
@@ -75,6 +77,7 @@ export const Route = createFileRoute('/api/v1/tags/')({
             name: parsed.data.name,
             color: parsed.data.color,
             description: parsed.data.description,
+            isPublic: parsed.data.isPublic,
           })
 
           return createdResponse({
@@ -82,6 +85,7 @@ export const Route = createFileRoute('/api/v1/tags/')({
             name: tag.name,
             color: tag.color,
             description: tag.description,
+            isPublic: tag.isPublic,
             createdAt: tag.createdAt.toISOString(),
           })
         } catch (error) {

--- a/packages/db/drizzle/0276_post_tags_is_public.sql
+++ b/packages/db/drizzle/0276_post_tags_is_public.sql
@@ -1,0 +1,4 @@
+-- Per-tag portal visibility. Existing tags were always shown on the public
+-- portal, so the default keeps that behaviour; admins opt individual tags out
+-- to make them internal (team-only). Additive / expand-only.
+ALTER TABLE "post_tags" ADD COLUMN IF NOT EXISTS "is_public" boolean DEFAULT true NOT NULL;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1772,6 +1772,13 @@
       "when": 1788732000000,
       "tag": "0275_slack_thread_sessions",
       "breakpoints": true
+    },
+    {
+      "idx": 253,
+      "version": "7",
+      "when": 1788818400000,
+      "tag": "0276_post_tags_is_public",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/__tests__/schema.test.ts
+++ b/packages/db/src/__tests__/schema.test.ts
@@ -95,7 +95,15 @@ describe('Schema definitions', () => {
       expect(columns).toContain('id')
       expect(columns).toContain('name')
       expect(columns).toContain('color')
+      expect(columns).toContain('isPublic')
       expect(columns).toContain('createdAt')
+    })
+
+    it('defaults isPublic to true so existing tags stay visible on the portal', () => {
+      const { isPublic } = getTableColumns(postTags)
+      expect(isPublic.notNull).toBe(true)
+      expect(isPublic.hasDefault).toBe(true)
+      expect(isPublic.default).toBe(true)
     })
   })
 

--- a/packages/db/src/schema/boards.ts
+++ b/packages/db/src/schema/boards.ts
@@ -4,6 +4,7 @@ import {
   timestamp,
   jsonb,
   integer,
+  boolean,
   index,
   uniqueIndex,
   check,
@@ -129,6 +130,9 @@ export const postTags = pgTable(
     // Matching rule for AI auto-tagging: new posts are evaluated against every
     // tag whose prompt is set, and matching tags are assigned automatically.
     aiPrompt: text('ai_prompt'),
+    // Portal visibility: when false the tag is internal — non-team portal
+    // viewers never see it in filter lists or on posts. Team actors see all.
+    isPublic: boolean('is_public').default(true).notNull(),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
     // Soft delete support
     deletedAt: timestamp('deleted_at', { withTimezone: true }),


### PR DESCRIPTION
## Summary
- Tags were always visible on the public portal, which surprised customers using them for internal triage. This adds a per-tag **"Show on portal"** switch (`post_tags.is_public`, default `true` so existing tags and behaviour are unchanged on upgrade). Tags with the switch off show an **Internal** badge in settings.
- Non-team portal viewers only receive public tags: in the portal/roadmap filter lists, on post cards and post detail, link-embed previews, widget search and the `/api/v1/apps/search|suggest` endpoints. A `tagIds` URL filter naming an internal tag is inert for them, so post membership of an internal tag can't be inferred. Team actors keep the full catalog so they can still assign internal tags from the portal.
- `isPublic` is exposed on `/api/v1/tags` (list/get/create/patch), the OpenAPI tag schemas, and the tags CSV export.

Out of scope (deliberately): customers picking tags on submission; per-segment tag visibility.

## Implementation notes
- Migration `0276_post_tags_is_public.sql` is purely additive; the migration-contract golden (`CONTRACT.md`) only changed its scanned-count line.
- `listPublicPostTags(actor)` now takes the policy actor; `post.public.ts` gains `publicTagCondition` / `publicTagSqlFilter` helpers used by the list, batched tag-row, `tagIds` subquery and `json_agg` paths (and by `post.public.detail.ts`).

## Test plan
- [x] `packages/db` schema test asserts the new column and its `true` default
- [x] `post-tag.service.test.ts` (new): anonymous/customer viewers get `is_public = true` filter, team actors don't; create defaults to public; update persists the flag
- [x] `post-public.test.ts`: `tagIds` subquery joins `post_tags` and applies the guard for non-team actors only; `json_agg` guard present/absent by actor
- [x] `portal-gate-extended.test.ts`: `fetchPortalData` / `fetchPublicTags` pass the resolved actor
- [x] `tag-list.test.tsx` (new): switch defaults on, mirrors saved flag on edit, payload carries `isPublic`, Internal badge renders
- [x] e2e `settings-tags.spec.ts` asserts the switch exists and is on by default
- [ ] Manual: mark a tag internal, confirm it disappears from the portal filter list and post cards while signed out, but stays visible/assignable when signed in as a team member

Made with [Cursor](https://cursor.com)