### PR TITLE
fix(fleet): include 0278 in the post-0248 replay-gate span

### DIFF
--- a/apps/web/src/lib/server/fleet/__tests__/migrator-gate.test.ts
+++ b/apps/web/src/lib/server/fleet/__tests__/migrator-gate.test.ts
@@ -352,6 +352,7 @@ describe('replayGateVerdict', () => {
       '0275_slack_thread_sessions',
       '0276_post_tags_is_public',
       '0277_widget_chat_to_messenger',
+      '0278_two_factor_lockout',
     ])
     const verdict = replayGateVerdict(before, verdictsFor(replaySetFor(before)), false)
     expect(verdict.ok).toBe(false)

--- a/apps/web/src/lib/server/policy/migration-contract/CONTRACT.md
+++ b/apps/web/src/lib/server/policy/migration-contract/CONTRACT.md
@@ -6,7 +6,7 @@ Regenerate with `bunx vitest run apps/web/src/lib/server/policy/migration-contra
 
 ## Summary
 
-Migrations scanned: 255. Migrations with destructive DDL: 34.
+Migrations scanned: 256. Migrations with destructive DDL: 34.
 
 | Kind | Occurrences |
 | --- | --- |


### PR DESCRIPTION
## Summary
- #536 added migration `0278_two_factor_lockout`. The fleet replay-gate test pins the post-0248 span, so CI shard `test (2/4)` failed with `expected [ …(30) ] to deeply equal [ …(29) ]`.
- Append `0278_two_factor_lockout` to that list. The migration is expand-only; the gate still refuses unattended heals because of 0257/0262/0263.

Follow-up to #536 / #432.

## Test plan
- [x] `apps/web/src/lib/server/fleet/__tests__/migrator-gate.test.ts` (22 tests)
- [ ] CI `test (2/4)` green on this PR before merge