### PR TITLE
feat(auth): identify new-sign-in devices by a signed cookie

### DIFF
--- a/apps/web/src/lib/server/auth/__tests__/hooks-new-device-notification.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/hooks-new-device-notification.test.ts
@@ -1,10 +1,10 @@
 /**
  * `handleNewDeviceNotification` — runs after `handleSignInSuccessAudit`
- * in the hooksAfter chain. Uses the two-phase tracker API:
- *   1. `isDeviceUnseen` atomically claims the fingerprint via SADD.
- *      Returns true iff this is the first sighting (SADD reply = 1).
- *   2. On true: send email + emit `auth.signin.new_device` audit.
- *      On success: call `markDeviceSeen` to refresh the 90-day TTL.
+ * in the hooksAfter chain. Identity is the signed device cookie.
+ *   1. Resolve / mint a cookie id, write it on every real sign-in.
+ *   2. `isDeviceUnseen` atomically claims the id.
+ *      Returns true iff this is an additional unseen device.
+ *   3. On true: send email + emit `auth.signin.new_device` audit.
  *      On failure: call `forgetDevice` to roll back the claim so the
  *      next sign-in re-fires the notification.
  */
@@ -16,9 +16,22 @@ vi.mock('@/lib/server/config', () => ({
   getBaseUrl: () => 'https://acme.example',
 }))
 
+vi.mock('@/lib/server/secret-key', () => ({
+  activeSecretKey: () => 'unit-test-device-cookie-secret',
+}))
+
+const MINTED_DEVICE_ID = 'ab'.repeat(16)
+
+vi.mock('../signin-device-cookie', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../signin-device-cookie')>()
+  return {
+    ...actual,
+    mintDeviceId: () => MINTED_DEVICE_ID,
+  }
+})
+
 const mockIsDeviceUnseen = vi.fn()
-const mockMarkDeviceSeen = vi.fn(async (_userId: string) => undefined)
-const mockForgetDevice = vi.fn(async (_userId: string, _fp: string) => undefined)
+const mockForgetDevice = vi.fn(async (_userId: string, _deviceId: string) => undefined)
 const mockSendNewSignInEmail = vi.fn(async (_params: unknown) => ({ sent: true }))
 const mockRecordAuditEvent = vi.fn(async (_spec: unknown) => undefined)
 
@@ -26,10 +39,8 @@ vi.mock('../signin-device-tracker', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../signin-device-tracker')>()
   return {
     ...actual,
-    computeDeviceFingerprint: (ua: string) => `fp-${ua}`,
-    isDeviceUnseen: (userId: string, fp: string) => mockIsDeviceUnseen(userId, fp),
-    markDeviceSeen: (userId: string) => mockMarkDeviceSeen(userId),
-    forgetDevice: (userId: string, fp: string) => mockForgetDevice(userId, fp),
+    isDeviceUnseen: (userId: string, deviceId: string) => mockIsDeviceUnseen(userId, deviceId),
+    forgetDevice: (userId: string, deviceId: string) => mockForgetDevice(userId, deviceId),
   }
 })
 
@@ -63,19 +74,27 @@ vi.mock('@/lib/server/db', async (orig) => {
   }
 })
 
+const defaultHeaders = () =>
+  new Headers({
+    'user-agent':
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36',
+    'x-forwarded-for': '203.0.113.42',
+  })
+
+const mockGetRequestHeaders = vi.fn(defaultHeaders)
+
 vi.mock('@tanstack/react-start/server', () => ({
-  getRequestHeaders: () =>
-    new Headers({
-      'user-agent':
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36',
-      'x-forwarded-for': '203.0.113.42',
-    }),
+  getRequestHeaders: () => mockGetRequestHeaders(),
 }))
 
 const { handleNewDeviceNotification } = await import('../hooks')
+const { deviceCookieAttributes, deviceCookieName, signDeviceCookie } =
+  await import('../signin-device-cookie')
 
 type Ctx = Parameters<typeof handleNewDeviceNotification>[0]
 type Workspace = Parameters<typeof handleNewDeviceNotification>[1]
+
+const mockSetCookie = vi.fn()
 
 const buildCtx = (overrides: Partial<Ctx> = {}): Ctx => ({
   path: '/sign-in/email',
@@ -85,6 +104,7 @@ const buildCtx = (overrides: Partial<Ctx> = {}): Ctx => ({
       session: { token: 'tok' },
     },
   },
+  setCookie: mockSetCookie,
   ...overrides,
 })
 
@@ -96,22 +116,34 @@ const workspace = () =>
 
 beforeEach(() => {
   vi.clearAllMocks()
+  mockGetRequestHeaders.mockImplementation(defaultHeaders)
   // Restore default impls — `clearAllMocks` clears history but `*Once`
   // implementations queued by prior tests can still influence the
   // first call. Explicit reset keeps each test independent.
   mockIsDeviceUnseen.mockReset().mockResolvedValue(false)
-  mockMarkDeviceSeen.mockReset().mockResolvedValue(undefined)
   mockForgetDevice.mockReset().mockResolvedValue(undefined)
   mockSendNewSignInEmail.mockReset().mockResolvedValue({ sent: true })
   mockRecordAuditEvent.mockReset().mockResolvedValue(undefined)
   mockListIdentityProviders.mockReset().mockResolvedValue([])
   mockGetRegisteredOidcProviderIds.mockReset().mockResolvedValue(new Set())
+  mockSetCookie.mockReset()
 })
 
+function expectDeviceCookieWritten(deviceId: string = MINTED_DEVICE_ID) {
+  expect(mockSetCookie).toHaveBeenCalledWith(
+    deviceCookieName('user_abc'),
+    signDeviceCookie('user_abc', deviceId),
+    deviceCookieAttributes(true)
+  )
+}
+
 describe('handleNewDeviceNotification — happy path', () => {
-  it('sends email + audits + markDeviceSeen on an additional unseen device', async () => {
+  it('sends email + audits on an additional unseen device', async () => {
     mockIsDeviceUnseen.mockResolvedValueOnce(true)
     await handleNewDeviceNotification(buildCtx(), workspace())
+
+    expect(mockIsDeviceUnseen).toHaveBeenCalledWith('user_abc', MINTED_DEVICE_ID)
+    expectDeviceCookieWritten()
 
     expect(mockSendNewSignInEmail).toHaveBeenCalledTimes(1)
     const emailArgs = mockSendNewSignInEmail.mock.calls[0][0] as {
@@ -134,8 +166,6 @@ describe('handleNewDeviceNotification — happy path', () => {
     const auditArgs = mockRecordAuditEvent.mock.calls[0][0] as { event: string }
     expect(auditArgs.event).toBe('auth.signin.new_device')
 
-    // TTL refreshed only on the success path.
-    expect(mockMarkDeviceSeen).toHaveBeenCalledWith('user_abc')
     expect(mockForgetDevice).not.toHaveBeenCalled()
   })
 
@@ -174,14 +204,47 @@ describe('handleNewDeviceNotification — happy path', () => {
     expect(mockForgetDevice).not.toHaveBeenCalled()
   })
 
-  it('no-ops when the device is already known', async () => {
+  it('still writes the cookie when the device is already known', async () => {
     mockIsDeviceUnseen.mockResolvedValueOnce(false)
     await handleNewDeviceNotification(buildCtx(), workspace())
 
+    expectDeviceCookieWritten()
+    expect(mockIsDeviceUnseen).toHaveBeenCalledWith('user_abc', MINTED_DEVICE_ID)
     expect(mockSendNewSignInEmail).not.toHaveBeenCalled()
     expect(mockRecordAuditEvent).not.toHaveBeenCalled()
-    expect(mockMarkDeviceSeen).not.toHaveBeenCalled()
     expect(mockForgetDevice).not.toHaveBeenCalled()
+  })
+
+  it('reuses a valid cookie id instead of minting', async () => {
+    const knownId = 'cd'.repeat(16)
+    const headers = defaultHeaders()
+    headers.set(
+      'cookie',
+      `${deviceCookieName('user_abc')}=${signDeviceCookie('user_abc', knownId)}`
+    )
+    mockGetRequestHeaders.mockReturnValueOnce(headers)
+    mockIsDeviceUnseen.mockResolvedValueOnce(false)
+
+    await handleNewDeviceNotification(buildCtx(), workspace())
+
+    expect(mockIsDeviceUnseen).toHaveBeenCalledWith('user_abc', knownId)
+    expectDeviceCookieWritten(knownId)
+  })
+
+  it("ignores another user's cookie on a shared browser", async () => {
+    const otherId = 'ee'.repeat(16)
+    const headers = defaultHeaders()
+    headers.set(
+      'cookie',
+      `${deviceCookieName('user_other')}=${signDeviceCookie('user_other', otherId)}`
+    )
+    mockGetRequestHeaders.mockReturnValueOnce(headers)
+    mockIsDeviceUnseen.mockResolvedValueOnce(true)
+
+    await handleNewDeviceNotification(buildCtx(), workspace())
+
+    expect(mockIsDeviceUnseen).toHaveBeenCalledWith('user_abc', MINTED_DEVICE_ID)
+    expectDeviceCookieWritten()
   })
 })
 
@@ -190,6 +253,7 @@ describe('handleNewDeviceNotification — guards', () => {
     const ctx = buildCtx({ context: { newSession: null } })
     await handleNewDeviceNotification(ctx, workspace())
     expect(mockIsDeviceUnseen).not.toHaveBeenCalled()
+    expect(mockSetCookie).not.toHaveBeenCalled()
   })
 
   it('bails when user.email is missing (can’t notify without an address)', async () => {
@@ -205,6 +269,7 @@ describe('handleNewDeviceNotification — guards', () => {
     await handleNewDeviceNotification(buildCtx({ path: '/get-session' }), workspace())
     expect(mockIsDeviceUnseen).not.toHaveBeenCalled()
     expect(mockSendNewSignInEmail).not.toHaveBeenCalled()
+    expect(mockSetCookie).not.toHaveBeenCalled()
   })
 
   it('does not notify on an anonymous widget mint', async () => {
@@ -213,16 +278,35 @@ describe('handleNewDeviceNotification — guards', () => {
     expect(mockIsDeviceUnseen).not.toHaveBeenCalled()
     expect(mockSendNewSignInEmail).not.toHaveBeenCalled()
   })
+
+  it('does not claim a minted id when setCookie is missing', async () => {
+    const ctx = buildCtx()
+    delete ctx.setCookie
+    await handleNewDeviceNotification(ctx, workspace())
+    expect(mockIsDeviceUnseen).not.toHaveBeenCalled()
+    expect(mockSendNewSignInEmail).not.toHaveBeenCalled()
+  })
+
+  it('still claims when an existing cookie cannot be refreshed', async () => {
+    const knownId = 'cd'.repeat(16)
+    const headers = defaultHeaders()
+    headers.set(
+      'cookie',
+      `${deviceCookieName('user_abc')}=${signDeviceCookie('user_abc', knownId)}`
+    )
+    mockGetRequestHeaders.mockReturnValueOnce(headers)
+    mockIsDeviceUnseen.mockResolvedValueOnce(true)
+    const ctx = buildCtx()
+    delete ctx.setCookie
+
+    await handleNewDeviceNotification(ctx, workspace())
+
+    expect(mockIsDeviceUnseen).toHaveBeenCalledWith('user_abc', knownId)
+    expect(mockSendNewSignInEmail).toHaveBeenCalled()
+  })
 })
 
 describe('handleNewDeviceNotification — failure tolerance', () => {
-  it('swallows isDeviceUnseen errors (Redis outage should not block sign-in)', async () => {
-    mockIsDeviceUnseen.mockRejectedValueOnce(new Error('redis down'))
-    await expect(handleNewDeviceNotification(buildCtx(), workspace())).resolves.toBeUndefined()
-    // Tracker errored before claiming → no rollback needed.
-    expect(mockForgetDevice).not.toHaveBeenCalled()
-  })
-
   it('rolls back via forgetDevice when sendNewSignInEmail throws', async () => {
     // This is the critical regression test for the original bug:
     // SMTP outage must NOT permanently mark the device as seen.
@@ -231,8 +315,7 @@ describe('handleNewDeviceNotification — failure tolerance', () => {
 
     await expect(handleNewDeviceNotification(buildCtx(), workspace())).resolves.toBeUndefined()
 
-    expect(mockForgetDevice).toHaveBeenCalledWith('user_abc', expect.stringMatching(/^fp-/))
-    expect(mockMarkDeviceSeen).not.toHaveBeenCalled()
+    expect(mockForgetDevice).toHaveBeenCalledWith('user_abc', MINTED_DEVICE_ID)
   })
 
   it('rolls back via forgetDevice when recordAuditEvent throws', async () => {
@@ -241,8 +324,7 @@ describe('handleNewDeviceNotification — failure tolerance', () => {
 
     await expect(handleNewDeviceNotification(buildCtx(), workspace())).resolves.toBeUndefined()
 
-    expect(mockForgetDevice).toHaveBeenCalled()
-    expect(mockMarkDeviceSeen).not.toHaveBeenCalled()
+    expect(mockForgetDevice).toHaveBeenCalledWith('user_abc', MINTED_DEVICE_ID)
   })
 })
 
@@ -250,8 +332,8 @@ describe('handleNewDeviceNotification — account with no deliverable address', 
   it('sends no alert, but still audits and marks the device seen', async () => {
     // Someone whose provider releases no email carries a placeholder. The alert
     // discloses IP, user agent and sign-in timing, so it must not fall back to
-    // a contact address an agent may have typed. Marking the device seen still
-    // has to happen, or every later sign-in retries a send that can never work.
+    // a contact address an agent may have typed. The claim must stay (no
+    // forgetDevice), or every later sign-in retries a send that can never work.
     mockIsDeviceUnseen.mockResolvedValueOnce(true)
     const { db } = await import('@/lib/server/db')
     vi.mocked(db.query.user.findFirst).mockResolvedValueOnce({
@@ -262,6 +344,6 @@ describe('handleNewDeviceNotification — account with no deliverable address', 
 
     expect(mockSendNewSignInEmail).not.toHaveBeenCalled()
     expect(mockRecordAuditEvent).toHaveBeenCalled()
-    expect(mockMarkDeviceSeen).toHaveBeenCalled()
+    expect(mockForgetDevice).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/lib/server/auth/__tests__/signin-device-cookie.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/signin-device-cookie.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Signed known-device cookie: HMAC-bound to userId, host-only attributes,
+ * per-user cookie name so two accounts on one browser do not overwrite.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@/lib/server/secret-key', () => ({
+  activeSecretKey: () => 'unit-test-device-cookie-secret',
+}))
+
+const {
+  DEVICE_TTL_SECONDS,
+  deviceCookieAttributes,
+  deviceCookieName,
+  mintDeviceId,
+  namedCookie,
+  readDeviceCookie,
+  signDeviceCookie,
+  verifyDeviceCookie,
+} = await import('../signin-device-cookie')
+
+const USER = 'user_abc'
+const OTHER = 'user_xyz'
+const DEVICE = 'aa'.repeat(16)
+
+describe('sign / verify', () => {
+  it('round-trips a device id for the same user', () => {
+    const value = signDeviceCookie(USER, DEVICE)
+    expect(value).toMatch(/^v1\.[0-9a-f]{32}\.[A-Za-z0-9_-]+$/)
+    expect(verifyDeviceCookie(USER, value)).toBe(DEVICE)
+  })
+
+  it('rejects a cookie minted for a different user', () => {
+    const value = signDeviceCookie(USER, DEVICE)
+    expect(verifyDeviceCookie(OTHER, value)).toBeNull()
+  })
+
+  it('rejects a tampered mac', () => {
+    const value = signDeviceCookie(USER, DEVICE)
+    const flipped = value.slice(0, -1) + (value.endsWith('a') ? 'b' : 'a')
+    expect(verifyDeviceCookie(USER, flipped)).toBeNull()
+  })
+
+  it('rejects a truncated mac (length guard before timingSafeEqual)', () => {
+    const value = signDeviceCookie(USER, DEVICE)
+    const truncated = value.slice(0, value.lastIndexOf('.') + 8)
+    expect(verifyDeviceCookie(USER, truncated)).toBeNull()
+  })
+
+  it('rejects a garbage value', () => {
+    expect(verifyDeviceCookie(USER, '')).toBeNull()
+    expect(verifyDeviceCookie(USER, 'v1.not-hex.sig')).toBeNull()
+    expect(verifyDeviceCookie(USER, `v2.${DEVICE}.aaaa`)).toBeNull()
+  })
+
+  it('refuses to sign a non-hex device id', () => {
+    expect(() => signDeviceCookie(USER, 'nope')).toThrow(/32 hex/)
+  })
+})
+
+describe('readDeviceCookie / namedCookie', () => {
+  it('reads the per-user cookie and ignores a sibling userId prefix', () => {
+    const ours = signDeviceCookie(USER, DEVICE)
+    const otherId = 'bb'.repeat(16)
+    const theirs = signDeviceCookie(`${USER}def`, otherId)
+    const header = [
+      `${deviceCookieName(`${USER}def`)}=${theirs}`,
+      `${deviceCookieName(USER)}=${ours}`,
+    ].join('; ')
+    expect(readDeviceCookie(header, USER)).toBe(DEVICE)
+    expect(namedCookie(header, deviceCookieName(`${USER}def`))).toBe(theirs)
+  })
+
+  it('returns null when the cookie is missing', () => {
+    expect(readDeviceCookie('', USER)).toBeNull()
+    expect(readDeviceCookie('session=abc', USER)).toBeNull()
+  })
+
+  it('uses the first matching pair when the header repeats the name', () => {
+    const first = signDeviceCookie(USER, DEVICE)
+    const second = signDeviceCookie(USER, 'cc'.repeat(16))
+    const name = deviceCookieName(USER)
+    expect(namedCookie(`${name}=${first}; ${name}=${second}`, name)).toBe(first)
+  })
+})
+
+describe('mintDeviceId / attributes / name', () => {
+  it('mints a 128-bit hex id', () => {
+    const a = mintDeviceId()
+    const b = mintDeviceId()
+    expect(a).toMatch(/^[0-9a-f]{32}$/)
+    expect(b).toMatch(/^[0-9a-f]{32}$/)
+    expect(a).not.toBe(b)
+  })
+
+  it('is host-only, HttpOnly, Lax, 90 days', () => {
+    expect(deviceCookieName(USER)).toBe(`qb.device.${USER}`)
+    expect(deviceCookieAttributes(true)).toEqual({
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax',
+      path: '/',
+      maxAge: DEVICE_TTL_SECONDS,
+    })
+    expect(deviceCookieAttributes(false).secure).toBe(false)
+    expect(DEVICE_TTL_SECONDS).toBe(7_776_000)
+  })
+
+  it('rejects a userId that cannot be a cookie-name token', () => {
+    expect(() => deviceCookieName('user id')).toThrow(/cookie-name/)
+    expect(() => deviceCookieName('user;abc')).toThrow(/cookie-name/)
+  })
+})

--- a/apps/web/src/lib/server/auth/__tests__/signin-device-tracker.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/signin-device-tracker.test.ts
@@ -1,9 +1,9 @@
 /**
- * Tests for the device-fingerprint tracker. Two-phase API (isDeviceUnseen →
- * markDeviceSeen | forgetDevice) so notification failures can roll back the
- * claim and re-fire on the next sign-in.
+ * Tests for the known-device tracker. `isDeviceUnseen` claims; on
+ * notification failure the caller `forgetDevice`s so the next sign-in
+ * re-fires. Members are cookie ids under v3.
  *
- * The tracker's subject is that two-phase protocol, so the set primitives it
+ * The tracker's subject is that protocol, so the set primitives it
  * delegates to (`kv/pg-kv.ts`) are stubbed here. Their own guarantees — one
  * statement per claim, and the workspace discriminator on every row — are proved
  * against a real database in `kv/__tests__/pg-kv-semantics.db.test.ts` and
@@ -12,24 +12,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const mockClaimCounted = vi.fn()
-const mockTouch = vi.fn()
+const mockMemberTouch = vi.fn()
 const mockRemove = vi.fn()
 
 vi.mock('@/lib/server/kv/pg-kv', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/lib/server/kv/pg-kv')>()),
   kvSetMemberClaimCounted: mockClaimCounted,
-  kvSetTouch: mockTouch,
+  kvSetMemberTouch: mockMemberTouch,
   kvSetMemberRemove: mockRemove,
 }))
 
-const {
-  computeDeviceFingerprint,
-  formatSignInDevice,
-  signInDeviceKey,
-  isDeviceUnseen,
-  markDeviceSeen,
-  forgetDevice,
-} = await import('../signin-device-tracker')
+const { formatSignInDevice, isDeviceUnseen, forgetDevice } =
+  await import('../signin-device-tracker')
 
 const CHROME_WIN_129 =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36'
@@ -44,44 +38,26 @@ beforeEach(() => {
   vi.clearAllMocks()
 })
 
-describe('signInDeviceKey / formatSignInDevice', () => {
-  it('strips browser versions so an auto-update is the same device', () => {
-    expect(signInDeviceKey(CHROME_WIN_129)).toBe(signInDeviceKey(CHROME_WIN_130))
+describe('formatSignInDevice', () => {
+  it('strips browser versions so an auto-update stays the same line', () => {
     expect(formatSignInDevice(CHROME_WIN_129)).toBe('Chrome on Windows')
+    expect(formatSignInDevice(CHROME_WIN_130)).toBe('Chrome on Windows')
   })
 
   it('differs across browser families', () => {
-    expect(signInDeviceKey(CHROME_WIN_129)).not.toBe(signInDeviceKey(FIREFOX_WIN))
     expect(formatSignInDevice(FIREFOX_WIN)).toBe('Firefox on Windows')
+    expect(formatSignInDevice(CHROME_WIN_129)).not.toBe(formatSignInDevice(FIREFOX_WIN))
   })
 
   it('differs across OS / platform', () => {
-    expect(signInDeviceKey(CHROME_WIN_129)).not.toBe(signInDeviceKey(CHROME_IOS))
     expect(formatSignInDevice(CHROME_IOS)).toMatch(/Chrome on iOS/i)
+    expect(formatSignInDevice(CHROME_WIN_129)).not.toBe(formatSignInDevice(CHROME_IOS))
   })
 
-  it('collapses empty and unparseable UAs onto one sentinel', () => {
-    expect(signInDeviceKey('')).toBe(signInDeviceKey('   '))
-    expect(signInDeviceKey('')).toBe(signInDeviceKey('???'))
+  it('collapses empty and unparseable UAs onto one line', () => {
     expect(formatSignInDevice('')).toBe('Unknown device')
-  })
-})
-
-describe('computeDeviceFingerprint', () => {
-  it('is independent of IP', () => {
-    const a = computeDeviceFingerprint(CHROME_WIN_129)
-    const b = computeDeviceFingerprint(CHROME_WIN_130)
-    expect(a).toBe(b)
-    expect(a).toMatch(/^[0-9a-f]{32}$/)
-  })
-
-  it('differs on browser family', () => {
-    expect(computeDeviceFingerprint(CHROME_WIN_129)).not.toBe(computeDeviceFingerprint(FIREFOX_WIN))
-  })
-
-  it('empty UA is a stable hash', () => {
-    expect(computeDeviceFingerprint('')).toBe(computeDeviceFingerprint(''))
-    expect(computeDeviceFingerprint('')).toMatch(/^[0-9a-f]{32}$/)
+    expect(formatSignInDevice('   ')).toBe('Unknown device')
+    expect(formatSignInDevice('???')).toBe('Unknown device')
   })
 })
 
@@ -99,20 +75,20 @@ describe('isDeviceUnseen', () => {
   it('returns false when the member was already present', async () => {
     mockClaimCounted.mockResolvedValueOnce({ claimed: false, liveCount: 2 })
     expect(await isDeviceUnseen('user_abc', 'fp')).toBe(false)
-    expect(mockTouch).toHaveBeenCalledWith('user:devices:v2:user_abc', 7_776_000)
+    expect(mockMemberTouch).toHaveBeenCalledWith('user:devices:v3:user_abc', 'fp', 7_776_000)
   })
 
   it('does not slide TTL on a first-device silent seed', async () => {
     mockClaimCounted.mockResolvedValueOnce({ claimed: true, liveCount: 1 })
     expect(await isDeviceUnseen('user_abc', 'fp')).toBe(false)
-    expect(mockTouch).not.toHaveBeenCalled()
+    expect(mockMemberTouch).not.toHaveBeenCalled()
   })
 
-  it('claims the fingerprint under the user set key with the 90-day TTL', async () => {
+  it('claims the cookie id under the v3 user set key with the 90-day TTL', async () => {
     mockClaimCounted.mockResolvedValueOnce({ claimed: true, liveCount: 2 })
     await isDeviceUnseen('user_abc', 'fp')
     expect(mockClaimCounted).toHaveBeenCalledTimes(1)
-    expect(mockClaimCounted).toHaveBeenCalledWith('user:devices:v2:user_abc', 'fp', 7_776_000)
+    expect(mockClaimCounted).toHaveBeenCalledWith('user:devices:v3:user_abc', 'fp', 7_776_000)
   })
 
   it('atomic across concurrent first-sights — only one caller gets a claim', async () => {
@@ -132,24 +108,11 @@ describe('isDeviceUnseen', () => {
   })
 })
 
-describe('markDeviceSeen', () => {
-  it('slides the 90-day TTL forward', async () => {
-    mockTouch.mockResolvedValueOnce(undefined)
-    await markDeviceSeen('user_abc')
-    expect(mockTouch).toHaveBeenCalledWith('user:devices:v2:user_abc', 7_776_000)
-  })
-
-  it('swallows store errors', async () => {
-    mockTouch.mockRejectedValueOnce(new Error('store down'))
-    await expect(markDeviceSeen('user_abc')).resolves.toBeUndefined()
-  })
-})
-
 describe('forgetDevice', () => {
-  it('removes the fingerprint from the user set', async () => {
+  it('removes the cookie id from the user set', async () => {
     mockRemove.mockResolvedValueOnce(undefined)
     await forgetDevice('user_abc', 'fp')
-    expect(mockRemove).toHaveBeenCalledWith('user:devices:v2:user_abc', 'fp')
+    expect(mockRemove).toHaveBeenCalledWith('user:devices:v3:user_abc', 'fp')
   })
 
   it('swallows store errors', async () => {

--- a/apps/web/src/lib/server/auth/hooks.ts
+++ b/apps/web/src/lib/server/auth/hooks.ts
@@ -38,13 +38,15 @@ import {
   type SignInRateLimiter,
 } from './signin-rate-limit'
 import { checkAnonMintRateLimit } from './widget-rate-limit'
+import { formatSignInDevice, forgetDevice, isDeviceUnseen } from './signin-device-tracker'
 import {
-  computeDeviceFingerprint,
-  formatSignInDevice,
-  forgetDevice,
-  isDeviceUnseen,
-  markDeviceSeen,
-} from './signin-device-tracker'
+  deviceCookieAttributes,
+  deviceCookieName,
+  mintDeviceId,
+  readDeviceCookie,
+  signDeviceCookie,
+} from './signin-device-cookie'
+import { getBaseUrl } from '@/lib/server/config'
 import { isSyntheticAnonEmail } from '@/lib/shared/anonymous-email'
 import { readSsoClaims, readSsoClaimsWithProvenance, type ClaimRead } from './read-sso-claims'
 import { applyClaimAttributesAfter } from './apply-claim-attributes'
@@ -1262,11 +1264,13 @@ export async function handleSignInSuccessAudit(ctx: {
 }
 
 /**
- * First-sight new-device notification. Atomic claim of the fingerprint;
- * on success we fire the email + audit row in parallel and refresh the
- * 90-day TTL. On failure we roll back the claim so the next sign-in
- * re-fires the alert rather than losing it to a transient SMTP outage.
- * All errors swallowed — store/SMTP outages must not break sign-in.
+ * First-sight new-device notification. Identity is the signed
+ * `qb.device.{userId}` cookie. Atomic claim of that id; on success we
+ * fire the email + audit row in parallel. On failure we roll back the
+ * claim so the next sign-in re-fires the alert rather than losing it
+ * to a transient SMTP outage. The cookie is written on every real
+ * sign-in (known or new) so a later request can reuse the id. All
+ * errors swallowed — store/SMTP outages must not break sign-in.
  *
  * Better Auth sets `newSession` whenever it writes a session cookie,
  * including `/get-session` sliding the 24h `updateAge`. That is not a
@@ -1284,6 +1288,7 @@ export async function handleNewDeviceNotification(
         session?: { token?: string }
       } | null
     }
+    setCookie?: (name: string, value: string, opts?: Record<string, unknown>) => string
   },
   workspace: Awaited<
     ReturnType<typeof import('@/lib/server/domains/settings/settings.service').getWorkspaceSettings>
@@ -1300,19 +1305,19 @@ export async function handleNewDeviceNotification(
   const headers = getRequestHeaders()
   const userAgent = headers.get('user-agent') ?? ''
   const ip = getClientIp(headers)
-  const fingerprint = computeDeviceFingerprint(userAgent)
 
-  const unseen = await isDeviceUnseen(userId, fingerprint).catch(() => false)
+  const deviceId = ensureSignInDeviceId(ctx, userId, headers.get('cookie') ?? '')
+  if (!deviceId) return
+
+  const unseen = await isDeviceUnseen(userId, deviceId)
   if (!unseen) return
 
-  // Email + audit are independent — fire in parallel. TTL refresh
-  // runs only on full success so a failure can roll back via
-  // `forgetDevice` and re-fire on the next sign-in.
+  // Email + audit are independent — fire in parallel. A failure
+  // rolls back via `forgetDevice` so the next sign-in re-fires.
   try {
     const { sendNewSignInEmail } = await import('@quackback/email')
     const { recordAuditEvent } = await import('@/lib/server/audit/log')
     const { resolveAccountRecipient } = await import('@/lib/server/email/recipient')
-    const { getBaseUrl } = await import('@/lib/server/config')
     const occurredAt = new Date().toISOString()
     const device = formatSignInDevice(userAgent)
     const location = captureCountryFromHeaders(headers)
@@ -1321,8 +1326,8 @@ export async function handleNewDeviceNotification(
     // Account class, and deliberately no contact-address fallback: this alert
     // discloses IP, user agent and sign-in timing, and a contact address can be
     // one an agent typed into the inbox. An account with no deliverable address
-    // simply does not get the alert. The audit row and markDeviceSeen still run,
-    // or every subsequent sign-in would retry a send that can never succeed.
+    // simply does not get the alert. The audit row still runs, or every
+    // subsequent sign-in would retry a send that can never succeed.
     const to = await resolveAccountRecipient(userId as UserId)
     if (!to) {
       log.warn({ user_id: userId }, 'new-device alert skipped: no deliverable account address')
@@ -1366,10 +1371,43 @@ export async function handleNewDeviceNotification(
         metadata: { ip, userAgent, device, location },
       }),
     ])
-    await markDeviceSeen(userId)
   } catch (error) {
     log.error({ err: error }, 'new-device notification failed')
-    await forgetDevice(userId, fingerprint)
+    await forgetDevice(userId, deviceId)
+  }
+}
+
+/** Mint or reuse the cookie id and write it. Returns null when we
+ *  cannot identify this browser (missing workspace secret, userId that
+ *  is not a cookie-name token, or a freshly minted id that never
+ *  reached the browser). */
+function ensureSignInDeviceId(
+  ctx: {
+    setCookie?: (name: string, value: string, opts?: Record<string, unknown>) => string
+  },
+  userId: string,
+  cookieHeader: string
+): string | null {
+  try {
+    const existing = readDeviceCookie(cookieHeader, userId)
+    const deviceId = existing ?? mintDeviceId()
+    const value = signDeviceCookie(userId, deviceId)
+    if (typeof ctx.setCookie !== 'function') {
+      if (!existing) {
+        log.warn('device cookie not set: Better Auth setCookie missing on after-hook ctx')
+        return null
+      }
+      return deviceId
+    }
+    ctx.setCookie(
+      deviceCookieName(userId),
+      value,
+      deviceCookieAttributes(getBaseUrl().startsWith('https://'))
+    )
+    return deviceId
+  } catch (error) {
+    log.error({ err: error }, 'device cookie failed; treating device as known')
+    return null
   }
 }
 
@@ -1429,9 +1467,10 @@ export async function handleCountryCapture(ctx: {
  *     prior steps). Runs after the gates so it only records sign-ins
  *     that actually stuck.
  *  6. `handleNewDeviceNotification` — sends a "new device" email +
- *     records an audit row when an additional (browser, OS) for this
- *     user hasn't been seen within the last 90 days. The first
- *     recorded device is seeded silently. Alerts cannot be disabled.
+ *     records an audit row when an additional signed device cookie
+ *     for this user hasn't been seen within the last 90 days. The
+ *     first recorded device is seeded silently. Alerts cannot be
+ *     disabled. Bowser labels the email; it is not the claim key.
  */
 export const hooksAfter = createAuthMiddleware(async (ctx) => {
   if (process.env.AUTH_HOOKS_DEBUG === '1') {

--- a/apps/web/src/lib/server/auth/signin-device-cookie.ts
+++ b/apps/web/src/lib/server/auth/signin-device-cookie.ts
@@ -1,0 +1,99 @@
+/**
+ * Signed known-device cookie.
+ *
+ * The cookie is the identity for new-sign-in mail. Bowser stays on the
+ * email as the display line (`Chrome on Windows`); it is not the claim
+ * key. A random 128-bit id is HMAC-SHA256'd with the workspace secret
+ * so another account on the same browser cannot reuse it, and so a
+ * forged cookie is rejected.
+ *
+ * Per-user cookie name (`qb.device.{userId}`) so two accounts on one
+ * browser keep separate ids — overwriting a single shared cookie would
+ * make the other person look new on the next sign-in.
+ *
+ * Host-only (no `Domain`): pooled custom hosts must not leak the cookie
+ * across sibling sites on a parent domain.
+ */
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto'
+import { activeSecretKey } from '@/lib/server/secret-key'
+
+const DEVICE_COOKIE_PREFIX = 'qb.device.'
+export const DEVICE_TTL_SECONDS = 90 * 24 * 60 * 60
+
+const DOMAIN_TAG = 'qb.device:v1\n'
+const DEVICE_ID_RE = /^[0-9a-f]{32}$/
+/** Cookie-name token: TypeIDs and the dotted prefix both match. */
+const COOKIE_TOKEN_RE = /^[A-Za-z0-9_.-]+$/
+
+export function deviceCookieName(userId: string): string {
+  if (!COOKIE_TOKEN_RE.test(userId)) {
+    throw new Error('device cookie: userId is not a valid cookie-name token')
+  }
+  return `${DEVICE_COOKIE_PREFIX}${userId}`
+}
+
+export function mintDeviceId(): string {
+  return randomBytes(16).toString('hex')
+}
+
+function macFor(userId: string, deviceId: string): string {
+  return createHmac('sha256', activeSecretKey())
+    .update(DOMAIN_TAG)
+    .update(`${userId}.${deviceId}`)
+    .digest('base64url')
+}
+
+/** `v1.{32-hex-id}.{hmac}` — all cookie-safe, no encoding needed. */
+export function signDeviceCookie(userId: string, deviceId: string): string {
+  if (!DEVICE_ID_RE.test(deviceId)) {
+    throw new Error('device cookie: deviceId must be 32 hex chars')
+  }
+  return `v1.${deviceId}.${macFor(userId, deviceId)}`
+}
+
+export function verifyDeviceCookie(userId: string, value: string): string | null {
+  const match = /^v1\.([0-9a-f]{32})\.([A-Za-z0-9_-]+)$/.exec(value)
+  if (!match) return null
+  const deviceId = match[1]
+  const provided = match[2]
+  const expected = macFor(userId, deviceId)
+  const a = Buffer.from(provided)
+  const b = Buffer.from(expected)
+  if (a.length !== b.length || !timingSafeEqual(a, b)) return null
+  return deviceId
+}
+
+/** First matching `name=` pair; later duplicates do not override. */
+export function namedCookie(cookieHeader: string, name: string): string | null {
+  if (!cookieHeader || !COOKIE_TOKEN_RE.test(name)) return null
+  for (const part of cookieHeader.split(';')) {
+    const trimmed = part.trim()
+    const eq = trimmed.indexOf('=')
+    if (eq <= 0) continue
+    if (trimmed.slice(0, eq) !== name) continue
+    return trimmed.slice(eq + 1)
+  }
+  return null
+}
+
+export function readDeviceCookie(cookieHeader: string, userId: string): string | null {
+  const value = namedCookie(cookieHeader, deviceCookieName(userId))
+  if (!value) return null
+  return verifyDeviceCookie(userId, value)
+}
+
+export function deviceCookieAttributes(secure: boolean): {
+  httpOnly: true
+  secure: boolean
+  sameSite: 'lax'
+  path: '/'
+  maxAge: number
+} {
+  return {
+    httpOnly: true,
+    secure,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: DEVICE_TTL_SECONDS,
+  }
+}

--- a/apps/web/src/lib/server/auth/signin-device-tracker.ts
+++ b/apps/web/src/lib/server/auth/signin-device-tracker.ts
@@ -1,42 +1,36 @@
 /**
- * Per-user device-fingerprint tracker. The set `user:devices:v2:{userId}`
- * holds the recent (browser + OS + platform) hashes seen for the user.
- * `v2` is a new key so leftover UA+/24 hashes from the previous format
- * cannot make the first normalised browser look like an additional device.
+ * Per-user known-device tracker. The set `user:devices:v3:{userId}`
+ * holds the signed cookie ids seen for the user. `v3` is a new key so
+ * leftover UA / browser-family hashes cannot make the first cookie id
+ * look like an additional device.
  *
- * Identity is the normalised user-agent, not the IP. IP belongs in the
- * new-sign-in email as forensic context; hashing it in treats 5G / CGNAT /
- * VPN / travel as a new device.
+ * Identity is the cookie, not the user-agent and not the IP. Bowser is
+ * the email's display line only (`formatSignInDevice`). IP belongs in
+ * the new-sign-in email as forensic context.
  *
- * Two-phase API so notification failures don't silently lose the
- * alert: `isDeviceUnseen` atomically claims the fingerprint in one
- * statement; the caller follows with `markDeviceSeen` on success or
- * `forgetDevice` on failure. Errors fail closed (treat as known
- * device) so a store outage suppresses notifications rather than
- * spamming users.
+ * `isDeviceUnseen` atomically claims the id. The claim already writes
+ * the 90-day TTL. On notification failure the caller `forgetDevice`s
+ * so the next sign-in re-fires. Errors fail closed (treat as known)
+ * so a store outage suppresses mail rather than spamming users.
  *
  * The first live member in a user's set is seeded silently — that is
  * the sign-in they just made. Mail fires only on an additional unseen
- * browser/OS.
+ * cookie. Known devices slide only that member's 90-day window, so an
+ * unused browser's id can expire on its own.
  */
-import { createHash } from 'node:crypto'
 import Bowser from 'bowser'
-import { kvSetMemberClaimCounted, kvSetTouch, kvSetMemberRemove } from '@/lib/server/kv/pg-kv'
+import { kvSetMemberClaimCounted, kvSetMemberRemove, kvSetMemberTouch } from '@/lib/server/kv/pg-kv'
 import { logger } from '@/lib/server/logger'
+import { DEVICE_TTL_SECONDS } from './signin-device-cookie'
 
 const log = logger.child({ component: 'signin-device-tracker' })
 
-const DEVICE_SET_TTL_SECONDS = 90 * 24 * 60 * 60
-
-/** Stable hash input when the UA is empty or unparseable. */
+/** Display sentinel when the UA is empty or unparseable. */
 const UNKNOWN_DEVICE_KEY = 'unknown||'
 
-/**
- * Browser + OS + platform, with versions stripped so an auto-update does
- * not look like a new device. Empty / unparseable UAs share one sentinel
- * rather than hashing each garbage string.
- */
-export function signInDeviceKey(userAgent: string): string {
+/** Browser + OS + platform for the email line. Versions stripped so an
+ *  auto-update does not change `Chrome on Windows`. */
+function signInDeviceKey(userAgent: string): string {
   const trimmed = userAgent.trim()
   if (!trimmed) return UNKNOWN_DEVICE_KEY
   try {
@@ -60,41 +54,33 @@ export function formatSignInDevice(userAgent: string): string {
   return browser || os || 'Unknown device'
 }
 
-/**
- * SHA-256 of the normalised device key, truncated to 128 bits / 32 hex
- * chars. IP is deliberately not part of the hash.
- */
-export function computeDeviceFingerprint(userAgent: string): string {
-  return createHash('sha256').update(signInDeviceKey(userAgent)).digest('hex').slice(0, 32)
-}
-
 // User ids are only unique within a workspace database, so an undiscriminated
 // set would let one workspace's sign-in suppress another's new-device alert — the
 // notification whose entire job is to be the first sign of a stolen credential.
 // `pg-kv.ts` writes the workspace into the row's key; under pooled tenancy the row
 // is additionally in that workspace's own database.
-const key = (userId: string) => `user:devices:v2:${userId}`
+const key = (userId: string) => `user:devices:v3:${userId}`
 
 /**
  * Atomic claim. Returns true iff this is an *additional* unseen device
  * (the set already had at least one live member). The first recorded
  * device is claimed and given the 90-day TTL but does not notify — that
- * is the user's own sign-in, and it also absorbs a hash-format change
+ * is the user's own sign-in, and it also absorbs a key-format change
  * without a one-time mail burst.
  *
- * Known devices slide the set's 90-day window here. Otherwise a daily
- * sign-in never calls `markDeviceSeen`, the member expires, and the next
- * distinct browser is treated as a silent first seed.
+ * Known devices slide only this member's 90-day window. A whole-set
+ * touch would keep unused cookie ids alive for as long as any one
+ * browser signs in.
  */
-export async function isDeviceUnseen(userId: string, fingerprint: string): Promise<boolean> {
+export async function isDeviceUnseen(userId: string, deviceId: string): Promise<boolean> {
   try {
     const { claimed, liveCount } = await kvSetMemberClaimCounted(
       key(userId),
-      fingerprint,
-      DEVICE_SET_TTL_SECONDS
+      deviceId,
+      DEVICE_TTL_SECONDS
     )
     if (!claimed) {
-      await kvSetTouch(key(userId), DEVICE_SET_TTL_SECONDS)
+      await kvSetMemberTouch(key(userId), deviceId, DEVICE_TTL_SECONDS)
       return false
     }
     return liveCount > 1
@@ -104,19 +90,10 @@ export async function isDeviceUnseen(userId: string, fingerprint: string): Promi
   }
 }
 
-/** Slide the 90-day window forward after a successful notification. */
-export async function markDeviceSeen(userId: string): Promise<void> {
-  try {
-    await kvSetTouch(key(userId), DEVICE_SET_TTL_SECONDS)
-  } catch (error) {
-    log.error({ err: error }, 'markDeviceSeen failed')
-  }
-}
-
 /** Roll back a claim so the next sign-in re-fires the notification. */
-export async function forgetDevice(userId: string, fingerprint: string): Promise<void> {
+export async function forgetDevice(userId: string, deviceId: string): Promise<void> {
   try {
-    await kvSetMemberRemove(key(userId), fingerprint)
+    await kvSetMemberRemove(key(userId), deviceId)
   } catch (error) {
     log.error({ err: error }, 'forgetDevice failed')
   }

--- a/apps/web/src/lib/server/kv/__tests__/workspace-separation.db.test.ts
+++ b/apps/web/src/lib/server/kv/__tests__/workspace-separation.db.test.ts
@@ -217,14 +217,12 @@ describe('workspace separation — device sets', () => {
       WHERE workspace_key = ${A} AND set_key = ${setKey} AND member = 'firefox'
     `
     await withRealWorkspace(A, () => kvSetMemberTouch(setKey, 'chrome', 60))
-    const rows = await testSql()`
+    const rows = await testSql()<{ member: string; secs: number | string }[]>`
       SELECT member, EXTRACT(EPOCH FROM (expires_at - now()))::int AS secs
       FROM kv_set_member
       WHERE workspace_key = ${A} AND set_key = ${setKey}
     `
-    const secs = Object.fromEntries(
-      (rows as { member: string; secs: number | string }[]).map((r) => [r.member, Number(r.secs)])
-    )
+    const secs = Object.fromEntries(rows.map((r) => [r.member, Number(r.secs)]))
     expect(secs.chrome).toBeGreaterThan(30)
     expect(secs.firefox).toBeLessThan(20)
     expect(secs.stale).toBeLessThan(0)

--- a/apps/web/src/lib/server/kv/__tests__/workspace-separation.db.test.ts
+++ b/apps/web/src/lib/server/kv/__tests__/workspace-separation.db.test.ts
@@ -36,6 +36,7 @@ import {
   kvSetMemberClaim,
   kvSetMemberClaimCounted,
   kvSetTouch,
+  kvSetMemberTouch,
 } from '../pg-kv'
 import {
   currentWorkspaceNamespace,
@@ -199,6 +200,37 @@ describe('workspace separation — device sets', () => {
     expect(await withRealWorkspace(A, () => kvSetMemberClaimCounted(setKey, 'stale', 60))).toEqual({
       claimed: true,
       liveCount: 2,
+    })
+  })
+
+  it('member touch slides only the named live row', async () => {
+    const setKey = uniqueKey('user:devices')
+    await withRealWorkspace(A, () => kvSetMemberClaimCounted(setKey, 'chrome', 60))
+    await withRealWorkspace(A, () => kvSetMemberClaimCounted(setKey, 'firefox', 60))
+    await withRealWorkspace(A, () => kvSetMemberClaimCounted(setKey, 'stale', 60))
+    await testSql()`
+      UPDATE kv_set_member SET expires_at = now() - interval '1 second'
+      WHERE workspace_key = ${A} AND set_key = ${setKey} AND member = 'stale'
+    `
+    await testSql()`
+      UPDATE kv_set_member SET expires_at = now() + interval '10 seconds'
+      WHERE workspace_key = ${A} AND set_key = ${setKey} AND member = 'firefox'
+    `
+    await withRealWorkspace(A, () => kvSetMemberTouch(setKey, 'chrome', 60))
+    const rows = await testSql()`
+      SELECT member, EXTRACT(EPOCH FROM (expires_at - now()))::int AS secs
+      FROM kv_set_member
+      WHERE workspace_key = ${A} AND set_key = ${setKey}
+    `
+    const secs = Object.fromEntries(
+      (rows as { member: string; secs: number | string }[]).map((r) => [r.member, Number(r.secs)])
+    )
+    expect(secs.chrome).toBeGreaterThan(30)
+    expect(secs.firefox).toBeLessThan(20)
+    expect(secs.stale).toBeLessThan(0)
+    expect(await withRealWorkspace(A, () => kvSetMemberClaimCounted(setKey, 'stale', 60))).toEqual({
+      claimed: true,
+      liveCount: 3,
     })
   })
 })

--- a/apps/web/src/lib/server/kv/pg-kv.ts
+++ b/apps/web/src/lib/server/kv/pg-kv.ts
@@ -145,7 +145,7 @@ export async function kvGetOrCreate<T>(key: string, create: T, seconds: number):
 }
 
 // ============================================================================
-// Sets — the one Redis SET we used, `user:devices:v2:<userId>`
+// Sets — the one Redis SET we used, `user:devices:v3:<userId>`
 // ============================================================================
 
 export interface SetMemberClaim {
@@ -245,6 +245,24 @@ export async function kvSetTouch(setKey: string, seconds: number): Promise<void>
     SET expires_at = now() + make_interval(secs => ${ttlSeconds(seconds)})
     WHERE workspace_key = ${currentWorkspaceNamespace()}
       AND set_key = ${setKey}
+      AND expires_at > now()
+  `)
+}
+
+/** Slide one live member's window. Unused siblings keep their own expiry
+ *  so a daily sign-in from Chrome does not keep a leftover Firefox id
+ *  alive forever. Expired rows stay dead, same as `kvSetTouch`. */
+export async function kvSetMemberTouch(
+  setKey: string,
+  member: string,
+  seconds: number
+): Promise<void> {
+  await db.execute(sql`
+    UPDATE kv_set_member
+    SET expires_at = now() + make_interval(secs => ${ttlSeconds(seconds)})
+    WHERE workspace_key = ${currentWorkspaceNamespace()}
+      AND set_key = ${setKey}
+      AND member = ${member}
       AND expires_at > now()
   `)
 }

--- a/packages/db/src/schema/kv.ts
+++ b/packages/db/src/schema/kv.ts
@@ -60,7 +60,7 @@ export const rateBucket = pgTable(
   ]
 )
 
-/** Members of a keyed set — today only `user:devices:v2:<userId>`. */
+/** Members of a keyed set — today only `user:devices:v3:<userId>`. */
 export const kvSetMember = pgTable(
   'kv_set_member',
   {

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -756,7 +756,8 @@ interface SendNewSignInParams {
 
 /** Additional-device sign-in alert. Triggered by
  * `handleNewDeviceNotification` after a successful sign-in lands on
- * an unseen (browser, OS) for that account. IP is shown, not hashed. */
+ * an unseen signed device cookie for that account. IP and browser/OS
+ * are shown, not used as the claim key. */
 export async function sendNewSignInEmail(params: SendNewSignInParams): Promise<EmailResult> {
   const {
     to,

--- a/packages/email/src/templates/new-sign-in.tsx
+++ b/packages/email/src/templates/new-sign-in.tsx
@@ -15,11 +15,11 @@ interface NewSignInEmailProps {
 }
 
 /**
- * "New device" sign-in notification — sent when an additional
- * (browser, OS) is seen for the recipient's account. IP and location
- * are shown as context; they are not the device identity. The user is
- * already signed in by the time this lands; the alert is purely
- * informational with a recovery path if it wasn't them.
+ * "New device" sign-in notification — sent when an additional signed
+ * device cookie is seen for the recipient's account. Browser/OS, IP
+ * and location are shown as context; they are not the device identity.
+ * The user is already signed in by the time this lands; the alert is
+ * purely informational with a recovery path if it wasn't them.
  */
 export function NewSignInEmail({
   workspaceName,


### PR DESCRIPTION
## Summary
- New-sign-in mail now claims a signed `qb.device.{userId}` cookie (HMAC + workspace secret). Bowser/OS and IP stay in the email as context; they are not the identity.
- Per-user cookie name so two accounts on one browser do not overwrite each other. Host-only, HttpOnly, SameSite=Lax, 90 days.
- Claims go in `user:devices:v3:{userId}` so leftover UA hashes cannot look like a second device. First live member is still a silent seed.
- Known devices slide only that cookie's TTL, so an unused browser can expire.

## Test plan
- [ ] `bunx vitest run --dir apps/web/src/lib/server/auth/__tests__ signin-device-cookie signin-device-tracker hooks-new-device-notification`
- [ ] Sign in from a new browser: first device is silent; a second browser emails.
- [ ] Same browser after IP/VPN change: no email (cookie reused).
- [ ] Shared computer, second account: other user's cookie ignored; first sign-in for that account is silent.
- [ ] SMTP/audit failure: next sign-in from that browser emails again.


Made with [Cursor](https://cursor.com)