### PR TITLE
fix(auth): identify new-sign-in devices by browser, not IP

### DIFF
--- a/apps/web/src/components/settings/password-form.tsx
+++ b/apps/web/src/components/settings/password-form.tsx
@@ -49,12 +49,12 @@ export function PasswordForm({ hasPassword, onSaved }: PasswordFormProps) {
         const result = await authClient.changePassword({
           currentPassword,
           newPassword,
-          revokeOtherSessions: false,
+          revokeOtherSessions: true,
         })
         if (result.error) {
           throw new Error(result.error.message || 'Failed to change password')
         }
-        toast.success('Password changed')
+        toast.success('Password changed. Other devices have been signed out.')
       } else {
         await setPasswordFn({ data: { newPassword } })
         toast.success('Password set')
@@ -76,7 +76,7 @@ export function PasswordForm({ hasPassword, onSaved }: PasswordFormProps) {
         <h2 className="font-medium mb-1">{hasPassword ? 'Change password' : 'Set password'}</h2>
         <p className="text-sm text-muted-foreground mb-4">
           {hasPassword
-            ? 'Update your current password'
+            ? 'Update your current password. Other signed-in devices will be signed out.'
             : 'Add a password to sign in with email and password'}
         </p>
 

--- a/apps/web/src/components/settings/password-form.tsx
+++ b/apps/web/src/components/settings/password-form.tsx
@@ -56,8 +56,8 @@ export function PasswordForm({ hasPassword, onSaved }: PasswordFormProps) {
         }
         toast.success('Password changed. Other devices have been signed out.')
       } else {
-        await setPasswordFn({ data: { newPassword } })
-        toast.success('Password set')
+        await setPasswordFn({ data: { newPassword, revokeOtherSessions: true } })
+        toast.success('Password set. Other devices have been signed out.')
       }
       setCurrentPassword('')
       setNewPassword('')
@@ -77,7 +77,7 @@ export function PasswordForm({ hasPassword, onSaved }: PasswordFormProps) {
         <p className="text-sm text-muted-foreground mb-4">
           {hasPassword
             ? 'Update your current password. Other signed-in devices will be signed out.'
-            : 'Add a password to sign in with email and password'}
+            : 'Add a password to sign in with email and password. Other signed-in devices will be signed out.'}
         </p>
 
         <div className="space-y-4">

--- a/apps/web/src/lib/server/auth/__tests__/hooks-new-device-notification.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/hooks-new-device-notification.test.ts
@@ -11,7 +11,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { makeAuthConfig, makeWorkspace } from './_helpers'
 
-vi.mock('@/lib/server/config', () => ({ config: { trustedProxyHops: 1 } }))
+vi.mock('@/lib/server/config', () => ({
+  config: { trustedProxyHops: 1 },
+  getBaseUrl: () => 'https://acme.example',
+}))
 
 const mockIsDeviceUnseen = vi.fn()
 const mockMarkDeviceSeen = vi.fn(async (_userId: string) => undefined)
@@ -19,12 +22,16 @@ const mockForgetDevice = vi.fn(async (_userId: string, _fp: string) => undefined
 const mockSendNewSignInEmail = vi.fn(async (_params: unknown) => ({ sent: true }))
 const mockRecordAuditEvent = vi.fn(async (_spec: unknown) => undefined)
 
-vi.mock('../signin-device-tracker', () => ({
-  computeDeviceFingerprint: (ua: string, ip: string) => `fp-${ua}-${ip}`,
-  isDeviceUnseen: (userId: string, fp: string) => mockIsDeviceUnseen(userId, fp),
-  markDeviceSeen: (userId: string) => mockMarkDeviceSeen(userId),
-  forgetDevice: (userId: string, fp: string) => mockForgetDevice(userId, fp),
-}))
+vi.mock('../signin-device-tracker', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../signin-device-tracker')>()
+  return {
+    ...actual,
+    computeDeviceFingerprint: (ua: string) => `fp-${ua}`,
+    isDeviceUnseen: (userId: string, fp: string) => mockIsDeviceUnseen(userId, fp),
+    markDeviceSeen: (userId: string) => mockMarkDeviceSeen(userId),
+    forgetDevice: (userId: string, fp: string) => mockForgetDevice(userId, fp),
+  }
+})
 
 vi.mock('@quackback/email', () => ({
   sendNewSignInEmail: (params: unknown) => mockSendNewSignInEmail(params),
@@ -47,7 +54,11 @@ vi.mock('@/lib/server/db', async (orig) => {
 
 vi.mock('@tanstack/react-start/server', () => ({
   getRequestHeaders: () =>
-    new Headers({ 'user-agent': 'Mozilla/5.0 Test', 'x-forwarded-for': '203.0.113.42' }),
+    new Headers({
+      'user-agent':
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36',
+      'x-forwarded-for': '203.0.113.42',
+    }),
 }))
 
 const { handleNewDeviceNotification } = await import('../hooks')
@@ -85,7 +96,7 @@ beforeEach(() => {
 })
 
 describe('handleNewDeviceNotification — happy path', () => {
-  it('sends email + audits + markDeviceSeen on first-seen device', async () => {
+  it('sends email + audits + markDeviceSeen on an additional unseen device', async () => {
     mockIsDeviceUnseen.mockResolvedValueOnce(true)
     await handleNewDeviceNotification(buildCtx(), workspace())
 
@@ -95,11 +106,16 @@ describe('handleNewDeviceNotification — happy path', () => {
       workspaceName: string
       ipAddress: string
       userAgent: string
+      settingsUrl?: string
+      location?: string | null
     }
     expect(emailArgs.to).toBe('a@b.com')
     expect(emailArgs.workspaceName).toBe('Acme')
     expect(emailArgs.ipAddress).toBe('203.0.113.42')
-    expect(emailArgs.userAgent).toBe('Mozilla/5.0 Test')
+    expect(emailArgs.userAgent).toBe('Chrome on Windows')
+    expect(emailArgs.settingsUrl).toBe(
+      'https://acme.example/admin/settings/security/authentication'
+    )
 
     expect(mockRecordAuditEvent).toHaveBeenCalledTimes(1)
     const auditArgs = mockRecordAuditEvent.mock.calls[0][0] as { event: string }

--- a/apps/web/src/lib/server/auth/__tests__/hooks-new-device-notification.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/hooks-new-device-notification.test.ts
@@ -113,9 +113,7 @@ describe('handleNewDeviceNotification — happy path', () => {
     expect(emailArgs.workspaceName).toBe('Acme')
     expect(emailArgs.ipAddress).toBe('203.0.113.42')
     expect(emailArgs.userAgent).toBe('Chrome on Windows')
-    expect(emailArgs.settingsUrl).toBe(
-      'https://acme.example/admin/settings/security/authentication'
-    )
+    expect(emailArgs.settingsUrl).toBe('https://acme.example/settings/profile')
 
     expect(mockRecordAuditEvent).toHaveBeenCalledTimes(1)
     const auditArgs = mockRecordAuditEvent.mock.calls[0][0] as { event: string }

--- a/apps/web/src/lib/server/auth/__tests__/hooks-new-device-notification.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/hooks-new-device-notification.test.ts
@@ -37,6 +37,16 @@ vi.mock('@quackback/email', () => ({
   sendNewSignInEmail: (params: unknown) => mockSendNewSignInEmail(params),
 }))
 
+const mockListIdentityProviders = vi.fn(async () => [])
+vi.mock('@/lib/server/domains/settings/identity-providers.service', () => ({
+  listIdentityProviders: () => mockListIdentityProviders(),
+}))
+
+const mockGetRegisteredOidcProviderIds = vi.fn(async () => new Set<string>())
+vi.mock('@/lib/server/auth/registered-providers', () => ({
+  getRegisteredOidcProviderIds: (...args: unknown[]) => mockGetRegisteredOidcProviderIds(...args),
+}))
+
 vi.mock('@/lib/server/audit/log', () => ({
   recordAuditEvent: (spec: unknown) => mockRecordAuditEvent(spec),
 }))
@@ -93,6 +103,8 @@ beforeEach(() => {
   mockForgetDevice.mockReset().mockResolvedValue(undefined)
   mockSendNewSignInEmail.mockReset().mockResolvedValue({ sent: true })
   mockRecordAuditEvent.mockReset().mockResolvedValue(undefined)
+  mockListIdentityProviders.mockReset().mockResolvedValue([])
+  mockGetRegisteredOidcProviderIds.mockReset().mockResolvedValue(new Set<string>())
 })
 
 describe('handleNewDeviceNotification — happy path', () => {
@@ -108,12 +120,14 @@ describe('handleNewDeviceNotification — happy path', () => {
       userAgent: string
       settingsUrl?: string
       location?: string | null
+      ssoEnforced?: boolean
     }
     expect(emailArgs.to).toBe('a@b.com')
     expect(emailArgs.workspaceName).toBe('Acme')
     expect(emailArgs.ipAddress).toBe('203.0.113.42')
     expect(emailArgs.userAgent).toBe('Chrome on Windows')
     expect(emailArgs.settingsUrl).toBe('https://acme.example/settings/profile')
+    expect(emailArgs.ssoEnforced).toBe(false)
 
     expect(mockRecordAuditEvent).toHaveBeenCalledTimes(1)
     const auditArgs = mockRecordAuditEvent.mock.calls[0][0] as { event: string }
@@ -121,6 +135,41 @@ describe('handleNewDeviceNotification — happy path', () => {
 
     // TTL refreshed only on the success path.
     expect(mockMarkDeviceSeen).toHaveBeenCalledWith('user_abc')
+    expect(mockForgetDevice).not.toHaveBeenCalled()
+  })
+
+  it('passes ssoEnforced: true when the recipient is SSO-bound', async () => {
+    mockIsDeviceUnseen.mockResolvedValueOnce(true)
+    mockListIdentityProviders.mockResolvedValueOnce([
+      {
+        id: 'idp_sso',
+        registrationId: 'sso',
+        showButton: false,
+        domains: [{ name: 'b.com', verifiedAt: '2026-05-01T00:00:00.000Z', enforced: true }],
+      },
+    ])
+    mockGetRegisteredOidcProviderIds.mockResolvedValueOnce(new Set(['sso']))
+
+    await handleNewDeviceNotification(buildCtx(), workspace())
+
+    expect(mockSendNewSignInEmail).toHaveBeenCalledTimes(1)
+    const emailArgs = mockSendNewSignInEmail.mock.calls[0][0] as {
+      ssoEnforced?: boolean
+      settingsUrl?: string
+    }
+    expect(emailArgs.ssoEnforced).toBe(true)
+    expect(emailArgs.settingsUrl).toBeUndefined()
+  })
+
+  it('still sends the alert when the SSO lookup throws', async () => {
+    mockIsDeviceUnseen.mockResolvedValueOnce(true)
+    mockListIdentityProviders.mockRejectedValueOnce(new Error('idp down'))
+
+    await expect(handleNewDeviceNotification(buildCtx(), workspace())).resolves.toBeUndefined()
+
+    expect(mockSendNewSignInEmail).toHaveBeenCalledTimes(1)
+    const emailArgs = mockSendNewSignInEmail.mock.calls[0][0] as { ssoEnforced?: boolean }
+    expect(emailArgs.ssoEnforced).toBe(false)
     expect(mockForgetDevice).not.toHaveBeenCalled()
   })
 

--- a/apps/web/src/lib/server/auth/__tests__/hooks-new-device-notification.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/hooks-new-device-notification.test.ts
@@ -37,14 +37,15 @@ vi.mock('@quackback/email', () => ({
   sendNewSignInEmail: (params: unknown) => mockSendNewSignInEmail(params),
 }))
 
-const mockListIdentityProviders = vi.fn(async () => [])
+const mockListIdentityProviders = vi.fn()
 vi.mock('@/lib/server/domains/settings/identity-providers.service', () => ({
   listIdentityProviders: () => mockListIdentityProviders(),
 }))
 
-const mockGetRegisteredOidcProviderIds = vi.fn(async () => new Set<string>())
+const mockGetRegisteredOidcProviderIds = vi.fn()
 vi.mock('@/lib/server/auth/registered-providers', () => ({
-  getRegisteredOidcProviderIds: (...args: unknown[]) => mockGetRegisteredOidcProviderIds(...args),
+  getRegisteredOidcProviderIds: (providers?: unknown) =>
+    mockGetRegisteredOidcProviderIds(providers),
 }))
 
 vi.mock('@/lib/server/audit/log', () => ({
@@ -104,7 +105,7 @@ beforeEach(() => {
   mockSendNewSignInEmail.mockReset().mockResolvedValue({ sent: true })
   mockRecordAuditEvent.mockReset().mockResolvedValue(undefined)
   mockListIdentityProviders.mockReset().mockResolvedValue([])
-  mockGetRegisteredOidcProviderIds.mockReset().mockResolvedValue(new Set<string>())
+  mockGetRegisteredOidcProviderIds.mockReset().mockResolvedValue(new Set())
 })
 
 describe('handleNewDeviceNotification — happy path', () => {

--- a/apps/web/src/lib/server/auth/__tests__/signin-device-tracker.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/signin-device-tracker.test.ts
@@ -11,85 +11,107 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const mockClaim = vi.fn()
+const mockClaimCounted = vi.fn()
 const mockTouch = vi.fn()
 const mockRemove = vi.fn()
 
 vi.mock('@/lib/server/kv/pg-kv', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/lib/server/kv/pg-kv')>()),
-  kvSetMemberClaim: mockClaim,
+  kvSetMemberClaimCounted: mockClaimCounted,
   kvSetTouch: mockTouch,
   kvSetMemberRemove: mockRemove,
 }))
 
-const { computeDeviceFingerprint, isDeviceUnseen, markDeviceSeen, forgetDevice } =
-  await import('../signin-device-tracker')
+const {
+  computeDeviceFingerprint,
+  formatSignInDevice,
+  signInDeviceKey,
+  isDeviceUnseen,
+  markDeviceSeen,
+  forgetDevice,
+} = await import('../signin-device-tracker')
+
+const CHROME_WIN_129 =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36'
+const CHROME_WIN_130 =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36'
+const FIREFOX_WIN =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:131.0) Gecko/20100101 Firefox/131.0'
+const CHROME_IOS =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/129.0.6668.69 Mobile/15E148 Safari/604.1'
 
 beforeEach(() => {
   vi.clearAllMocks()
 })
 
+describe('signInDeviceKey / formatSignInDevice', () => {
+  it('strips browser versions so an auto-update is the same device', () => {
+    expect(signInDeviceKey(CHROME_WIN_129)).toBe(signInDeviceKey(CHROME_WIN_130))
+    expect(formatSignInDevice(CHROME_WIN_129)).toBe('Chrome on Windows')
+  })
+
+  it('differs across browser families', () => {
+    expect(signInDeviceKey(CHROME_WIN_129)).not.toBe(signInDeviceKey(FIREFOX_WIN))
+    expect(formatSignInDevice(FIREFOX_WIN)).toBe('Firefox on Windows')
+  })
+
+  it('differs across OS / platform', () => {
+    expect(signInDeviceKey(CHROME_WIN_129)).not.toBe(signInDeviceKey(CHROME_IOS))
+    expect(formatSignInDevice(CHROME_IOS)).toMatch(/Chrome on iOS/i)
+  })
+
+  it('collapses empty and unparseable UAs onto one sentinel', () => {
+    expect(signInDeviceKey('')).toBe(signInDeviceKey('   '))
+    expect(signInDeviceKey('')).toBe(signInDeviceKey('???'))
+    expect(formatSignInDevice('')).toBe('Unknown device')
+  })
+})
+
 describe('computeDeviceFingerprint', () => {
-  it('truncates IPv4 to /24 before hashing', () => {
-    const a = computeDeviceFingerprint('Mozilla/5.0', '203.0.113.42')
-    const b = computeDeviceFingerprint('Mozilla/5.0', '203.0.113.99')
+  it('is independent of IP', () => {
+    const a = computeDeviceFingerprint(CHROME_WIN_129)
+    const b = computeDeviceFingerprint(CHROME_WIN_130)
     expect(a).toBe(b)
+    expect(a).toMatch(/^[0-9a-f]{32}$/)
   })
 
-  it('differs on UA change', () => {
-    const a = computeDeviceFingerprint('Mozilla/5.0', '203.0.113.42')
-    const b = computeDeviceFingerprint('Different/5.0', '203.0.113.42')
-    expect(a).not.toBe(b)
+  it('differs on browser family', () => {
+    expect(computeDeviceFingerprint(CHROME_WIN_129)).not.toBe(computeDeviceFingerprint(FIREFOX_WIN))
   })
 
-  it('differs on /24 change', () => {
-    expect(computeDeviceFingerprint('UA', '203.0.113.42')).not.toBe(
-      computeDeviceFingerprint('UA', '203.0.114.42')
-    )
-  })
-
-  it('hashes IPv6 whole (no truncation)', () => {
-    expect(computeDeviceFingerprint('UA', '2001:db8::1')).not.toBe(
-      computeDeviceFingerprint('UA', '2001:db8::2')
-    )
-  })
-
-  it('unmaps IPv4-mapped IPv6 and still collapses /24', () => {
-    const a = computeDeviceFingerprint('Mozilla/5.0', '::ffff:203.0.113.42')
-    const b = computeDeviceFingerprint('Mozilla/5.0', '::ffff:203.0.113.99')
-    const c = computeDeviceFingerprint('Mozilla/5.0', '203.0.113.7')
-    expect(a).toBe(b)
-    expect(a).toBe(c)
-    expect(a).not.toBe(computeDeviceFingerprint('Mozilla/5.0', '::ffff:203.0.114.42'))
-  })
-
-  it('returns 32-char hex', () => {
-    expect(computeDeviceFingerprint('UA', '203.0.113.42')).toMatch(/^[0-9a-f]{32}$/)
+  it('empty UA is a stable hash', () => {
+    expect(computeDeviceFingerprint('')).toBe(computeDeviceFingerprint(''))
+    expect(computeDeviceFingerprint('')).toMatch(/^[0-9a-f]{32}$/)
   })
 })
 
 describe('isDeviceUnseen', () => {
-  it('returns true when the claim takes the member', async () => {
-    mockClaim.mockResolvedValueOnce(true)
+  it('returns false for the first recorded device (silent seed)', async () => {
+    mockClaimCounted.mockResolvedValueOnce({ claimed: true, liveCount: 1 })
+    expect(await isDeviceUnseen('user_abc', 'fp')).toBe(false)
+  })
+
+  it('returns true when the claim takes an additional member', async () => {
+    mockClaimCounted.mockResolvedValueOnce({ claimed: true, liveCount: 2 })
     expect(await isDeviceUnseen('user_abc', 'fp')).toBe(true)
   })
 
   it('returns false when the member was already present', async () => {
-    mockClaim.mockResolvedValueOnce(false)
+    mockClaimCounted.mockResolvedValueOnce({ claimed: false, liveCount: 2 })
     expect(await isDeviceUnseen('user_abc', 'fp')).toBe(false)
   })
 
   it('claims the fingerprint under the user set key with the 90-day TTL', async () => {
-    mockClaim.mockResolvedValueOnce(true)
+    mockClaimCounted.mockResolvedValueOnce({ claimed: true, liveCount: 2 })
     await isDeviceUnseen('user_abc', 'fp')
-    // One call, so the claim and the expiry cannot separate: a caller that
-    // crashes before markDeviceSeen still leaves an expiring member.
-    expect(mockClaim).toHaveBeenCalledTimes(1)
-    expect(mockClaim).toHaveBeenCalledWith('user:devices:user_abc', 'fp', 7_776_000)
+    expect(mockClaimCounted).toHaveBeenCalledTimes(1)
+    expect(mockClaimCounted).toHaveBeenCalledWith('user:devices:user_abc', 'fp', 7_776_000)
   })
 
-  it('atomic across concurrent first-sights — only one caller gets true', async () => {
-    mockClaim.mockResolvedValueOnce(true).mockResolvedValueOnce(false)
+  it('atomic across concurrent first-sights — only one caller gets a claim', async () => {
+    mockClaimCounted
+      .mockResolvedValueOnce({ claimed: true, liveCount: 2 })
+      .mockResolvedValueOnce({ claimed: false, liveCount: 2 })
     const [a, b] = await Promise.all([
       isDeviceUnseen('user_abc', 'fp'),
       isDeviceUnseen('user_abc', 'fp'),
@@ -98,7 +120,7 @@ describe('isDeviceUnseen', () => {
   })
 
   it('fails closed on a store error (returns false, no notification spam)', async () => {
-    mockClaim.mockRejectedValueOnce(new Error('store down'))
+    mockClaimCounted.mockRejectedValueOnce(new Error('store down'))
     expect(await isDeviceUnseen('user_abc', 'fp')).toBe(false)
   })
 })

--- a/apps/web/src/lib/server/auth/__tests__/signin-device-tracker.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/signin-device-tracker.test.ts
@@ -105,7 +105,7 @@ describe('isDeviceUnseen', () => {
     mockClaimCounted.mockResolvedValueOnce({ claimed: true, liveCount: 2 })
     await isDeviceUnseen('user_abc', 'fp')
     expect(mockClaimCounted).toHaveBeenCalledTimes(1)
-    expect(mockClaimCounted).toHaveBeenCalledWith('user:devices:user_abc', 'fp', 7_776_000)
+    expect(mockClaimCounted).toHaveBeenCalledWith('user:devices:v2:user_abc', 'fp', 7_776_000)
   })
 
   it('atomic across concurrent first-sights — only one caller gets a claim', async () => {
@@ -129,7 +129,7 @@ describe('markDeviceSeen', () => {
   it('slides the 90-day TTL forward', async () => {
     mockTouch.mockResolvedValueOnce(undefined)
     await markDeviceSeen('user_abc')
-    expect(mockTouch).toHaveBeenCalledWith('user:devices:user_abc', 7_776_000)
+    expect(mockTouch).toHaveBeenCalledWith('user:devices:v2:user_abc', 7_776_000)
   })
 
   it('swallows store errors', async () => {
@@ -142,7 +142,7 @@ describe('forgetDevice', () => {
   it('removes the fingerprint from the user set', async () => {
     mockRemove.mockResolvedValueOnce(undefined)
     await forgetDevice('user_abc', 'fp')
-    expect(mockRemove).toHaveBeenCalledWith('user:devices:user_abc', 'fp')
+    expect(mockRemove).toHaveBeenCalledWith('user:devices:v2:user_abc', 'fp')
   })
 
   it('swallows store errors', async () => {

--- a/apps/web/src/lib/server/auth/__tests__/signin-device-tracker.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/signin-device-tracker.test.ts
@@ -99,6 +99,13 @@ describe('isDeviceUnseen', () => {
   it('returns false when the member was already present', async () => {
     mockClaimCounted.mockResolvedValueOnce({ claimed: false, liveCount: 2 })
     expect(await isDeviceUnseen('user_abc', 'fp')).toBe(false)
+    expect(mockTouch).toHaveBeenCalledWith('user:devices:v2:user_abc', 7_776_000)
+  })
+
+  it('does not slide TTL on a first-device silent seed', async () => {
+    mockClaimCounted.mockResolvedValueOnce({ claimed: true, liveCount: 1 })
+    expect(await isDeviceUnseen('user_abc', 'fp')).toBe(false)
+    expect(mockTouch).not.toHaveBeenCalled()
   })
 
   it('claims the fingerprint under the user set key with the 90-day TTL', async () => {

--- a/apps/web/src/lib/server/auth/hooks.ts
+++ b/apps/web/src/lib/server/auth/hooks.ts
@@ -1327,6 +1327,23 @@ export async function handleNewDeviceNotification(
     if (!to) {
       log.warn({ user_id: userId }, 'new-device alert skipped: no deliverable account address')
     }
+    // Same predicate the profile page uses to hide PasswordForm. Fail open
+    // so a registry miss still sends the alert (password copy) rather than
+    // skipping it or blocking sign-in.
+    let ssoEnforced = false
+    if (to) {
+      try {
+        const { isHardBound } = await import('./auth-restrictions')
+        const { listIdentityProviders } =
+          await import('@/lib/server/domains/settings/identity-providers.service')
+        const { getRegisteredOidcProviderIds } = await import('./registered-providers')
+        const providers = await listIdentityProviders()
+        const registeredOidcIds = await getRegisteredOidcProviderIds(providers)
+        ssoEnforced = isHardBound('credential', email, providers, registeredOidcIds)
+      } catch (error) {
+        log.warn({ err: error }, 'sso-enforced lookup failed; sending password recovery copy')
+      }
+    }
     await Promise.all([
       to
         ? sendNewSignInEmail({
@@ -1336,7 +1353,8 @@ export async function handleNewDeviceNotification(
             ipAddress: ip,
             userAgent: device,
             location,
-            settingsUrl,
+            settingsUrl: ssoEnforced ? undefined : settingsUrl,
+            ssoEnforced,
             logoUrl: workspace?.brandingData?.logoUrl ?? undefined,
           })
         : Promise.resolve(),

--- a/apps/web/src/lib/server/auth/hooks.ts
+++ b/apps/web/src/lib/server/auth/hooks.ts
@@ -40,6 +40,7 @@ import {
 import { checkAnonMintRateLimit } from './widget-rate-limit'
 import {
   computeDeviceFingerprint,
+  formatSignInDevice,
   forgetDevice,
   isDeviceUnseen,
   markDeviceSeen,
@@ -1299,7 +1300,7 @@ export async function handleNewDeviceNotification(
   const headers = getRequestHeaders()
   const userAgent = headers.get('user-agent') ?? ''
   const ip = getClientIp(headers)
-  const fingerprint = computeDeviceFingerprint(userAgent, ip)
+  const fingerprint = computeDeviceFingerprint(userAgent)
 
   const unseen = await isDeviceUnseen(userId, fingerprint).catch(() => false)
   if (!unseen) return
@@ -1311,7 +1312,12 @@ export async function handleNewDeviceNotification(
     const { sendNewSignInEmail } = await import('@quackback/email')
     const { recordAuditEvent } = await import('@/lib/server/audit/log')
     const { resolveAccountRecipient } = await import('@/lib/server/email/recipient')
+    const { getBaseUrl } = await import('@/lib/server/config')
     const occurredAt = new Date().toISOString()
+    const device = formatSignInDevice(userAgent)
+    const location = captureCountryFromHeaders(headers)
+    const base = getBaseUrl().replace(/\/$/, '')
+    const settingsUrl = base ? `${base}/admin/settings/security/authentication` : undefined
     // Account class, and deliberately no contact-address fallback: this alert
     // discloses IP, user agent and sign-in timing, and a contact address can be
     // one an agent typed into the inbox. An account with no deliverable address
@@ -1328,7 +1334,9 @@ export async function handleNewDeviceNotification(
             workspaceName: workspace?.name,
             occurredAt,
             ipAddress: ip,
-            userAgent,
+            userAgent: device,
+            location,
+            settingsUrl,
             logoUrl: workspace?.brandingData?.logoUrl ?? undefined,
           })
         : Promise.resolve(),
@@ -1337,7 +1345,7 @@ export async function handleNewDeviceNotification(
         outcome: 'success',
         actor: { userId: userId as `user_${string}`, email },
         headers,
-        metadata: { ip, userAgent },
+        metadata: { ip, userAgent, device, location },
       }),
     ])
     await markDeviceSeen(userId)
@@ -1403,8 +1411,9 @@ export async function handleCountryCapture(ctx: {
  *     prior steps). Runs after the gates so it only records sign-ins
  *     that actually stuck.
  *  6. `handleNewDeviceNotification` — sends a "new device" email +
- *     records an audit row when the user's UA + /24-IP combination
- *     hasn't been seen for them within the last 90 days.
+ *     records an audit row when an additional (browser, OS) for this
+ *     user hasn't been seen within the last 90 days. The first
+ *     recorded device is seeded silently. Alerts cannot be disabled.
  */
 export const hooksAfter = createAuthMiddleware(async (ctx) => {
   if (process.env.AUTH_HOOKS_DEBUG === '1') {
@@ -1508,7 +1517,7 @@ export const hooksAfter = createAuthMiddleware(async (ctx) => {
   await handleSignInSuccessAudit(ctx as Parameters<typeof handleSignInSuccessAudit>[0])
   // Geo-IP country from CDN headers; written best-effort, never blocks.
   await handleCountryCapture(ctx as Parameters<typeof handleCountryCapture>[0])
-  // Fires only on a real sign-in path when the UA + /24 is unseen.
+  // Fires only on a real sign-in path when an additional device is unseen.
   await handleNewDeviceNotification(
     ctx as Parameters<typeof handleNewDeviceNotification>[0],
     workspace

--- a/apps/web/src/lib/server/auth/hooks.ts
+++ b/apps/web/src/lib/server/auth/hooks.ts
@@ -1317,7 +1317,7 @@ export async function handleNewDeviceNotification(
     const device = formatSignInDevice(userAgent)
     const location = captureCountryFromHeaders(headers)
     const base = getBaseUrl().replace(/\/$/, '')
-    const settingsUrl = base ? `${base}/admin/settings/security/authentication` : undefined
+    const settingsUrl = base ? `${base}/settings/profile` : undefined
     // Account class, and deliberately no contact-address fallback: this alert
     // discloses IP, user agent and sign-in timing, and a contact address can be
     // one an agent typed into the inbox. An account with no deliverable address

--- a/apps/web/src/lib/server/auth/signin-device-tracker.ts
+++ b/apps/web/src/lib/server/auth/signin-device-tracker.ts
@@ -1,6 +1,8 @@
 /**
- * Per-user device-fingerprint tracker. The set `user:devices:{userId}` holds
- * the recent (browser + OS + platform) hashes seen for the user.
+ * Per-user device-fingerprint tracker. The set `user:devices:v2:{userId}`
+ * holds the recent (browser + OS + platform) hashes seen for the user.
+ * `v2` is a new key so leftover UA+/24 hashes from the previous format
+ * cannot make the first normalised browser look like an additional device.
  *
  * Identity is the normalised user-agent, not the IP. IP belongs in the
  * new-sign-in email as forensic context; hashing it in treats 5G / CGNAT /
@@ -71,7 +73,7 @@ export function computeDeviceFingerprint(userAgent: string): string {
 // notification whose entire job is to be the first sign of a stolen credential.
 // `pg-kv.ts` writes the workspace into the row's key; under pooled tenancy the row
 // is additionally in that workspace's own database.
-const key = (userId: string) => `user:devices:${userId}`
+const key = (userId: string) => `user:devices:v2:${userId}`
 
 /**
  * Atomic claim. Returns true iff this is an *additional* unseen device

--- a/apps/web/src/lib/server/auth/signin-device-tracker.ts
+++ b/apps/web/src/lib/server/auth/signin-device-tracker.ts
@@ -82,9 +82,9 @@ const key = (userId: string) => `user:devices:v2:${userId}`
  * is the user's own sign-in, and it also absorbs a hash-format change
  * without a one-time mail burst.
  *
- * One statement, so the claim and the expiry cannot separate — even if
- * the caller crashes before `markDeviceSeen` runs, the member still
- * expires after 90 days.
+ * Known devices slide the set's 90-day window here. Otherwise a daily
+ * sign-in never calls `markDeviceSeen`, the member expires, and the next
+ * distinct browser is treated as a silent first seed.
  */
 export async function isDeviceUnseen(userId: string, fingerprint: string): Promise<boolean> {
   try {
@@ -93,7 +93,11 @@ export async function isDeviceUnseen(userId: string, fingerprint: string): Promi
       fingerprint,
       DEVICE_SET_TTL_SECONDS
     )
-    return claimed && liveCount > 1
+    if (!claimed) {
+      await kvSetTouch(key(userId), DEVICE_SET_TTL_SECONDS)
+      return false
+    }
+    return liveCount > 1
   } catch (error) {
     log.error({ err: error }, 'isDeviceUnseen failed; treating device as known')
     return false

--- a/apps/web/src/lib/server/auth/signin-device-tracker.ts
+++ b/apps/web/src/lib/server/auth/signin-device-tracker.ts
@@ -1,7 +1,10 @@
 /**
- * Per-user device-fingerprint tracker. The set `user:devices:{userId}` holds the
- * recent (UA + /24 IP) hashes seen for the user; new-device notifications fire
- * only on first-sight.
+ * Per-user device-fingerprint tracker. The set `user:devices:{userId}` holds
+ * the recent (browser + OS + platform) hashes seen for the user.
+ *
+ * Identity is the normalised user-agent, not the IP. IP belongs in the
+ * new-sign-in email as forensic context; hashing it in treats 5G / CGNAT /
+ * VPN / travel as a new device.
  *
  * Two-phase API so notification failures don't silently lose the
  * alert: `isDeviceUnseen` atomically claims the fingerprint in one
@@ -9,39 +12,58 @@
  * `forgetDevice` on failure. Errors fail closed (treat as known
  * device) so a store outage suppresses notifications rather than
  * spamming users.
+ *
+ * The first live member in a user's set is seeded silently — that is
+ * the sign-in they just made. Mail fires only on an additional unseen
+ * browser/OS.
  */
 import { createHash } from 'node:crypto'
-import { kvSetMemberClaim, kvSetTouch, kvSetMemberRemove } from '@/lib/server/kv/pg-kv'
+import Bowser from 'bowser'
+import { kvSetMemberClaimCounted, kvSetTouch, kvSetMemberRemove } from '@/lib/server/kv/pg-kv'
 import { logger } from '@/lib/server/logger'
 
 const log = logger.child({ component: 'signin-device-tracker' })
 
 const DEVICE_SET_TTL_SECONDS = 90 * 24 * 60 * 60
 
+/** Stable hash input when the UA is empty or unparseable. */
+const UNKNOWN_DEVICE_KEY = 'unknown||'
+
 /**
- * SHA-256 of (UA + /24 IPv4 subnet) truncated to 128 bits / 32 hex
- * chars. /24 keeps dynamic-IP users on the same network from tripping
- * on every connection; IPv6 is hashed whole (most carriers hand out
- * stable /64s, but we don't bias on carrier data here).
- *
- * IPv4-mapped IPv6 (`::ffff:a.b.c.d`) is unmapped before the /24 cut.
- * `ip.includes(':')` would otherwise treat those as IPv6 and hash the
- * last octet, so a rotating CGNAT/mesh hop on the same /24 looks like a
- * new device every sign-in.
+ * Browser + OS + platform, with versions stripped so an auto-update does
+ * not look like a new device. Empty / unparseable UAs share one sentinel
+ * rather than hashing each garbage string.
  */
-export function computeDeviceFingerprint(userAgent: string, ip: string): string {
-  return createHash('sha256')
-    .update(`${userAgent}|${normaliseIpForFingerprint(ip)}`)
-    .digest('hex')
-    .slice(0, 32)
+export function signInDeviceKey(userAgent: string): string {
+  const trimmed = userAgent.trim()
+  if (!trimmed) return UNKNOWN_DEVICE_KEY
+  try {
+    const parser = Bowser.getParser(trimmed)
+    const browser = parser.getBrowserName() || ''
+    const os = parser.getOSName() || ''
+    const platform = parser.getPlatformType() || ''
+    if (!browser && !os && !platform) return UNKNOWN_DEVICE_KEY
+    return `${browser}|${os}|${platform}`
+  } catch {
+    return UNKNOWN_DEVICE_KEY
+  }
 }
 
-/** /24 for IPv4 (including :ffff: mapped); whole address for real IPv6. */
-export function normaliseIpForFingerprint(ip: string): string {
-  const mapped = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/i.exec(ip.trim())
-  const v4 = mapped?.[1] ?? (ip.includes(':') ? null : ip.trim())
-  if (v4 && /^\d{1,3}(?:\.\d{1,3}){3}$/.test(v4)) return v4.split('.').slice(0, 3).join('.')
-  return ip.trim()
+/** Human-readable line for the new-sign-in email, e.g. `Chrome on Windows`. */
+export function formatSignInDevice(userAgent: string): string {
+  const key = signInDeviceKey(userAgent)
+  if (key === UNKNOWN_DEVICE_KEY) return 'Unknown device'
+  const [browser, os] = key.split('|')
+  if (browser && os) return `${browser} on ${os}`
+  return browser || os || 'Unknown device'
+}
+
+/**
+ * SHA-256 of the normalised device key, truncated to 128 bits / 32 hex
+ * chars. IP is deliberately not part of the hash.
+ */
+export function computeDeviceFingerprint(userAgent: string): string {
+  return createHash('sha256').update(signInDeviceKey(userAgent)).digest('hex').slice(0, 32)
 }
 
 // User ids are only unique within a workspace database, so an undiscriminated
@@ -52,13 +74,24 @@ export function normaliseIpForFingerprint(ip: string): string {
 const key = (userId: string) => `user:devices:${userId}`
 
 /**
- * Atomic claim: returns true iff this is the first sighting. One statement, so
- * the claim and the expiry cannot separate — even if the caller crashes before
- * `markDeviceSeen` runs, the member still expires after 90 days.
+ * Atomic claim. Returns true iff this is an *additional* unseen device
+ * (the set already had at least one live member). The first recorded
+ * device is claimed and given the 90-day TTL but does not notify — that
+ * is the user's own sign-in, and it also absorbs a hash-format change
+ * without a one-time mail burst.
+ *
+ * One statement, so the claim and the expiry cannot separate — even if
+ * the caller crashes before `markDeviceSeen` runs, the member still
+ * expires after 90 days.
  */
 export async function isDeviceUnseen(userId: string, fingerprint: string): Promise<boolean> {
   try {
-    return await kvSetMemberClaim(key(userId), fingerprint, DEVICE_SET_TTL_SECONDS)
+    const { claimed, liveCount } = await kvSetMemberClaimCounted(
+      key(userId),
+      fingerprint,
+      DEVICE_SET_TTL_SECONDS
+    )
+    return claimed && liveCount > 1
   } catch (error) {
     log.error({ err: error }, 'isDeviceUnseen failed; treating device as known')
     return false

--- a/apps/web/src/lib/server/functions/__tests__/invitations-accept.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/invitations-accept.test.ts
@@ -95,8 +95,19 @@ const hoisted = vi.hoisted(() => {
     mockRevokeMagicLinkTokens: vi.fn(),
     mockCacheDel: vi.fn(),
     mockEnforceSeatLimit: vi.fn(),
+    mockSetPassword: vi.fn(),
+    mockRevokeOtherSessions: vi.fn(),
   }
 })
+
+vi.mock('@/lib/server/auth', () => ({
+  auth: {
+    api: {
+      setPassword: hoisted.mockSetPassword,
+      revokeOtherSessions: hoisted.mockRevokeOtherSessions,
+    },
+  },
+}))
 
 vi.mock('@/lib/server/db', () => ({
   db: {
@@ -148,6 +159,7 @@ vi.mock('@/lib/server/domains/principals/seat-limit', () => ({
 // ---------------------------------------------------------------------------
 
 const ACCEPT_IDX = 1
+const SET_PASSWORD_IDX = 2
 
 const FUTURE = new Date(Date.now() + 14 * 24 * 60 * 60 * 1000)
 const PAST = new Date(Date.now() - 1000)
@@ -202,6 +214,8 @@ beforeEach(async () => {
   hoisted.mockRevokeMagicLinkTokens.mockResolvedValue(undefined)
   hoisted.mockCacheDel.mockResolvedValue(undefined)
   hoisted.mockEnforceSeatLimit.mockResolvedValue(undefined)
+  hoisted.mockSetPassword.mockResolvedValue({ status: true })
+  hoisted.mockRevokeOtherSessions.mockResolvedValue({ status: true })
 })
 
 // ---------------------------------------------------------------------------
@@ -530,5 +544,43 @@ describe('acceptInvitationFn — seat cap', () => {
       convertingInvite: true,
       executor: hoisted.tx,
     })
+  })
+})
+
+describe('setPasswordFn', () => {
+  let setPasswordHandler: AnyHandler
+
+  beforeEach(() => {
+    setPasswordHandler = handlers[SET_PASSWORD_IDX]
+  })
+
+  it('sets a password without revoking other sessions by default', async () => {
+    const result = await setPasswordHandler({ data: { newPassword: 'password1' } })
+
+    expect(result).toEqual({ status: true })
+    expect(hoisted.mockSetPassword).toHaveBeenCalledWith({
+      body: { newPassword: 'password1' },
+      headers: expect.any(Headers),
+    })
+    expect(hoisted.mockRevokeOtherSessions).not.toHaveBeenCalled()
+  })
+
+  it('revokes other sessions after setPassword when the profile form asks', async () => {
+    await setPasswordHandler({ data: { newPassword: 'password1', revokeOtherSessions: true } })
+
+    expect(hoisted.mockSetPassword).toHaveBeenCalledOnce()
+    expect(hoisted.mockRevokeOtherSessions).toHaveBeenCalledWith({
+      headers: expect.any(Headers),
+    })
+    expect(hoisted.mockSetPassword.mock.invocationCallOrder[0]).toBeLessThan(
+      hoisted.mockRevokeOtherSessions.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('does not revoke when the flag is false', async () => {
+    await setPasswordHandler({ data: { newPassword: 'password1', revokeOtherSessions: false } })
+
+    expect(hoisted.mockSetPassword).toHaveBeenCalledOnce()
+    expect(hoisted.mockRevokeOtherSessions).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/lib/server/functions/invitations.ts
+++ b/apps/web/src/lib/server/functions/invitations.ts
@@ -335,13 +335,33 @@ export const acceptInvitationFn = createServerFn({ method: 'POST' })
  * so we must call auth.api.setPassword() from a server function.
  */
 export const setPasswordFn = createServerFn({ method: 'POST' })
-  .validator(z.object({ newPassword: z.string().min(8) }))
+  .validator(
+    z.object({
+      newPassword: z.string().min(8),
+      /** Drop every session except the current one. Off by default so
+       *  complete-signup can set a first password without kicking the
+       *  just-minted session; the profile recovery form turns it on. */
+      revokeOtherSessions: z.boolean().optional(),
+    })
+  )
   .handler(async ({ data }) => {
+    const headers = getRequestHeaders()
     const { auth } = await import('@/lib/server/auth')
     await auth.api.setPassword({
       body: { newPassword: data.newPassword },
-      headers: getRequestHeaders(),
+      headers,
     })
+    if (data.revokeOtherSessions) {
+      const current = await auth.api.getSession({ headers })
+      const token = current?.session?.token
+      const userId = current?.user?.id
+      if (typeof token === 'string' && typeof userId === 'string') {
+        const { db, session: sessionTable, and, eq, ne } = await import('@/lib/server/db')
+        await db
+          .delete(sessionTable)
+          .where(and(eq(sessionTable.userId, userId as UserId), ne(sessionTable.token, token)))
+      }
+    }
     return { status: true }
   })
 

--- a/apps/web/src/lib/server/functions/invitations.ts
+++ b/apps/web/src/lib/server/functions/invitations.ts
@@ -352,15 +352,7 @@ export const setPasswordFn = createServerFn({ method: 'POST' })
       headers,
     })
     if (data.revokeOtherSessions) {
-      const current = await auth.api.getSession({ headers })
-      const token = current?.session?.token
-      const userId = current?.user?.id
-      if (typeof token === 'string' && typeof userId === 'string') {
-        const { db, session: sessionTable, and, eq, ne } = await import('@/lib/server/db')
-        await db
-          .delete(sessionTable)
-          .where(and(eq(sessionTable.userId, userId as UserId), ne(sessionTable.token, token)))
-      }
+      await auth.api.revokeOtherSessions({ headers })
     }
     return { status: true }
   })

--- a/apps/web/src/lib/server/kv/__tests__/workspace-separation.db.test.ts
+++ b/apps/web/src/lib/server/kv/__tests__/workspace-separation.db.test.ts
@@ -28,7 +28,14 @@ import {
   closeHarness,
   testSql,
 } from './harness'
-import { kvGet, kvSet, kvSetNx, kvGetOrCreate, kvSetMemberClaim } from '../pg-kv'
+import {
+  kvGet,
+  kvSet,
+  kvSetNx,
+  kvGetOrCreate,
+  kvSetMemberClaim,
+  kvSetMemberClaimCounted,
+} from '../pg-kv'
 import {
   currentWorkspaceNamespace,
   SINGLE_WORKSPACE_NAMESPACE,
@@ -128,10 +135,16 @@ describe('workspace separation — device sets', () => {
     const userId = 'user_01collision'
     const fingerprint = 'ffffffffffffffffffffffffffffffff'
 
-    expect(await withRealWorkspace(A, () => isDeviceUnseen(userId, fingerprint))).toBe(true)
-    // Same workspace, second sighting: known. The positive control for the line below.
+    // First live member is a silent seed (the user's own sign-in).
     expect(await withRealWorkspace(A, () => isDeviceUnseen(userId, fingerprint))).toBe(false)
-    expect(await withRealWorkspace(B, () => isDeviceUnseen(userId, fingerprint))).toBe(true)
+    // Same workspace, second sighting of the same fingerprint: known.
+    expect(await withRealWorkspace(A, () => isDeviceUnseen(userId, fingerprint))).toBe(false)
+    // An additional fingerprint in A is a new device and should notify.
+    expect(
+      await withRealWorkspace(A, () => isDeviceUnseen(userId, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'))
+    ).toBe(true)
+    // B is a different workspace: first member there is also a silent seed.
+    expect(await withRealWorkspace(B, () => isDeviceUnseen(userId, fingerprint))).toBe(false)
 
     await testSql()`DELETE FROM kv_set_member WHERE workspace_key IN (${A}, ${B})`
   })
@@ -145,6 +158,22 @@ describe('workspace separation — device sets', () => {
       WHERE workspace_key = ${A} AND set_key = ${setKey}
     `
     expect(await withRealWorkspace(A, () => kvSetMemberClaim(setKey, 'm', 60))).toBe(true)
+  })
+
+  it('liveCount distinguishes first member from an additional one', async () => {
+    const setKey = uniqueKey('user:devices')
+    expect(await withRealWorkspace(A, () => kvSetMemberClaimCounted(setKey, 'a', 60))).toEqual({
+      claimed: true,
+      liveCount: 1,
+    })
+    expect(await withRealWorkspace(A, () => kvSetMemberClaimCounted(setKey, 'a', 60))).toEqual({
+      claimed: false,
+      liveCount: 1,
+    })
+    expect(await withRealWorkspace(A, () => kvSetMemberClaimCounted(setKey, 'b', 60))).toEqual({
+      claimed: true,
+      liveCount: 2,
+    })
   })
 })
 

--- a/apps/web/src/lib/server/kv/__tests__/workspace-separation.db.test.ts
+++ b/apps/web/src/lib/server/kv/__tests__/workspace-separation.db.test.ts
@@ -35,6 +35,7 @@ import {
   kvGetOrCreate,
   kvSetMemberClaim,
   kvSetMemberClaimCounted,
+  kvSetTouch,
 } from '../pg-kv'
 import {
   currentWorkspaceNamespace,
@@ -184,6 +185,21 @@ describe('workspace separation — device sets', () => {
     ])
     expect(results.every((r) => r.claimed)).toBe(true)
     expect(results.map((r) => r.liveCount).sort()).toEqual([1, 2])
+  })
+
+  it('touch does not revive an expired member', async () => {
+    const setKey = uniqueKey('user:devices')
+    await withRealWorkspace(A, () => kvSetMemberClaimCounted(setKey, 'live', 60))
+    await withRealWorkspace(A, () => kvSetMemberClaimCounted(setKey, 'stale', 60))
+    await testSql()`
+      UPDATE kv_set_member SET expires_at = now() - interval '1 second'
+      WHERE workspace_key = ${A} AND set_key = ${setKey} AND member = 'stale'
+    `
+    await withRealWorkspace(A, () => kvSetTouch(setKey, 60))
+    expect(await withRealWorkspace(A, () => kvSetMemberClaimCounted(setKey, 'stale', 60))).toEqual({
+      claimed: true,
+      liveCount: 2,
+    })
   })
 })
 

--- a/apps/web/src/lib/server/kv/__tests__/workspace-separation.db.test.ts
+++ b/apps/web/src/lib/server/kv/__tests__/workspace-separation.db.test.ts
@@ -175,6 +175,16 @@ describe('workspace separation — device sets', () => {
       liveCount: 2,
     })
   })
+
+  it('concurrent first fingerprints: exactly one is the silent seed', async () => {
+    const setKey = uniqueKey('user:devices')
+    const results = await Promise.all([
+      withRealWorkspace(A, () => kvSetMemberClaimCounted(setKey, 'a', 60)),
+      withRealWorkspace(A, () => kvSetMemberClaimCounted(setKey, 'b', 60)),
+    ])
+    expect(results.every((r) => r.claimed)).toBe(true)
+    expect(results.map((r) => r.liveCount).sort()).toEqual([1, 2])
+  })
 })
 
 describe('workspace separation — presence', () => {

--- a/apps/web/src/lib/server/kv/pg-kv.ts
+++ b/apps/web/src/lib/server/kv/pg-kv.ts
@@ -146,33 +146,73 @@ export async function kvGetOrCreate<T>(key: string, create: T, seconds: number):
 // Sets — the one Redis SET we used, `user:devices:<userId>`
 // ============================================================================
 
+export interface SetMemberClaim {
+  /** True iff this caller inserted (or revived an expired) member. */
+  claimed: boolean
+  /** Live members in the set after this statement, including a just-claimed one. */
+  liveCount: number
+}
+
+function asBool(value: unknown): boolean {
+  return value === true || value === 't' || value === 'true'
+}
+
 /**
- * SADD + EXPIRE NX, as one statement. True iff the member was not already
- * present and live — i.e. Redis's `SADD` reply of 1.
+ * SADD + EXPIRE NX plus live cardinality, as one statement.
  *
- * An expired member is not present, so it is re-claimed and its expiry
- * refreshed. That matches Redis, where the whole set would already have been
- * dropped by its TTL.
+ * `claimed` is Redis's `SADD` reply of 1: the member was not already
+ * present and live. An expired member is not present, so it is
+ * re-claimed and its expiry refreshed.
+ *
+ * `liveCount` is counted in the same statement as the insert so a
+ * caller can tell first-member (seed, no alert) from an additional
+ * unseen member (alert) without a second round trip.
  */
+export async function kvSetMemberClaimCounted(
+  setKey: string,
+  member: string,
+  seconds: number
+): Promise<SetMemberClaim> {
+  const ttl = ttlSeconds(seconds)
+  const workspaceKey = currentWorkspaceNamespace()
+  const result = await db.execute(sql`
+    WITH claimed AS (
+      INSERT INTO kv_set_member (workspace_key, set_key, member, expires_at)
+      VALUES (
+        ${workspaceKey},
+        ${setKey},
+        ${member},
+        now() + make_interval(secs => ${ttl})
+      )
+      ON CONFLICT (workspace_key, set_key, member) DO UPDATE
+        SET expires_at = EXCLUDED.expires_at
+        WHERE kv_set_member.expires_at <= now()
+      RETURNING member
+    )
+    SELECT
+      EXISTS (SELECT 1 FROM claimed) AS claimed,
+      (
+        SELECT count(*)::int
+        FROM kv_set_member
+        WHERE workspace_key = ${workspaceKey}
+          AND set_key = ${setKey}
+          AND expires_at > now()
+      ) AS live_count
+  `)
+  const row = getExecuteRows<{ claimed: unknown; live_count: unknown }>(result)[0]
+  return {
+    claimed: asBool(row?.claimed),
+    liveCount: Number(row?.live_count ?? 0),
+  }
+}
+
+/** SADD + EXPIRE NX, as one statement. True iff the member was not already live. */
 export async function kvSetMemberClaim(
   setKey: string,
   member: string,
   seconds: number
 ): Promise<boolean> {
-  const result = await db.execute(sql`
-    INSERT INTO kv_set_member (workspace_key, set_key, member, expires_at)
-    VALUES (
-      ${currentWorkspaceNamespace()},
-      ${setKey},
-      ${member},
-      now() + make_interval(secs => ${ttlSeconds(seconds)})
-    )
-    ON CONFLICT (workspace_key, set_key, member) DO UPDATE
-      SET expires_at = EXCLUDED.expires_at
-      WHERE kv_set_member.expires_at <= now()
-    RETURNING member
-  `)
-  return getExecuteRows<{ member: string }>(result).length > 0
+  return (await kvSetMemberClaimCounted(setKey, member, seconds)).claimed
 }
 
 /** EXPIRE on the whole set: slide every live member's window forward. */

--- a/apps/web/src/lib/server/kv/pg-kv.ts
+++ b/apps/web/src/lib/server/kv/pg-kv.ts
@@ -16,7 +16,9 @@
  *
  * **One round trip.** The round trip, not the statement, is the whole cost of
  * moving these paths onto Postgres (measured in `KV.md`), and it is why none of
- * these is expressed as a transaction with two statements in it.
+ * these is expressed as a transaction with two statements in it — except
+ * `kvSetMemberClaimCounted`, which must lock in a prior statement so the
+ * counted insert takes a snapshot that includes concurrent commits.
  *
  * **The workspace is in the key.** `currentWorkspaceNamespace()` is the same function
  * that built the `t:<workspaceKey>:` prefix on the Redis wire key, so the
@@ -174,10 +176,11 @@ function asBool(value: unknown): boolean {
  * row whether or not the snapshot has it; UNION also dedupes if it has.
  *
  * Two concurrent first-claims on an empty set would otherwise both see
- * liveCount 1 and both skip the alert. An advisory xact lock on
- * (workspace, set) serializes those statements so the second snapshot
- * includes the first insert. The INSERT…SELECT FROM lock is what forces
- * the lock CTE to run; an unreferenced SELECT CTE can be skipped.
+ * liveCount 1 and both skip the alert. READ COMMITTED takes the snapshot
+ * at statement start, so a lock CTE in the *same* statement is too late
+ * — the waiter resumes with the empty snapshot it already took. Lock in
+ * a prior statement of the same transaction; the counted insert then
+ * snapshots after the first claim has committed.
  */
 export async function kvSetMemberClaimCounted(
   setKey: string,
@@ -186,40 +189,42 @@ export async function kvSetMemberClaimCounted(
 ): Promise<SetMemberClaim> {
   const ttl = ttlSeconds(seconds)
   const workspaceKey = currentWorkspaceNamespace()
-  const result = await db.execute(sql`
-    WITH lock AS (
+  return await db.transaction(async (tx) => {
+    await tx.execute(sql`
       SELECT pg_advisory_xact_lock(hashtext(${workspaceKey}), hashtext(${setKey}))
-    ),
-    claimed AS (
-      INSERT INTO kv_set_member (workspace_key, set_key, member, expires_at)
+    `)
+    const result = await tx.execute(sql`
+      WITH claimed AS (
+        INSERT INTO kv_set_member (workspace_key, set_key, member, expires_at)
+        VALUES (
+          ${workspaceKey},
+          ${setKey},
+          ${member},
+          now() + make_interval(secs => ${ttl})
+        )
+        ON CONFLICT (workspace_key, set_key, member) DO UPDATE
+          SET expires_at = EXCLUDED.expires_at
+          WHERE kv_set_member.expires_at <= now()
+        RETURNING member
+      ),
+      live AS (
+        SELECT member FROM kv_set_member
+        WHERE workspace_key = ${workspaceKey}
+          AND set_key = ${setKey}
+          AND expires_at > now()
+        UNION
+        SELECT member FROM claimed
+      )
       SELECT
-        ${workspaceKey},
-        ${setKey},
-        ${member},
-        now() + make_interval(secs => ${ttl})
-      FROM lock
-      ON CONFLICT (workspace_key, set_key, member) DO UPDATE
-        SET expires_at = EXCLUDED.expires_at
-        WHERE kv_set_member.expires_at <= now()
-      RETURNING member
-    ),
-    live AS (
-      SELECT member FROM kv_set_member
-      WHERE workspace_key = ${workspaceKey}
-        AND set_key = ${setKey}
-        AND expires_at > now()
-      UNION
-      SELECT member FROM claimed
-    )
-    SELECT
-      EXISTS (SELECT 1 FROM claimed) AS claimed,
-      (SELECT count(*)::int FROM live) AS live_count
-  `)
-  const row = getExecuteRows<{ claimed: unknown; live_count: unknown }>(result)[0]
-  return {
-    claimed: asBool(row?.claimed),
-    liveCount: Number(row?.live_count ?? 0),
-  }
+        EXISTS (SELECT 1 FROM claimed) AS claimed,
+        (SELECT count(*)::int FROM live) AS live_count
+    `)
+    const row = getExecuteRows<{ claimed: unknown; live_count: unknown }>(result)[0]
+    return {
+      claimed: asBool(row?.claimed),
+      liveCount: Number(row?.live_count ?? 0),
+    }
+  })
 }
 
 /** SADD + EXPIRE NX, as one statement. True iff the member was not already live. */

--- a/apps/web/src/lib/server/kv/pg-kv.ts
+++ b/apps/web/src/lib/server/kv/pg-kv.ts
@@ -143,7 +143,7 @@ export async function kvGetOrCreate<T>(key: string, create: T, seconds: number):
 }
 
 // ============================================================================
-// Sets — the one Redis SET we used, `user:devices:<userId>`
+// Sets — the one Redis SET we used, `user:devices:v2:<userId>`
 // ============================================================================
 
 export interface SetMemberClaim {
@@ -167,6 +167,11 @@ function asBool(value: unknown): boolean {
  * `liveCount` is counted in the same statement as the insert so a
  * caller can tell first-member (seed, no alert) from an additional
  * unseen member (alert) without a second round trip.
+ *
+ * Data-modifying CTEs share the main query's snapshot, so a scan of
+ * `kv_set_member` cannot see the row this statement just inserted.
+ * UNION the `RETURNING` member in so cardinality includes a just-claimed
+ * row whether or not the snapshot has it; UNION also dedupes if it has.
  */
 export async function kvSetMemberClaimCounted(
   setKey: string,
@@ -188,16 +193,18 @@ export async function kvSetMemberClaimCounted(
         SET expires_at = EXCLUDED.expires_at
         WHERE kv_set_member.expires_at <= now()
       RETURNING member
+    ),
+    live AS (
+      SELECT member FROM kv_set_member
+      WHERE workspace_key = ${workspaceKey}
+        AND set_key = ${setKey}
+        AND expires_at > now()
+      UNION
+      SELECT member FROM claimed
     )
     SELECT
       EXISTS (SELECT 1 FROM claimed) AS claimed,
-      (
-        SELECT count(*)::int
-        FROM kv_set_member
-        WHERE workspace_key = ${workspaceKey}
-          AND set_key = ${setKey}
-          AND expires_at > now()
-      ) AS live_count
+      (SELECT count(*)::int FROM live) AS live_count
   `)
   const row = getExecuteRows<{ claimed: unknown; live_count: unknown }>(result)[0]
   return {

--- a/apps/web/src/lib/server/kv/pg-kv.ts
+++ b/apps/web/src/lib/server/kv/pg-kv.ts
@@ -172,6 +172,12 @@ function asBool(value: unknown): boolean {
  * `kv_set_member` cannot see the row this statement just inserted.
  * UNION the `RETURNING` member in so cardinality includes a just-claimed
  * row whether or not the snapshot has it; UNION also dedupes if it has.
+ *
+ * Two concurrent first-claims on an empty set would otherwise both see
+ * liveCount 1 and both skip the alert. An advisory xact lock on
+ * (workspace, set) serializes those statements so the second snapshot
+ * includes the first insert. The INSERT…SELECT FROM lock is what forces
+ * the lock CTE to run; an unreferenced SELECT CTE can be skipped.
  */
 export async function kvSetMemberClaimCounted(
   setKey: string,
@@ -181,14 +187,17 @@ export async function kvSetMemberClaimCounted(
   const ttl = ttlSeconds(seconds)
   const workspaceKey = currentWorkspaceNamespace()
   const result = await db.execute(sql`
-    WITH claimed AS (
+    WITH lock AS (
+      SELECT pg_advisory_xact_lock(hashtext(${workspaceKey}), hashtext(${setKey}))
+    ),
+    claimed AS (
       INSERT INTO kv_set_member (workspace_key, set_key, member, expires_at)
-      VALUES (
+      SELECT
         ${workspaceKey},
         ${setKey},
         ${member},
         now() + make_interval(secs => ${ttl})
-      )
+      FROM lock
       ON CONFLICT (workspace_key, set_key, member) DO UPDATE
         SET expires_at = EXCLUDED.expires_at
         WHERE kv_set_member.expires_at <= now()

--- a/apps/web/src/lib/server/kv/pg-kv.ts
+++ b/apps/web/src/lib/server/kv/pg-kv.ts
@@ -236,12 +236,16 @@ export async function kvSetMemberClaim(
   return (await kvSetMemberClaimCounted(setKey, member, seconds)).claimed
 }
 
-/** EXPIRE on the whole set: slide every live member's window forward. */
+/** EXPIRE on the whole set: slide every *live* member's window forward.
+ *  Expired rows stay expired — otherwise a known-device touch would
+ *  resurrect stale fingerprints and suppress a later new-device alert. */
 export async function kvSetTouch(setKey: string, seconds: number): Promise<void> {
   await db.execute(sql`
     UPDATE kv_set_member
     SET expires_at = now() + make_interval(secs => ${ttlSeconds(seconds)})
-    WHERE workspace_key = ${currentWorkspaceNamespace()} AND set_key = ${setKey}
+    WHERE workspace_key = ${currentWorkspaceNamespace()}
+      AND set_key = ${setKey}
+      AND expires_at > now()
   `)
 }
 

--- a/packages/db/src/schema/kv.ts
+++ b/packages/db/src/schema/kv.ts
@@ -60,7 +60,7 @@ export const rateBucket = pgTable(
   ]
 )
 
-/** Members of a keyed set — today only `user:devices:<userId>`. */
+/** Members of a keyed set — today only `user:devices:v2:<userId>`. */
 export const kvSetMember = pgTable(
   'kv_set_member',
   {

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -750,6 +750,7 @@ interface SendNewSignInParams {
   userAgent?: string | null
   location?: string | null
   settingsUrl?: string | null
+  ssoEnforced?: boolean
   logoUrl?: string
 }
 
@@ -757,8 +758,17 @@ interface SendNewSignInParams {
  * `handleNewDeviceNotification` after a successful sign-in lands on
  * an unseen (browser, OS) for that account. IP is shown, not hashed. */
 export async function sendNewSignInEmail(params: SendNewSignInParams): Promise<EmailResult> {
-  const { to, workspaceName, occurredAt, ipAddress, userAgent, location, settingsUrl, logoUrl } =
-    params
+  const {
+    to,
+    workspaceName,
+    occurredAt,
+    ipAddress,
+    userAgent,
+    location,
+    settingsUrl,
+    ssoEnforced,
+    logoUrl,
+  } = params
 
   log.debug('sending new-sign-in alert')
   return sendEmail({
@@ -770,7 +780,8 @@ export async function sendNewSignInEmail(params: SendNewSignInParams): Promise<E
       ipAddress,
       userAgent,
       location,
-      settingsUrl,
+      settingsUrl: ssoEnforced ? undefined : settingsUrl,
+      ssoEnforced,
       logoUrl,
     }),
     emailType: 'NewSignInEmail',

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -748,20 +748,31 @@ interface SendNewSignInParams {
   occurredAt: string
   ipAddress?: string | null
   userAgent?: string | null
+  location?: string | null
+  settingsUrl?: string | null
   logoUrl?: string
 }
 
-/** First-sight new-device sign-in alert. Triggered by
+/** Additional-device sign-in alert. Triggered by
  * `handleNewDeviceNotification` after a successful sign-in lands on
- * an unseen (UA, /24 IP) combination. */
+ * an unseen (browser, OS) for that account. IP is shown, not hashed. */
 export async function sendNewSignInEmail(params: SendNewSignInParams): Promise<EmailResult> {
-  const { to, workspaceName, occurredAt, ipAddress, userAgent, logoUrl } = params
+  const { to, workspaceName, occurredAt, ipAddress, userAgent, location, settingsUrl, logoUrl } =
+    params
 
   log.debug('sending new-sign-in alert')
   return sendEmail({
     to,
     subject: 'New sign-in to your account',
-    react: NewSignInEmail({ workspaceName, occurredAt, ipAddress, userAgent, logoUrl }),
+    react: NewSignInEmail({
+      workspaceName,
+      occurredAt,
+      ipAddress,
+      userAgent,
+      location,
+      settingsUrl,
+      logoUrl,
+    }),
     emailType: 'NewSignInEmail',
     preview: { occurredAt },
   })

--- a/packages/email/src/templates/new-sign-in.tsx
+++ b/packages/email/src/templates/new-sign-in.tsx
@@ -72,12 +72,12 @@ export function NewSignInEmail({
             {settingsUrl ? (
               <>
                 <Link href={settingsUrl} style={utils.link}>
-                  change your password
+                  set or change your password
                 </Link>{' '}
                 from your profile settings — this signs out other sessions.
               </>
             ) : (
-              'change your password from your profile settings — this signs out other sessions.'
+              'set or change your password from your profile settings — this signs out other sessions.'
             )}
           </>
         )}

--- a/packages/email/src/templates/new-sign-in.tsx
+++ b/packages/email/src/templates/new-sign-in.tsx
@@ -9,6 +9,8 @@ interface NewSignInEmailProps {
   userAgent?: string | null
   location?: string | null
   settingsUrl?: string | null
+  /** When true, skip the password CTA — the profile page hides PasswordForm. */
+  ssoEnforced?: boolean
   logoUrl?: string
 }
 
@@ -26,6 +28,7 @@ export function NewSignInEmail({
   userAgent,
   location,
   settingsUrl,
+  ssoEnforced,
   logoUrl,
 }: NewSignInEmailProps) {
   return (
@@ -61,16 +64,22 @@ export function NewSignInEmail({
       <Hr style={{ margin: '24px 0', borderColor: '#e5e7eb' }} />
 
       <Text style={typography.text}>
-        If that was you, no action needed. If it wasn’t,{' '}
-        {settingsUrl ? (
-          <>
-            <Link href={settingsUrl} style={utils.link}>
-              change your password
-            </Link>{' '}
-            from your profile settings.
-          </>
+        {ssoEnforced ? (
+          'If that was you, no action needed. If it wasn’t, sign in through your organization’s identity provider and review or revoke sessions there.'
         ) : (
-          'change your password from your profile settings.'
+          <>
+            If that was you, no action needed. If it wasn’t,{' '}
+            {settingsUrl ? (
+              <>
+                <Link href={settingsUrl} style={utils.link}>
+                  change your password
+                </Link>{' '}
+                from your profile settings — this signs out other sessions.
+              </>
+            ) : (
+              'change your password from your profile settings — this signs out other sessions.'
+            )}
+          </>
         )}
       </Text>
 

--- a/packages/email/src/templates/new-sign-in.tsx
+++ b/packages/email/src/templates/new-sign-in.tsx
@@ -1,4 +1,4 @@
-import { Heading, Hr, Section, Text } from '@react-email/components'
+import { Heading, Hr, Link, Section, Text } from '@react-email/components'
 import { EmailLayout, TransactionalFooter } from './email-layout'
 import { typography, utils } from './shared-styles'
 
@@ -7,12 +7,15 @@ interface NewSignInEmailProps {
   occurredAt: string
   ipAddress?: string | null
   userAgent?: string | null
+  location?: string | null
+  settingsUrl?: string | null
   logoUrl?: string
 }
 
 /**
- * "New device" sign-in notification — sent only on first-sight of a
- * (UA, /24 IP) combination for the recipient's account. The user is
+ * "New device" sign-in notification — sent when an additional
+ * (browser, OS) is seen for the recipient's account. IP and location
+ * are shown as context; they are not the device identity. The user is
  * already signed in by the time this lands; the alert is purely
  * informational with a recovery path if it wasn't them.
  */
@@ -21,6 +24,8 @@ export function NewSignInEmail({
   occurredAt,
   ipAddress,
   userAgent,
+  location,
+  settingsUrl,
   logoUrl,
 }: NewSignInEmailProps) {
   return (
@@ -41,6 +46,11 @@ export function NewSignInEmail({
             <strong>IP:</strong> {ipAddress}
           </Text>
         ) : null}
+        {location ? (
+          <Text style={typography.text}>
+            <strong>Location:</strong> {location}
+          </Text>
+        ) : null}
         {userAgent ? (
           <Text style={typography.text}>
             <strong>Device:</strong> {userAgent}
@@ -51,8 +61,17 @@ export function NewSignInEmail({
       <Hr style={{ margin: '24px 0', borderColor: '#e5e7eb' }} />
 
       <Text style={typography.text}>
-        If that was you, no action needed. If it wasn’t, change your password and revoke any other
-        active sessions.
+        If that was you, no action needed. If it wasn’t,{' '}
+        {settingsUrl ? (
+          <>
+            <Link href={settingsUrl} style={utils.link}>
+              change your password
+            </Link>{' '}
+            from Security settings.
+          </>
+        ) : (
+          'change your password from Security settings.'
+        )}
       </Text>
 
       <TransactionalFooter>

--- a/packages/email/src/templates/new-sign-in.tsx
+++ b/packages/email/src/templates/new-sign-in.tsx
@@ -67,10 +67,10 @@ export function NewSignInEmail({
             <Link href={settingsUrl} style={utils.link}>
               change your password
             </Link>{' '}
-            from Security settings.
+            from your profile settings.
           </>
         ) : (
-          'change your password from Security settings.'
+          'change your password from your profile settings.'
         )}
       </Text>
 

--- a/packages/email/src/templates/new-sign-in.tsx
+++ b/packages/email/src/templates/new-sign-in.tsx
@@ -65,7 +65,7 @@ export function NewSignInEmail({
 
       <Text style={typography.text}>
         {ssoEnforced ? (
-          'If that was you, no action needed. If it wasn’t, sign in through your organization’s identity provider and review or revoke sessions there.'
+          'If that was you, no action needed. If it wasn’t, change your password at your identity provider and ask a workspace admin to sign out other sessions.'
         ) : (
           <>
             If that was you, no action needed. If it wasn’t,{' '}


### PR DESCRIPTION
## Summary

New-sign-in mail was keyed on user-agent plus a `/24` of the client IP. The same browser on a rotating address (mobile, CGNAT, VPN, travel) looked like a new device.

This change:

- Fingerprints **browser + OS + platform** (versions stripped, via Bowser). IP is not part of the identity.
- Still **shows IP** in the mail, plus country when a CDN header is present, as context.
- **Seeds the first recorded device silently.** Mail fires only on an additional unseen browser/OS. That also avoids a one-time re-alert when the hash format changes.
- Uses a human-readable device line (`Chrome on Windows`) and links “change your password” at Security settings.
- Leaves session-refresh exclusion, required-alert policy, and fail-closed store behaviour as they are.

## Test plan

- [x] Unit: same browser family across IPs/versions → one fingerprint; Chrome vs Firefox / desktop vs mobile differ
- [x] Unit: first live member does not notify; an additional member does
- [x] Unit: `/get-session` and anonymous widget mints still skip the alert
- [x] Unit: mail still includes IP; device line is formatted; settings URL is passed
- [ ] CI: workspace-separation db test for first-vs-additional liveCount