### PR TITLE
fix(widget): keep a private portal usable for SDK-identified visitors

### DIFF
--- a/apps/web/src/components/widget/__tests__/widget-board-selection.test.ts
+++ b/apps/web/src/components/widget/__tests__/widget-board-selection.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { reconcileBoardSelection, resolveDefaultBoardId } from '../widget-board-selection'
+
+const ideas = { id: 'board_1', slug: 'ideas' }
+const bugs = { id: 'board_2', slug: 'bugs' }
+
+describe('resolveDefaultBoardId', () => {
+  it('prefers the configured default board when it is visible', () => {
+    expect(resolveDefaultBoardId([ideas, bugs], 'bugs')).toBe('board_2')
+  })
+
+  it('auto-selects a single board', () => {
+    expect(resolveDefaultBoardId([ideas], undefined)).toBe('board_1')
+    expect(resolveDefaultBoardId([ideas], 'not-visible')).toBe('board_1')
+  })
+
+  it('leaves the choice open for several boards without a default', () => {
+    expect(resolveDefaultBoardId([ideas, bugs], undefined)).toBe('')
+  })
+
+  it('has nothing to select from an empty list', () => {
+    // The anonymous SSR seed on a private portal — the composer must not
+    // point at a board that is not there.
+    expect(resolveDefaultBoardId([], 'ideas')).toBe('')
+  })
+})
+
+describe('reconcileBoardSelection', () => {
+  it('keeps a selection that is still in the list', () => {
+    expect(reconcileBoardSelection('board_2', [ideas, bugs], 'ideas')).toBe('board_2')
+  })
+
+  it('re-derives an empty selection once boards arrive', () => {
+    // Mount on the empty SSR seed, then the post-identify refetch lands.
+    expect(reconcileBoardSelection('', [], 'ideas')).toBe('')
+    expect(reconcileBoardSelection('', [ideas], 'ideas')).toBe('board_1')
+  })
+
+  it('drops a selection that is no longer visible', () => {
+    expect(reconcileBoardSelection('board_9', [ideas], undefined)).toBe('board_1')
+    expect(reconcileBoardSelection('board_9', [ideas, bugs], undefined)).toBe('')
+  })
+})

--- a/apps/web/src/components/widget/widget-board-selection.ts
+++ b/apps/web/src/components/widget/widget-board-selection.ts
@@ -1,0 +1,35 @@
+/**
+ * Which board the composer should target, given the boards the viewer can
+ * see. Extracted so the rule has one home: it seeds the selection on mount
+ * and re-derives it whenever the list changes — on a private portal the SSR
+ * seed is empty and the real list only lands with the post-identify refetch.
+ *
+ * - The configured default board wins when it is in the list.
+ * - A single board is auto-selected (the selector is hidden for one board).
+ * - Several boards without a default leave the choice to the visitor ('').
+ */
+export function resolveDefaultBoardId(
+  boards: ReadonlyArray<{ id: string; slug: string }>,
+  defaultBoard: string | undefined
+): string {
+  if (defaultBoard) {
+    const match = boards.find((b) => b.slug === defaultBoard)
+    if (match) return match.id
+  }
+  if (boards.length === 1) return boards[0].id
+  return ''
+}
+
+/**
+ * Keep a selection that is still valid; otherwise re-derive it. A visitor who
+ * picked a board keeps it as long as it exists; an empty or stale selection
+ * follows the list.
+ */
+export function reconcileBoardSelection(
+  current: string,
+  boards: ReadonlyArray<{ id: string; slug: string }>,
+  defaultBoard: string | undefined
+): string {
+  if (current && boards.some((b) => b.id === current)) return current
+  return resolveDefaultBoardId(boards, defaultBoard)
+}

--- a/apps/web/src/components/widget/widget-home-animated.tsx
+++ b/apps/web/src/components/widget/widget-home-animated.tsx
@@ -22,7 +22,9 @@ import { listPublicPostsFn } from '@/lib/server/functions/public-posts'
 import { useInfiniteScroll } from '@/lib/client/hooks/use-infinite-scroll'
 import { WidgetVoteButton } from './widget-vote-button'
 import { WidgetPostListSkeleton } from './widget-skeletons'
-import { widgetQueryKeys } from '@/lib/client/hooks/use-widget-vote'
+import { widgetQueryKeys, INITIAL_SESSION_VERSION } from '@/lib/client/hooks/use-widget-vote'
+import { getWidgetAuthHeaders } from '@/lib/client/widget-auth'
+import { reconcileBoardSelection, resolveDefaultBoardId } from './widget-board-selection'
 import { cn } from '@/lib/shared/utils'
 import { useWidgetAuth } from './widget-auth-provider'
 import { sendToHost } from '@/lib/client/widget-bridge'
@@ -231,22 +233,24 @@ export function WidgetHomeAnimated({
     emitEvent,
     metadata,
     getSessionVersion,
+    sessionVersion,
   } = useWidgetAuth()
   const queryClient = useQueryClient()
   const inputRef = useRef<HTMLInputElement>(null)
 
   const [title, setTitle] = useState('')
   const [expanded, setExpanded] = useState(false)
-  const [selectedBoardId, setSelectedBoardId] = useState(() => {
-    if (defaultBoard) {
-      const match = boards.find((b) => b.slug === defaultBoard)
-      if (match) return match.id
-    }
-    // Single board: auto-select (selector is hidden anyway). Multiple boards with no
-    // default: leave empty so the user is prompted to pick one.
-    if (boards.length === 1) return boards[0].id
-    return ''
-  })
+  const [selectedBoardId, setSelectedBoardId] = useState(() =>
+    resolveDefaultBoardId(boards, defaultBoard)
+  )
+  // The list can change after mount: on a private portal the SSR seed is
+  // empty and the boards only land with the post-identify Bearer refetch. A
+  // selection the visitor made survives as long as its board is listed; an
+  // empty or stale one follows the list, or the composer keeps pointing at
+  // nothing and submit stays dead under a "Posting as …" footer.
+  useEffect(() => {
+    setSelectedBoardId((current) => reconcileBoardSelection(current, boards, defaultBoard))
+  }, [boards, defaultBoard])
   const [contentJson, setContentJson] = useState<JSONContent | null>(null)
   const [contentHtml, setContentHtml] = useState('')
   const handleEditorChange = useCallback((json: JSONContent, html: string) => {
@@ -317,7 +321,10 @@ export function WidgetHomeAnimated({
     isFetchingNextPage,
     isFetching: isFetchingPosts,
   } = useInfiniteQuery({
-    queryKey: ['widget', 'posts', 'popular', 'top', activeBoardSlug ?? 'all'],
+    // Keyed on sessionVersion and sent with the Bearer, like every other
+    // widget query: the SSR seed is the anonymous baseline, and on a private
+    // portal that is an empty feed even for a visitor who is about to identify.
+    queryKey: ['widget', 'posts', 'popular', 'top', activeBoardSlug ?? 'all', sessionVersion],
     queryFn: async ({ pageParam }) => {
       const page = await listPublicPostsFn({
         data: {
@@ -326,19 +333,25 @@ export function WidgetHomeAnimated({
           limit: 20,
           boardSlug: activeBoardSlug ?? undefined,
         },
+        headers: getWidgetAuthHeaders(),
       })
       return { ...page, items: page.items.map(toWidgetPost) }
     },
     initialPageParam: 1,
     getNextPageParam: (lastPage, allPages) => (lastPage.hasMore ? allPages.length + 1 : undefined),
-    // Only seed from SSR data on the initial unfiltered view
+    // Only seed from SSR data on the initial unfiltered view, and only for the
+    // SSR session version — after identify the key changes, carries no seed,
+    // and page 1 is fetched again for the real actor.
     initialData:
-      activeBoardSlug === null
+      activeBoardSlug === null && sessionVersion === INITIAL_SESSION_VERSION
         ? {
             pages: [{ items: initialPosts, total: undefined, hasMore: initialHasMore }],
             pageParams: [1],
           }
         : undefined,
+    // Hold the previous pages while the re-keyed fetch runs instead of
+    // flashing the skeleton between "anonymous" and "identified".
+    placeholderData: keepPreviousData,
   })
 
   const allPopularPosts: WidgetPost[] = useMemo(

--- a/apps/web/src/components/widget/widget-home-animated.tsx
+++ b/apps/web/src/components/widget/widget-home-animated.tsx
@@ -349,9 +349,10 @@ export function WidgetHomeAnimated({
             pageParams: [1],
           }
         : undefined,
-    // Hold the previous pages while the re-keyed fetch runs instead of
-    // flashing the skeleton between "anonymous" and "identified".
-    placeholderData: keepPreviousData,
+    // Deliberately no placeholderData across the re-key: the previous pages
+    // belong to the previous actor, and after a logout or re-identify their
+    // audience-filtered titles must not linger while the new request is
+    // pending. A brief skeleton is the correct state in between.
   })
 
   const allPopularPosts: WidgetPost[] = useMemo(

--- a/apps/web/src/lib/server/functions/__tests__/resolve-portal-access.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/resolve-portal-access.test.ts
@@ -46,6 +46,7 @@ vi.mock('@/lib/server/auth/index', () => ({
 const mockPrincipalFindFirst = vi.fn()
 const mockInvitationFindFirst = vi.fn()
 const mockWidgetOriginSessionFindFirst = vi.fn()
+const mockWidgetIdentifiedSessionFindFirst = vi.fn()
 
 vi.mock('@/lib/server/db', () => ({
   db: {
@@ -55,11 +56,15 @@ vi.mock('@/lib/server/db', () => ({
       widgetOriginSession: {
         findFirst: (...args: unknown[]) => mockWidgetOriginSessionFindFirst(...args),
       },
+      widgetIdentifiedSession: {
+        findFirst: (...args: unknown[]) => mockWidgetIdentifiedSessionFindFirst(...args),
+      },
     },
   },
   principal: { userId: 'userId', id: 'id' },
   invitation: { email: 'email', kind: 'kind', status: 'status' },
   widgetOriginSession: { sessionId: 'sessionId' },
+  widgetIdentifiedSession: { sessionId: 'sessionId', hmacVerified: 'hmacVerified' },
   eq: vi.fn(),
   and: vi.fn((...args: unknown[]) => args),
   inArray: vi.fn(),
@@ -107,6 +112,8 @@ beforeEach(() => {
   mockInvitationFindFirst.mockResolvedValue(null)
   // Default: no widget origin marker.
   mockWidgetOriginSessionFindFirst.mockResolvedValue(null)
+  // Default: no hmac-verified identify provenance for the session either.
+  mockWidgetIdentifiedSessionFindFirst.mockResolvedValue(null)
   // Default: identifyVerification off (email-capture mode).
   mockGetWidgetConfig.mockResolvedValue({ identifyVerification: false })
   // Default: no segment memberships.
@@ -642,5 +649,84 @@ describe('resolvePortalAccessForRequest — segment lookup', () => {
     await resolvePortalAccessForRequest()
 
     expect(mockSegmentIdsForPrincipal).not.toHaveBeenCalled()
+  })
+})
+
+describe('resolvePortalAccessForRequest — widget Bearer session (hmac-verified identify)', () => {
+  // The session the SDK identify minted and the widget sends as Bearer on
+  // every data refetch. It never passes through the handoff route, so it has
+  // no widget_origin_session row — only the provenance row identify wrote.
+  const BEARER_SESSION = {
+    user: { id: 'user_sdk', email: 'sdk@example.com', emailVerified: false },
+    session: { id: 'sess_sdk_1' },
+  }
+  const PRIVATE_WIDGET_SIGN_IN = {
+    access: { visibility: 'private', allowedDomains: [], widgetSignIn: true },
+  }
+
+  it('grants the widget branch when identify recorded the session as hmac-verified', async () => {
+    mockGetSession.mockResolvedValue(BEARER_SESSION)
+    mockPrincipalFindFirst.mockResolvedValue({ type: 'user', role: 'user' })
+    mockWidgetOriginSessionFindFirst.mockResolvedValue(null)
+    mockWidgetIdentifiedSessionFindFirst.mockResolvedValue({ sessionId: 'sess_sdk_1' })
+    mockGetPortalConfig.mockResolvedValue(PRIVATE_WIDGET_SIGN_IN)
+
+    const result = await resolvePortalAccessForRequest()
+
+    expect(result).toEqual({ granted: true, reason: 'widget' })
+  })
+
+  it('does not consult the provenance row when the origin marker already grants', async () => {
+    mockGetSession.mockResolvedValue(BEARER_SESSION)
+    mockPrincipalFindFirst.mockResolvedValue({ type: 'user', role: 'user' })
+    mockWidgetOriginSessionFindFirst.mockResolvedValue({ sessionId: 'sess_sdk_1' })
+    mockGetPortalConfig.mockResolvedValue(PRIVATE_WIDGET_SIGN_IN)
+
+    const result = await resolvePortalAccessForRequest()
+
+    expect(result).toEqual({ granted: true, reason: 'widget' })
+    expect(mockWidgetIdentifiedSessionFindFirst).not.toHaveBeenCalled()
+  })
+
+  it('denies when neither the origin marker nor hmac-verified provenance exists', async () => {
+    mockGetSession.mockResolvedValue(BEARER_SESSION)
+    mockPrincipalFindFirst.mockResolvedValue({ type: 'user', role: 'user' })
+    mockWidgetOriginSessionFindFirst.mockResolvedValue(null)
+    // The provenance lookup filters on hmac_verified=true, so an unverified
+    // identify (or none at all) answers null here.
+    mockWidgetIdentifiedSessionFindFirst.mockResolvedValue(null)
+    mockGetPortalConfig.mockResolvedValue(PRIVATE_WIDGET_SIGN_IN)
+
+    const result = await resolvePortalAccessForRequest()
+
+    expect(result.granted).toBe(false)
+    if (!result.granted) expect(result.reason).toBe('unauthorized')
+  })
+
+  it('still requires widgetSignIn: hmac-verified provenance alone does not open a private portal', async () => {
+    mockGetSession.mockResolvedValue(BEARER_SESSION)
+    mockPrincipalFindFirst.mockResolvedValue({ type: 'user', role: 'user' })
+    mockWidgetOriginSessionFindFirst.mockResolvedValue(null)
+    mockWidgetIdentifiedSessionFindFirst.mockResolvedValue({ sessionId: 'sess_sdk_1' })
+    mockGetPortalConfig.mockResolvedValue({
+      access: { visibility: 'private', allowedDomains: [], widgetSignIn: false },
+    })
+
+    const result = await resolvePortalAccessForRequest()
+
+    expect(result.granted).toBe(false)
+  })
+
+  it('fails CLOSED on a widget_identified_session DB error', async () => {
+    mockGetSession.mockResolvedValue(BEARER_SESSION)
+    mockPrincipalFindFirst.mockResolvedValue({ type: 'user', role: 'user' })
+    mockWidgetOriginSessionFindFirst.mockResolvedValue(null)
+    mockWidgetIdentifiedSessionFindFirst.mockRejectedValue(new Error('DB_ERROR'))
+    mockGetPortalConfig.mockResolvedValue(PRIVATE_WIDGET_SIGN_IN)
+
+    const result = await resolvePortalAccessForRequest()
+
+    expect(result.granted).toBe(false)
+    if (!result.granted) expect(result.reason).toBe('unauthorized')
   })
 })

--- a/apps/web/src/lib/server/functions/portal-access.ts
+++ b/apps/web/src/lib/server/functions/portal-access.ts
@@ -144,13 +144,35 @@ export const resolvePortalAccessForRequest = createServerOnlyFn(
     // Fail CLOSED on DB error: a lookup failure never grants widget access.
     let hasViaWidgetMarker = false
     if (isAuthenticated && session?.session?.id) {
-      const { widgetOriginSession } = await import('@/lib/server/db')
+      const {
+        widgetOriginSession,
+        widgetIdentifiedSession,
+        and: dbAnd,
+      } = await import('@/lib/server/db')
+      const sessionId = session.session.id
       try {
         const markerRow = await db.query.widgetOriginSession.findFirst({
-          where: eq(widgetOriginSession.sessionId, session.session.id),
+          where: eq(widgetOriginSession.sessionId, sessionId),
           columns: { sessionId: true },
         })
         hasViaWidgetMarker = !!markerRow
+        // The widget's own Bearer session. Identify records its provenance in
+        // widget_identified_session, and the handoff route consults that very
+        // row before it writes the origin marker — so an hmac_verified=true
+        // row carries exactly the trust the marker is derived from. Without
+        // this branch every SDK data refetch (boards, feed, capabilities) ran
+        // as a denied caller on a private portal, and an identified visitor
+        // got an empty widget: no board to post to, no ideas to vote on.
+        if (!hasViaWidgetMarker) {
+          const identifiedRow = await db.query.widgetIdentifiedSession.findFirst({
+            where: dbAnd(
+              eq(widgetIdentifiedSession.sessionId, sessionId),
+              eq(widgetIdentifiedSession.hmacVerified, true)
+            ),
+            columns: { sessionId: true },
+          })
+          hasViaWidgetMarker = !!identifiedRow
+        }
       } catch {
         // DB error — fail closed (no widget marker).
         hasViaWidgetMarker = false

--- a/apps/web/src/routes/widget/index.tsx
+++ b/apps/web/src/routes/widget/index.tsx
@@ -36,7 +36,7 @@ import { useWidgetAuth } from '@/components/widget/widget-auth-provider'
 import { portalQueries } from '@/lib/client/queries/portal'
 import { publicChangelogQueries } from '@/lib/client/queries/changelog'
 import { publicHelpCenterQueries } from '@/lib/client/queries/help-center'
-import { fetchBoardCapabilitiesFn } from '@/lib/server/functions/portal'
+import { fetchBoardCapabilitiesFn, fetchPortalData } from '@/lib/server/functions/portal'
 import { getShowPoweredByFn } from '@/lib/server/functions/powered-by'
 import { listPublicArticlesFn } from '@/lib/server/functions/help-center'
 import { getWidgetAuthHeaders } from '@/lib/client/widget-auth'
@@ -380,8 +380,8 @@ function WidgetPage() {
   const {
     posts,
     postsHasMore,
-    statuses,
-    boards,
+    statuses: loaderStatuses,
+    boards: loaderBoards,
     orgSlug,
     boardPermissions,
     tabs,
@@ -422,7 +422,40 @@ function WidgetPage() {
     enabled: !!tabs.feedback,
   })
 
-  const { c: resumeConversationId } = Route.useSearch()
+  const { c: resumeConversationId, board: boardSlug } = Route.useSearch()
+
+  // Boards and statuses come from the same anonymous SSR baseline as the
+  // permissions above — and on a private portal that baseline is EMPTY: the
+  // portal gate admits the widget's Bearer session, never the cookie-less SSR
+  // request. An identified visitor therefore kept the empty board list the
+  // loader handed over: the composer had no board to post to and the feed
+  // nothing to show, while the footer still said "Posting as …". Refetch the
+  // pair for the real actor once the session moves past the SSR version, the
+  // way livePermissions does; until then the loader data is the seed.
+  const { data: livePortal } = useQuery({
+    queryKey: ['widget', 'portalData', sessionVersion, boardSlug ?? 'all'],
+    queryFn: () =>
+      fetchPortalData({
+        data: { boardSlug, sort: 'top' },
+        headers: getWidgetAuthHeaders(),
+      }),
+    staleTime: 30 * 1000,
+    enabled: !!tabs.feedback && sessionVersion !== INITIAL_SESSION_VERSION,
+  })
+  const boards = useMemo(
+    () =>
+      livePortal
+        ? livePortal.boards.map((b) => ({ id: b.id as string, name: b.name, slug: b.slug }))
+        : loaderBoards,
+    [livePortal, loaderBoards]
+  )
+  const statuses = useMemo(
+    () =>
+      livePortal
+        ? livePortal.statuses.map((s) => ({ id: s.id as string, name: s.name, color: s.color }))
+        : loaderStatuses,
+    [livePortal, loaderStatuses]
+  )
   const { hasTickets } = useTicketStageBadge(!!tabs.tickets)
   const threadTab: WidgetTab | null = tabs.messages ? 'messages' : tabs.tickets ? 'tickets' : null
   const initialTab = resolveInitialTab(tabs)


### PR DESCRIPTION

### What breaks

With `portalConfig.access.visibility = 'private'` and `widgetSignIn = true`, a visitor identified through the SDK (`Quackback.init({ identity: { ssoToken } })`) gets a widget that looks signed in but cannot do anything:

- the composer footer says **"Posting as <name>"**, yet **Submit stays disabled** — there is no board selected and none to pick;
- the "Popular ideas" list is **empty** although the board has posts;
- `boardPermissions` refetched with the Bearer comes back as `{}`.

Anyone who also carries a Quackback **cookie** (a teammate logged into `/admin` in the same browser) sees a working widget, which is why this hides during team testing: the same widget, same board, same SSO token — different result depending on a cookie the customer never has.

### Why

1. `resolvePortalAccessForRequest` only grants the widget branch through `widget_origin_session` — the marker the `/auth/widget-handoff` route writes. The widget's own Bearer session (the one every SDK data refetch runs under) never passes through that route, so on a private portal it is denied even though identify recorded it as `hmac_verified = true` in `widget_identified_session`. Note that the handoff route itself derives the origin marker from that very row, so the trust is the same.
2. The widget route seeds boards, statuses and the feed from the anonymous SSR loader (no Bearer at loader time) and only ever refetches `boardPermissions` after identify — boards, statuses and the feed stay whatever the anonymous baseline was, which on a private portal is nothing. `WidgetHome` additionally derives `selectedBoardId` once in a `useState` initialiser, so a board list that arrives later never becomes the selection.

### What this PR does

**Portal access** (`lib/server/functions/portal-access.ts`): a session with an `hmac_verified = true` row in `widget_identified_session` now satisfies `hasViaWidgetMarker`, looked up only when the origin marker is absent. Everything else in the widget branch is unchanged: `widgetSignIn` is still required, the identify-verification guard still applies, DB errors still fail closed.

**Widget** (`routes/widget/index.tsx`, `components/widget/widget-home-animated.tsx`):

- boards and statuses are refetched with the Bearer once `sessionVersion` moves past `INITIAL_SESSION_VERSION`, mirroring the existing `livePermissions` query; the loader data remains the SSR seed until then;
- the popular-ideas infinite query is keyed on `sessionVersion`, sent with `getWidgetAuthHeaders()`, seeds `initialData` only for the SSR version and keeps the previous pages during the re-keyed fetch;
- the composer's board selection follows the list (`widget-board-selection.ts`): a selection the visitor made survives while its board exists, an empty or stale one is re-derived.

### Tests

- `resolve-portal-access.test.ts`: grant via hmac-verified provenance; origin marker short-circuits the provenance lookup; deny without either; `widgetSignIn` still required; fail closed on a `widget_identified_session` DB error.
- `widget-board-selection.test.ts`: default/single/multi-board resolution and reconciliation against a changing list.

`bun run test` for `components/widget`, `lib/server/functions`, `routes/api/widget`, `lib/server/domains/settings`: 1927 passed. `tsc --noEmit` for `apps/web`: clean. `bun run build` + `check:server-fn-manifest`: pass. `check:widget-bundle` reports 591 KB gz against the 550 KB budget both with and without this change (measured on `main` at 4ef5beb) — pre-existing, not introduced here.

### Not in this PR

`/api/widget/search` is still called without the Bearer, so search on a private portal returns nothing for identified visitors. Same root cause, separate change.

### How to reproduce before / verify after

1. Settings → Portal → Access: `visibility = private`, `widgetSignIn = true`; one board, any tier.
2. Embed the widget on a host page with a signed `ssoToken`; open it in a browser **without** a Quackback cookie (private window).
3. Before: "Posting as …", Submit disabled, empty list. After: board selected, Submit enabled, posts listed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5FqRoi3VVbsbpHTn5Q9Ru
