### PR TITLE
fix(db): keep 0.13 upgrades on core products and migrate chat widget settings

### DIFF
--- a/apps/web/src/lib/server/domains/settings/settings.types.ts
+++ b/apps/web/src/lib/server/domains/settings/settings.types.ts
@@ -1143,10 +1143,10 @@ export function resolveFeatureFlags(storedJson: string | null | undefined): Feat
  * onboarding goal turns them on.
  *
  * Existing workspaces with an explicit `featureFlags` JSON row keep stored
- * values. A one-time SQL stamp wrote today's previous all-on object onto
- * null rows before this default flipped, so already-running installs do
- * not lose surfaces. Only missing keys and new null rows pick up these
- * defaults (merged in settings.service).
+ * values. A one-time SQL stamp writes this same core-only object onto null
+ * rows so a 0.13.x upgrade does not turn Support, Help Center, or Status on.
+ * Only missing keys and new null rows pick up these defaults (merged in
+ * settings.service).
  */
 export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   feedback: true,

--- a/apps/web/src/lib/server/fleet/__tests__/migrator-gate.test.ts
+++ b/apps/web/src/lib/server/fleet/__tests__/migrator-gate.test.ts
@@ -351,6 +351,7 @@ describe('replayGateVerdict', () => {
       '0274_slack_agent_gateway',
       '0275_slack_thread_sessions',
       '0276_post_tags_is_public',
+      '0277_widget_chat_to_messenger',
     ])
     const verdict = replayGateVerdict(before, verdictsFor(replaySetFor(before)), false)
     expect(verdict.ok).toBe(false)

--- a/apps/web/src/lib/server/policy/migration-contract/CONTRACT.md
+++ b/apps/web/src/lib/server/policy/migration-contract/CONTRACT.md
@@ -6,7 +6,7 @@ Regenerate with `bunx vitest run apps/web/src/lib/server/policy/migration-contra
 
 ## Summary
 
-Migrations scanned: 254. Migrations with destructive DDL: 34.
+Migrations scanned: 255. Migrations with destructive DDL: 34.
 
 | Kind | Occurrences |
 | --- | --- |

--- a/apps/web/src/lib/server/policy/migration-contract/__tests__/replay-safety.test.ts
+++ b/apps/web/src/lib/server/policy/migration-contract/__tests__/replay-safety.test.ts
@@ -278,8 +278,8 @@ describe('the real corpus', () => {
     // collapse that same window.
     // 0274 checks the installed constraint definitions and updates only version 3 configs.
     // A replay preserves widened constraints, workspace customizations and revisions.
-    // 0277 rewrites leftover widget `chat` keys and inserts macros only when a
-    // name+body pair is missing, so a second run writes zero rows.
+    // 0277 rewrites leftover widget `chat` keys and inserts chat-only macros
+    // that are not already live, so a second run writes zero rows.
     const vouching = files.filter(
       (f) => assessReplaySafety(f, readFileSync(join(MIGRATIONS_DIR, f), 'utf8')).vouched.length > 0
     )

--- a/apps/web/src/lib/server/policy/migration-contract/__tests__/replay-safety.test.ts
+++ b/apps/web/src/lib/server/policy/migration-contract/__tests__/replay-safety.test.ts
@@ -279,7 +279,7 @@ describe('the real corpus', () => {
     // 0274 checks the installed constraint definitions and updates only version 3 configs.
     // A replay preserves widened constraints, workspace customizations and revisions.
     // 0277 rewrites leftover widget `chat` keys and inserts chat-only macros
-    // that are not already live, so a second run writes zero rows.
+    // that are not already present, so a second run writes zero rows.
     const vouching = files.filter(
       (f) => assessReplaySafety(f, readFileSync(join(MIGRATIONS_DIR, f), 'utf8')).vouched.length > 0
     )

--- a/apps/web/src/lib/server/policy/migration-contract/__tests__/replay-safety.test.ts
+++ b/apps/web/src/lib/server/policy/migration-contract/__tests__/replay-safety.test.ts
@@ -278,6 +278,8 @@ describe('the real corpus', () => {
     // collapse that same window.
     // 0274 checks the installed constraint definitions and updates only version 3 configs.
     // A replay preserves widened constraints, workspace customizations and revisions.
+    // 0277 rewrites leftover widget `chat` keys and inserts macros only when a
+    // name+body pair is missing, so a second run writes zero rows.
     const vouching = files.filter(
       (f) => assessReplaySafety(f, readFileSync(join(MIGRATIONS_DIR, f), 'utf8')).vouched.length > 0
     )
@@ -289,6 +291,7 @@ describe('the real corpus', () => {
       '0261_connectors.sql',
       '0269_messenger_ai_default_on.sql',
       '0274_slack_agent_gateway.sql',
+      '0277_widget_chat_to_messenger.sql',
     ])
   })
 

--- a/packages/db/drizzle/0263_core_product_flag_defaults.sql
+++ b/packages/db/drizzle/0263_core_product_flag_defaults.sql
@@ -1,12 +1,8 @@
--- Stamp workspaces that never persisted product flags so they keep today's
--- all-on surface after DEFAULT_FEATURE_FLAGS becomes core-only (Feedback +
--- Changelog). Stored keys win; missing keys receive the previous defaults.
--- New workspaces write an explicit JSON blob on insert and pick up the new
--- defaults instead.
+-- Stamp workspaces that never persisted product flags so they match
+-- DEFAULT_FEATURE_FLAGS: Feedback + Changelog on; Support, Help Center, and
+-- Status off until Settings → General (or an onboarding goal) turns them on.
+-- Only null/empty rows are touched; an already-stored Labs blob is left alone.
 UPDATE "settings"
-SET "feature_flags" = (
-  '{"feedback":true,"changelog":true,"helpCenter":true,"supportInbox":true,"supportTickets":true,"statusPage":true,"inboxAi":true,"assistantConnectors":false,"assistantSkills":false}'::jsonb
-  || coalesce("feature_flags"::jsonb, '{}'::jsonb)
-)::text
+SET "feature_flags" = '{"feedback":true,"changelog":true,"helpCenter":false,"supportInbox":false,"supportTickets":false,"statusPage":false}'
 WHERE "feature_flags" IS NULL
    OR btrim("feature_flags") IN ('', 'null');

--- a/packages/db/drizzle/0277_widget_chat_to_messenger.sql
+++ b/packages/db/drizzle/0277_widget_chat_to_messenger.sql
@@ -4,9 +4,10 @@
 -- chat array and skips any reply that is also listed under messenger. A
 -- live-macro name+body check cannot prove that: if an admin later edited
 -- or soft-deleted the 0146 row, the stale chat copy would look new.
--- Chat-only replies still skip a live name+body match, including one later
--- scoped to feedback or both. Repeated title+body pairs in one chat array
--- are inserted once; NOT EXISTS cannot see sibling rows in the same SELECT.
+-- Chat-only replies still skip a name+body match, including a later
+-- retarget to feedback or both, or a later soft-delete. Repeated
+-- title+body pairs in one chat array are inserted once; NOT EXISTS
+-- cannot see sibling rows in the same SELECT.
 --
 -- Messenger keys win on conflict; chat fills gaps. tabs.messenger is copied
 -- from tabs.chat only when it was never stored. The leftover chat keys are
@@ -69,8 +70,7 @@ BEGIN
       AND NOT EXISTS (
         SELECT 1
         FROM "macros" m
-        WHERE m.deleted_at IS NULL
-          AND m.name = cr->>'title'
+        WHERE m.name = cr->>'title'
           AND m.body = cr->>'body'
       )
   ) unique_replies;

--- a/packages/db/drizzle/0277_widget_chat_to_messenger.sql
+++ b/packages/db/drizzle/0277_widget_chat_to_messenger.sql
@@ -1,0 +1,94 @@
+-- Rewrite leftover 0.13.x widget `chat` keys onto `messenger`, then copy
+-- canned replies into macros. 0146 only read messenger.cannedReplies, so a
+-- straight 0.13.2 upgrade would otherwise keep welcome copy, office hours,
+-- and saved replies on a key the app no longer reads.
+--
+-- Messenger keys win on conflict; chat fills gaps. tabs.messenger is copied
+-- from tabs.chat only when it was never stored. The leftover chat keys are
+-- dropped so a second run matches zero rows. The INSERT skips a name+body
+-- that 0146 (or a previous apply) already copied.
+
+-- @replay: guarded-by leftover widget_config chat keys and macros of the same name and body
+DO $$
+BEGIN
+  UPDATE "settings" AS s
+  SET "widget_config" = r.rewritten
+  FROM (
+    SELECT
+      src.id,
+      (
+        (src.cfg - 'chat')
+        || jsonb_build_object('messenger', src.messenger)
+        || jsonb_build_object('tabs', src.tabs)
+      )::text AS rewritten
+    FROM (
+      SELECT
+        id,
+        cfg,
+        (
+          CASE
+            WHEN jsonb_typeof(merged->'cannedReplies') = 'array'
+              AND jsonb_array_length(merged->'cannedReplies') = 0
+              AND jsonb_typeof(cfg#>'{chat,cannedReplies}') = 'array'
+              AND jsonb_array_length(cfg#>'{chat,cannedReplies}') > 0
+              THEN jsonb_set(merged, '{cannedReplies}', cfg#>'{chat,cannedReplies}')
+            ELSE merged
+          END
+        ) - 'preChatEmail' AS messenger,
+        (coalesce(cfg->'tabs', '{}'::jsonb) - 'chat')
+          || CASE
+            WHEN (cfg#>'{tabs,messenger}') IS NULL
+              AND (cfg#>'{tabs,chat}') IS NOT NULL
+              THEN jsonb_build_object('messenger', cfg#>'{tabs,chat}')
+            ELSE '{}'::jsonb
+          END AS tabs
+      FROM (
+        SELECT
+          id,
+          cfg,
+          CASE
+            WHEN jsonb_typeof(cfg->'chat') = 'object'
+              THEN (cfg->'chat') || CASE
+                WHEN jsonb_typeof(cfg->'messenger') = 'object' THEN cfg->'messenger'
+                ELSE '{}'::jsonb
+              END
+            WHEN jsonb_typeof(cfg->'messenger') = 'object' THEN cfg->'messenger'
+            ELSE coalesce(cfg->'messenger', '{}'::jsonb)
+          END AS merged
+        FROM (
+          SELECT id, widget_config::jsonb AS cfg
+          FROM "settings"
+          WHERE widget_config IS NOT NULL
+            AND btrim(widget_config) NOT IN ('', 'null')
+            AND (
+              widget_config::jsonb ? 'chat'
+              OR (widget_config::jsonb)#>'{tabs,chat}' IS NOT NULL
+            )
+        ) parsed
+      ) built
+    ) src
+  ) r
+  WHERE s.id = r.id;
+
+  INSERT INTO "macros" ("id", "name", "body", "scope", "actions", "created_at", "updated_at")
+  SELECT gen_random_uuid(), cr->>'title', cr->>'body', 'support', '[]'::jsonb, now(), now()
+  FROM "settings" s
+  CROSS JOIN LATERAL jsonb_array_elements(
+    CASE
+      WHEN s.widget_config IS NULL OR btrim(s.widget_config) IN ('', 'null') THEN '[]'::jsonb
+      WHEN jsonb_typeof((s.widget_config::jsonb)#>'{messenger,cannedReplies}') = 'array'
+        THEN (s.widget_config::jsonb)#>'{messenger,cannedReplies}'
+      ELSE '[]'::jsonb
+    END
+  ) AS cr
+  WHERE coalesce(cr->>'title', '') <> ''
+    AND coalesce(cr->>'body', '') <> ''
+    AND NOT EXISTS (
+      SELECT 1
+      FROM "macros" m
+      WHERE m.deleted_at IS NULL
+        AND m.name = cr->>'title'
+        AND m.body = cr->>'body'
+        AND m.scope = 'support'
+    );
+END $$;

--- a/packages/db/drizzle/0277_widget_chat_to_messenger.sql
+++ b/packages/db/drizzle/0277_widget_chat_to_messenger.sql
@@ -1,16 +1,39 @@
--- Rewrite leftover 0.13.x widget `chat` keys onto `messenger`, then copy
--- canned replies into macros. 0146 only read messenger.cannedReplies, so a
--- straight 0.13.2 upgrade would otherwise keep welcome copy, office hours,
--- and saved replies on a key the app no longer reads.
+-- Rewrite leftover 0.13.x widget `chat` keys onto `messenger`, and copy
+-- canned replies that still live under `chat` into macros. 0146 already
+-- imported messenger.cannedReplies, so this INSERT reads only the legacy
+-- chat array. Scanning messenger after the rewrite would recreate a
+-- support macro that an admin later edited, retargeted, or soft-deleted.
 --
 -- Messenger keys win on conflict; chat fills gaps. tabs.messenger is copied
 -- from tabs.chat only when it was never stored. The leftover chat keys are
 -- dropped so a second run matches zero rows. The INSERT skips a name+body
--- that 0146 (or a previous apply) already copied.
+-- that already exists as a live support macro.
 
 -- @replay: guarded-by leftover widget_config chat keys and macros of the same name and body
 DO $$
 BEGIN
+  INSERT INTO "macros" ("id", "name", "body", "scope", "actions", "created_at", "updated_at")
+  SELECT gen_random_uuid(), cr->>'title', cr->>'body', 'support', '[]'::jsonb, now(), now()
+  FROM "settings" s
+  CROSS JOIN LATERAL jsonb_array_elements(
+    CASE
+      WHEN s.widget_config IS NULL OR btrim(s.widget_config) IN ('', 'null') THEN '[]'::jsonb
+      WHEN jsonb_typeof((s.widget_config::jsonb)#>'{chat,cannedReplies}') = 'array'
+        THEN (s.widget_config::jsonb)#>'{chat,cannedReplies}'
+      ELSE '[]'::jsonb
+    END
+  ) AS cr
+  WHERE coalesce(cr->>'title', '') <> ''
+    AND coalesce(cr->>'body', '') <> ''
+    AND NOT EXISTS (
+      SELECT 1
+      FROM "macros" m
+      WHERE m.deleted_at IS NULL
+        AND m.name = cr->>'title'
+        AND m.body = cr->>'body'
+        AND m.scope = 'support'
+    );
+
   UPDATE "settings" AS s
   SET "widget_config" = r.rewritten
   FROM (
@@ -69,26 +92,4 @@ BEGIN
     ) src
   ) r
   WHERE s.id = r.id;
-
-  INSERT INTO "macros" ("id", "name", "body", "scope", "actions", "created_at", "updated_at")
-  SELECT gen_random_uuid(), cr->>'title', cr->>'body', 'support', '[]'::jsonb, now(), now()
-  FROM "settings" s
-  CROSS JOIN LATERAL jsonb_array_elements(
-    CASE
-      WHEN s.widget_config IS NULL OR btrim(s.widget_config) IN ('', 'null') THEN '[]'::jsonb
-      WHEN jsonb_typeof((s.widget_config::jsonb)#>'{messenger,cannedReplies}') = 'array'
-        THEN (s.widget_config::jsonb)#>'{messenger,cannedReplies}'
-      ELSE '[]'::jsonb
-    END
-  ) AS cr
-  WHERE coalesce(cr->>'title', '') <> ''
-    AND coalesce(cr->>'body', '') <> ''
-    AND NOT EXISTS (
-      SELECT 1
-      FROM "macros" m
-      WHERE m.deleted_at IS NULL
-        AND m.name = cr->>'title'
-        AND m.body = cr->>'body'
-        AND m.scope = 'support'
-    );
 END $$;

--- a/packages/db/drizzle/0277_widget_chat_to_messenger.sql
+++ b/packages/db/drizzle/0277_widget_chat_to_messenger.sql
@@ -10,6 +10,28 @@
 -- Messenger keys win on conflict; chat fills gaps. tabs.messenger is copied
 -- from tabs.chat only when it was never stored. The leftover chat keys are
 -- dropped so a second run matches zero rows.
+--
+-- widget_config is text and a corrupt row is tolerated by parseWidgetConfig
+-- and by 0196. A hard ::jsonb cast on every settings row would abort the
+-- whole upgrade for one bad blob, even when that row has no leftover chat
+-- keys. This reader returns NULL on empty or invalid JSON so those rows
+-- are skipped.
+
+CREATE OR REPLACE FUNCTION pg_temp._m0277_widget_json(settings_id uuid, raw text)
+RETURNS jsonb
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF raw IS NULL OR btrim(raw) IN ('', 'null') THEN
+    RETURN NULL;
+  END IF;
+  RETURN raw::jsonb;
+EXCEPTION WHEN OTHERS THEN
+  RAISE WARNING 'settings row % has invalid widget_config JSON; skipping chat-to-messenger rewrite', settings_id;
+  RETURN NULL;
+END;
+$$;
+--> statement-breakpoint
 
 -- @replay: guarded-by leftover widget_config chat keys and macros of the same name and body
 DO $$
@@ -17,11 +39,13 @@ BEGIN
   INSERT INTO "macros" ("id", "name", "body", "scope", "actions", "created_at", "updated_at")
   SELECT gen_random_uuid(), cr->>'title', cr->>'body', 'support', '[]'::jsonb, now(), now()
   FROM "settings" s
+  CROSS JOIN LATERAL (
+    SELECT pg_temp._m0277_widget_json(s.id, s.widget_config) AS cfg
+  ) parsed
   CROSS JOIN LATERAL jsonb_array_elements(
     CASE
-      WHEN s.widget_config IS NULL OR btrim(s.widget_config) IN ('', 'null') THEN '[]'::jsonb
-      WHEN jsonb_typeof((s.widget_config::jsonb)#>'{chat,cannedReplies}') = 'array'
-        THEN (s.widget_config::jsonb)#>'{chat,cannedReplies}'
+      WHEN jsonb_typeof(parsed.cfg#>'{chat,cannedReplies}') = 'array'
+        THEN parsed.cfg#>'{chat,cannedReplies}'
       ELSE '[]'::jsonb
     END
   ) AS cr
@@ -31,8 +55,8 @@ BEGIN
       SELECT 1
       FROM jsonb_array_elements(
         CASE
-          WHEN jsonb_typeof((s.widget_config::jsonb)#>'{messenger,cannedReplies}') = 'array'
-            THEN (s.widget_config::jsonb)#>'{messenger,cannedReplies}'
+          WHEN jsonb_typeof(parsed.cfg#>'{messenger,cannedReplies}') = 'array'
+            THEN parsed.cfg#>'{messenger,cannedReplies}'
           ELSE '[]'::jsonb
         END
       ) AS mr
@@ -92,15 +116,14 @@ BEGIN
             ELSE coalesce(cfg->'messenger', '{}'::jsonb)
           END AS merged
         FROM (
-          SELECT id, widget_config::jsonb AS cfg
+          SELECT id, pg_temp._m0277_widget_json(id, widget_config) AS cfg
           FROM "settings"
-          WHERE widget_config IS NOT NULL
-            AND btrim(widget_config) NOT IN ('', 'null')
-            AND (
-              widget_config::jsonb ? 'chat'
-              OR (widget_config::jsonb)#>'{tabs,chat}' IS NOT NULL
-            )
         ) parsed
+        WHERE jsonb_typeof(parsed.cfg) = 'object'
+          AND (
+            parsed.cfg ? 'chat'
+            OR parsed.cfg#>'{tabs,chat}' IS NOT NULL
+          )
       ) built
     ) src
   ) r

--- a/packages/db/drizzle/0277_widget_chat_to_messenger.sql
+++ b/packages/db/drizzle/0277_widget_chat_to_messenger.sql
@@ -7,7 +7,8 @@
 -- Messenger keys win on conflict; chat fills gaps. tabs.messenger is copied
 -- from tabs.chat only when it was never stored. The leftover chat keys are
 -- dropped so a second run matches zero rows. The INSERT skips a name+body
--- that already exists as a live support macro.
+-- that already exists as a live macro, including one later scoped to
+-- feedback or both.
 
 -- @replay: guarded-by leftover widget_config chat keys and macros of the same name and body
 DO $$
@@ -31,7 +32,6 @@ BEGIN
       WHERE m.deleted_at IS NULL
         AND m.name = cr->>'title'
         AND m.body = cr->>'body'
-        AND m.scope = 'support'
     );
 
   UPDATE "settings" AS s

--- a/packages/db/drizzle/0277_widget_chat_to_messenger.sql
+++ b/packages/db/drizzle/0277_widget_chat_to_messenger.sql
@@ -5,7 +5,8 @@
 -- live-macro name+body check cannot prove that: if an admin later edited
 -- or soft-deleted the 0146 row, the stale chat copy would look new.
 -- Chat-only replies still skip a live name+body match, including one later
--- scoped to feedback or both.
+-- scoped to feedback or both. Repeated title+body pairs in one chat array
+-- are inserted once; NOT EXISTS cannot see sibling rows in the same SELECT.
 --
 -- Messenger keys win on conflict; chat fills gaps. tabs.messenger is copied
 -- from tabs.chat only when it was never stored. The leftover chat keys are
@@ -37,39 +38,42 @@ $$;
 DO $$
 BEGIN
   INSERT INTO "macros" ("id", "name", "body", "scope", "actions", "created_at", "updated_at")
-  SELECT gen_random_uuid(), cr->>'title', cr->>'body', 'support', '[]'::jsonb, now(), now()
-  FROM "settings" s
-  CROSS JOIN LATERAL (
-    SELECT pg_temp._m0277_widget_json(s.id, s.widget_config) AS cfg
-  ) parsed
-  CROSS JOIN LATERAL jsonb_array_elements(
-    CASE
-      WHEN jsonb_typeof(parsed.cfg#>'{chat,cannedReplies}') = 'array'
-        THEN parsed.cfg#>'{chat,cannedReplies}'
-      ELSE '[]'::jsonb
-    END
-  ) AS cr
-  WHERE coalesce(cr->>'title', '') <> ''
-    AND coalesce(cr->>'body', '') <> ''
-    AND NOT EXISTS (
-      SELECT 1
-      FROM jsonb_array_elements(
-        CASE
-          WHEN jsonb_typeof(parsed.cfg#>'{messenger,cannedReplies}') = 'array'
-            THEN parsed.cfg#>'{messenger,cannedReplies}'
-          ELSE '[]'::jsonb
-        END
-      ) AS mr
-      WHERE mr->>'title' = cr->>'title'
-        AND mr->>'body' = cr->>'body'
-    )
-    AND NOT EXISTS (
-      SELECT 1
-      FROM "macros" m
-      WHERE m.deleted_at IS NULL
-        AND m.name = cr->>'title'
-        AND m.body = cr->>'body'
-    );
+  SELECT gen_random_uuid(), title, body, 'support', '[]'::jsonb, now(), now()
+  FROM (
+    SELECT DISTINCT cr->>'title' AS title, cr->>'body' AS body
+    FROM "settings" s
+    CROSS JOIN LATERAL (
+      SELECT pg_temp._m0277_widget_json(s.id, s.widget_config) AS cfg
+    ) parsed
+    CROSS JOIN LATERAL jsonb_array_elements(
+      CASE
+        WHEN jsonb_typeof(parsed.cfg#>'{chat,cannedReplies}') = 'array'
+          THEN parsed.cfg#>'{chat,cannedReplies}'
+        ELSE '[]'::jsonb
+      END
+    ) AS cr
+    WHERE coalesce(cr->>'title', '') <> ''
+      AND coalesce(cr->>'body', '') <> ''
+      AND NOT EXISTS (
+        SELECT 1
+        FROM jsonb_array_elements(
+          CASE
+            WHEN jsonb_typeof(parsed.cfg#>'{messenger,cannedReplies}') = 'array'
+              THEN parsed.cfg#>'{messenger,cannedReplies}'
+            ELSE '[]'::jsonb
+          END
+        ) AS mr
+        WHERE mr->>'title' = cr->>'title'
+          AND mr->>'body' = cr->>'body'
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM "macros" m
+        WHERE m.deleted_at IS NULL
+          AND m.name = cr->>'title'
+          AND m.body = cr->>'body'
+      )
+  ) unique_replies;
 
   UPDATE "settings" AS s
   SET "widget_config" = r.rewritten

--- a/packages/db/drizzle/0277_widget_chat_to_messenger.sql
+++ b/packages/db/drizzle/0277_widget_chat_to_messenger.sql
@@ -1,14 +1,15 @@
 -- Rewrite leftover 0.13.x widget `chat` keys onto `messenger`, and copy
 -- canned replies that still live under `chat` into macros. 0146 already
--- imported messenger.cannedReplies, so this INSERT reads only the legacy
--- chat array. Scanning messenger after the rewrite would recreate a
--- support macro that an admin later edited, retargeted, or soft-deleted.
+-- imported messenger.cannedReplies, so this INSERT reads only the leftover
+-- chat array and skips any reply that is also listed under messenger. A
+-- live-macro name+body check cannot prove that: if an admin later edited
+-- or soft-deleted the 0146 row, the stale chat copy would look new.
+-- Chat-only replies still skip a live name+body match, including one later
+-- scoped to feedback or both.
 --
 -- Messenger keys win on conflict; chat fills gaps. tabs.messenger is copied
 -- from tabs.chat only when it was never stored. The leftover chat keys are
--- dropped so a second run matches zero rows. The INSERT skips a name+body
--- that already exists as a live macro, including one later scoped to
--- feedback or both.
+-- dropped so a second run matches zero rows.
 
 -- @replay: guarded-by leftover widget_config chat keys and macros of the same name and body
 DO $$
@@ -26,6 +27,18 @@ BEGIN
   ) AS cr
   WHERE coalesce(cr->>'title', '') <> ''
     AND coalesce(cr->>'body', '') <> ''
+    AND NOT EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(
+        CASE
+          WHEN jsonb_typeof((s.widget_config::jsonb)#>'{messenger,cannedReplies}') = 'array'
+            THEN (s.widget_config::jsonb)#>'{messenger,cannedReplies}'
+          ELSE '[]'::jsonb
+        END
+      ) AS mr
+      WHERE mr->>'title' = cr->>'title'
+        AND mr->>'body' = cr->>'body'
+    )
     AND NOT EXISTS (
       SELECT 1
       FROM "macros" m

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1779,6 +1779,13 @@
       "when": 1788818400000,
       "tag": "0276_post_tags_is_public",
       "breakpoints": true
+    },
+    {
+      "idx": 254,
+      "version": "7",
+      "when": 1788991200000,
+      "tag": "0277_widget_chat_to_messenger",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/__tests__/migration-0263-core-product-flags.test.ts
+++ b/packages/db/src/__tests__/migration-0263-core-product-flags.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, afterAll } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { sql } from 'drizzle-orm'
+import { createDb, type Database } from '../client'
+
+/**
+ * 0263 writes core-only product flags onto rows that never persisted them, so
+ * a 0.13.x upgrade does not turn Support, Help Center, or Status on. Stored
+ * blobs are left alone. The statement is read from disk and pointed at a
+ * scratch table so a change that stamped those products on fails here.
+ */
+const MIGRATION_SQL = readFileSync(
+  join(__dirname, '../../drizzle/0263_core_product_flag_defaults.sql'),
+  'utf8'
+)
+const SCRATCH_SQL = MIGRATION_SQL.replace(/"settings"/g, '"_m0263_settings"')
+
+const DB_URL = process.env.DATABASE_URL
+let db: Database | null = null
+const dbAvailable = !!DB_URL
+if (DB_URL) db = createDb(DB_URL, { max: 1 })
+
+afterAll(async () => {
+  // @ts-expect-error optional teardown
+  await db?.$client?.end?.()
+})
+
+const CORE_ONLY = {
+  feedback: true,
+  changelog: true,
+  helpCenter: false,
+  supportInbox: false,
+  supportTickets: false,
+  statusPage: false,
+}
+
+describe.skipIf(!dbAvailable)('migration 0263 core product flag defaults', () => {
+  it('stamps core-only flags onto null or empty rows and leaves stored blobs alone', async () => {
+    if (!db) return
+    await db
+      .transaction(async (tx) => {
+        await tx.execute(sql`
+          CREATE TABLE "_m0263_settings" (
+            "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+            "feature_flags" text
+          )
+        `)
+        await tx.execute(sql`
+          INSERT INTO "_m0263_settings" (id, feature_flags) VALUES
+            (gen_random_uuid(), NULL),
+            (gen_random_uuid(), ''),
+            (gen_random_uuid(), 'null'),
+            (gen_random_uuid(), '{"helpCenter":true,"supportInbox":true}')
+        `)
+
+        await tx.execute(sql.raw(SCRATCH_SQL))
+
+        const rows = await tx.execute<{ feature_flags: string }>(
+          sql`SELECT feature_flags FROM "_m0263_settings" ORDER BY feature_flags NULLS FIRST`
+        )
+        const flags = (rows as unknown as { feature_flags: string }[]).map((r) =>
+          JSON.parse(r.feature_flags)
+        )
+
+        const stamped = flags.filter(
+          (f) => f.helpCenter === false && f.supportInbox === false && f.statusPage === false
+        )
+        expect(stamped).toHaveLength(3)
+        for (const blob of stamped) {
+          expect(blob).toMatchObject(CORE_ONLY)
+        }
+
+        const kept = flags.find((f) => f.helpCenter === true)
+        expect(kept).toEqual({ helpCenter: true, supportInbox: true })
+
+        throw new Error('rollback')
+      })
+      .catch((err: unknown) => {
+        if (err instanceof Error && err.message === 'rollback') return
+        throw err
+      })
+  })
+})

--- a/packages/db/src/__tests__/migration-0277-widget-chat-to-messenger.test.ts
+++ b/packages/db/src/__tests__/migration-0277-widget-chat-to-messenger.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, afterAll } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { sql } from 'drizzle-orm'
+import { createDb, type Database } from '../client'
+
+/**
+ * 0277 copies leftover 0.13.x widget `chat` keys onto `messenger` and turns
+ * canned replies into macros. The file is applied verbatim against scratch
+ * tables so a rewrite that dropped welcome copy or double-inserted macros
+ * fails here rather than on a self-host upgrade.
+ */
+const MIGRATION_SQL = readFileSync(
+  join(__dirname, '../../drizzle/0277_widget_chat_to_messenger.sql'),
+  'utf8'
+)
+const SCRATCH_SQL = MIGRATION_SQL.replace(/"settings"/g, '"_m0277_settings"').replace(
+  /"macros"/g,
+  '"_m0277_macros"'
+)
+
+const DB_URL = process.env.DATABASE_URL
+let db: Database | null = null
+const dbAvailable = !!DB_URL
+if (DB_URL) db = createDb(DB_URL, { max: 1 })
+
+afterAll(async () => {
+  // @ts-expect-error optional teardown
+  await db?.$client?.end?.()
+})
+
+const LEGACY_CHAT = JSON.stringify({
+  enabled: true,
+  tabs: { feedback: true, changelog: true, chat: true, home: true },
+  chat: {
+    enabled: true,
+    welcomeMessage: 'Hi from the old chat tab',
+    offlineMessage: 'We are away',
+    teamName: 'Support',
+    preChatEmail: 'optional',
+    officeHours: { enabled: true, timezone: 'Europe/London', days: [] },
+    cannedReplies: [
+      { title: 'Thanks', body: 'Thanks for writing in.' },
+      { title: 'Missing body', body: '' },
+    ],
+  },
+})
+
+const MESSENGER_WINS = JSON.stringify({
+  enabled: true,
+  tabs: { feedback: true, chat: true, messenger: false },
+  chat: {
+    welcomeMessage: 'Legacy welcome',
+    cannedReplies: [{ title: 'Old', body: 'From chat' }],
+  },
+  messenger: {
+    enabled: true,
+    welcomeMessage: 'Already migrated',
+    cannedReplies: [{ title: 'New', body: 'From messenger' }],
+  },
+})
+
+async function withScratch(
+  run: (tx: Parameters<Parameters<Database['transaction']>[0]>[0]) => Promise<void>
+) {
+  if (!db) return
+  await db
+    .transaction(async (tx) => {
+      await tx.execute(sql`
+        CREATE TABLE "_m0277_settings" (
+          "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+          "widget_config" text
+        )
+      `)
+      await tx.execute(sql`
+        CREATE TABLE "_m0277_macros" (
+          "id" uuid PRIMARY KEY,
+          "name" text NOT NULL,
+          "body" text NOT NULL,
+          "scope" text NOT NULL DEFAULT 'support',
+          "actions" jsonb NOT NULL DEFAULT '[]'::jsonb,
+          "created_at" timestamptz NOT NULL DEFAULT now(),
+          "updated_at" timestamptz NOT NULL DEFAULT now(),
+          "deleted_at" timestamptz
+        )
+      `)
+      await run(tx)
+      throw new Error('rollback')
+    })
+    .catch((err: unknown) => {
+      if (err instanceof Error && err.message === 'rollback') return
+      throw err
+    })
+}
+
+describe.skipIf(!dbAvailable)('migration 0277 widget chat to messenger', () => {
+  it('rewrites chat onto messenger, copies canned replies once, and no-ops on replay', async () => {
+    await withScratch(async (tx) => {
+      const inserted = await tx.execute<{ id: string }>(sql`
+        INSERT INTO "_m0277_settings" (id, widget_config) VALUES
+          (gen_random_uuid(), ${LEGACY_CHAT}),
+          (gen_random_uuid(), ${MESSENGER_WINS}),
+          (gen_random_uuid(), '{"enabled":true,"tabs":{"feedback":true}}')
+        RETURNING id
+      `)
+      const ids = (inserted as unknown as { id: string }[]).map((r) => r.id)
+
+      await tx.execute(sql.raw(SCRATCH_SQL))
+      await tx.execute(sql.raw(SCRATCH_SQL))
+
+      const rows = await tx.execute<{ id: string; widget_config: string }>(
+        sql`SELECT id, widget_config FROM "_m0277_settings"`
+      )
+      const byId = new Map(
+        (rows as unknown as { id: string; widget_config: string }[]).map((r) => [
+          r.id,
+          JSON.parse(r.widget_config) as Record<string, unknown>,
+        ])
+      )
+
+      const legacy = byId.get(ids[0]!)!
+      expect(legacy).not.toHaveProperty('chat')
+      expect((legacy.tabs as { chat?: unknown; messenger?: boolean }).chat).toBeUndefined()
+      expect((legacy.tabs as { messenger?: boolean }).messenger).toBe(true)
+      const messenger = legacy.messenger as {
+        welcomeMessage: string
+        offlineMessage: string
+        teamName: string
+        preChatEmail?: string
+        officeHours: { timezone: string }
+        cannedReplies: Array<{ title: string; body: string }>
+      }
+      expect(messenger.welcomeMessage).toBe('Hi from the old chat tab')
+      expect(messenger.offlineMessage).toBe('We are away')
+      expect(messenger.teamName).toBe('Support')
+      expect(messenger.preChatEmail).toBeUndefined()
+      expect(messenger.officeHours.timezone).toBe('Europe/London')
+      expect(messenger.cannedReplies).toEqual([
+        { title: 'Thanks', body: 'Thanks for writing in.' },
+        { title: 'Missing body', body: '' },
+      ])
+
+      const overlay = byId.get(ids[1]!)!
+      expect(overlay).not.toHaveProperty('chat')
+      expect((overlay.tabs as { messenger?: boolean }).messenger).toBe(false)
+      expect((overlay.messenger as { welcomeMessage: string }).welcomeMessage).toBe(
+        'Already migrated'
+      )
+
+      const untouched = byId.get(ids[2]!)!
+      expect(untouched).toEqual({ enabled: true, tabs: { feedback: true } })
+
+      const macros = await tx.execute<{ name: string; body: string }>(
+        sql`SELECT name, body FROM "_m0277_macros" ORDER BY name, body`
+      )
+      expect(macros as unknown as { name: string; body: string }[]).toEqual([
+        { name: 'New', body: 'From messenger' },
+        { name: 'Thanks', body: 'Thanks for writing in.' },
+      ])
+    })
+  })
+})

--- a/packages/db/src/__tests__/migration-0277-widget-chat-to-messenger.test.ts
+++ b/packages/db/src/__tests__/migration-0277-widget-chat-to-messenger.test.ts
@@ -115,6 +115,11 @@ describe.skipIf(!dbAvailable)('migration 0277 widget chat to messenger', () => {
       `)
       const ids = (inserted as unknown as { id: string }[]).map((r) => r.id)
 
+      await tx.execute(sql`
+        INSERT INTO "_m0277_macros" (id, name, body, scope)
+        VALUES (gen_random_uuid(), 'Old', 'From chat', 'feedback')
+      `)
+
       await tx.execute(sql.raw(SCRATCH_SQL))
       await tx.execute(sql.raw(SCRATCH_SQL))
 
@@ -163,12 +168,12 @@ describe.skipIf(!dbAvailable)('migration 0277 widget chat to messenger', () => {
       const messengerOnly = byId.get(ids[3]!)!
       expect(messengerOnly).toEqual(JSON.parse(MESSENGER_ONLY))
 
-      const macros = await tx.execute<{ name: string; body: string }>(
-        sql`SELECT name, body FROM "_m0277_macros" ORDER BY name, body`
+      const macros = await tx.execute<{ name: string; body: string; scope: string }>(
+        sql`SELECT name, body, scope FROM "_m0277_macros" ORDER BY name, body, scope`
       )
-      expect(macros as unknown as { name: string; body: string }[]).toEqual([
-        { name: 'Old', body: 'From chat' },
-        { name: 'Thanks', body: 'Thanks for writing in.' },
+      expect(macros as unknown as { name: string; body: string; scope: string }[]).toEqual([
+        { name: 'Old', body: 'From chat', scope: 'feedback' },
+        { name: 'Thanks', body: 'Thanks for writing in.', scope: 'support' },
       ])
     })
   })

--- a/packages/db/src/__tests__/migration-0277-widget-chat-to-messenger.test.ts
+++ b/packages/db/src/__tests__/migration-0277-widget-chat-to-messenger.test.ts
@@ -60,6 +60,15 @@ const MESSENGER_WINS = JSON.stringify({
   },
 })
 
+const MESSENGER_ONLY = JSON.stringify({
+  enabled: true,
+  tabs: { feedback: true, messenger: true },
+  messenger: {
+    enabled: true,
+    cannedReplies: [{ title: 'Already imported', body: 'Do not recreate' }],
+  },
+})
+
 async function withScratch(
   run: (tx: Parameters<Parameters<Database['transaction']>[0]>[0]) => Promise<void>
 ) {
@@ -100,7 +109,8 @@ describe.skipIf(!dbAvailable)('migration 0277 widget chat to messenger', () => {
         INSERT INTO "_m0277_settings" (id, widget_config) VALUES
           (gen_random_uuid(), ${LEGACY_CHAT}),
           (gen_random_uuid(), ${MESSENGER_WINS}),
-          (gen_random_uuid(), '{"enabled":true,"tabs":{"feedback":true}}')
+          (gen_random_uuid(), '{"enabled":true,"tabs":{"feedback":true}}'),
+          (gen_random_uuid(), ${MESSENGER_ONLY})
         RETURNING id
       `)
       const ids = (inserted as unknown as { id: string }[]).map((r) => r.id)
@@ -150,11 +160,14 @@ describe.skipIf(!dbAvailable)('migration 0277 widget chat to messenger', () => {
       const untouched = byId.get(ids[2]!)!
       expect(untouched).toEqual({ enabled: true, tabs: { feedback: true } })
 
+      const messengerOnly = byId.get(ids[3]!)!
+      expect(messengerOnly).toEqual(JSON.parse(MESSENGER_ONLY))
+
       const macros = await tx.execute<{ name: string; body: string }>(
         sql`SELECT name, body FROM "_m0277_macros" ORDER BY name, body`
       )
       expect(macros as unknown as { name: string; body: string }[]).toEqual([
-        { name: 'New', body: 'From messenger' },
+        { name: 'Old', body: 'From chat' },
         { name: 'Thanks', body: 'Thanks for writing in.' },
       ])
     })

--- a/packages/db/src/__tests__/migration-0277-widget-chat-to-messenger.test.ts
+++ b/packages/db/src/__tests__/migration-0277-widget-chat-to-messenger.test.ts
@@ -7,18 +7,24 @@ import { createDb, type Database } from '../client'
 /**
  * 0277 copies leftover 0.13.x widget `chat` keys onto `messenger` and turns
  * chat-only canned replies into macros. Replies also listed under messenger
- * were already imported by 0146 and must not be recreated. The file is
- * applied verbatim against scratch tables so a rewrite that dropped welcome
- * copy or double-inserted macros fails here rather than on a self-host upgrade.
+ * were already imported by 0146 and must not be recreated. Invalid
+ * widget_config JSON is skipped so one corrupt row cannot abort the upgrade.
+ * The file is applied verbatim against scratch tables so a rewrite that
+ * dropped welcome copy or double-inserted macros fails here rather than on
+ * a self-host upgrade.
  */
-const MIGRATION_SQL = readFileSync(
+const STATEMENTS = readFileSync(
   join(__dirname, '../../drizzle/0277_widget_chat_to_messenger.sql'),
   'utf8'
 )
-const SCRATCH_SQL = MIGRATION_SQL.replace(/"settings"/g, '"_m0277_settings"').replace(
-  /"macros"/g,
-  '"_m0277_macros"'
-)
+  .split('--> statement-breakpoint')
+  .map((s) =>
+    s
+      .replace(/"settings"/g, '"_m0277_settings"')
+      .replace(/"macros"/g, '"_m0277_macros"')
+      .trim()
+  )
+  .filter(Boolean)
 
 const DB_URL = process.env.DATABASE_URL
 let db: Database | null = null
@@ -119,7 +125,9 @@ describe.skipIf(!dbAvailable)('migration 0277 widget chat to messenger', () => {
           (gen_random_uuid(), ${LEGACY_CHAT}),
           (gen_random_uuid(), ${MESSENGER_WINS}),
           (gen_random_uuid(), '{"enabled":true,"tabs":{"feedback":true}}'),
-          (gen_random_uuid(), ${MESSENGER_ONLY})
+          (gen_random_uuid(), ${MESSENGER_ONLY}),
+          (gen_random_uuid(), '{not json'),
+          (gen_random_uuid(), '"not-an-object"')
         RETURNING id
       `)
       const ids = (inserted as unknown as { id: string }[]).map((r) => r.id)
@@ -132,17 +140,34 @@ describe.skipIf(!dbAvailable)('migration 0277 widget chat to messenger', () => {
           (gen_random_uuid(), 'Gone', 'Soft deleted after 0146', 'support', now())
       `)
 
-      await tx.execute(sql.raw(SCRATCH_SQL))
-      await tx.execute(sql.raw(SCRATCH_SQL))
+      for (const statement of STATEMENTS) {
+        await tx.execute(sql.raw(statement))
+      }
+      for (const statement of STATEMENTS) {
+        await tx.execute(sql.raw(statement))
+      }
 
       const rows = await tx.execute<{ id: string; widget_config: string }>(
         sql`SELECT id, widget_config FROM "_m0277_settings"`
       )
-      const byId = new Map(
+      const rawById = new Map(
         (rows as unknown as { id: string; widget_config: string }[]).map((r) => [
           r.id,
-          JSON.parse(r.widget_config) as Record<string, unknown>,
+          r.widget_config,
         ])
+      )
+      const byId = new Map(
+        [...rawById.entries()].flatMap(([id, raw]) => {
+          try {
+            const parsed = JSON.parse(raw) as unknown
+            if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+              return [[id, parsed as Record<string, unknown>]] as const
+            }
+          } catch {
+            // Corrupt rows stay raw and are asserted separately.
+          }
+          return []
+        })
       )
 
       const legacy = byId.get(ids[0]!)!
@@ -179,6 +204,9 @@ describe.skipIf(!dbAvailable)('migration 0277 widget chat to messenger', () => {
 
       const messengerOnly = byId.get(ids[3]!)!
       expect(messengerOnly).toEqual(JSON.parse(MESSENGER_ONLY))
+
+      expect(rawById.get(ids[4]!)).toBe('{not json')
+      expect(rawById.get(ids[5]!)).toBe('"not-an-object"')
 
       const macros = await tx.execute<{
         name: string

--- a/packages/db/src/__tests__/migration-0277-widget-chat-to-messenger.test.ts
+++ b/packages/db/src/__tests__/migration-0277-widget-chat-to-messenger.test.ts
@@ -48,6 +48,7 @@ const LEGACY_CHAT = JSON.stringify({
     officeHours: { enabled: true, timezone: 'Europe/London', days: [] },
     cannedReplies: [
       { title: 'Thanks', body: 'Thanks for writing in.' },
+      { title: 'Thanks', body: 'Thanks for writing in.' },
       { title: 'Missing body', body: '' },
     ],
   },
@@ -188,6 +189,7 @@ describe.skipIf(!dbAvailable)('migration 0277 widget chat to messenger', () => {
       expect(messenger.preChatEmail).toBeUndefined()
       expect(messenger.officeHours.timezone).toBe('Europe/London')
       expect(messenger.cannedReplies).toEqual([
+        { title: 'Thanks', body: 'Thanks for writing in.' },
         { title: 'Thanks', body: 'Thanks for writing in.' },
         { title: 'Missing body', body: '' },
       ])

--- a/packages/db/src/__tests__/migration-0277-widget-chat-to-messenger.test.ts
+++ b/packages/db/src/__tests__/migration-0277-widget-chat-to-messenger.test.ts
@@ -6,9 +6,10 @@ import { createDb, type Database } from '../client'
 
 /**
  * 0277 copies leftover 0.13.x widget `chat` keys onto `messenger` and turns
- * canned replies into macros. The file is applied verbatim against scratch
- * tables so a rewrite that dropped welcome copy or double-inserted macros
- * fails here rather than on a self-host upgrade.
+ * chat-only canned replies into macros. Replies also listed under messenger
+ * were already imported by 0146 and must not be recreated. The file is
+ * applied verbatim against scratch tables so a rewrite that dropped welcome
+ * copy or double-inserted macros fails here rather than on a self-host upgrade.
  */
 const MIGRATION_SQL = readFileSync(
   join(__dirname, '../../drizzle/0277_widget_chat_to_messenger.sql'),
@@ -51,12 +52,20 @@ const MESSENGER_WINS = JSON.stringify({
   tabs: { feedback: true, chat: true, messenger: false },
   chat: {
     welcomeMessage: 'Legacy welcome',
-    cannedReplies: [{ title: 'Old', body: 'From chat' }],
+    cannedReplies: [
+      { title: 'Old', body: 'From chat' },
+      { title: 'Shared', body: 'Same in both' },
+      { title: 'Gone', body: 'Soft deleted after 0146' },
+    ],
   },
   messenger: {
     enabled: true,
     welcomeMessage: 'Already migrated',
-    cannedReplies: [{ title: 'New', body: 'From messenger' }],
+    cannedReplies: [
+      { title: 'New', body: 'From messenger' },
+      { title: 'Shared', body: 'Same in both' },
+      { title: 'Gone', body: 'Soft deleted after 0146' },
+    ],
   },
 })
 
@@ -116,8 +125,11 @@ describe.skipIf(!dbAvailable)('migration 0277 widget chat to messenger', () => {
       const ids = (inserted as unknown as { id: string }[]).map((r) => r.id)
 
       await tx.execute(sql`
-        INSERT INTO "_m0277_macros" (id, name, body, scope)
-        VALUES (gen_random_uuid(), 'Old', 'From chat', 'feedback')
+        INSERT INTO "_m0277_macros" (id, name, body, scope, deleted_at)
+        VALUES
+          (gen_random_uuid(), 'Old', 'From chat', 'feedback', NULL),
+          (gen_random_uuid(), 'Shared', 'Edited after import', 'support', NULL),
+          (gen_random_uuid(), 'Gone', 'Soft deleted after 0146', 'support', now())
       `)
 
       await tx.execute(sql.raw(SCRATCH_SQL))
@@ -168,12 +180,23 @@ describe.skipIf(!dbAvailable)('migration 0277 widget chat to messenger', () => {
       const messengerOnly = byId.get(ids[3]!)!
       expect(messengerOnly).toEqual(JSON.parse(MESSENGER_ONLY))
 
-      const macros = await tx.execute<{ name: string; body: string; scope: string }>(
-        sql`SELECT name, body, scope FROM "_m0277_macros" ORDER BY name, body, scope`
-      )
-      expect(macros as unknown as { name: string; body: string; scope: string }[]).toEqual([
-        { name: 'Old', body: 'From chat', scope: 'feedback' },
-        { name: 'Thanks', body: 'Thanks for writing in.', scope: 'support' },
+      const macros = await tx.execute<{
+        name: string
+        body: string
+        scope: string
+        deleted: boolean
+      }>(sql`
+        SELECT name, body, scope, (deleted_at IS NOT NULL) AS deleted
+        FROM "_m0277_macros"
+        ORDER BY name, body, scope
+      `)
+      expect(
+        macros as unknown as { name: string; body: string; scope: string; deleted: boolean }[]
+      ).toEqual([
+        { name: 'Gone', body: 'Soft deleted after 0146', scope: 'support', deleted: true },
+        { name: 'Old', body: 'From chat', scope: 'feedback', deleted: false },
+        { name: 'Shared', body: 'Edited after import', scope: 'support', deleted: false },
+        { name: 'Thanks', body: 'Thanks for writing in.', scope: 'support', deleted: false },
       ])
     })
   })

--- a/packages/db/src/__tests__/migration-0277-widget-chat-to-messenger.test.ts
+++ b/packages/db/src/__tests__/migration-0277-widget-chat-to-messenger.test.ts
@@ -49,6 +49,7 @@ const LEGACY_CHAT = JSON.stringify({
     cannedReplies: [
       { title: 'Thanks', body: 'Thanks for writing in.' },
       { title: 'Thanks', body: 'Thanks for writing in.' },
+      { title: 'Dropped', body: 'Chat only then deleted' },
       { title: 'Missing body', body: '' },
     ],
   },
@@ -138,7 +139,8 @@ describe.skipIf(!dbAvailable)('migration 0277 widget chat to messenger', () => {
         VALUES
           (gen_random_uuid(), 'Old', 'From chat', 'feedback', NULL),
           (gen_random_uuid(), 'Shared', 'Edited after import', 'support', NULL),
-          (gen_random_uuid(), 'Gone', 'Soft deleted after 0146', 'support', now())
+          (gen_random_uuid(), 'Gone', 'Soft deleted after 0146', 'support', now()),
+          (gen_random_uuid(), 'Dropped', 'Chat only then deleted', 'support', now())
       `)
 
       for (const statement of STATEMENTS) {
@@ -191,6 +193,7 @@ describe.skipIf(!dbAvailable)('migration 0277 widget chat to messenger', () => {
       expect(messenger.cannedReplies).toEqual([
         { title: 'Thanks', body: 'Thanks for writing in.' },
         { title: 'Thanks', body: 'Thanks for writing in.' },
+        { title: 'Dropped', body: 'Chat only then deleted' },
         { title: 'Missing body', body: '' },
       ])
 
@@ -223,6 +226,7 @@ describe.skipIf(!dbAvailable)('migration 0277 widget chat to messenger', () => {
       expect(
         macros as unknown as { name: string; body: string; scope: string; deleted: boolean }[]
       ).toEqual([
+        { name: 'Dropped', body: 'Chat only then deleted', scope: 'support', deleted: true },
         { name: 'Gone', body: 'Soft deleted after 0146', scope: 'support', deleted: true },
         { name: 'Old', body: 'From chat', scope: 'feedback', deleted: false },
         { name: 'Shared', body: 'Edited after import', scope: 'support', deleted: false },

--- a/packages/db/src/schema/macros.ts
+++ b/packages/db/src/schema/macros.ts
@@ -4,7 +4,8 @@
  * body supports {firstName}-style variables rendered against the live
  * conversation, and it can carry a list of actions (assign, tag, set priority,
  * snooze, close, ...) applied when an agent uses it. Supersedes the old
- * settings-JSON `cannedReplies`; the 0146 migration copies those in.
+ * settings-JSON `cannedReplies`; 0146 copies `messenger.cannedReplies`, and
+ * 0277 copies leftover 0.13.x `chat.cannedReplies` after rewriting that key.
  *
  * `created_by_principal_id` is a team actor (macros are authored by staff), so
  * it is exempt from the anonymous-to-identified principal re-point.


### PR DESCRIPTION
## Summary
- Stamp empty `feature_flags` as Feedback + Changelog only, so a 0.13.x upgrade does not turn Support, Help Center, or Status on. Stored Labs blobs are left alone.
- Add `0277` to copy leftover widget `tabs.chat` / `chat` (welcome copy, office hours, canned replies) onto `messenger` and into macros. Messenger keys win when both exist; a second run is a no-op.

## Test plan
- [x] `migration-0263` and `migration-0277` scratch-table tests
- [x] Journal / migrator-gate / replay-safety / CONTRACT snapshot
- [x] Local 0.13.2 → current `main` upgrade simulation (null flags stay core-only; chat welcome + Thanks macro copied; stored Labs-off flags kept)
- [ ] Confirm a workspace that already applied the old 0263 all-on stamp is unchanged (0263 does not re-run); leftover `chat` JSON is still rewritten by 0277


Made with [Cursor](https://cursor.com)