### PR TITLE
fix(auth): only send new-sign-in mail on a real sign-in

### DIFF
--- a/apps/web/src/lib/server/auth/__tests__/hooks-new-device-notification.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/hooks-new-device-notification.test.ts
@@ -135,6 +135,20 @@ describe('handleNewDeviceNotification — guards', () => {
     await handleNewDeviceNotification(ctx, workspace())
     expect(mockIsDeviceUnseen).not.toHaveBeenCalled()
   })
+
+  it('does not treat a session-cookie refresh as a sign-in', async () => {
+    mockIsDeviceUnseen.mockResolvedValueOnce(true)
+    await handleNewDeviceNotification(buildCtx({ path: '/get-session' }), workspace())
+    expect(mockIsDeviceUnseen).not.toHaveBeenCalled()
+    expect(mockSendNewSignInEmail).not.toHaveBeenCalled()
+  })
+
+  it('does not notify on an anonymous widget mint', async () => {
+    mockIsDeviceUnseen.mockResolvedValueOnce(true)
+    await handleNewDeviceNotification(buildCtx({ path: '/sign-in/anonymous' }), workspace())
+    expect(mockIsDeviceUnseen).not.toHaveBeenCalled()
+    expect(mockSendNewSignInEmail).not.toHaveBeenCalled()
+  })
 })
 
 describe('handleNewDeviceNotification — failure tolerance', () => {

--- a/apps/web/src/lib/server/auth/__tests__/signin-device-tracker.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/signin-device-tracker.test.ts
@@ -54,6 +54,15 @@ describe('computeDeviceFingerprint', () => {
     )
   })
 
+  it('unmaps IPv4-mapped IPv6 and still collapses /24', () => {
+    const a = computeDeviceFingerprint('Mozilla/5.0', '::ffff:203.0.113.42')
+    const b = computeDeviceFingerprint('Mozilla/5.0', '::ffff:203.0.113.99')
+    const c = computeDeviceFingerprint('Mozilla/5.0', '203.0.113.7')
+    expect(a).toBe(b)
+    expect(a).toBe(c)
+    expect(a).not.toBe(computeDeviceFingerprint('Mozilla/5.0', '::ffff:203.0.114.42'))
+  })
+
   it('returns 32-char hex', () => {
     expect(computeDeviceFingerprint('UA', '203.0.113.42')).toMatch(/^[0-9a-f]{32}$/)
   })

--- a/apps/web/src/lib/server/auth/hooks.ts
+++ b/apps/web/src/lib/server/auth/hooks.ts
@@ -1261,16 +1261,22 @@ export async function handleSignInSuccessAudit(ctx: {
 }
 
 /**
- * First-sight new-device notification. Atomic SADD claims the
- * fingerprint; on success we fire the email + audit row in parallel
- * and refresh the SET's 90-day TTL. On failure we roll back the
- * claim so the next sign-in re-fires the alert rather than losing
- * it to a transient SMTP outage. All errors swallowed — Redis/SMTP
- * outages must not break sign-in.
+ * First-sight new-device notification. Atomic claim of the fingerprint;
+ * on success we fire the email + audit row in parallel and refresh the
+ * 90-day TTL. On failure we roll back the claim so the next sign-in
+ * re-fires the alert rather than losing it to a transient SMTP outage.
+ * All errors swallowed — store/SMTP outages must not break sign-in.
+ *
+ * Better Auth sets `newSession` whenever it writes a session cookie,
+ * including `/get-session` sliding the 24h `updateAge`. That is not a
+ * sign-in. Gate on `inferProvider` the same way `handleSignInSuccessAudit`
+ * does, and skip anonymous widget mints.
  */
 export async function handleNewDeviceNotification(
   ctx: {
     path?: string
+    params?: Record<string, unknown>
+    body?: Record<string, unknown>
     context?: {
       newSession?: {
         user?: { id?: string; email?: string }
@@ -1286,6 +1292,9 @@ export async function handleNewDeviceNotification(
   const email = ctx.context?.newSession?.user?.email
   const token = ctx.context?.newSession?.session?.token
   if (typeof userId !== 'string' || typeof email !== 'string' || typeof token !== 'string') return
+
+  const provider = inferProvider(ctx)
+  if (!provider || provider === 'anonymous') return
 
   const headers = getRequestHeaders()
   const userAgent = headers.get('user-agent') ?? ''
@@ -1499,8 +1508,7 @@ export const hooksAfter = createAuthMiddleware(async (ctx) => {
   await handleSignInSuccessAudit(ctx as Parameters<typeof handleSignInSuccessAudit>[0])
   // Geo-IP country from CDN headers; written best-effort, never blocks.
   await handleCountryCapture(ctx as Parameters<typeof handleCountryCapture>[0])
-  // Fires only when a new device fingerprint (UA + /24) for this user
-  // is observed; default-on but workspace can opt out.
+  // Fires only on a real sign-in path when the UA + /24 is unseen.
   await handleNewDeviceNotification(
     ctx as Parameters<typeof handleNewDeviceNotification>[0],
     workspace

--- a/apps/web/src/lib/server/auth/signin-device-tracker.ts
+++ b/apps/web/src/lib/server/auth/signin-device-tracker.ts
@@ -23,10 +23,25 @@ const DEVICE_SET_TTL_SECONDS = 90 * 24 * 60 * 60
  * chars. /24 keeps dynamic-IP users on the same network from tripping
  * on every connection; IPv6 is hashed whole (most carriers hand out
  * stable /64s, but we don't bias on carrier data here).
+ *
+ * IPv4-mapped IPv6 (`::ffff:a.b.c.d`) is unmapped before the /24 cut.
+ * `ip.includes(':')` would otherwise treat those as IPv6 and hash the
+ * last octet, so a rotating CGNAT/mesh hop on the same /24 looks like a
+ * new device every sign-in.
  */
 export function computeDeviceFingerprint(userAgent: string, ip: string): string {
-  const normalisedIp = ip.includes(':') ? ip : ip.split('.').slice(0, 3).join('.')
-  return createHash('sha256').update(`${userAgent}|${normalisedIp}`).digest('hex').slice(0, 32)
+  return createHash('sha256')
+    .update(`${userAgent}|${normaliseIpForFingerprint(ip)}`)
+    .digest('hex')
+    .slice(0, 32)
+}
+
+/** /24 for IPv4 (including :ffff: mapped); whole address for real IPv6. */
+export function normaliseIpForFingerprint(ip: string): string {
+  const mapped = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/i.exec(ip.trim())
+  const v4 = mapped?.[1] ?? (ip.includes(':') ? null : ip.trim())
+  if (v4 && /^\d{1,3}(?:\.\d{1,3}){3}$/.test(v4)) return v4.split('.').slice(0, 3).join('.')
+  return ip.trim()
 }
 
 // User ids are only unique within a workspace database, so an undiscriminated


### PR DESCRIPTION
Better Auth sets `newSession` whenever it writes a session cookie, including the 24h `/get-session` refresh. That is not a sign-in, but the new-device alert treated it as one.

## Changes
- Gate `handleNewDeviceNotification` on `inferProvider` (same as the success audit) and skip anonymous widget mints.
- Unmap IPv4-mapped IPv6 before the `/24` fingerprint cut.

## Test plan
- [x] `signin-device-tracker` tests, including mapped-v4 addresses collapsing on the same `/24`
- [x] new-device notification tests: `/get-session` and `/sign-in/anonymous` do not send; `/sign-in/email` still does