### PR TITLE
fix(auth): persist better-auth 2FA lockout columns

### DIFF
--- a/packages/db/drizzle/0278_two_factor_lockout.sql
+++ b/packages/db/drizzle/0278_two_factor_lockout.sql
@@ -1,0 +1,8 @@
+-- better-auth 1.6.30 twoFactor account-lockout columns. The plugin writes
+-- failed_verification_count / locked_until on every TOTP verify (success
+-- and failure). Without matching Drizzle fields the adapter emits
+-- `update "two_factor" set  where …` and enrolment / sign-in 500. See #432.
+-- Additive / expand-only.
+ALTER TABLE "two_factor" ADD COLUMN IF NOT EXISTS "failed_verification_count" integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE "two_factor" ADD COLUMN IF NOT EXISTS "locked_until" timestamptz;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1786,6 +1786,13 @@
       "when": 1788991200000,
       "tag": "0277_widget_chat_to_messenger",
       "breakpoints": true
+    },
+    {
+      "idx": 255,
+      "version": "7",
+      "when": 1789030800000,
+      "tag": "0278_two_factor_lockout",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/__tests__/schema-two-factor.test.ts
+++ b/packages/db/src/__tests__/schema-two-factor.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { eq, getTableColumns, getTableName } from 'drizzle-orm'
+import { drizzle } from 'drizzle-orm/postgres-js'
+import postgres from 'postgres'
+import { generateId } from '@quackback/ids'
+import { twoFactor } from '../schema/auth'
+
+/**
+ * better-auth 1.6.30 writes `failedVerificationCount` / `lockedUntil` on
+ * every TOTP verify. Drizzle drops unknown keys from `.set()` rather than
+ * erroring, which produced `update "two_factor" set  where …` and 500'd
+ * both enrolment and sign-in (#432). These assertions pin the columns on
+ * the table object so a future plugin bump cannot silently drop them.
+ */
+describe('two_factor schema', () => {
+  it('has correct table name', () => {
+    expect(getTableName(twoFactor)).toBe('two_factor')
+  })
+
+  it('declares the better-auth 1.6.30 lockout columns', () => {
+    const cols = getTableColumns(twoFactor)
+    expect(Object.keys(cols)).toEqual(
+      expect.arrayContaining(['failedVerificationCount', 'lockedUntil'])
+    )
+    expect(cols.failedVerificationCount.name).toBe('failed_verification_count')
+    expect(cols.lockedUntil.name).toBe('locked_until')
+    expect(cols.failedVerificationCount.notNull).toBe(true)
+    expect(cols.lockedUntil.notNull).toBe(false)
+  })
+
+  it('emits a non-empty SET for the verify-success lockout reset', async () => {
+    // The reproduction from #432: missing keys → `update "two_factor" set  where`.
+    // postgres.js does not connect until a query runs; toSQL() is sync.
+    const client = postgres('postgresql://postgres:password@127.0.0.1:1/unused', { max: 1 })
+    const db = drizzle(client)
+    try {
+      const { sql } = db
+        .update(twoFactor)
+        .set({ failedVerificationCount: 0, lockedUntil: null })
+        .where(eq(twoFactor.id, generateId('two_factor')))
+        .toSQL()
+      expect(sql).toMatch(/"failed_verification_count"/)
+      expect(sql).toMatch(/"locked_until"/)
+      expect(sql).not.toMatch(/set\s+where/i)
+    } finally {
+      await client.end({ timeout: 0 })
+    }
+  })
+})

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -223,6 +223,12 @@ export const user = pgTable(
  * during the brief window between `/two-factor/enable` and the
  * subsequent `/two-factor/verify-totp`; the default `true` matches
  * Better-Auth's expectation for newly-inserted rows.
+ *
+ * `failedVerificationCount` / `lockedUntil` are the 1.6.30 account-
+ * lockout fields. The plugin writes both on every TOTP verify (success
+ * resets, failure increments). Drizzle drops unknown keys from `.set()`,
+ * so omitting them produces `update "two_factor" set  where …` and
+ * enrolment / sign-in 500. See #432.
  */
 export const twoFactor = pgTable(
   'two_factor',
@@ -233,6 +239,8 @@ export const twoFactor = pgTable(
     backupCodes: text('backup_codes').notNull(),
     verified: boolean('verified').notNull().default(true),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    failedVerificationCount: integer('failed_verification_count').notNull().default(0),
+    lockedUntil: timestamp('locked_until', { withTimezone: true }),
   },
   (table) => [
     // Named to match the constraint the SQL migration created.


### PR DESCRIPTION
## Summary
- `better-auth` 1.6.30's two-factor plugin writes `failedVerificationCount` / `lockedUntil` on every TOTP verify (success resets, failure increments). `two_factor` never declared those fields.
- Drizzle drops unknown keys from `.set()` instead of erroring, so the adapter emitted `update "two_factor" set  where …` and **enrolment and sign-in both 500'd** on a valid code.
- Add the columns in the Drizzle table and migration `0278_two_factor_lockout`, and pin them with a schema test that reproduces the empty-`SET` SQL.

Fixes #432

## Test plan
- [x] `schema-two-factor.test.ts` — lockout columns exist; `update … set { failedVerificationCount: 0, lockedUntil: null }` emits both column names and is not `set  where`
- [x] `migration-journal-integrity.test.ts`
- [x] `db:migrate` post-conditions: every column this build declares exists
- [ ] After merge: enable 2FA on a workspace, complete TOTP enrolment, sign out, sign in with a valid code