### PR TITLE
feat(tags): restyle the create/edit tag dialog

### DIFF
--- a/apps/web/e2e/tests/admin/settings-tags.spec.ts
+++ b/apps/web/e2e/tests/admin/settings-tags.spec.ts
@@ -28,20 +28,14 @@ test.describe('Admin Tags Settings', () => {
     }
   })
 
-  test('tags show color indicator and name', async ({ page }) => {
+  test('tags show as colored chips with a visibility label', async ({ page }) => {
     await page.waitForTimeout(500)
 
-    // Color indicator is a button with inline background-color style
-    const colorDots = page.locator('button[style*="background-color"]').filter({
-      hasNot: page.locator('[data-radix-popover-trigger]'),
-    })
+    const chips = page.locator('button[style*="background-color"]')
 
-    if ((await colorDots.count()) > 0) {
-      await expect(colorDots.first()).toBeVisible()
-
-      // Each tag row should also have a name span (text in a <span> next to the dot)
-      const tagNameSpans = page.locator('span.text-sm.font-medium')
-      await expect(tagNameSpans.first()).toBeVisible()
+    if ((await chips.count()) > 0) {
+      await expect(chips.first()).toBeVisible()
+      await expect(page.getByText(/portal|internal/i).first()).toBeVisible()
     }
   })
 

--- a/apps/web/e2e/tests/admin/settings-tags.spec.ts
+++ b/apps/web/e2e/tests/admin/settings-tags.spec.ts
@@ -73,10 +73,14 @@ test.describe('Admin Tags Settings', () => {
     // Color section label
     await expect(dialog.getByText('Color')).toBeVisible()
 
-    // Portal visibility switch, on by default for new tags
-    const portalSwitch = dialog.getByRole('switch', { name: /show on portal/i })
-    await expect(portalSwitch).toBeVisible()
-    await expect(portalSwitch).toHaveAttribute('aria-checked', 'true')
+    // Portal visibility, on by default for new tags
+    const portalRadio = dialog.getByRole('radio', { name: /^portal$/i })
+    await expect(portalRadio).toBeVisible()
+    await expect(portalRadio).toHaveAttribute('aria-checked', 'true')
+    await expect(dialog.getByRole('radio', { name: /^internal$/i })).toHaveAttribute(
+      'aria-checked',
+      'false'
+    )
 
     // Create and Cancel buttons
     await expect(dialog.getByRole('button', { name: /cancel/i })).toBeVisible()

--- a/apps/web/e2e/tests/admin/settings-tags.spec.ts
+++ b/apps/web/e2e/tests/admin/settings-tags.spec.ts
@@ -70,8 +70,7 @@ test.describe('Admin Tags Settings', () => {
     // Description textarea
     await expect(dialog.getByRole('textbox', { name: /description/i })).toBeVisible()
 
-    // Color section label
-    await expect(dialog.getByText('Color')).toBeVisible()
+    await expect(dialog.getByRole('button', { name: /^color$/i })).toBeVisible()
 
     // Portal visibility, on by default for new tags
     const portalRadio = dialog.getByRole('radio', { name: /^portal$/i })

--- a/apps/web/src/components/admin/settings/tags/__tests__/tag-list.test.tsx
+++ b/apps/web/src/components/admin/settings/tags/__tests__/tag-list.test.tsx
@@ -1,11 +1,10 @@
 // @vitest-environment happy-dom
 /**
- * Tag settings — "Show on portal" visibility control.
+ * Tag settings — create/edit dialog and portal visibility.
  *
- * Covers the admin-facing half of tag portal visibility: the create/edit
- * dialog exposes a switch that defaults to public for new tags, mirrors the
- * saved flag when editing, and sends `isPublic` on save; internal tags are
- * marked in the list so the state is visible without opening the dialog.
+ * The dialog defaults new tags to Portal, mirrors the saved flag when
+ * editing, and sends `isPublic` on save. Internal tags are marked in the
+ * list so the state is visible without opening the dialog.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
@@ -56,8 +55,12 @@ beforeEach(() => {
   mockUpdate.mockImplementation(async ({ data }) => ({ ...PUBLIC_TAG, ...data }))
 })
 
-function portalSwitch() {
-  return screen.getByRole('switch', { name: /show on portal/i })
+function portalRadio() {
+  return screen.getByRole('radio', { name: /^portal$/i })
+}
+
+function internalRadio() {
+  return screen.getByRole('radio', { name: /^internal$/i })
 }
 
 describe('<TagList> — portal visibility', () => {
@@ -75,7 +78,8 @@ describe('<TagList> — portal visibility', () => {
     render(<TagList initialTags={[]} />)
 
     fireEvent.click(screen.getByRole('button', { name: /add new tag/i }))
-    expect(portalSwitch()).toHaveAttribute('aria-checked', 'true')
+    expect(portalRadio()).toHaveAttribute('aria-checked', 'true')
+    expect(internalRadio()).toHaveAttribute('aria-checked', 'false')
 
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Design' } })
     fireEvent.click(screen.getByRole('button', { name: /create tag/i }))
@@ -87,13 +91,14 @@ describe('<TagList> — portal visibility', () => {
     )
   })
 
-  it('lets an admin create an internal tag by turning the switch off', async () => {
+  it('lets an admin create an internal tag by choosing Internal', async () => {
     render(<TagList initialTags={[]} />)
 
     fireEvent.click(screen.getByRole('button', { name: /add new tag/i }))
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Churn risk' } })
-    fireEvent.click(portalSwitch())
-    expect(portalSwitch()).toHaveAttribute('aria-checked', 'false')
+    fireEvent.click(internalRadio())
+    expect(internalRadio()).toHaveAttribute('aria-checked', 'true')
+    expect(portalRadio()).toHaveAttribute('aria-checked', 'false')
 
     fireEvent.click(screen.getByRole('button', { name: /create tag/i }))
 
@@ -108,15 +113,55 @@ describe('<TagList> — portal visibility', () => {
     render(<TagList initialTags={[INTERNAL_TAG]} />)
 
     fireEvent.click(screen.getByRole('button', { name: /edit tag/i }))
-    expect(portalSwitch()).toHaveAttribute('aria-checked', 'false')
+    expect(internalRadio()).toHaveAttribute('aria-checked', 'true')
 
-    fireEvent.click(portalSwitch())
+    fireEvent.click(portalRadio())
     fireEvent.click(screen.getByRole('button', { name: /save changes/i }))
 
     await waitFor(() =>
       expect(mockUpdate).toHaveBeenCalledWith({
         data: expect.objectContaining({ id: 'post_tag_internal', isPublic: true }),
       })
+    )
+  })
+})
+
+describe('<TagList> — create dialog layout', () => {
+  it('keeps Create tag disabled until a name is entered', () => {
+    render(<TagList initialTags={[]} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /add new tag/i }))
+    expect(screen.getByRole('button', { name: /create tag/i })).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Design' } })
+    expect(screen.getByRole('button', { name: /create tag/i })).toBeEnabled()
+  })
+
+  it('previews the typed name next to the field, not a PostTag placeholder', () => {
+    render(<TagList initialTags={[]} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /add new tag/i }))
+    expect(screen.getByText('Tag name')).toBeTruthy()
+    expect(screen.queryByText('PostTag name')).toBeNull()
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Design' } })
+    expect(screen.getByText('Design')).toBeTruthy()
+    expect(screen.queryByText('Tag name')).toBeNull()
+  })
+
+  it('hides the extra color palette until More colors is opened', () => {
+    render(<TagList initialTags={[]} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /add new tag/i }))
+    expect(screen.getByRole('button', { name: /more colors/i })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /more colors/i }))
+    expect(screen.getByRole('button', { name: /show less/i })).toHaveAttribute(
+      'aria-expanded',
+      'true'
     )
   })
 })

--- a/apps/web/src/components/admin/settings/tags/__tests__/tag-list.test.tsx
+++ b/apps/web/src/components/admin/settings/tags/__tests__/tag-list.test.tsx
@@ -64,14 +64,16 @@ function internalRadio() {
 }
 
 describe('<TagList> — portal visibility', () => {
-  it('marks internal tags in the list and leaves public tags unmarked', () => {
+  it('renders each tag as a colored chip and labels Portal vs Internal', () => {
     render(<TagList initialTags={[PUBLIC_TAG, INTERNAL_TAG]} />)
+
+    const publicRow = screen.getByText('Bug').closest('div')!
+    expect(within(publicRow).getByText('Portal')).toBeTruthy()
+    expect(within(publicRow).queryByText('Internal')).toBeNull()
 
     const internalRow = screen.getByText('Churn risk').closest('div')!
     expect(within(internalRow).getByText('Internal')).toBeTruthy()
-
-    const publicRow = screen.getByText('Bug').closest('div')!
-    expect(within(publicRow).queryByText('Internal')).toBeNull()
+    expect(within(internalRow).queryByText('Portal')).toBeNull()
   })
 
   it('defaults a new tag to public and sends isPublic on create', async () => {

--- a/apps/web/src/components/admin/settings/tags/__tests__/tag-list.test.tsx
+++ b/apps/web/src/components/admin/settings/tags/__tests__/tag-list.test.tsx
@@ -67,11 +67,13 @@ describe('<TagList> — portal visibility', () => {
   it('renders each tag as a colored chip and labels Portal vs Internal', () => {
     render(<TagList initialTags={[PUBLIC_TAG, INTERNAL_TAG]} />)
 
-    const publicRow = screen.getByRole('button', { name: 'Bug' }).closest('.group')!
+    const publicRow = screen.getByRole('button', { name: 'Bug' }).closest('.group') as HTMLElement
     expect(within(publicRow).getByText('Portal')).toBeTruthy()
     expect(within(publicRow).queryByText('Internal')).toBeNull()
 
-    const internalRow = screen.getByRole('button', { name: 'Churn risk' }).closest('.group')!
+    const internalRow = screen
+      .getByRole('button', { name: 'Churn risk' })
+      .closest('.group') as HTMLElement
     expect(within(internalRow).getByText('Internal')).toBeTruthy()
     expect(within(internalRow).queryByText('Portal')).toBeNull()
   })

--- a/apps/web/src/components/admin/settings/tags/__tests__/tag-list.test.tsx
+++ b/apps/web/src/components/admin/settings/tags/__tests__/tag-list.test.tsx
@@ -137,31 +137,18 @@ describe('<TagList> — create dialog layout', () => {
     expect(screen.getByRole('button', { name: /create tag/i })).toBeEnabled()
   })
 
-  it('previews the typed name next to the field, not a PostTag placeholder', () => {
+  it('does not leak the PostTag type name as a placeholder', () => {
     render(<TagList initialTags={[]} />)
 
     fireEvent.click(screen.getByRole('button', { name: /add new tag/i }))
-    expect(screen.getByText('Tag name')).toBeTruthy()
     expect(screen.queryByText('PostTag name')).toBeNull()
-
-    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Design' } })
-    expect(screen.getByText('Design')).toBeTruthy()
-    expect(screen.queryByText('Tag name')).toBeNull()
   })
 
-  it('hides the extra color palette until More colors is opened', () => {
+  it('opens the color palette from a single swatch', () => {
     render(<TagList initialTags={[]} />)
 
     fireEvent.click(screen.getByRole('button', { name: /add new tag/i }))
-    expect(screen.getByRole('button', { name: /more colors/i })).toHaveAttribute(
-      'aria-expanded',
-      'false'
-    )
-
-    fireEvent.click(screen.getByRole('button', { name: /more colors/i }))
-    expect(screen.getByRole('button', { name: /show less/i })).toHaveAttribute(
-      'aria-expanded',
-      'true'
-    )
+    fireEvent.click(screen.getByRole('button', { name: /^color$/i }))
+    expect(screen.getByPlaceholderText('#000000')).toBeTruthy()
   })
 })

--- a/apps/web/src/components/admin/settings/tags/__tests__/tag-list.test.tsx
+++ b/apps/web/src/components/admin/settings/tags/__tests__/tag-list.test.tsx
@@ -67,11 +67,11 @@ describe('<TagList> — portal visibility', () => {
   it('renders each tag as a colored chip and labels Portal vs Internal', () => {
     render(<TagList initialTags={[PUBLIC_TAG, INTERNAL_TAG]} />)
 
-    const publicRow = screen.getByText('Bug').closest('div')!
+    const publicRow = screen.getByRole('button', { name: 'Bug' }).closest('.group')!
     expect(within(publicRow).getByText('Portal')).toBeTruthy()
     expect(within(publicRow).queryByText('Internal')).toBeNull()
 
-    const internalRow = screen.getByText('Churn risk').closest('div')!
+    const internalRow = screen.getByRole('button', { name: 'Churn risk' }).closest('.group')!
     expect(within(internalRow).getByText('Internal')).toBeTruthy()
     expect(within(internalRow).queryByText('Portal')).toBeNull()
   })

--- a/apps/web/src/components/admin/settings/tags/tag-list.tsx
+++ b/apps/web/src/components/admin/settings/tags/tag-list.tsx
@@ -23,19 +23,31 @@ import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { ConfirmDialog } from '@/components/shared/confirm-dialog'
-import {
-  ColorPickerGrid,
-  ColorHexInput,
-  PRESET_COLORS,
-  randomColor,
-} from '@/components/shared/color-picker'
+import { ColorPickerGrid, ColorHexInput, randomColor } from '@/components/shared/color-picker'
 import { SettingsCard } from '@/components/admin/settings/settings-card'
 import { cn } from '@/lib/shared/utils'
 import type { PostTag } from '@/lib/shared/db-types'
 import { createPostTagFn, updatePostTagFn, deletePostTagFn } from '@/lib/server/functions/post-tags'
 
-const COMPACT_COLORS = PRESET_COLORS.slice(0, 8)
-const MORE_COLORS = PRESET_COLORS.slice(8)
+function ColorPickerPopover({
+  color,
+  onColorChange,
+  trigger,
+}: {
+  color: string
+  onColorChange: (color: string) => void
+  trigger: ReactNode
+}) {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+      <PopoverContent className="w-auto p-2 space-y-2" align="start">
+        <ColorPickerGrid selectedColor={color} onColorChange={onColorChange} />
+        <ColorHexInput color={color} onColorChange={onColorChange} />
+      </PopoverContent>
+    </Popover>
+  )
+}
 
 // ============================================================================
 // PostTag Dialog (Create + Edit)
@@ -53,12 +65,10 @@ function TagDialog({ open, onOpenChange, tag, onSaved }: TagDialogProps) {
   const [description, setDescription] = useState('')
   const [color, setColor] = useState('#6b7280')
   const [isPublic, setIsPublic] = useState(true)
-  const [showMoreColors, setShowMoreColors] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [isSaving, setIsSaving] = useState(false)
 
   const isEdit = tag !== null
-  const previewName = name.trim() || 'Tag name'
 
   useEffect(() => {
     if (open) {
@@ -73,7 +83,6 @@ function TagDialog({ open, onOpenChange, tag, onSaved }: TagDialogProps) {
         setColor(randomColor())
         setIsPublic(true)
       }
-      setShowMoreColors(false)
       setError(null)
     }
   }, [open, tag])
@@ -130,7 +139,7 @@ function TagDialog({ open, onOpenChange, tag, onSaved }: TagDialogProps) {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-lg">
+      <DialogContent className="sm:max-w-md">
         <form
           onSubmit={(e) => {
             e.preventDefault()
@@ -144,10 +153,23 @@ function TagDialog({ open, onOpenChange, tag, onSaved }: TagDialogProps) {
             </DialogDescription>
           </DialogHeader>
 
-          <div className="space-y-5 py-4">
+          <div className="space-y-4 py-4">
             <div className="space-y-2">
               <Label htmlFor="tag-name">Name</Label>
-              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+              <div className="flex items-center gap-2">
+                <ColorPickerPopover
+                  color={color}
+                  onColorChange={setColor}
+                  trigger={
+                    <button
+                      type="button"
+                      className="h-9 w-9 rounded-full border border-border shrink-0 hover:ring-2 hover:ring-offset-1 hover:ring-muted-foreground/50 focus-visible:ring-2 focus-visible:ring-ring"
+                      style={{ backgroundColor: color }}
+                      aria-label="Color"
+                      title="Change color"
+                    />
+                  }
+                />
                 <Input
                   id="tag-name"
                   value={name}
@@ -157,38 +179,7 @@ function TagDialog({ open, onOpenChange, tag, onSaved }: TagDialogProps) {
                   autoFocus
                   className="flex-1 min-w-0"
                 />
-                <span
-                  className="inline-flex self-start items-center px-2.5 py-0.5 rounded-md text-sm font-medium shrink-0 max-w-[8.5rem] truncate"
-                  style={{ backgroundColor: color + '20', color }}
-                >
-                  {previewName}
-                </span>
               </div>
-            </div>
-
-            <div className="space-y-2">
-              <Label>Color</Label>
-              <ColorPickerGrid
-                selectedColor={color}
-                onColorChange={setColor}
-                colors={COMPACT_COLORS}
-              />
-              <ColorHexInput color={color} onColorChange={setColor} />
-              <button
-                type="button"
-                className="text-xs text-muted-foreground hover:text-foreground"
-                aria-expanded={showMoreColors}
-                onClick={() => setShowMoreColors((visible) => !visible)}
-              >
-                {showMoreColors ? 'Show less' : 'More colors'}
-              </button>
-              {showMoreColors && (
-                <ColorPickerGrid
-                  selectedColor={color}
-                  onColorChange={setColor}
-                  colors={MORE_COLORS}
-                />
-              )}
             </div>
 
             <div className="space-y-2">
@@ -372,25 +363,16 @@ export function TagList({ initialTags }: TagListProps) {
               key={tag.id}
               className="flex items-center gap-2 py-1.5 px-2 rounded-md hover:bg-muted/50 group"
             >
-              {/* Color dot with popover */}
-              <Popover>
-                <PopoverTrigger asChild>
+              <ColorPickerPopover
+                color={tag.color}
+                onColorChange={(c) => handleColorChange(tag, c)}
+                trigger={
                   <button
                     className="h-3 w-3 rounded-full shrink-0 cursor-pointer hover:ring-2 hover:ring-offset-1 hover:ring-muted-foreground/50"
                     style={{ backgroundColor: tag.color }}
                   />
-                </PopoverTrigger>
-                <PopoverContent className="w-auto p-2 space-y-2" align="start">
-                  <ColorPickerGrid
-                    selectedColor={tag.color}
-                    onColorChange={(c) => handleColorChange(tag, c)}
-                  />
-                  <ColorHexInput
-                    color={tag.color}
-                    onColorChange={(c) => handleColorChange(tag, c)}
-                  />
-                </PopoverContent>
-              </Popover>
+                }
+              />
 
               {/* Name */}
               <span className="text-sm font-medium">{tag.name}</span>

--- a/apps/web/src/components/admin/settings/tags/tag-list.tsx
+++ b/apps/web/src/components/admin/settings/tags/tag-list.tsx
@@ -361,9 +361,9 @@ export function TagList({ initialTags }: TagListProps) {
           {tags.map((tag) => (
             <div
               key={tag.id}
-              className="flex items-center gap-3 py-1.5 px-2 rounded-md hover:bg-muted/50 group"
+              className="flex items-center gap-2 sm:gap-3 py-1.5 px-2 rounded-md hover:bg-muted/50 group min-w-0"
             >
-              <div className="w-40 shrink-0">
+              <div className="min-w-0 max-w-[8rem] sm:w-40 sm:max-w-none sm:shrink-0">
                 <ColorPickerPopover
                   color={tag.color}
                   onColorChange={(c) => handleColorChange(tag, c)}
@@ -394,7 +394,7 @@ export function TagList({ initialTags }: TagListProps) {
                 {tag.isPublic ? 'Portal' : 'Internal'}
               </span>
 
-              <span className="text-xs text-muted-foreground truncate flex-1">
+              <span className="hidden sm:block text-xs text-muted-foreground truncate flex-1 min-w-0">
                 {tag.description ?? ''}
               </span>
 
@@ -407,7 +407,7 @@ export function TagList({ initialTags }: TagListProps) {
               <Button
                 variant="ghost"
                 size="icon"
-                className="h-7 w-7 text-muted-foreground opacity-0 group-hover:opacity-100"
+                className="h-7 w-7 shrink-0 text-muted-foreground opacity-100 sm:opacity-0 sm:group-hover:opacity-100"
                 onClick={() => openEdit(tag)}
                 title="Edit tag"
               >
@@ -418,7 +418,7 @@ export function TagList({ initialTags }: TagListProps) {
               <Button
                 variant="ghost"
                 size="icon"
-                className="h-7 w-7 text-muted-foreground hover:text-destructive opacity-0 group-hover:opacity-100"
+                className="h-7 w-7 shrink-0 text-muted-foreground hover:text-destructive opacity-100 sm:opacity-0 sm:group-hover:opacity-100"
                 onClick={() => setDeletingTag(tag)}
                 title="Delete tag"
               >

--- a/apps/web/src/components/admin/settings/tags/tag-list.tsx
+++ b/apps/web/src/components/admin/settings/tags/tag-list.tsx
@@ -21,6 +21,8 @@ import {
 } from '@/components/ui/dialog'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
+import { RadioGroup } from '@/components/ui/radio-group'
+import * as RadioGroupPrimitive from '@radix-ui/react-radio-group'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { ConfirmDialog } from '@/components/shared/confirm-dialog'
 import { ColorPickerGrid, ColorHexInput, randomColor } from '@/components/shared/color-picker'
@@ -139,7 +141,7 @@ function TagDialog({ open, onOpenChange, tag, onSaved }: TagDialogProps) {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="sm:max-w-md" aria-describedby="tag-dialog-desc">
         <form
           onSubmit={(e) => {
             e.preventDefault()
@@ -148,7 +150,7 @@ function TagDialog({ open, onOpenChange, tag, onSaved }: TagDialogProps) {
         >
           <DialogHeader>
             <DialogTitle>{isEdit ? 'Edit tag' : 'New tag'}</DialogTitle>
-            <DialogDescription>
+            <DialogDescription id="tag-dialog-desc">
               Label posts for filtering. Visible on the portal unless marked internal.
             </DialogDescription>
           </DialogHeader>
@@ -184,26 +186,25 @@ function TagDialog({ open, onOpenChange, tag, onSaved }: TagDialogProps) {
 
             <div className="space-y-2">
               <Label id="tag-visibility-label">Visibility</Label>
-              <div
-                role="radiogroup"
+              <RadioGroup
+                value={isPublic ? 'portal' : 'internal'}
+                onValueChange={(value) => setIsPublic(value === 'portal')}
                 aria-labelledby="tag-visibility-label"
                 className="grid grid-cols-1 gap-2 sm:grid-cols-2"
               >
                 <VisibilityCard
-                  active={isPublic}
+                  value="portal"
                   label="Portal"
                   description="Shown on the public portal"
                   icon={<GlobeAltIcon className="h-3.5 w-3.5" />}
-                  onClick={() => setIsPublic(true)}
                 />
                 <VisibilityCard
-                  active={!isPublic}
+                  value="internal"
                   label="Internal"
                   description="Hidden from the portal"
                   icon={<EyeSlashIcon className="h-3.5 w-3.5" />}
-                  onClick={() => setIsPublic(false)}
                 />
-              </div>
+              </RadioGroup>
             </div>
 
             <div className="space-y-2">
@@ -243,38 +244,37 @@ function TagDialog({ open, onOpenChange, tag, onSaved }: TagDialogProps) {
 }
 
 function VisibilityCard({
-  active,
+  value,
   label,
   description,
   icon,
-  onClick,
 }: {
-  active: boolean
+  value: string
   label: string
   description: string
   icon: ReactNode
-  onClick: () => void
 }) {
   return (
-    <button
-      type="button"
-      role="radio"
-      aria-checked={active}
+    <RadioGroupPrimitive.Item
+      value={value}
       aria-label={label}
-      onClick={onClick}
       className={cn(
-        'flex flex-col items-stretch gap-1 rounded-lg border px-3 py-2.5 text-left transition-colors',
-        active
-          ? 'border-primary bg-primary/10'
-          : 'border-border bg-muted/30 hover:bg-muted/60 cursor-pointer'
+        'group flex flex-col items-stretch gap-1 rounded-lg border px-3 py-2.5 text-left transition-colors outline-none',
+        'border-border bg-muted/30 hover:bg-muted/60 cursor-pointer',
+        'focus-visible:ring-2 focus-visible:ring-ring/50',
+        'data-[state=checked]:border-primary data-[state=checked]:bg-primary/10'
       )}
     >
       <div className="flex items-center gap-2">
-        <span className={active ? 'text-primary' : 'text-muted-foreground'}>{icon}</span>
-        <span className={cn('text-sm font-semibold', active && 'text-primary')}>{label}</span>
+        <span className="text-muted-foreground group-data-[state=checked]:text-primary">
+          {icon}
+        </span>
+        <span className="text-sm font-semibold group-data-[state=checked]:text-primary">
+          {label}
+        </span>
       </div>
       <span className="text-xs text-muted-foreground leading-snug">{description}</span>
-    </button>
+    </RadioGroupPrimitive.Item>
   )
 }
 

--- a/apps/web/src/components/admin/settings/tags/tag-list.tsx
+++ b/apps/web/src/components/admin/settings/tags/tag-list.tsx
@@ -361,33 +361,39 @@ export function TagList({ initialTags }: TagListProps) {
           {tags.map((tag) => (
             <div
               key={tag.id}
-              className="flex items-center gap-2 py-1.5 px-2 rounded-md hover:bg-muted/50 group"
+              className="flex items-center gap-3 py-1.5 px-2 rounded-md hover:bg-muted/50 group"
             >
-              <ColorPickerPopover
-                color={tag.color}
-                onColorChange={(c) => handleColorChange(tag, c)}
-                trigger={
-                  <button
-                    className="h-3 w-3 rounded-full shrink-0 cursor-pointer hover:ring-2 hover:ring-offset-1 hover:ring-muted-foreground/50"
-                    style={{ backgroundColor: tag.color }}
-                  />
+              <div className="w-40 shrink-0">
+                <ColorPickerPopover
+                  color={tag.color}
+                  onColorChange={(c) => handleColorChange(tag, c)}
+                  trigger={
+                    <button
+                      type="button"
+                      className="inline-flex items-center px-2 py-0.5 rounded-md text-sm font-medium max-w-full truncate hover:ring-2 hover:ring-offset-1 hover:ring-muted-foreground/40"
+                      style={{ backgroundColor: tag.color + '20', color: tag.color }}
+                      title="Change color"
+                    >
+                      {tag.name}
+                    </button>
+                  }
+                />
+              </div>
+
+              <span
+                className="inline-flex items-center gap-1 text-xs text-muted-foreground shrink-0 w-[4.75rem]"
+                title={
+                  tag.isPublic ? 'Shown on the public portal' : 'Hidden from the public portal'
                 }
-              />
-
-              {/* Name */}
-              <span className="text-sm font-medium">{tag.name}</span>
-
-              {!tag.isPublic && (
-                <span
-                  className="inline-flex items-center gap-1 rounded-md bg-muted px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground shrink-0"
-                  title="Hidden from the public portal"
-                >
+              >
+                {tag.isPublic ? (
+                  <GlobeAltIcon className="h-3 w-3" />
+                ) : (
                   <EyeSlashIcon className="h-3 w-3" />
-                  Internal
-                </span>
-              )}
+                )}
+                {tag.isPublic ? 'Portal' : 'Internal'}
+              </span>
 
-              {/* Description */}
               <span className="text-xs text-muted-foreground truncate flex-1">
                 {tag.description ?? ''}
               </span>

--- a/apps/web/src/components/admin/settings/tags/tag-list.tsx
+++ b/apps/web/src/components/admin/settings/tags/tag-list.tsx
@@ -147,7 +147,7 @@ function TagDialog({ open, onOpenChange, tag, onSaved }: TagDialogProps) {
           <div className="space-y-5 py-4">
             <div className="space-y-2">
               <Label htmlFor="tag-name">Name</Label>
-              <div className="flex items-center gap-3">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
                 <Input
                   id="tag-name"
                   value={name}
@@ -158,7 +158,7 @@ function TagDialog({ open, onOpenChange, tag, onSaved }: TagDialogProps) {
                   className="flex-1 min-w-0"
                 />
                 <span
-                  className="inline-flex items-center px-2.5 py-0.5 rounded-md text-sm font-medium shrink-0 max-w-[8.5rem] truncate"
+                  className="inline-flex self-start items-center px-2.5 py-0.5 rounded-md text-sm font-medium shrink-0 max-w-[8.5rem] truncate"
                   style={{ backgroundColor: color + '20', color }}
                 >
                   {previewName}

--- a/apps/web/src/components/admin/settings/tags/tag-list.tsx
+++ b/apps/web/src/components/admin/settings/tags/tag-list.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useTransition } from 'react'
+import { useState, useEffect, useTransition, type ReactNode } from 'react'
 import { useRouter } from '@tanstack/react-router'
 import { toast } from 'sonner'
 import {
@@ -7,13 +7,14 @@ import {
   PencilSquareIcon,
   ArrowPathIcon,
   EyeSlashIcon,
+  GlobeAltIcon,
 } from '@heroicons/react/24/solid'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { Switch } from '@/components/ui/switch'
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -22,139 +23,19 @@ import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { ConfirmDialog } from '@/components/shared/confirm-dialog'
+import {
+  ColorPickerGrid,
+  ColorHexInput,
+  PRESET_COLORS,
+  randomColor,
+} from '@/components/shared/color-picker'
 import { SettingsCard } from '@/components/admin/settings/settings-card'
 import { cn } from '@/lib/shared/utils'
 import type { PostTag } from '@/lib/shared/db-types'
 import { createPostTagFn, updatePostTagFn, deletePostTagFn } from '@/lib/server/functions/post-tags'
 
-// ============================================================================
-// Constants
-// ============================================================================
-
-const PRESET_COLORS = [
-  '#ef4444',
-  '#f97316',
-  '#eab308',
-  '#22c55e',
-  '#14b8a6',
-  '#3b82f6',
-  '#8b5cf6',
-  '#ec4899',
-  '#f87171',
-  '#fb923c',
-  '#facc15',
-  '#4ade80',
-  '#2dd4bf',
-  '#60a5fa',
-  '#a78bfa',
-  '#f472b6',
-  '#b91c1c',
-  '#c2410c',
-  '#a16207',
-  '#15803d',
-  '#0f766e',
-  '#1d4ed8',
-  '#6d28d9',
-  '#be185d',
-  '#0f172a',
-  '#334155',
-  '#64748b',
-  '#94a3b8',
-  '#475569',
-  '#1e293b',
-  '#78716c',
-  '#a8a29e',
-]
-
-function randomColor(): string {
-  return (
-    '#' +
-    Math.floor(Math.random() * 0xffffff)
-      .toString(16)
-      .padStart(6, '0')
-  )
-}
-
-// ============================================================================
-// Color Picker Components
-// ============================================================================
-
-function ColorPickerGrid({
-  selectedColor,
-  onColorChange,
-}: {
-  selectedColor: string
-  onColorChange: (color: string) => void
-}) {
-  return (
-    <div className="grid grid-cols-8 gap-1.5">
-      {PRESET_COLORS.map((c) => (
-        <button
-          key={c}
-          type="button"
-          className={cn(
-            'h-6 w-6 rounded-full border-2 transition-colors',
-            selectedColor.toLowerCase() === c.toLowerCase()
-              ? 'border-foreground'
-              : 'border-transparent'
-          )}
-          style={{ backgroundColor: c }}
-          onClick={() => onColorChange(c)}
-        />
-      ))}
-    </div>
-  )
-}
-
-function ColorHexInput({
-  color,
-  onColorChange,
-}: {
-  color: string
-  onColorChange: (color: string) => void
-}) {
-  const [hexInput, setHexInput] = useState(color)
-
-  useEffect(() => {
-    setHexInput(color)
-  }, [color])
-
-  function handleHexChange(value: string) {
-    setHexInput(value)
-    if (/^#[0-9A-Fa-f]{6}$/.test(value)) {
-      onColorChange(value)
-    }
-  }
-
-  return (
-    <div className="flex items-center gap-2">
-      <span
-        className="h-6 w-6 rounded-md border border-border shrink-0"
-        style={{ backgroundColor: color }}
-      />
-      <Input
-        value={hexInput}
-        onChange={(e) => handleHexChange(e.target.value)}
-        className="font-mono text-xs h-7"
-        placeholder="#000000"
-      />
-      <Button
-        type="button"
-        variant="outline"
-        size="icon"
-        className="h-7 w-7 shrink-0"
-        onClick={() => {
-          const c = randomColor()
-          setHexInput(c)
-          onColorChange(c)
-        }}
-        title="Random color"
-      >
-        <ArrowPathIcon className="h-3.5 w-3.5" />
-      </Button>
-    </div>
-  )
-}
+const COMPACT_COLORS = PRESET_COLORS.slice(0, 8)
+const MORE_COLORS = PRESET_COLORS.slice(8)
 
 // ============================================================================
 // PostTag Dialog (Create + Edit)
@@ -172,10 +53,12 @@ function TagDialog({ open, onOpenChange, tag, onSaved }: TagDialogProps) {
   const [description, setDescription] = useState('')
   const [color, setColor] = useState('#6b7280')
   const [isPublic, setIsPublic] = useState(true)
+  const [showMoreColors, setShowMoreColors] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [isSaving, setIsSaving] = useState(false)
 
   const isEdit = tag !== null
+  const previewName = name.trim() || 'Tag name'
 
   useEffect(() => {
     if (open) {
@@ -190,6 +73,7 @@ function TagDialog({ open, onOpenChange, tag, onSaved }: TagDialogProps) {
         setColor(randomColor())
         setIsPublic(true)
       }
+      setShowMoreColors(false)
       setError(null)
     }
   }, [open, tag])
@@ -246,75 +130,160 @@ function TagDialog({ open, onOpenChange, tag, onSaved }: TagDialogProps) {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>{isEdit ? 'Edit tag' : 'New tag'}</DialogTitle>
-        </DialogHeader>
+      <DialogContent className="sm:max-w-lg">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            void handleSave()
+          }}
+        >
+          <DialogHeader>
+            <DialogTitle>{isEdit ? 'Edit tag' : 'New tag'}</DialogTitle>
+            <DialogDescription>
+              Label posts for filtering. Visible on the portal unless marked internal.
+            </DialogDescription>
+          </DialogHeader>
 
-        {/* Live preview */}
-        <div className="flex justify-center py-3 bg-muted/30 rounded-lg">
-          <span
-            className="inline-flex items-center px-3 py-0.5 rounded-md text-sm font-medium"
-            style={{ backgroundColor: color + '20', color }}
-          >
-            {name.trim() || 'PostTag name'}
-          </span>
-        </div>
+          <div className="space-y-5 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="tag-name">Name</Label>
+              <div className="flex items-center gap-3">
+                <Input
+                  id="tag-name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="e.g. bug, enhancement, design"
+                  maxLength={50}
+                  autoFocus
+                  className="flex-1 min-w-0"
+                />
+                <span
+                  className="inline-flex items-center px-2.5 py-0.5 rounded-md text-sm font-medium shrink-0 max-w-[8.5rem] truncate"
+                  style={{ backgroundColor: color + '20', color }}
+                >
+                  {previewName}
+                </span>
+              </div>
+            </div>
 
-        <div className="space-y-2">
-          <Label htmlFor="tag-name">Name</Label>
-          <Input
-            id="tag-name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="e.g. bug, enhancement, design"
-            maxLength={50}
-          />
-        </div>
+            <div className="space-y-2">
+              <Label>Color</Label>
+              <ColorPickerGrid
+                selectedColor={color}
+                onColorChange={setColor}
+                colors={COMPACT_COLORS}
+              />
+              <ColorHexInput color={color} onColorChange={setColor} />
+              <button
+                type="button"
+                className="text-xs text-muted-foreground hover:text-foreground"
+                aria-expanded={showMoreColors}
+                onClick={() => setShowMoreColors((visible) => !visible)}
+              >
+                {showMoreColors ? 'Show less' : 'More colors'}
+              </button>
+              {showMoreColors && (
+                <ColorPickerGrid
+                  selectedColor={color}
+                  onColorChange={setColor}
+                  colors={MORE_COLORS}
+                />
+              )}
+            </div>
 
-        <div className="space-y-2">
-          <Label htmlFor="tag-desc">
-            Description <span className="text-muted-foreground font-normal">(optional)</span>
-          </Label>
-          <Textarea
-            id="tag-desc"
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            placeholder="Brief description of when to use this tag"
-            rows={2}
-            maxLength={200}
-          />
-        </div>
+            <div className="space-y-2">
+              <Label id="tag-visibility-label">Visibility</Label>
+              <div
+                role="radiogroup"
+                aria-labelledby="tag-visibility-label"
+                className="grid grid-cols-1 gap-2 sm:grid-cols-2"
+              >
+                <VisibilityCard
+                  active={isPublic}
+                  label="Portal"
+                  description="Shown on the public portal"
+                  icon={<GlobeAltIcon className="h-3.5 w-3.5" />}
+                  onClick={() => setIsPublic(true)}
+                />
+                <VisibilityCard
+                  active={!isPublic}
+                  label="Internal"
+                  description="Hidden from the portal"
+                  icon={<EyeSlashIcon className="h-3.5 w-3.5" />}
+                  onClick={() => setIsPublic(false)}
+                />
+              </div>
+            </div>
 
-        <div className="space-y-2">
-          <Label>Color</Label>
-          <ColorPickerGrid selectedColor={color} onColorChange={setColor} />
-          <ColorHexInput color={color} onColorChange={setColor} />
-        </div>
+            <div className="space-y-2">
+              <Label htmlFor="tag-desc">
+                Description <span className="text-muted-foreground font-normal">(optional)</span>
+              </Label>
+              <Textarea
+                id="tag-desc"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="When to use this tag"
+                rows={2}
+                maxLength={200}
+              />
+            </div>
 
-        <div className="flex items-center justify-between gap-4">
-          <div>
-            <Label htmlFor="tag-is-public">Show on portal</Label>
-            <p className="text-xs text-muted-foreground">
-              Customers can see this tag on posts and filter by it in the public portal. Turn off to
-              keep it internal to your team.
-            </p>
+            {error && <p className="text-sm text-destructive">{error}</p>}
           </div>
-          <Switch id="tag-is-public" checked={isPublic} onCheckedChange={setIsPublic} />
-        </div>
 
-        {error && <p className="text-sm text-destructive">{error}</p>}
-
-        <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isSaving}>
-            Cancel
-          </Button>
-          <Button onClick={handleSave} disabled={isSaving}>
-            {isSaving ? 'Saving...' : isEdit ? 'Save changes' : 'Create tag'}
-          </Button>
-        </DialogFooter>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isSaving}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSaving || !name.trim()}>
+              {isSaving ? 'Saving...' : isEdit ? 'Save changes' : 'Create tag'}
+            </Button>
+          </DialogFooter>
+        </form>
       </DialogContent>
     </Dialog>
+  )
+}
+
+function VisibilityCard({
+  active,
+  label,
+  description,
+  icon,
+  onClick,
+}: {
+  active: boolean
+  label: string
+  description: string
+  icon: ReactNode
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={active}
+      aria-label={label}
+      onClick={onClick}
+      className={cn(
+        'flex flex-col items-stretch gap-1 rounded-lg border px-3 py-2.5 text-left transition-colors',
+        active
+          ? 'border-primary bg-primary/10'
+          : 'border-border bg-muted/30 hover:bg-muted/60 cursor-pointer'
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <span className={active ? 'text-primary' : 'text-muted-foreground'}>{icon}</span>
+        <span className={cn('text-sm font-semibold', active && 'text-primary')}>{label}</span>
+      </div>
+      <span className="text-xs text-muted-foreground leading-snug">{description}</span>
+    </button>
   )
 }
 

--- a/apps/web/src/components/shared/color-picker.tsx
+++ b/apps/web/src/components/shared/color-picker.tsx
@@ -61,16 +61,19 @@ export function randomColor(): string {
 interface ColorPickerGridProps {
   selectedColor: string
   onColorChange: (color: string) => void
+  /** Defaults to the full preset palette. Pass a slice for a compact row. */
+  colors?: readonly string[]
 }
 
 /** An 8-column grid of preset swatches, the current color ringed. */
 export function ColorPickerGrid({
   selectedColor,
   onColorChange,
+  colors = PRESET_COLORS,
 }: ColorPickerGridProps): React.ReactElement {
   return (
     <div className="grid grid-cols-8 gap-1.5">
-      {PRESET_COLORS.map((c) => (
+      {colors.map((c) => (
         <button
           key={c}
           type="button"


### PR DESCRIPTION
## Summary

The New tag dialog was a vertical stack: a disconnected preview, a 32-swatch palette as the visual centre, and a switch squeezed against a three-line paragraph.

This restyles it to match the rest of settings (Create board tiles, compact color row):

- **Name + live chip** side by side. Empty state is `Tag name`, not `PostTag name`.
- **Color** is the eight saturated presets plus hex/random. The rest of the palette is behind **More colors**.
- **Visibility** is two cards — Portal / Internal — instead of a switch. Same default (`isPublic: true`).
- **Description** is last and marked optional.
- **Create tag** stays disabled until a name is entered. Enter submits.

Same fields and save payload. The inline list color popover still shows the full palette.

## Test plan

- [x] Unit tests for portal/internal radios, disabled Create, preview copy, More colors
- [ ] Open `/admin/settings/tags` → Add new tag
- [ ] Type a name: chip updates, Create enables
- [ ] Pick a preset, open More colors, type a hex, randomize
- [ ] Switch Portal ↔ Internal
- [ ] Create, then Edit: fields and visibility match
- [ ] Cancel closes without saving