### PR TITLE
fix(editor): let Enter insert a newline in comments

### DIFF
--- a/apps/web/src/components/public/__tests__/comment-editor-features.test.ts
+++ b/apps/web/src/components/public/__tests__/comment-editor-features.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Guards the comment editor preset against accidental flag drift. enterAsHardBreak
+ * was dropped once when comments reused the post composer feature set — pin it
+ * so plain Enter stays a newline (Cmd/Ctrl+Enter submits on the wrapping form).
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { EditorFeatures } from '@/components/ui/rich-text-editor'
+import { COMMENT_EDITOR_FEATURES } from '../comment-editor-features'
+
+const COMMENT: EditorFeatures = {
+  headings: true,
+  codeBlocks: true,
+  taskLists: true,
+  blockquotes: true,
+  dividers: true,
+  images: true,
+  tables: true,
+  embeds: true,
+  quackbackEmbeds: true,
+  bubbleMenu: true,
+  slashMenu: true,
+  emojiPicker: true,
+  enterAsHardBreak: true,
+}
+
+describe('comment editor preset', () => {
+  it('COMMENT_EDITOR_FEATURES matches the pinned shape', () => {
+    expect(COMMENT_EDITOR_FEATURES).toEqual(COMMENT)
+  })
+
+  it('keeps Enter as a line break (not a submit)', () => {
+    expect(COMMENT_EDITOR_FEATURES.enterAsHardBreak).toBe(true)
+  })
+})

--- a/apps/web/src/components/public/comment-editor-features.ts
+++ b/apps/web/src/components/public/comment-editor-features.ts
@@ -1,8 +1,10 @@
 import type { EditorFeatures } from '@/components/ui/rich-text-editor'
 
 /**
- * Same TipTap feature set as the post composer (admin / widget). Image insert
- * affordances still stay hidden until the composer also passes `onImageUpload`.
+ * Same TipTap feature set as the post composer (admin / widget), but chat-shaped
+ * on Enter: a line break, not a submit. Image insert affordances still stay
+ * hidden until the composer also passes `onImageUpload`. Cmd/Ctrl+Enter on the
+ * wrapping form remains the keyboard submit.
  */
 export const COMMENT_EDITOR_FEATURES: EditorFeatures = {
   headings: true,
@@ -17,4 +19,5 @@ export const COMMENT_EDITOR_FEATURES: EditorFeatures = {
   bubbleMenu: true,
   slashMenu: true,
   emojiPicker: true,
+  enterAsHardBreak: true,
 }

--- a/apps/web/src/components/public/comment-form.tsx
+++ b/apps/web/src/components/public/comment-form.tsx
@@ -404,7 +404,13 @@ export function CommentForm({
                   })}
                 </Button>
               )}
-              <Button type="submit" size="sm" disabled={isSubmitting} className="h-7 text-xs">
+              <Button
+                type="button"
+                size="sm"
+                disabled={isSubmitting}
+                className="h-7 text-xs"
+                onClick={() => void form.handleSubmit(onSubmit)()}
+              >
                 {isSubmitting
                   ? intl.formatMessage({
                       id: 'portal.commentForm.submitting',
@@ -563,7 +569,12 @@ export function CommentForm({
               </Tooltip>
             </TooltipProvider>
           )}
-          <Button type="submit" size="sm" disabled={isSubmitting}>
+          <Button
+            type="button"
+            size="sm"
+            disabled={isSubmitting}
+            onClick={() => void form.handleSubmit(onSubmit)()}
+          >
             {isSubmitting
               ? intl.formatMessage({
                   id: 'portal.commentForm.submitting',

--- a/apps/web/src/components/ui/__tests__/rich-text-editor-extensions.test.ts
+++ b/apps/web/src/components/ui/__tests__/rich-text-editor-extensions.test.ts
@@ -13,7 +13,13 @@
 
 import { describe, it, expect, vi } from 'vitest'
 import type { EditorFeatures } from '../rich-text-editor'
-import { buildExtensions, generateContentHTML, hasActiveSuggestion } from '../rich-text-editor'
+import {
+  buildExtensions,
+  generateContentHTML,
+  hasActiveSuggestion,
+  stopEnterFromReachingParentForm,
+} from '../rich-text-editor'
+import { COMMENT_EDITOR_FEATURES } from '@/components/public/comment-editor-features'
 
 // Full widget feature set (worst-case for duplicates)
 const WIDGET_FEATURES: EditorFeatures = {
@@ -117,6 +123,14 @@ describe('buildExtensions', () => {
     const exts = buildExtensions({ enterAsHardBreak: true }, { placeholder: '' })
     const names = exts.map((e) => (e as { name: string }).name)
     expect(names).toContain('enterAsHardBreak')
+  })
+
+  it('COMMENT_EDITOR_FEATURES registers enterAsHardBreak (plain Enter is a newline)', () => {
+    const names = buildExtensions(COMMENT_EDITOR_FEATURES, { placeholder: '' }).map(
+      (e) => (e as { name: string }).name
+    )
+    expect(names).toContain('enterAsHardBreak')
+    expect(names).not.toContain('submitOnEnter')
   })
 
   // P2.1 — mentions feature flag (default TRUE; undefined must mean enabled so
@@ -270,6 +284,50 @@ describe('submitOnEnter (onSubmit)', () => {
     const submitPriority = byName.get('submitOnEnter')!.config.priority ?? 100
     const hardBreakPriority = byName.get('enterAsHardBreak')!.config.priority ?? 100
     expect(submitPriority).toBeGreaterThan(hardBreakPriority)
+  })
+})
+
+describe('stopEnterFromReachingParentForm', () => {
+  function keyEvent(key: string, mods: { metaKey?: boolean; ctrlKey?: boolean } = {}) {
+    return {
+      key,
+      metaKey: !!mods.metaKey,
+      ctrlKey: !!mods.ctrlKey,
+      stopPropagation: vi.fn(),
+    } as unknown as KeyboardEvent
+  }
+
+  it('stops plain Enter so a parent form cannot implicitly submit', () => {
+    const event = keyEvent('Enter')
+    expect(stopEnterFromReachingParentForm(event)).toBe(false)
+    expect(event.stopPropagation).toHaveBeenCalledOnce()
+  })
+
+  it('stops Shift+Enter the same way (newline, not submit)', () => {
+    const event = {
+      key: 'Enter',
+      metaKey: false,
+      ctrlKey: false,
+      shiftKey: true,
+      stopPropagation: vi.fn(),
+    } as unknown as KeyboardEvent
+    expect(stopEnterFromReachingParentForm(event)).toBe(false)
+    expect(event.stopPropagation).toHaveBeenCalledOnce()
+  })
+
+  it('leaves Cmd/Ctrl+Enter alone for wrapper keyboard-submit handlers', () => {
+    const meta = keyEvent('Enter', { metaKey: true })
+    const ctrl = keyEvent('Enter', { ctrlKey: true })
+    expect(stopEnterFromReachingParentForm(meta)).toBe(false)
+    expect(stopEnterFromReachingParentForm(ctrl)).toBe(false)
+    expect(meta.stopPropagation).not.toHaveBeenCalled()
+    expect(ctrl.stopPropagation).not.toHaveBeenCalled()
+  })
+
+  it('ignores keys other than Enter', () => {
+    const event = keyEvent('Escape')
+    expect(stopEnterFromReachingParentForm(event)).toBe(false)
+    expect(event.stopPropagation).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/web/src/components/ui/rich-text-editor.tsx
+++ b/apps/web/src/components/ui/rich-text-editor.tsx
@@ -349,6 +349,19 @@ function createSubmitOnEnter(onSubmit: () => void) {
 // every plugin generically rather than importing each PluginKey because
 // MentionExtension constructs an anonymous key per instance and isn't reachable
 // from here. Non-object states are skipped — those are unrelated plugins.
+/**
+ * Stop Enter (and Shift+Enter) bubbling out of the editor so a parent <form>
+ * cannot treat it as implicit submit. Cmd/Ctrl+Enter is left alone — comment
+ * composers listen for that chord in capture on the wrapper. Returns false so
+ * TipTap keymaps still insert the break / split the block / send (onSubmit).
+ */
+export function stopEnterFromReachingParentForm(event: KeyboardEvent): boolean {
+  if (event.key === 'Enter' && !event.metaKey && !event.ctrlKey) {
+    event.stopPropagation()
+  }
+  return false
+}
+
 export function hasActiveSuggestion(editor: Pick<Editor, 'state'>): boolean {
   for (const plugin of editor.state.plugins) {
     const state = plugin.getState(editor.state) as { active?: unknown } | null | undefined
@@ -1259,6 +1272,9 @@ function RichTextEditorBase({
       },
       handleDrop: features.images && onImageUpload ? handleImageDrop(onImageUpload) : undefined,
       handlePaste: features.images && onImageUpload ? handleImagePaste(onImageUpload) : undefined,
+      handleDOMEvents: {
+        keydown: (_view, event) => stopEnterFromReachingParentForm(event),
+      },
     }),
 
     [features.images, onImageUpload, borderless, minHeight]

--- a/apps/web/src/components/ui/rich-text-editor.tsx
+++ b/apps/web/src/components/ui/rich-text-editor.tsx
@@ -1273,7 +1273,8 @@ function RichTextEditorBase({
       handleDrop: features.images && onImageUpload ? handleImageDrop(onImageUpload) : undefined,
       handlePaste: features.images && onImageUpload ? handleImagePaste(onImageUpload) : undefined,
       handleDOMEvents: {
-        keydown: (_view, event) => stopEnterFromReachingParentForm(event),
+        keydown: (_view: import('@tiptap/pm/view').EditorView, event: KeyboardEvent) =>
+          stopEnterFromReachingParentForm(event),
       },
     }),
 


### PR DESCRIPTION
## Summary
- Restore `enterAsHardBreak` on the comment editor preset (dropped when comments reused the post composer) so portal/widget comments, replies, and in-place edits insert a newline on Enter. Cmd/Ctrl+Enter still submits.
- Stop Enter from bubbling out of `RichTextEditor` and switch portal comment buttons off `type="submit"` so a wrapping `<form>` cannot treat Enter as implicit submit.
- Inbox reply, visitor messenger, and the copilot ask box stay Enter-to-send.

## Test plan
- [x] Portal comment composer: Enter inserts a line without posting; the Comment button posts both lines as one comment (local Playwright on `acme.localhost:3006`)
- [x] Unit tests: `comment-editor-features` + `rich-text-editor-extensions` (local + CI)
- [x] CI: `check`, four unit shards, `e2e-smoke`, `live-api`
- [x] Portal reply / in-place edit / widget comment+reply: same `COMMENT_EDITOR_FEATURES` preset (`enterAsHardBreak: true`, no `onSubmit`); pinned so it cannot be dropped again
- [x] Form-wrapped document editors (new-post, changelog, help): Enter no longer bubbles to the parent `<form>` (`stopEnterFromReachingParentForm`)
- [x] Inbox reply, visitor messenger, copilot: left as Enter-to-send (`submitOnEnter` still outranks the hard-break binding)