### PR TITLE
fix(conversation): keep pasted screenshots in aspect on the attachment tray

### DIFF
--- a/apps/web/e2e/scripts/seed-conversation.ts
+++ b/apps/web/e2e/scripts/seed-conversation.ts
@@ -12,19 +12,27 @@
  * explicitly ('messenger'), status 'open', priority 'none', and the
  * denormalized last-message preview/timestamp are populated.
  *
- * Prints a JSON blob: { conversationId, visitorPrincipalId, subject, messages }
- * where conversationId is the TypeID string used in /admin/inbox?c=... URLs.
+ * `--legacy-image` prepends a smashed 500×500 resizableImage so conversation-
+ * image e2e can assert the read-time lift. Default seeds stay text-only so
+ * convert-to-post still uses the first visitor line.
  *
- * Usage: bun seed-conversation.ts "<subject>" [visitor-email]
+ * Prints a JSON blob: { conversationId, visitorPrincipalId, subject, messages,
+ * legacyImageName } where conversationId is the TypeID string used in
+ * /admin/inbox?c=... URLs.
+ *
+ * Usage: bun seed-conversation.ts "<subject>" [visitor-email] [--legacy-image]
  */
 import { generateId, toUuid } from '@quackback/ids'
 import { openDb } from './_lib'
 
-const subject = process.argv[2]
-const visitorEmail = process.argv[3]
+const args = process.argv.slice(2)
+const legacyImage = args.includes('--legacy-image')
+const positional = args.filter((a) => a !== '--legacy-image')
+const subject = positional[0]
+const visitorEmail = positional[1]
 
 if (!subject) {
-  console.error('Usage: bun seed-conversation.ts "<subject>" [visitor-email]')
+  console.error('Usage: bun seed-conversation.ts "<subject>" [visitor-email] [--legacy-image]')
   process.exit(1)
 }
 
@@ -61,6 +69,7 @@ try {
     : await createAnonymousVisitor()
 
   const messages = [`${subject} - visitor message one`, `${subject} - visitor message two`]
+  const legacyImageName = legacyImage ? 'e2e-legacy-wide.png' : null
 
   const conversationTypeId = generateId('conversation')
   const conversationUuid = toUuid(conversationTypeId)
@@ -72,7 +81,32 @@ try {
       (${conversationUuid}, ${visitorUuid}, 'open', 'messenger', 'none', ${subject},
        ${messages[1]}, NOW(), NOW())`
 
-  // Two visitor messages, a minute apart, so thread ordering is deterministic.
+  if (legacyImageName) {
+    const smashedInlineImage = {
+      type: 'doc',
+      content: [
+        {
+          type: 'resizableImage',
+          attrs: {
+            src: `/api/storage/chat-images/${legacyImageName}`,
+            width: 500,
+            height: 500,
+            'data-keep-ratio': true,
+            alt: legacyImageName,
+          },
+        },
+      ],
+    }
+    const imageMsgUuid = toUuid(generateId('conversation_msg'))
+    await sql`
+      INSERT INTO conversation_messages
+        (id, conversation_id, principal_id, sender_type, content, content_json,
+         is_internal, created_at)
+      VALUES
+        (${imageMsgUuid}, ${conversationUuid}, ${visitorUuid}, 'visitor', ${'Image'},
+         ${sql.json(smashedInlineImage)}, false, NOW() - make_interval(mins => 3))`
+  }
+
   for (let i = 0; i < messages.length; i++) {
     const msgUuid = toUuid(generateId('conversation_msg'))
     await sql`
@@ -89,6 +123,7 @@ try {
       visitorPrincipalId: visitorUuid,
       subject,
       messages,
+      legacyImageName,
     })
   )
   await sql.end()

--- a/apps/web/e2e/tests/admin/conversation-images.spec.ts
+++ b/apps/web/e2e/tests/admin/conversation-images.spec.ts
@@ -7,7 +7,9 @@ import {
 import {
   CHANGELOG_PNG,
   LEGACY_WIDE_PNG,
+  POST_PNG,
   expectLandscapeContainThumb,
+  expectLoadedImage,
   landscapePng,
   pasteImageOn,
   stubConversationImageNetwork,
@@ -110,5 +112,88 @@ test.describe('Changelog images stay inline', () => {
     await expect(editor.locator(`img[src*="${CHANGELOG_PNG}"]`)).toBeVisible({ timeout: 10000 })
     await expect(dialog.getByRole('button', { name: 'Remove attachment' })).toHaveCount(0)
     await expect(dialog.getByRole('button', { name: /Enlarge / })).toHaveCount(0)
+  })
+})
+
+test.describe('Post images stay inline', () => {
+  test('paste in a new post inserts an editor image, not a chat tray', async ({ page }) => {
+    test.setTimeout(45_000)
+    const png = await stubConversationImageNetwork(page)
+    await page.goto('/admin/feedback')
+    await expect(page.getByRole('heading', { name: 'Feedback', level: 1 })).toBeVisible({
+      timeout: 15000,
+    })
+    const create = page.getByTitle('Create new post')
+    await expect(create).toBeVisible()
+    await expect(async () => {
+      if (
+        !(await page
+          .getByRole('dialog')
+          .isVisible()
+          .catch(() => false))
+      ) {
+        await create.click()
+      }
+      await expect(page.getByRole('dialog')).toBeVisible({ timeout: 2000 })
+    }).toPass({ timeout: 15000 })
+    const dialog = page.getByRole('dialog')
+
+    const editor = dialog.locator('.ProseMirror[contenteditable="true"]')
+    await editor.click()
+    await pasteImageOn(editor, png, 'post-shot.png')
+
+    await expect(editor.locator(`img[src*="${POST_PNG}"]`)).toBeVisible({ timeout: 10000 })
+    await expect(dialog.getByRole('button', { name: 'Remove attachment' })).toHaveCount(0)
+    await expect(dialog.getByRole('button', { name: /Enlarge / })).toHaveCount(0)
+  })
+})
+
+test.describe('Local Vite storage serves conversation thumbs', () => {
+  test('sec-fetch-dest:image hits the storage route, not Vite Cannot GET', async ({ request }) => {
+    const res = await request.get('/api/storage/chat-images/e2e-missing.png', {
+      headers: {
+        Accept: 'image/avif,image/webp,image/apng,image/*,*/*;q=0.8',
+        'Sec-Fetch-Dest': 'image',
+      },
+    })
+    const body = await res.text()
+    expect(body).not.toMatch(/Cannot GET/i)
+    expect(res.headers()['content-type'] ?? '').toMatch(/json|image/)
+    expect(res.status()).not.toBe(404)
+  })
+
+  test('real paste thumb still decodes after a full page refresh', async ({ page }) => {
+    test.setTimeout(60_000)
+    const seeded = seedConversation(`E2E real paste refresh ${Date.now()}`)
+    const png = landscapePng()
+    await page.goto(`/admin/inbox?i=${seeded.conversationId}`)
+    await expect(page.getByText(seeded.messages[0]).first()).toBeVisible({ timeout: 15000 })
+
+    const composer = page.locator('[data-inbox-composer]')
+    await expect(composer).toBeVisible()
+    await pasteImageOn(composer, png, 'real-refresh.png')
+
+    const trayThumb = composer.getByRole('button', { name: 'Enlarge real-refresh.png' })
+    await expect(trayThumb).toBeVisible({ timeout: 15000 })
+    await expectLoadedImage(trayThumb.locator('img'))
+    await expect(composer.locator('.ProseMirror img')).toHaveCount(0)
+
+    await page.getByRole('button', { name: 'Send reply' }).click()
+    const sent = page
+      .getByRole('button', { name: 'Enlarge real-refresh.png' })
+      .filter({ has: page.locator('img.object-contain') })
+    await expect(sent).toBeVisible({ timeout: 15000 })
+    await expectLoadedImage(sent.locator('img'))
+    await expectLandscapeContainThumb(sent)
+
+    await page.reload()
+    await expect(page.getByText(seeded.messages[0]).first()).toBeVisible({ timeout: 15000 })
+    const afterReload = page
+      .getByRole('button', { name: 'Enlarge real-refresh.png' })
+      .filter({ has: page.locator('img.object-contain') })
+    await expect(afterReload).toBeVisible({ timeout: 15000 })
+    await expectLoadedImage(afterReload.locator('img'))
+    await expectLandscapeContainThumb(afterReload)
+    await expect(page.getByRole('link', { name: /real-refresh\.png/i })).toHaveCount(0)
   })
 })

--- a/apps/web/e2e/tests/admin/conversation-images.spec.ts
+++ b/apps/web/e2e/tests/admin/conversation-images.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect } from '@playwright/test'
+import {
+  setSupportSurfaces,
+  seedConversation,
+  type SeededConversation,
+} from '../../utils/db-helpers'
+import {
+  CHANGELOG_PNG,
+  LEGACY_WIDE_PNG,
+  expectLandscapeContainThumb,
+  landscapePng,
+  pasteImageOn,
+  stubConversationImageNetwork,
+} from '../../utils/conversation-images'
+
+test.describe('Admin conversation images', { tag: '@smoke' }, () => {
+  test.use({ viewport: { width: 1920, height: 1080 } })
+  let seeded: SeededConversation
+
+  test.beforeAll(() => {
+    setSupportSurfaces(true)
+    seeded = seedConversation(`E2E conversation images ${Date.now()}`, undefined, {
+      legacyImage: true,
+    })
+  })
+
+  test('lifts a smashed inline screenshot to a contain thumb and zoom modal', async ({ page }) => {
+    test.setTimeout(60_000)
+    await stubConversationImageNetwork(page)
+    await page.goto('/admin/inbox')
+
+    const row = page.getByText(seeded.messages[1]).first()
+    await expect(row).toBeVisible({ timeout: 15000 })
+    await expect(async () => {
+      await row.click()
+      await expect(page).toHaveURL(new RegExp(`i=${seeded.conversationId}`), { timeout: 2000 })
+    }).toPass({ timeout: 15000 })
+
+    const legacy = page.getByRole('button', { name: `Enlarge ${LEGACY_WIDE_PNG}` })
+    await expect(legacy).toBeVisible({ timeout: 10000 })
+    await expectLandscapeContainThumb(legacy)
+    await expect(page.locator(`img[width="500"][height="500"]`)).toHaveCount(0)
+
+    await legacy.click()
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+    await expect(dialog.getByRole('img', { name: LEGACY_WIDE_PNG })).toBeVisible()
+    await expect(dialog.getByRole('button', { name: 'Zoom in' })).toBeVisible()
+    await page.keyboard.press('Escape')
+    await expect(dialog).toBeHidden()
+  })
+
+  test('paste and paperclip stage the tray, then send a contain thumb', async ({ page }) => {
+    test.setTimeout(60_000)
+    const png = await stubConversationImageNetwork(page)
+    await page.goto(`/admin/inbox?i=${seeded.conversationId}`)
+    await expect(page.getByText(seeded.messages[0]).first()).toBeVisible({ timeout: 15000 })
+
+    const composer = page.locator('[data-inbox-composer]')
+    await expect(composer).toBeVisible()
+    await pasteImageOn(composer, png, 'pasted-shot.png')
+
+    const trayThumb = composer.getByRole('button', { name: 'Enlarge pasted-shot.png' })
+    await expect(trayThumb).toBeVisible({ timeout: 10000 })
+    await expect(composer.locator('.ProseMirror img')).toHaveCount(0)
+
+    const [chooser] = await Promise.all([
+      page.waitForEvent('filechooser'),
+      page.getByRole('button', { name: 'Attach image' }).click(),
+    ])
+    await chooser.setFiles({
+      name: 'paperclip.png',
+      mimeType: 'image/png',
+      buffer: landscapePng(),
+    })
+    await expect(composer.getByRole('button', { name: 'Enlarge paperclip.png' })).toBeVisible({
+      timeout: 10000,
+    })
+
+    await page.getByRole('button', { name: 'Send reply' }).click()
+    const sent = page
+      .getByRole('button', { name: 'Enlarge pasted-shot.png' })
+      .filter({ has: page.locator('img.object-contain') })
+    await expect(sent).toBeVisible({ timeout: 15000 })
+    await expectLandscapeContainThumb(sent)
+    await sent.click()
+    await expect(page.getByRole('dialog').getByRole('button', { name: 'Zoom in' })).toBeVisible()
+  })
+})
+
+test.describe('Changelog images stay inline', () => {
+  test('paste in a changelog entry inserts an editor image, not a chat tray', async ({ page }) => {
+    test.setTimeout(45_000)
+    const png = await stubConversationImageNetwork(page)
+    await page.goto('/admin/changelog')
+    const newEntry = page.getByRole('button', { name: /new entry/i })
+    await expect(newEntry.first()).toBeVisible({ timeout: 15000 })
+    const dialog = page.getByRole('dialog')
+    await expect(async () => {
+      if (!(await dialog.isVisible().catch(() => false))) {
+        await newEntry.first().click()
+      }
+      await expect(dialog).toBeVisible({ timeout: 2000 })
+    }).toPass({ timeout: 15000 })
+
+    const editor = dialog.locator('.ProseMirror[contenteditable="true"]')
+    await editor.click()
+    await pasteImageOn(editor, png, 'changelog-shot.png')
+
+    await expect(editor.locator(`img[src*="${CHANGELOG_PNG}"]`)).toBeVisible({ timeout: 10000 })
+    await expect(dialog.getByRole('button', { name: 'Remove attachment' })).toHaveCount(0)
+    await expect(dialog.getByRole('button', { name: /Enlarge / })).toHaveCount(0)
+  })
+})

--- a/apps/web/e2e/tests/widget/conversation-images.spec.ts
+++ b/apps/web/e2e/tests/widget/conversation-images.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test'
+import { setSupportSurfaces } from '../../utils/db-helpers'
+import {
+  expectLandscapeContainThumb,
+  landscapePng,
+  pasteImageOn,
+  stubConversationImageNetwork,
+} from '../../utils/conversation-images'
+
+test.describe('Widget conversation images', { tag: '@smoke' }, () => {
+  test.beforeAll(() => {
+    setSupportSurfaces(true)
+  })
+
+  test('paste and attach land in the tray, then render a contain thumb + zoom', async ({
+    page,
+  }) => {
+    test.setTimeout(60_000)
+    const png = await stubConversationImageNetwork(page)
+    await page.goto('/widget')
+    await page.getByRole('button', { name: 'Messages', exact: true }).click()
+    await expect(page.getByText('No conversations yet')).toBeVisible({ timeout: 10000 })
+    await page.getByRole('button', { name: /Ask a question/ }).click()
+
+    const composer = page.locator('.ProseMirror[contenteditable="true"]')
+    await expect(composer).toBeVisible({ timeout: 10000 })
+
+    const composerBox = page.locator('.rounded-2xl.border').filter({ has: composer })
+    await pasteImageOn(composerBox, png, 'widget-paste.png')
+    await expect(page.getByRole('button', { name: 'Enlarge widget-paste.png' })).toBeVisible({
+      timeout: 10000,
+    })
+    await expect(composer.locator('img')).toHaveCount(0)
+
+    const [chooser] = await Promise.all([
+      page.waitForEvent('filechooser'),
+      page.getByRole('button', { name: 'Attach image' }).click(),
+    ])
+    await chooser.setFiles({
+      name: 'widget-clip.png',
+      mimeType: 'image/png',
+      buffer: landscapePng(),
+    })
+    await expect(page.getByRole('button', { name: 'Enlarge widget-clip.png' })).toBeVisible({
+      timeout: 10000,
+    })
+
+    const send = page.getByRole('button', { name: 'Send', exact: true })
+    await expect(send).toBeEnabled({ timeout: 10000 })
+    await send.click()
+    const sent = page
+      .getByRole('button', { name: 'Enlarge widget-paste.png' })
+      .filter({ has: page.locator('img.object-contain') })
+    await expect(sent).toBeVisible({ timeout: 15000 })
+    await expectLandscapeContainThumb(sent)
+    await sent.click()
+    await expect(page.getByRole('dialog').getByRole('button', { name: 'Zoom in' })).toBeVisible()
+  })
+})

--- a/apps/web/e2e/utils/conversation-images.ts
+++ b/apps/web/e2e/utils/conversation-images.ts
@@ -1,0 +1,120 @@
+import { deflateSync } from 'node:zlib'
+import type { Locator, Page, Route } from '@playwright/test'
+
+function crc32(data: Buffer): number {
+  let c = ~0
+  for (const b of data) {
+    c ^= b
+    for (let i = 0; i < 8; i++) c = (c >>> 1) ^ (0xedb88320 & -(c & 1))
+  }
+  return ~c >>> 0
+}
+
+function chunk(type: string, data: Buffer): Buffer {
+  const typeBuf = Buffer.from(type)
+  const len = Buffer.alloc(4)
+  len.writeUInt32BE(data.length)
+  const crc = Buffer.alloc(4)
+  crc.writeUInt32BE(crc32(Buffer.concat([typeBuf, data])))
+  return Buffer.concat([len, typeBuf, data, crc])
+}
+
+/** Landscape RGB PNG so thumbs can be asserted as not 1:1. */
+export function landscapePng(width = 60, height = 20): Buffer {
+  const ihdr = Buffer.alloc(13)
+  ihdr.writeUInt32BE(width, 0)
+  ihdr.writeUInt32BE(height, 4)
+  ihdr[8] = 8
+  ihdr[9] = 2
+  const raw = Buffer.alloc(height * (1 + width * 3))
+  for (let y = 0; y < height; y++) {
+    const row = y * (1 + width * 3)
+    raw[row] = 0
+    for (let x = 0; x < width; x++) {
+      const i = row + 1 + x * 3
+      raw[i] = 30
+      raw[i + 1] = 80
+      raw[i + 2] = 200
+    }
+  }
+  return Buffer.concat([
+    Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]),
+    chunk('IHDR', ihdr),
+    chunk('IDAT', deflateSync(raw)),
+    chunk('IEND', Buffer.alloc(0)),
+  ])
+}
+
+export const LEGACY_WIDE_PNG = 'e2e-legacy-wide.png'
+export const PASTED_PNG = 'e2e-pasted.png'
+export const WIDGET_PNG = 'e2e-widget.png'
+export const CHANGELOG_PNG = 'e2e-changelog.png'
+
+/** Serve fixture PNGs and stub upload endpoints so e2e never hits MinIO. */
+export async function stubConversationImageNetwork(page: Page): Promise<Buffer> {
+  const png = landscapePng()
+  const fulfillPng = async (route: Route) => {
+    await route.fulfill({ status: 200, contentType: 'image/png', body: png })
+  }
+
+  await page.route('**/api/upload/image', async (route) => {
+    if (route.request().method() !== 'POST') return route.continue()
+    const body = route.request().postDataBuffer()?.toString('utf8') ?? ''
+    const prefix = /name="prefix"\r\n\r\n([^\r]+)/.exec(body)?.[1] ?? 'chat-images'
+    const name = prefix.includes('changelog') ? CHANGELOG_PNG : PASTED_PNG
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ publicUrl: `/api/storage/${prefix}/${name}` }),
+    })
+  })
+
+  await page.route('**/api/widget/upload', async (route) => {
+    if (route.request().method() !== 'POST') return route.continue()
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ publicUrl: `/api/storage/chat-images/${WIDGET_PNG}` }),
+    })
+  })
+
+  await page.route(`**/api/storage/chat-images/${LEGACY_WIDE_PNG}*`, fulfillPng)
+  await page.route(`**/api/storage/chat-images/${PASTED_PNG}*`, fulfillPng)
+  await page.route(`**/api/storage/chat-images/${WIDGET_PNG}*`, fulfillPng)
+  await page.route(`**/api/storage/changelog-images/${CHANGELOG_PNG}*`, fulfillPng)
+
+  return png
+}
+
+export async function pasteImageOn(locator: Locator, png: Buffer, name = 'shot.png') {
+  const handle = await locator.elementHandle()
+  if (!handle) throw new Error('paste target is not attached')
+  await locator.page().evaluate(
+    ({ el, b64, fileName }) => {
+      const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0))
+      const file = new File([bytes], fileName, { type: 'image/png' })
+      const dt = new DataTransfer()
+      dt.items.add(file)
+      const ev = new Event('paste', { bubbles: true, cancelable: true })
+      Object.defineProperty(ev, 'clipboardData', { value: dt })
+      el.dispatchEvent(ev)
+    },
+    { el: handle, b64: png.toString('base64'), fileName: name }
+  )
+}
+
+export async function expectLandscapeContainThumb(button: Locator) {
+  const img = button.locator('img')
+  await img.waitFor({ state: 'visible' })
+  const className = (await img.getAttribute('class')) ?? ''
+  if (!className.split(/\s+/).includes('object-contain')) {
+    throw new Error(`expected object-contain on thumb, got "${className}"`)
+  }
+  const box = await img.boundingBox()
+  if (!box) throw new Error('thumb has no box')
+  if (box.width <= box.height * 1.4) {
+    throw new Error(
+      `expected landscape thumb, got ${Math.round(box.width)}×${Math.round(box.height)}`
+    )
+  }
+}

--- a/apps/web/e2e/utils/conversation-images.ts
+++ b/apps/web/e2e/utils/conversation-images.ts
@@ -49,6 +49,7 @@ export const LEGACY_WIDE_PNG = 'e2e-legacy-wide.png'
 export const PASTED_PNG = 'e2e-pasted.png'
 export const WIDGET_PNG = 'e2e-widget.png'
 export const CHANGELOG_PNG = 'e2e-changelog.png'
+export const POST_PNG = 'e2e-post.png'
 
 /** Serve fixture PNGs and stub upload endpoints so e2e never hits MinIO. */
 export async function stubConversationImageNetwork(page: Page): Promise<Buffer> {
@@ -61,7 +62,11 @@ export async function stubConversationImageNetwork(page: Page): Promise<Buffer> 
     if (route.request().method() !== 'POST') return route.continue()
     const body = route.request().postDataBuffer()?.toString('utf8') ?? ''
     const prefix = /name="prefix"\r\n\r\n([^\r]+)/.exec(body)?.[1] ?? 'chat-images'
-    const name = prefix.includes('changelog') ? CHANGELOG_PNG : PASTED_PNG
+    const name = prefix.includes('changelog')
+      ? CHANGELOG_PNG
+      : prefix.includes('post')
+        ? POST_PNG
+        : PASTED_PNG
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -82,6 +87,7 @@ export async function stubConversationImageNetwork(page: Page): Promise<Buffer> 
   await page.route(`**/api/storage/chat-images/${PASTED_PNG}*`, fulfillPng)
   await page.route(`**/api/storage/chat-images/${WIDGET_PNG}*`, fulfillPng)
   await page.route(`**/api/storage/changelog-images/${CHANGELOG_PNG}*`, fulfillPng)
+  await page.route(`**/api/storage/post-images/${POST_PNG}*`, fulfillPng)
 
   return png
 }
@@ -116,5 +122,22 @@ export async function expectLandscapeContainThumb(button: Locator) {
     throw new Error(
       `expected landscape thumb, got ${Math.round(box.width)}×${Math.round(box.height)}`
     )
+  }
+}
+
+/** The displayed <img> decoded real bytes (not a broken-image / filename chip). */
+export async function expectLoadedImage(img: Locator) {
+  await img.waitFor({ state: 'visible' })
+  const loaded = await img.evaluate((el) => {
+    if (!(el instanceof HTMLImageElement)) return { ok: false, reason: 'not an img' }
+    return {
+      ok: el.complete && el.naturalWidth > 0 && el.naturalHeight > 0,
+      naturalWidth: el.naturalWidth,
+      naturalHeight: el.naturalHeight,
+      src: el.currentSrc || el.src,
+    }
+  })
+  if (!loaded.ok) {
+    throw new Error(`expected a decoded image, got ${JSON.stringify(loaded)}`)
   }
 }

--- a/apps/web/e2e/utils/db-helpers.ts
+++ b/apps/web/e2e/utils/db-helpers.ts
@@ -81,6 +81,8 @@ export interface SeededConversation {
   subject: string
   /** The two visitor messages, oldest first. */
   messages: [string, string]
+  /** Present when seeded with `{ legacyImage: true }`. */
+  legacyImageName: string | null
 }
 
 /**
@@ -88,8 +90,16 @@ export interface SeededConversation {
  * email the visitor is a fresh anonymous principal; with an email the
  * conversation is owned by that user's principal (for portal /support specs).
  */
-export function seedConversation(subject: string, visitorEmail?: string): SeededConversation {
-  const args = visitorEmail ? [subject, visitorEmail] : [subject]
+export function seedConversation(
+  subject: string,
+  visitorEmail?: string,
+  opts?: { legacyImage?: boolean }
+): SeededConversation {
+  const args = [
+    subject,
+    ...(visitorEmail ? [visitorEmail] : []),
+    ...(opts?.legacyImage ? ['--legacy-image'] : []),
+  ]
   return JSON.parse(
     runScript('seed-conversation.ts', args, 'seed conversation')
   ) as SeededConversation

--- a/apps/web/src/components/admin/conversation/new-conversation-dialog.tsx
+++ b/apps/web/src/components/admin/conversation/new-conversation-dialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState, type ClipboardEvent, type DragEvent } from 'react'
 import { useMutation } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
 import { toast } from 'sonner'
@@ -12,8 +12,10 @@ import { realEmail } from '@/lib/shared/anonymous-email'
 import { PortalUserPicker } from '@/components/shared/portal-user-picker'
 import { RichTextEditor } from '@/components/ui/rich-text-editor'
 import { CONVERSATION_EDITOR_FEATURES } from '@/components/conversation/conversation-editor-features'
+import { ComposerAttachmentTray } from '@/components/shared/composer-attachment-tray'
 import { isEmptyTiptapDoc } from '@/lib/shared/utils/is-empty-tiptap-doc'
 import { useImageUpload } from '@/lib/client/hooks/use-image-upload'
+import { useConversationComposerAttachments } from '@/lib/client/hooks/use-conversation-composer-attachments'
 import {
   Dialog,
   DialogContent,
@@ -67,16 +69,47 @@ export function NewConversationDialog({
       setMessageJson(undefined)
       setMessageMarkdown('')
       setComposerKey((k) => k + 1)
+      clearAttachments()
     }
   }, [open, initialTarget])
 
   const { upload: uploadImage } = useImageUpload({ prefix: 'chat-images' })
+  const {
+    pending: pendingAttachments,
+    addFiles,
+    remove: removeAttachment,
+    clear: clearAttachments,
+  } = useConversationComposerAttachments(uploadImage)
+
+  const handleComposerPaste = useCallback(
+    (e: ClipboardEvent<HTMLDivElement>) => {
+      const images = Array.from(e.clipboardData?.files ?? []).filter((f) =>
+        f.type.startsWith('image/')
+      )
+      if (images.length === 0) return
+      e.preventDefault()
+      void addFiles(images)
+    },
+    [addFiles]
+  )
+  const handleComposerDrop = useCallback(
+    (e: DragEvent<HTMLDivElement>) => {
+      const images = Array.from(e.dataTransfer?.files ?? []).filter((f) =>
+        f.type.startsWith('image/')
+      )
+      if (images.length === 0) return
+      e.preventDefault()
+      void addFiles(images)
+    },
+    [addFiles]
+  )
 
   const send = useMutation({
     mutationFn: (vars: {
       targetPrincipalId: PrincipalId
       content: string
       contentJson?: TiptapContent | null
+      attachments?: typeof pendingAttachments
     }) => startAgentConversationFn({ data: vars }),
     onSuccess: (result) => {
       toast.success('Message sent')
@@ -89,7 +122,7 @@ export function NewConversationDialog({
   })
 
   const isEmpty = isEmptyTiptapDoc(messageJson as TiptapContent | undefined)
-  const canSend = !!target && !isEmpty && !send.isPending
+  const canSend = !!target && (!isEmpty || pendingAttachments.length > 0) && !send.isPending
 
   const submit = () => {
     if (!canSend || !target) return
@@ -107,6 +140,7 @@ export function NewConversationDialog({
       targetPrincipalId: target.principalId as PrincipalId,
       content,
       contentJson: isEmpty ? null : (messageJson as TiptapContent),
+      attachments: pendingAttachments.length > 0 ? pendingAttachments : undefined,
     })
   }
 
@@ -154,19 +188,24 @@ export function NewConversationDialog({
                 </span>
               </span>
             </div>
-            <RichTextEditor
-              key={composerKey}
-              value={messageJson ?? ''}
-              onChange={(json, _html, markdown) => {
-                setMessageJson(json)
-                setMessageMarkdown(markdown)
-              }}
-              features={CONVERSATION_EDITOR_FEATURES}
-              onImageUpload={uploadImage}
-              autofocus
-              minHeight="100px"
-              placeholder="Write your message…"
-            />
+            <div onPaste={handleComposerPaste} onDrop={handleComposerDrop}>
+              <RichTextEditor
+                key={composerKey}
+                value={messageJson ?? ''}
+                onChange={(json, _html, markdown) => {
+                  setMessageJson(json)
+                  setMessageMarkdown(markdown)
+                }}
+                features={CONVERSATION_EDITOR_FEATURES}
+                autofocus
+                minHeight="100px"
+                placeholder="Write your message…"
+              />
+              <ComposerAttachmentTray
+                attachments={pendingAttachments}
+                onRemove={removeAttachment}
+              />
+            </div>
             <div className="flex justify-end">
               <Button onClick={submit} disabled={!canSend}>
                 <PaperAirplaneIcon className="me-1.5 size-4" />

--- a/apps/web/src/components/admin/conversation/new-conversation-dialog.tsx
+++ b/apps/web/src/components/admin/conversation/new-conversation-dialog.tsx
@@ -33,6 +33,10 @@ import {
 import { Button } from '@/components/ui/button'
 import { Avatar } from '@/components/ui/avatar'
 
+function toastImageUploadError(error: Error) {
+  toast.error(error.message)
+}
+
 export interface NewConversationTarget {
   principalId: string
   name: string | null
@@ -80,7 +84,10 @@ export function NewConversationDialog({
     }
   }, [open, initialTarget])
 
-  const { upload: uploadImage } = useImageUpload({ prefix: 'chat-images' })
+  const { upload: uploadImage } = useImageUpload({
+    prefix: 'chat-images',
+    onError: toastImageUploadError,
+  })
   const {
     pending: pendingAttachments,
     addFiles,

--- a/apps/web/src/components/admin/conversation/new-conversation-dialog.tsx
+++ b/apps/web/src/components/admin/conversation/new-conversation-dialog.tsx
@@ -1,8 +1,15 @@
-import { useCallback, useEffect, useState, type ClipboardEvent, type DragEvent } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ClipboardEvent,
+  type DragEvent,
+} from 'react'
 import { useMutation } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
 import { toast } from 'sonner'
-import { ArrowLeftIcon, PaperAirplaneIcon } from '@heroicons/react/24/solid'
+import { ArrowLeftIcon, PaperAirplaneIcon, PaperClipIcon } from '@heroicons/react/24/solid'
 import type { JSONContent } from '@tiptap/react'
 import type { PrincipalId } from '@quackback/ids'
 import type { TiptapContent } from '@/lib/shared/db-types'
@@ -79,7 +86,9 @@ export function NewConversationDialog({
     addFiles,
     remove: removeAttachment,
     clear: clearAttachments,
+    uploading,
   } = useConversationComposerAttachments(uploadImage)
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   const handleComposerPaste = useCallback(
     (e: ClipboardEvent<HTMLDivElement>) => {
@@ -122,7 +131,8 @@ export function NewConversationDialog({
   })
 
   const isEmpty = isEmptyTiptapDoc(messageJson as TiptapContent | undefined)
-  const canSend = !!target && (!isEmpty || pendingAttachments.length > 0) && !send.isPending
+  const canSend =
+    !!target && (!isEmpty || pendingAttachments.length > 0) && !send.isPending && !uploading
 
   const submit = () => {
     if (!canSend || !target) return
@@ -206,7 +216,28 @@ export function NewConversationDialog({
                 onRemove={removeAttachment}
               />
             </div>
-            <div className="flex justify-end">
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              multiple
+              className="hidden"
+              onChange={(e) => {
+                const files = e.target.files
+                if (files && files.length > 0) void addFiles(files)
+                e.target.value = ''
+              }}
+            />
+            <div className="flex items-center justify-between gap-2">
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={uploading}
+                className="flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted disabled:opacity-40 transition-colors"
+                aria-label="Attach image"
+              >
+                <PaperClipIcon className="h-4 w-4" />
+              </button>
               <Button onClick={submit} disabled={!canSend}>
                 <PaperAirplaneIcon className="me-1.5 size-4" />
                 {send.isPending ? 'Sending…' : 'Send message'}

--- a/apps/web/src/components/admin/inbox/__tests__/create-ticket-dialog.test.tsx
+++ b/apps/web/src/components/admin/inbox/__tests__/create-ticket-dialog.test.tsx
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => ({
   linkTicketToConversationFn: vi.fn(),
   suggestTicketFieldValuesFn: vi.fn(),
   toastInfo: vi.fn(),
+  uploading: false,
   routeContext: {
     settings: { featureFlags: {} },
   } as Record<string, unknown>,
@@ -56,6 +57,15 @@ vi.mock('sonner', () => ({
 vi.mock('@/components/ui/rich-text-editor', () => ({ RichTextEditor: () => null }))
 vi.mock('@/lib/client/hooks/use-image-upload', () => ({
   useImageUpload: () => ({ upload: vi.fn() }),
+}))
+vi.mock('@/lib/client/hooks/use-conversation-composer-attachments', () => ({
+  useConversationComposerAttachments: () => ({
+    pending: [],
+    addFiles: vi.fn(),
+    remove: vi.fn(),
+    clear: vi.fn(),
+    uploading: mocks.uploading,
+  }),
 }))
 vi.mock('@/components/shared/portal-user-picker', () => ({ PortalUserPicker: () => null }))
 
@@ -163,6 +173,7 @@ beforeEach(() => {
   mocks.routeContext = { settings: { featureFlags: {} } }
   mocks.listTicketTypesFn.mockReset()
   mocks.listTicketTypesFn.mockResolvedValue([bugType, refundType, taskType, outageType])
+  mocks.uploading = false
 })
 
 afterEach(cleanup)
@@ -407,5 +418,23 @@ describe('CreateTicketDialog — Phase 5 copilot auto-fill', () => {
     expect((screen.getByPlaceholderText('Summarize the request…') as HTMLInputElement).value).toBe(
       'Suggested'
     )
+  })
+})
+
+describe('CreateTicketDialog — attachment tray', () => {
+  it('offers a file picker next to the description composer', async () => {
+    renderDialog()
+    expect(await screen.findByRole('button', { name: 'Attach image' })).toBeInTheDocument()
+  })
+
+  it('blocks create while an image is still uploading', async () => {
+    mocks.uploading = true
+    renderDialog()
+    fireEvent.change(await screen.findByPlaceholderText('Summarize the request…'), {
+      target: { value: 'Has a title' },
+    })
+    expect(screen.getByRole('button', { name: 'Create ticket' })).toBeDisabled()
+    fireEvent.click(screen.getByRole('button', { name: 'Create ticket' }))
+    expect(mocks.mutate).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/components/admin/inbox/create-ticket-dialog.tsx
+++ b/apps/web/src/components/admin/inbox/create-ticket-dialog.tsx
@@ -57,6 +57,10 @@ import {
 // mutation errors.
 const DESCRIPTION_MAX_LENGTH = 4000
 
+function toastImageUploadError(error: Error) {
+  toast.error(error.message)
+}
+
 interface Requester {
   principalId: string
   name: string | null
@@ -226,7 +230,10 @@ export function CreateTicketDialog({
   }, [open, candidates, selectedTypeId])
 
   const create = useCreateTicket()
-  const { upload: uploadImage } = useImageUpload({ prefix: 'chat-images' })
+  const { upload: uploadImage } = useImageUpload({
+    prefix: 'chat-images',
+    onError: toastImageUploadError,
+  })
   const {
     pending: pendingAttachments,
     addFiles,

--- a/apps/web/src/components/admin/inbox/create-ticket-dialog.tsx
+++ b/apps/web/src/components/admin/inbox/create-ticket-dialog.tsx
@@ -2,13 +2,14 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ClipboardEvent,
   type DragEvent,
 } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { toast } from 'sonner'
-import { XMarkIcon } from '@heroicons/react/24/solid'
+import { PaperClipIcon, XMarkIcon } from '@heroicons/react/24/solid'
 import type { JSONContent } from '@tiptap/react'
 import type { ConversationId, PrincipalId, TicketId, TicketTypeId } from '@quackback/ids'
 import type { TicketType, TiptapContent } from '@/lib/shared/db-types'
@@ -231,7 +232,9 @@ export function CreateTicketDialog({
     addFiles,
     remove: removeAttachment,
     clear: clearAttachments,
+    uploading,
   } = useConversationComposerAttachments(uploadImage)
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   const handleComposerPaste = useCallback(
     (e: ClipboardEvent<HTMLDivElement>) => {
@@ -256,7 +259,7 @@ export function CreateTicketDialog({
     [addFiles]
   )
   const [linking, setLinking] = useState(false)
-  const canCreate = title.trim().length > 0 && !create.isPending && !linking
+  const canCreate = title.trim().length > 0 && !create.isPending && !linking && !uploading
 
   /** Type swap: change the field set and drop the old type's answers (the
    *  retype rule protects STORED answers, not a draft's stale keys). Any
@@ -505,6 +508,27 @@ export function CreateTicketDialog({
                 attachments={pendingAttachments}
                 onRemove={removeAttachment}
               />
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                multiple
+                className="hidden"
+                onChange={(e) => {
+                  const files = e.target.files
+                  if (files && files.length > 0) void addFiles(files)
+                  e.target.value = ''
+                }}
+              />
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={uploading}
+                className="mt-1 flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted disabled:opacity-40 transition-colors"
+                aria-label="Attach image"
+              >
+                <PaperClipIcon className="h-4 w-4" />
+              </button>
             </div>
           </div>
 

--- a/apps/web/src/components/admin/inbox/create-ticket-dialog.tsx
+++ b/apps/web/src/components/admin/inbox/create-ticket-dialog.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useMemo, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ClipboardEvent,
+  type DragEvent,
+} from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { XMarkIcon } from '@heroicons/react/24/solid'
@@ -20,8 +27,10 @@ import { RichTextEditor } from '@/components/ui/rich-text-editor'
 import { TicketFormFields } from '@/components/shared/ticket-form-fields'
 import { useTicketIntakeForm } from '@/components/shared/use-ticket-intake-form'
 import { CONVERSATION_EDITOR_FEATURES } from '@/components/conversation/conversation-editor-features'
+import { ComposerAttachmentTray } from '@/components/shared/composer-attachment-tray'
 import { isEmptyTiptapDoc } from '@/lib/shared/utils/is-empty-tiptap-doc'
 import { useImageUpload } from '@/lib/client/hooks/use-image-upload'
+import { useConversationComposerAttachments } from '@/lib/client/hooks/use-conversation-composer-attachments'
 import {
   Dialog,
   DialogContent,
@@ -195,6 +204,7 @@ export function CreateTicketDialog({
       setTitle(fromConversation ? (defaultTitle ?? '') : '')
       setDescriptionJson(undefined)
       setDescriptionMarkdown('')
+      clearAttachments()
       setRequester(fromConversation ? (defaultRequester ?? null) : null)
       setFieldValues({})
       setFieldErrors({})
@@ -216,6 +226,35 @@ export function CreateTicketDialog({
 
   const create = useCreateTicket()
   const { upload: uploadImage } = useImageUpload({ prefix: 'chat-images' })
+  const {
+    pending: pendingAttachments,
+    addFiles,
+    remove: removeAttachment,
+    clear: clearAttachments,
+  } = useConversationComposerAttachments(uploadImage)
+
+  const handleComposerPaste = useCallback(
+    (e: ClipboardEvent<HTMLDivElement>) => {
+      const images = Array.from(e.clipboardData?.files ?? []).filter((f) =>
+        f.type.startsWith('image/')
+      )
+      if (images.length === 0) return
+      e.preventDefault()
+      void addFiles(images)
+    },
+    [addFiles]
+  )
+  const handleComposerDrop = useCallback(
+    (e: DragEvent<HTMLDivElement>) => {
+      const images = Array.from(e.dataTransfer?.files ?? []).filter((f) =>
+        f.type.startsWith('image/')
+      )
+      if (images.length === 0) return
+      e.preventDefault()
+      void addFiles(images)
+    },
+    [addFiles]
+  )
   const [linking, setLinking] = useState(false)
   const canCreate = title.trim().length > 0 && !create.isPending && !linking
 
@@ -314,6 +353,7 @@ export function CreateTicketDialog({
         descriptionJson: isEmptyTiptapDoc(descriptionJson as TiptapContent | undefined)
           ? null
           : (descriptionJson as TiptapContent),
+        attachments: pendingAttachments.length > 0 ? pendingAttachments : undefined,
         requesterPrincipalId: requester?.principalId as PrincipalId | undefined,
         customAttributes,
         // Lets the create inherit this conversation's assignee (born owned by
@@ -450,17 +490,22 @@ export function CreateTicketDialog({
 
           <div className="space-y-1.5">
             <label className="text-xs font-medium text-muted-foreground">Description</label>
-            <RichTextEditor
-              value={descriptionJson ?? ''}
-              onChange={(json, _html, markdown) => {
-                setDescriptionJson(json)
-                setDescriptionMarkdown(markdown)
-              }}
-              features={CONVERSATION_EDITOR_FEATURES}
-              onImageUpload={uploadImage}
-              minHeight="120px"
-              placeholder="Add details (optional). This opens the ticket thread."
-            />
+            <div onPaste={handleComposerPaste} onDrop={handleComposerDrop}>
+              <RichTextEditor
+                value={descriptionJson ?? ''}
+                onChange={(json, _html, markdown) => {
+                  setDescriptionJson(json)
+                  setDescriptionMarkdown(markdown)
+                }}
+                features={CONVERSATION_EDITOR_FEATURES}
+                minHeight="120px"
+                placeholder="Add details (optional). This opens the ticket thread."
+              />
+              <ComposerAttachmentTray
+                attachments={pendingAttachments}
+                onRemove={removeAttachment}
+              />
+            </div>
           </div>
 
           {/* The chosen type's field set — agents fill the full set (customer-

--- a/apps/web/src/components/conversation/__tests__/agent-conversation-thread.test.tsx
+++ b/apps/web/src/components/conversation/__tests__/agent-conversation-thread.test.tsx
@@ -187,10 +187,11 @@ vi.mock('@/lib/client/hooks/use-copilot-insert', () => ({ useCopilotInsert: () =
 vi.mock('@/lib/client/hooks/use-image-upload', () => ({
   useImageUpload: () => ({ upload: vi.fn() }),
 }))
+const addFiles = vi.fn()
 vi.mock('@/lib/client/hooks/use-conversation-composer-attachments', () => ({
   useConversationComposerAttachments: () => ({
     pending: [],
-    addFiles: vi.fn(),
+    addFiles,
     remove: vi.fn(),
     clear: vi.fn(),
     uploading: false,
@@ -722,6 +723,18 @@ describe('AgentConversationThread — composer focus handle', () => {
     // The marker follows the note composer too — the modes share one box.
     act(() => composerRef.current?.focusComposer('note'))
     expect(screen.getByTestId('editor').closest('[data-inbox-composer]')).not.toBeNull()
+  })
+
+  it('pasting an image on the composer stages the attachment tray, not an inline node', async () => {
+    renderWithHandle({ kind: 'conversation', id: 'conversation_1' })
+    const editor = await screen.findByTestId('editor')
+    const box = editor.closest('[data-inbox-composer]')
+    expect(box).not.toBeNull()
+    const file = new File([new Uint8Array([1, 2, 3])], 'shot.png', { type: 'image/png' })
+    fireEvent.paste(box as HTMLElement, {
+      clipboardData: { files: [file], items: [] },
+    })
+    expect(addFiles).toHaveBeenCalledWith([file])
   })
 
   it('focusComposer("reply") focuses the reply editor already showing, leaving the mode alone', async () => {

--- a/apps/web/src/components/conversation/__tests__/conversation-editor-features.test.ts
+++ b/apps/web/src/components/conversation/__tests__/conversation-editor-features.test.ts
@@ -19,7 +19,7 @@ const REPLY: EditorFeatures = {
   taskLists: false,
   dividers: false,
   codeBlocks: true,
-  images: true,
+  images: false,
   blockquotes: true,
   embeds: true,
   quackbackEmbeds: true,

--- a/apps/web/src/components/conversation/agent-conversation-thread.tsx
+++ b/apps/web/src/components/conversation/agent-conversation-thread.tsx
@@ -268,6 +268,10 @@ export interface ThreadComposerHandle {
   openMacros: () => void
 }
 
+function toastImageUploadError(error: Error) {
+  toast.error(error.message)
+}
+
 export function AgentConversationThread({
   item,
   targetMessageId,
@@ -393,7 +397,11 @@ export function AgentConversationThread({
   const sendTyping = useTypingSender(isTicket ? null : conversationId)
   const { onLocalInput } = useConversationTyping(sendTyping)
 
-  const { upload } = useImageUpload({ endpoint: '/api/upload/image', prefix: 'chat-images' })
+  const { upload } = useImageUpload({
+    endpoint: '/api/upload/image',
+    prefix: 'chat-images',
+    onError: toastImageUploadError,
+  })
   const {
     pending: pendingAttachments,
     addFiles,

--- a/apps/web/src/components/conversation/agent-conversation-thread.tsx
+++ b/apps/web/src/components/conversation/agent-conversation-thread.tsx
@@ -22,6 +22,8 @@ import {
   useMemo,
   useRef,
   useState,
+  type ClipboardEvent,
+  type DragEvent,
   type ReactNode,
   type RefObject,
 } from 'react'
@@ -400,6 +402,30 @@ export function AgentConversationThread({
     uploading,
   } = useConversationComposerAttachments(upload)
   const fileInputRef = useRef<HTMLInputElement>(null)
+  // Same as the visitor messenger: paste/drop stages the tray. The editor has
+  // no onImageUpload, so it never inlines a resizableImage into the draft.
+  const handleComposerPaste = useCallback(
+    (e: ClipboardEvent<HTMLDivElement>) => {
+      const images = Array.from(e.clipboardData?.files ?? []).filter((f) =>
+        f.type.startsWith('image/')
+      )
+      if (images.length === 0) return
+      e.preventDefault()
+      void addFiles(images)
+    },
+    [addFiles]
+  )
+  const handleComposerDrop = useCallback(
+    (e: DragEvent<HTMLDivElement>) => {
+      const images = Array.from(e.dataTransfer?.files ?? []).filter((f) =>
+        f.type.startsWith('image/')
+      )
+      if (images.length === 0) return
+      e.preventDefault()
+      void addFiles(images)
+    },
+    [addFiles]
+  )
 
   // Both kind's thread queries are always called (rules of hooks) but only one
   // is ever `enabled` — the conversation adapter is unchanged from before the
@@ -1969,6 +1995,8 @@ export function AgentConversationThread({
                 ? 'border-amber-400/50 bg-amber-400/5 focus-within:ring-amber-400/20'
                 : 'border-border bg-background focus-within:ring-primary/20'
             )}
+            onPaste={handleComposerPaste}
+            onDrop={handleComposerDrop}
           >
             {/* Reply vs internal-note mode — a back_office/tracker ticket has
                 no reply capability, so Note is the only mode: hide the
@@ -2020,8 +2048,9 @@ export function AgentConversationThread({
             {/* Reply and Note share the unified RichTextEditor; reply keeps
                 @-mentions on (agent surface), note is the team-internal preset.
                 Enter sends, Shift+Enter breaks; formatting comes from the editor's
-                own bubble/slash/`:` surfaces. Pasted/dropped images inline via
-                onImageUpload; the paperclip still stages files in the tray below. */}
+                own bubble/slash/`:` surfaces. Images stay tray-only (paste/drop
+                and the paperclip stage files below) — the editor has no
+                onImageUpload, so it never inlines a resizableImage. */}
             {noteMode || !capabilities.reply ? (
               <RichTextEditor
                 key={`note-${noteKey}`}
@@ -2036,7 +2065,6 @@ export function AgentConversationThread({
                 className="max-h-64 overflow-y-auto"
                 onChange={onNoteChange}
                 onSubmit={onSend}
-                onImageUpload={upload}
               />
             ) : (
               <RichTextEditor
@@ -2055,7 +2083,6 @@ export function AgentConversationThread({
                 className="max-h-64 overflow-y-auto"
                 onChange={onReplyChange}
                 onSubmit={onSend}
-                onImageUpload={upload}
               />
             )}
             <ComposerAttachmentTray attachments={pendingAttachments} onRemove={removeAttachment} />

--- a/apps/web/src/components/conversation/conversation-editor-features.ts
+++ b/apps/web/src/components/conversation/conversation-editor-features.ts
@@ -3,10 +3,11 @@ import type { EditorFeatures } from '@/components/ui/rich-text-editor'
 /**
  * EditorFeatures presets for conversation composers (agent replies, internal
  * notes, and visitor-facing messengers). Richer than the comment preset — code
- * blocks, images, blockquotes, and Quackback embeds are all on — but still
- * chat-shaped: headings, tables, task lists, and dividers stay off, and Enter
- * inserts a line break (a consumer that wants Enter-to-send passes onSubmit to
- * RichTextEditor, which overrides enterAsHardBreak).
+ * blocks, blockquotes, and Quackback embeds are on — but still chat-shaped:
+ * headings, tables, task lists, dividers, and inline images stay off (images
+ * go through the attachment tray). Enter inserts a line break (a consumer that
+ * wants Enter-to-send passes onSubmit to RichTextEditor, which overrides
+ * enterAsHardBreak).
  */
 
 /** Agent reply composer. */
@@ -16,7 +17,7 @@ export const CONVERSATION_EDITOR_FEATURES: EditorFeatures = {
   taskLists: false,
   dividers: false,
   codeBlocks: true,
-  images: true,
+  images: false,
   blockquotes: true,
   embeds: true,
   quackbackEmbeds: true,
@@ -38,7 +39,7 @@ export const CONVERSATION_NOTE_FEATURES: EditorFeatures = {
   taskLists: false,
   dividers: false,
   codeBlocks: true,
-  images: true,
+  images: false,
   blockquotes: true,
   embeds: true,
   quackbackEmbeds: true,
@@ -59,7 +60,7 @@ export const VISITOR_CONVERSATION_FEATURES: EditorFeatures = {
   taskLists: false,
   dividers: false,
   codeBlocks: true,
-  images: true,
+  images: false,
   blockquotes: true,
   embeds: true,
   quackbackEmbeds: true,

--- a/apps/web/src/components/shared/__tests__/conversation-attachments.test.tsx
+++ b/apps/web/src/components/shared/__tests__/conversation-attachments.test.tsx
@@ -22,4 +22,36 @@ describe('ConversationAttachmentList', () => {
     expect(img?.className).toContain('object-contain')
     expect(img?.className).not.toContain('object-cover')
   })
+
+  it('renders a safe raster data-URI that lift would attach', () => {
+    const src = 'data:image/png;base64,aaaa'
+    const { container } = render(
+      <ConversationAttachmentList
+        attachments={[{ url: src, name: 'shot.png', contentType: 'image/png', size: 0 }]}
+      />
+    )
+    expect(container.querySelector('img')?.getAttribute('src')).toBe(src)
+  })
+
+  it('drops javascript: and svg data-URI image srcs', () => {
+    const { container } = render(
+      <ConversationAttachmentList
+        attachments={[
+          {
+            url: 'javascript:alert(1)',
+            name: 'x',
+            contentType: 'image/png',
+            size: 0,
+          },
+          {
+            url: 'data:image/svg+xml;base64,PHN2Zz4=',
+            name: 'x.svg',
+            contentType: 'image/svg+xml',
+            size: 0,
+          },
+        ]}
+      />
+    )
+    expect(container.querySelector('img')).toBeNull()
+  })
 })

--- a/apps/web/src/components/shared/__tests__/conversation-attachments.test.tsx
+++ b/apps/web/src/components/shared/__tests__/conversation-attachments.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { ConversationAttachmentList } from '../conversation-attachments'
+
+describe('ConversationAttachmentList', () => {
+  it('renders image attachments with a contain-fitted thumb, not object-cover', () => {
+    const { container } = render(
+      <ConversationAttachmentList
+        attachments={[
+          {
+            url: 'https://cdn.example.com/wide.png',
+            name: 'wide.png',
+            contentType: 'image/png',
+            size: 100,
+          },
+        ]}
+      />
+    )
+    const img = container.querySelector('img')
+    expect(img).not.toBeNull()
+    expect(img?.className).toContain('object-contain')
+    expect(img?.className).not.toContain('object-cover')
+  })
+})

--- a/apps/web/src/components/shared/conversation-attachments.tsx
+++ b/apps/web/src/components/shared/conversation-attachments.tsx
@@ -40,7 +40,7 @@ export function ConversationAttachmentList({
             src={a.url}
             alt={a.name}
             className="block w-fit overflow-hidden rounded-lg border border-border/40"
-            thumbClassName="max-h-40 max-w-[14rem] object-cover"
+            thumbClassName="max-h-40 max-w-full w-auto h-auto object-contain"
           />
         ) : (
           <a

--- a/apps/web/src/components/shared/conversation-attachments.tsx
+++ b/apps/web/src/components/shared/conversation-attachments.tsx
@@ -1,6 +1,7 @@
 import { PaperClipIcon } from '@heroicons/react/24/outline'
 import { ZoomableImage } from '@/components/shared/zoomable-image'
 import type { ConversationAttachment } from '@/lib/shared/conversation/types'
+import { sanitizeImageUrl } from '@/lib/shared/utils/sanitize'
 
 function humanSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`
@@ -9,13 +10,15 @@ function humanSize(bytes: number): string {
 }
 
 /**
- * Defense-in-depth: only ever render http(s) or same-origin relative URLs into
- * href/src, so a malformed/hostile URL can never become a javascript: sink.
+ * Defense-in-depth: never render a javascript: (or other hostile) URL into
+ * href/src. Image srcs use the same raster-data-URI policy as lift/sanitize
+ * so a stored `data:image/png;...` that we lift onto attachments still shows.
  */
-function isSafeUrl(url: string): boolean {
-  if (url.startsWith('/')) return true
+function isSafeAttachment(a: ConversationAttachment): boolean {
+  if (a.contentType.startsWith('image/')) return sanitizeImageUrl(a.url).length > 0
+  if (a.url.startsWith('/')) return true
   try {
-    const proto = new URL(url).protocol
+    const proto = new URL(a.url).protocol
     return proto === 'https:' || proto === 'http:'
   } catch {
     return false
@@ -28,7 +31,7 @@ export function ConversationAttachmentList({
 }: {
   attachments: ConversationAttachment[]
 }) {
-  const safe = (attachments ?? []).filter((a) => isSafeUrl(a.url))
+  const safe = (attachments ?? []).filter(isSafeAttachment)
   if (safe.length === 0) return null
   return (
     <div className="mt-1.5 flex flex-col gap-1.5">

--- a/apps/web/src/components/ui/__tests__/rich-text-editor-extensions.test.ts
+++ b/apps/web/src/components/ui/__tests__/rich-text-editor-extensions.test.ts
@@ -12,6 +12,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest'
+import { Editor } from '@tiptap/core'
 import type { EditorFeatures } from '../rich-text-editor'
 import {
   buildExtensions,
@@ -87,6 +88,33 @@ describe('buildExtensions', () => {
     const withoutNames = without.map((e) => (e as { name: string }).name)
     expect(withNames).toContain('image')
     expect(withoutNames).toContain('image')
+  })
+
+  it('does not materialize 0×0 or 500×500 on a stored image that omitted dimensions', () => {
+    const editor = new Editor({
+      extensions: buildExtensions(
+        { images: true, slashMenu: false, emojiPicker: false, mentions: false },
+        { placeholder: '' }
+      ),
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [{ type: 'image', attrs: { src: 'https://cdn.example.com/wide.png' } }],
+          },
+        ],
+      },
+    })
+    try {
+      const img = editor.getJSON().content?.[0]?.content?.[0]
+      expect(img?.type).toBe('image')
+      expect(img?.attrs?.src).toBe('https://cdn.example.com/wide.png')
+      expect(img?.attrs?.width).toBeNull()
+      expect(img?.attrs?.height).toBeNull()
+    } finally {
+      editor.destroy()
+    }
   })
 
   it('includes slashCommands extension by default', () => {

--- a/apps/web/src/components/ui/__tests__/rich-text-editor-extensions.test.ts
+++ b/apps/web/src/components/ui/__tests__/rich-text-editor-extensions.test.ts
@@ -507,7 +507,7 @@ describe('generateContentHTML — chatImage nodes', () => {
     expect(html).toContain('<img')
     expect(html).toContain('src="https://example.com/photo.png"')
     expect(html).toContain('alt="A screenshot"')
-    expect(html).toContain('class="max-w-xs rounded-md"')
+    expect(html).toContain('class="max-w-xs h-auto object-contain rounded-md"')
   })
 
   it('renders nothing for a chatImage with no src', () => {

--- a/apps/web/src/components/ui/__tests__/rich-text-editor-extensions.test.ts
+++ b/apps/web/src/components/ui/__tests__/rich-text-editor-extensions.test.ts
@@ -107,7 +107,9 @@ describe('buildExtensions', () => {
       },
     })
     try {
-      const img = editor.getJSON().content?.[0]?.content?.[0]
+      const img = editor.getJSON().content?.[0]?.content?.[0] as
+        | { type?: string; attrs?: { src?: string; width?: number | null; height?: number | null } }
+        | undefined
       expect(img?.type).toBe('image')
       expect(img?.attrs?.src).toBe('https://cdn.example.com/wide.png')
       expect(img?.attrs?.width).toBeNull()

--- a/apps/web/src/components/ui/conversation-image-node.tsx
+++ b/apps/web/src/components/ui/conversation-image-node.tsx
@@ -14,7 +14,9 @@ function ConversationImageNodeView({ node, selected, deleteNode }: ReactNodeView
   const alt = (node.attrs.alt as string | null) ?? ''
   return (
     <NodeViewWrapper className="group relative my-1 inline-block" contentEditable={false}>
-      {src ? <img src={src} alt={alt} className="max-w-xs rounded-md" /> : null}
+      {src ? (
+        <img src={src} alt={alt} className="max-w-xs h-auto object-contain rounded-md" />
+      ) : null}
       {/* Remove control. mousedown-preventDefault so it doesn't steal the
           editor selection before the click fires. */}
       <button

--- a/apps/web/src/components/ui/rich-text-editor.tsx
+++ b/apps/web/src/components/ui/rich-text-editor.tsx
@@ -60,6 +60,7 @@ import {
 } from 'react'
 import { computePosition, flip, shift, offset } from '@floating-ui/dom'
 import { cn } from '@/lib/shared/utils'
+import { resizableImageInsertAttrs } from '@/lib/client/resizable-image-insert-attrs'
 // The read-only JSON→HTML serializer now lives in a browser-free shared module
 // so server-side consumers (e.g. outbound conversation email) can import it
 // without pulling in React/tiptap-react. Re-exported below for existing callers.
@@ -207,6 +208,10 @@ export function buildExtensions(
         class: 'max-w-full h-auto rounded-lg',
       },
       allowBase64: false,
+      // 0 so a node created with only `{ src, data-keep-ratio }` is not stored
+      // as the extension's 500×500 square default (that forced 1:1 on display).
+      defaultWidth: 0,
+      defaultHeight: 0,
     }),
     // Always register so saved embed nodes round-trip in any editor; paste rules
     // only fire when quackbackEmbeds is enabled for this editor.
@@ -595,8 +600,7 @@ function getSlashMenuItems(
           if (!file) return
           try {
             const src = await onImageUpload(file)
-            // Use setResizableImage for the resizable image extension
-            editor.commands.setResizableImage({ src, 'data-keep-ratio': true })
+            editor.commands.setResizableImage(await resizableImageInsertAttrs(src, file))
           } catch (error) {
             console.error('Failed to upload image:', error)
             const { toast } = await import('sonner')
@@ -1656,10 +1660,9 @@ function handleImageDrop(
 
     images.forEach((image) => {
       onImageUpload(image)
-        .then((src) => {
-          // Use resizableImage node type for resizable images
+        .then(async (src) => {
           const nodeType = schema.nodes.resizableImage || schema.nodes.image
-          const node = nodeType?.create({ src, 'data-keep-ratio': true })
+          const node = nodeType?.create(await resizableImageInsertAttrs(src, image))
           if (node && coordinates) {
             const transaction = view.state.tr.insert(coordinates.pos, node)
             view.dispatch(transaction)
@@ -1698,11 +1701,10 @@ function handleImagePaste(
       if (!file) return
 
       onImageUpload(file)
-        .then((src) => {
+        .then(async (src) => {
           const { schema } = view.state
-          // Use resizableImage node type for resizable images
           const nodeType = schema.nodes.resizableImage || schema.nodes.image
-          const node = nodeType?.create({ src, 'data-keep-ratio': true })
+          const node = nodeType?.create(await resizableImageInsertAttrs(src, file))
           if (node) {
             const transaction = view.state.tr.replaceSelectionWith(node)
             view.dispatch(transaction)
@@ -2238,8 +2240,7 @@ function MenuBar({
 
       try {
         const src = await onImageUpload(file)
-        // Use setResizableImage for resizable images
-        editor.commands.setResizableImage({ src, 'data-keep-ratio': true })
+        editor.commands.setResizableImage(await resizableImageInsertAttrs(src, file))
       } catch (error) {
         console.error('Failed to upload image:', error)
         const { toast } = await import('sonner')

--- a/apps/web/src/components/ui/rich-text-editor.tsx
+++ b/apps/web/src/components/ui/rich-text-editor.tsx
@@ -202,16 +202,36 @@ export function buildExtensions(
         class: 'text-primary underline',
       },
     }),
-    // Always register so the schema can parse image nodes in existing content
-    ResizableImage.configure({
+    // Always register so the schema can parse image nodes in existing content.
+    // Width/height default to null (not the extension's 500×500, and not 0): a
+    // stored post/changelog image that omitted dims must keep its natural box.
+    // New inserts still get a measured box from `resizableImageInsertAttrs`.
+    ResizableImage.extend({
+      addAttributes() {
+        const parent = this.parent?.() ?? {}
+        const keepRatio = parent['data-keep-ratio']
+        return {
+          ...parent,
+          width: { ...parent.width, default: null },
+          height: { ...parent.height, default: null },
+          'data-keep-ratio': {
+            ...keepRatio,
+            renderHTML(attributes: { width?: number | null; 'data-keep-ratio'?: boolean }) {
+              if (!attributes['data-keep-ratio']) return {}
+              const width = Number(attributes.width)
+              if (Number.isFinite(width) && width > 0) {
+                return { style: `max-width: ${width}px`, 'data-keep-ratio': 'true' }
+              }
+              return { 'data-keep-ratio': 'true' }
+            },
+          },
+        }
+      },
+    }).configure({
       HTMLAttributes: {
         class: 'max-w-full h-auto rounded-lg',
       },
       allowBase64: false,
-      // 0 so a node created with only `{ src, data-keep-ratio }` is not stored
-      // as the extension's 500×500 square default (that forced 1:1 on display).
-      defaultWidth: 0,
-      defaultHeight: 0,
     }),
     // Always register so saved embed nodes round-trip in any editor; paste rules
     // only fire when quackbackEmbeds is enabled for this editor.

--- a/apps/web/src/lib/client/__tests__/resizable-image-insert-attrs.test.ts
+++ b/apps/web/src/lib/client/__tests__/resizable-image-insert-attrs.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { scaleImageInsertSize } from '../resizable-image-insert-attrs'
+
+describe('scaleImageInsertSize', () => {
+  it('keeps a landscape screenshot proportional under the 500px cap', () => {
+    expect(scaleImageInsertSize(1920, 1080)).toEqual({ width: 500, height: 281 })
+  })
+
+  it('does not upscale a small image', () => {
+    expect(scaleImageInsertSize(200, 100)).toEqual({ width: 200, height: 100 })
+  })
+
+  it('does not emit a 1:1 box for a wide image', () => {
+    const { width, height } = scaleImageInsertSize(1600, 900)
+    expect(width).toBe(500)
+    expect(width / height).toBeCloseTo(1600 / 900, 2)
+  })
+})

--- a/apps/web/src/lib/client/hooks/__tests__/use-conversation-composer-attachments.test.ts
+++ b/apps/web/src/lib/client/hooks/__tests__/use-conversation-composer-attachments.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { act, renderHook } from '@testing-library/react'
+import { MAX_CONVERSATION_ATTACHMENTS } from '@/lib/shared/conversation/types'
 import { useConversationComposerAttachments } from '../use-conversation-composer-attachments'
 
 function png(name: string) {
@@ -66,6 +67,62 @@ describe('useConversationComposerAttachments', () => {
       await addDone
     })
     expect(result.current.pending).toEqual([])
+    expect(result.current.uploading).toBe(false)
+  })
+
+  it('does not upload a second near-cap paste while the last slot is reserved', async () => {
+    const upload = vi.fn((file: File) => Promise.resolve(`/api/storage/chat-images/${file.name}`))
+    const { result } = renderHook(() => useConversationComposerAttachments(upload))
+    act(() => {
+      result.current.restore(
+        Array.from({ length: MAX_CONVERSATION_ATTACHMENTS - 1 }, (_, i) => ({
+          url: `/api/storage/chat-images/${i}.png`,
+          name: `${i}.png`,
+          contentType: 'image/png',
+          size: 1,
+        }))
+      )
+    })
+
+    const first = deferred<string>()
+    upload.mockImplementationOnce(() => first.promise)
+
+    let firstDone!: Promise<void>
+    let secondDone!: Promise<void>
+    act(() => {
+      firstDone = result.current.addFiles([png('last.png')])
+      secondDone = result.current.addFiles([png('overflow.png')])
+    })
+    expect(upload).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      first.resolve('/api/storage/chat-images/last.png')
+      await firstDone
+      await secondDone
+    })
+    expect(result.current.pending).toHaveLength(MAX_CONVERSATION_ATTACHMENTS)
+    expect(result.current.pending.at(-1)?.name).toBe('last.png')
+  })
+
+  it('keeps the files that uploaded when one image in a multi-pick fails', async () => {
+    const upload = vi.fn((file: File) =>
+      file.name === 'bad.png'
+        ? Promise.reject(new Error('too large'))
+        : Promise.resolve(`/api/storage/chat-images/${file.name}`)
+    )
+    const { result } = renderHook(() => useConversationComposerAttachments(upload))
+
+    await act(async () => {
+      await result.current.addFiles([png('ok.png'), png('bad.png')])
+    })
+    expect(result.current.pending).toEqual([
+      {
+        url: '/api/storage/chat-images/ok.png',
+        name: 'ok.png',
+        contentType: 'image/png',
+        size: 1,
+      },
+    ])
     expect(result.current.uploading).toBe(false)
   })
 })

--- a/apps/web/src/lib/client/hooks/__tests__/use-conversation-composer-attachments.test.ts
+++ b/apps/web/src/lib/client/hooks/__tests__/use-conversation-composer-attachments.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { useConversationComposerAttachments } from '../use-conversation-composer-attachments'
+
+function png(name: string) {
+  return new File(['x'], name, { type: 'image/png' })
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+describe('useConversationComposerAttachments', () => {
+  it('keeps uploading true until every overlapping addFiles finishes', async () => {
+    const first = deferred<string>()
+    const second = deferred<string>()
+    const upload = (file: File) => (file.name === 'a.png' ? first.promise : second.promise)
+    const { result } = renderHook(() => useConversationComposerAttachments(upload))
+
+    let firstDone!: Promise<void>
+    let secondDone!: Promise<void>
+    act(() => {
+      firstDone = result.current.addFiles([png('a.png')])
+      secondDone = result.current.addFiles([png('b.png')])
+    })
+    expect(result.current.uploading).toBe(true)
+
+    await act(async () => {
+      second.resolve('/api/storage/chat-images/b.png')
+      await secondDone
+    })
+    expect(result.current.uploading).toBe(true)
+    expect(result.current.pending).toHaveLength(1)
+
+    await act(async () => {
+      first.resolve('/api/storage/chat-images/a.png')
+      await firstDone
+    })
+    expect(result.current.uploading).toBe(false)
+    expect(result.current.pending.map((a) => a.name).sort()).toEqual(['a.png', 'b.png'])
+  })
+
+  it('drops an in-flight upload after clear so a reopened composer stays empty', async () => {
+    const pending = deferred<string>()
+    const { result } = renderHook(() => useConversationComposerAttachments(() => pending.promise))
+
+    let addDone!: Promise<void>
+    act(() => {
+      addDone = result.current.addFiles([png('stale.png')])
+    })
+    expect(result.current.uploading).toBe(true)
+
+    act(() => {
+      result.current.clear()
+    })
+    expect(result.current.uploading).toBe(false)
+    expect(result.current.pending).toEqual([])
+
+    await act(async () => {
+      pending.resolve('/api/storage/chat-images/stale.png')
+      await addDone
+    })
+    expect(result.current.pending).toEqual([])
+    expect(result.current.uploading).toBe(false)
+  })
+})

--- a/apps/web/src/lib/client/hooks/use-conversation-composer-attachments.ts
+++ b/apps/web/src/lib/client/hooks/use-conversation-composer-attachments.ts
@@ -7,6 +7,11 @@ import { MAX_CONVERSATION_ATTACHMENTS } from '@/lib/shared/conversation/types'
  * provided upload fn (which returns a public URL), tracks them with their
  * name/type/size for the send payload, and exposes add/remove/clear + an
  * uploading flag.
+ *
+ * `uploading` is an in-flight count (not a boolean flip), so two overlapping
+ * paste/drops keep Send disabled until both finish. `clear` bumps a generation
+ * so a dialog reset drops in-flight results instead of leaking them onto the
+ * next compose.
  */
 export function useConversationComposerAttachments(upload: (file: File) => Promise<string>) {
   const [pending, setPending] = useState<ConversationAttachment[]>([])
@@ -15,14 +20,18 @@ export function useConversationComposerAttachments(upload: (file: File) => Promi
   // slot calculation) without a stale closure or re-creating the callback.
   const pendingRef = useRef<ConversationAttachment[]>([])
   pendingRef.current = pending
+  const generationRef = useRef(0)
+  const inFlightRef = useRef(0)
 
   const addFiles = useCallback(
     async (files: FileList | File[]) => {
       // Only take as many as still fit, so we don't upload files we'd then have
       // to silently drop past the cap.
+      const generation = generationRef.current
       const slotsLeft = MAX_CONVERSATION_ATTACHMENTS - pendingRef.current.length
       const list = Array.from(files).slice(0, Math.max(0, slotsLeft))
       if (list.length === 0) return
+      inFlightRef.current += 1
       setUploading(true)
       try {
         const uploaded = await Promise.all(
@@ -33,12 +42,15 @@ export function useConversationComposerAttachments(upload: (file: File) => Promi
             size: f.size,
           }))
         )
+        if (generation !== generationRef.current) return
         setPending((prev) => [...prev, ...uploaded].slice(0, MAX_CONVERSATION_ATTACHMENTS))
       } catch {
         // The upload fn's onError handler (when the caller wires one) surfaces
         // the failure to the user; either way, drop the failed batch.
       } finally {
-        setUploading(false)
+        if (generation !== generationRef.current) return
+        inFlightRef.current = Math.max(0, inFlightRef.current - 1)
+        setUploading(inFlightRef.current > 0)
       }
     },
     [upload]
@@ -48,7 +60,12 @@ export function useConversationComposerAttachments(upload: (file: File) => Promi
     setPending((prev) => prev.filter((_, i) => i !== index))
   }, [])
 
-  const clear = useCallback(() => setPending([]), [])
+  const clear = useCallback(() => {
+    generationRef.current += 1
+    inFlightRef.current = 0
+    setUploading(false)
+    setPending([])
+  }, [])
   // Re-populate the composer, e.g. to restore a snapshot after a failed send so
   // the already-uploaded files aren't lost.
   const restore = useCallback((items: ConversationAttachment[]) => setPending(items), [])

--- a/apps/web/src/lib/client/hooks/use-conversation-composer-attachments.ts
+++ b/apps/web/src/lib/client/hooks/use-conversation-composer-attachments.ts
@@ -9,9 +9,11 @@ import { MAX_CONVERSATION_ATTACHMENTS } from '@/lib/shared/conversation/types'
  * uploading flag.
  *
  * `uploading` is an in-flight count (not a boolean flip), so two overlapping
- * paste/drops keep Send disabled until both finish. `clear` bumps a generation
- * so a dialog reset drops in-flight results instead of leaking them onto the
- * next compose.
+ * paste/drops keep Send disabled until both finish. Slot math also reserves
+ * files already uploading so two near-cap pastes cannot both claim the last
+ * seat. `clear` bumps a generation so a dialog reset drops in-flight results
+ * instead of leaking them onto the next compose. A mixed multi-file pick keeps
+ * the files that uploaded; failures stay dropped (the upload fn reports them).
  */
 export function useConversationComposerAttachments(upload: (file: File) => Promise<string>) {
   const [pending, setPending] = useState<ConversationAttachment[]>([])
@@ -21,20 +23,24 @@ export function useConversationComposerAttachments(upload: (file: File) => Promi
   const pendingRef = useRef<ConversationAttachment[]>([])
   pendingRef.current = pending
   const generationRef = useRef(0)
-  const inFlightRef = useRef(0)
+  const inFlightBatchesRef = useRef(0)
+  const reservedSlotsRef = useRef(0)
 
   const addFiles = useCallback(
     async (files: FileList | File[]) => {
       // Only take as many as still fit, so we don't upload files we'd then have
-      // to silently drop past the cap.
+      // to silently drop past the cap. Reserved slots are in-flight files from
+      // overlapping addFiles calls that have not landed in `pending` yet.
       const generation = generationRef.current
-      const slotsLeft = MAX_CONVERSATION_ATTACHMENTS - pendingRef.current.length
+      const slotsLeft =
+        MAX_CONVERSATION_ATTACHMENTS - pendingRef.current.length - reservedSlotsRef.current
       const list = Array.from(files).slice(0, Math.max(0, slotsLeft))
       if (list.length === 0) return
-      inFlightRef.current += 1
+      reservedSlotsRef.current += list.length
+      inFlightBatchesRef.current += 1
       setUploading(true)
       try {
-        const uploaded = await Promise.all(
+        const results = await Promise.allSettled(
           list.map(async (f) => ({
             url: await upload(f),
             name: f.name,
@@ -43,14 +49,14 @@ export function useConversationComposerAttachments(upload: (file: File) => Promi
           }))
         )
         if (generation !== generationRef.current) return
+        const uploaded = results.flatMap((r) => (r.status === 'fulfilled' ? [r.value] : []))
+        if (uploaded.length === 0) return
         setPending((prev) => [...prev, ...uploaded].slice(0, MAX_CONVERSATION_ATTACHMENTS))
-      } catch {
-        // The upload fn's onError handler (when the caller wires one) surfaces
-        // the failure to the user; either way, drop the failed batch.
       } finally {
         if (generation !== generationRef.current) return
-        inFlightRef.current = Math.max(0, inFlightRef.current - 1)
-        setUploading(inFlightRef.current > 0)
+        reservedSlotsRef.current = Math.max(0, reservedSlotsRef.current - list.length)
+        inFlightBatchesRef.current = Math.max(0, inFlightBatchesRef.current - 1)
+        setUploading(inFlightBatchesRef.current > 0)
       }
     },
     [upload]
@@ -62,7 +68,8 @@ export function useConversationComposerAttachments(upload: (file: File) => Promi
 
   const clear = useCallback(() => {
     generationRef.current += 1
-    inFlightRef.current = 0
+    inFlightBatchesRef.current = 0
+    reservedSlotsRef.current = 0
     setUploading(false)
     setPending([])
   }, [])

--- a/apps/web/src/lib/client/resizable-image-insert-attrs.ts
+++ b/apps/web/src/lib/client/resizable-image-insert-attrs.ts
@@ -1,0 +1,51 @@
+/**
+ * Attrs for inserting a `resizableImage` node after upload.
+ *
+ * `tiptap-extension-resizable-image` defaults missing width/height to 500×500.
+ * We probe the file's natural size and store a proportional box (capped at the
+ * extension's default width) so the serializer does not emit a 1:1 aspect-ratio.
+ */
+const MAX_INSERT_WIDTH = 500
+
+export function scaleImageInsertSize(
+  naturalWidth: number,
+  naturalHeight: number,
+  maxWidth = MAX_INSERT_WIDTH
+): { width: number; height: number } {
+  if (naturalWidth <= maxWidth) {
+    return { width: naturalWidth, height: naturalHeight }
+  }
+  return {
+    width: maxWidth,
+    height: Math.max(1, Math.round((maxWidth * naturalHeight) / naturalWidth)),
+  }
+}
+
+function naturalImageSize(file: File): Promise<{ width: number; height: number }> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file)
+    const image = new Image()
+    image.onload = () => {
+      URL.revokeObjectURL(url)
+      resolve({ width: image.naturalWidth, height: image.naturalHeight })
+    }
+    image.onerror = () => {
+      URL.revokeObjectURL(url)
+      reject(new Error('Failed to load image'))
+    }
+    image.src = url
+  })
+}
+
+export async function resizableImageInsertAttrs(
+  src: string,
+  file: File
+): Promise<{ src: string; 'data-keep-ratio': true; width?: number; height?: number }> {
+  try {
+    const { width, height } = await naturalImageSize(file)
+    if (width < 1 || height < 1) throw new Error('invalid image size')
+    return { src, 'data-keep-ratio': true, ...scaleImageInsertSize(width, height) }
+  } catch {
+    return { src, 'data-keep-ratio': true }
+  }
+}

--- a/apps/web/src/lib/server/domains/conversation/__tests__/conversation-notes-service.test.ts
+++ b/apps/web/src/lib/server/domains/conversation/__tests__/conversation-notes-service.test.ts
@@ -281,4 +281,32 @@ describe('addAgentNote', () => {
       ],
     })
   })
+
+  it('rejects an image-only note whose attachment URL is not from our storage', async () => {
+    await expect(
+      addAgentNote(conversationId, '', agent, agentActor, null, [
+        {
+          url: 'https://evil.example.com/x.png',
+          name: 'x.png',
+          contentType: 'image/png',
+          size: 10,
+        },
+      ])
+    ).rejects.toBeInstanceOf(ValidationError)
+    expect(insertedMessages).toHaveLength(0)
+  })
+
+  it('rejects an image-only note whose attachment exceeds the size cap', async () => {
+    await expect(
+      addAgentNote(conversationId, '', agent, agentActor, null, [
+        {
+          url: '/api/storage/chat-images/shot.png',
+          name: 'shot.png',
+          contentType: 'image/png',
+          size: 6 * 1024 * 1024,
+        },
+      ])
+    ).rejects.toBeInstanceOf(ValidationError)
+    expect(insertedMessages).toHaveLength(0)
+  })
 })

--- a/apps/web/src/lib/server/domains/conversation/__tests__/conversation-notes-service.test.ts
+++ b/apps/web/src/lib/server/domains/conversation/__tests__/conversation-notes-service.test.ts
@@ -258,4 +258,27 @@ describe('addAgentNote', () => {
     )
     expect(insertedMessages).toHaveLength(0)
   })
+
+  it('accepts an image-only note the tray can now send', async () => {
+    await addAgentNote(conversationId, '', agent, agentActor, null, [
+      {
+        url: '/api/storage/chat-images/shot.png',
+        name: 'shot.png',
+        contentType: 'image/png',
+        size: 10,
+      },
+    ])
+    expect(insertedMessages[0]).toMatchObject({
+      content: '',
+      isInternal: true,
+      attachments: [
+        {
+          url: '/api/storage/chat-images/shot.png',
+          name: 'shot.png',
+          contentType: 'image/png',
+          size: 10,
+        },
+      ],
+    })
+  })
 })

--- a/apps/web/src/lib/server/domains/conversation/__tests__/conversation-start-agent-conversation.test.ts
+++ b/apps/web/src/lib/server/domains/conversation/__tests__/conversation-start-agent-conversation.test.ts
@@ -310,6 +310,31 @@ describe('startAgentConversation happy path', () => {
     expect(notify.notifyVisitorMessage).not.toHaveBeenCalled()
   })
 
+  it('emails an attachment name when the opening message has no text', async () => {
+    await startAgentConversation(
+      {
+        targetPrincipalId,
+        content: '',
+        attachments: [
+          {
+            url: '/api/storage/chat-images/shot.png',
+            name: 'shot.png',
+            contentType: 'image/png',
+            size: 10,
+          },
+        ],
+      },
+      agent,
+      agentActor
+    )
+
+    expect(notify.notifyConversationStarted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: 'shot.png',
+      })
+    )
+  })
+
   it('passes the FULL content and contentJson to the notify layer (not a truncated preview)', async () => {
     const longContent = 'A'.repeat(300)
     const contentJson = {

--- a/apps/web/src/lib/server/domains/conversation/conversation.service.ts
+++ b/apps/web/src/lib/server/domains/conversation/conversation.service.ts
@@ -873,11 +873,11 @@ export async function addAgentNote(
 ): Promise<SendAgentMessageResult> {
   const decision = canActAsAgent(actor)
   if (!decision.allowed) throw new ForbiddenError('FORBIDDEN', decision.reason)
-  const content = validateContent(rawContent)
   const noteAttachments =
     attachments && attachments.length > 0
       ? attachments.slice(0, MAX_CONVERSATION_ATTACHMENTS)
       : null
+  const content = validateContent(rawContent, (noteAttachments?.length ?? 0) > 0)
 
   // Sanitize on write (Layer 1), like every other TipTap-doc path (comments,
   // posts, changelog). Drops disallowed nodes/attrs + caps depth, so a tampered

--- a/apps/web/src/lib/server/domains/conversation/conversation.service.ts
+++ b/apps/web/src/lib/server/domains/conversation/conversation.service.ts
@@ -56,7 +56,6 @@ import {
 } from '@/lib/server/policy/conversation'
 import type { Actor } from '@/lib/server/policy/types'
 import {
-  MAX_CONVERSATION_ATTACHMENTS,
   HANDOFF_REASON_LABELS,
   CONVERSATION_SPAM_FILED_BY_LABELS,
   type ConversationStatus,
@@ -873,11 +872,11 @@ export async function addAgentNote(
 ): Promise<SendAgentMessageResult> {
   const decision = canActAsAgent(actor)
   if (!decision.allowed) throw new ForbiddenError('FORBIDDEN', decision.reason)
-  const noteAttachments =
-    attachments && attachments.length > 0
-      ? attachments.slice(0, MAX_CONVERSATION_ATTACHMENTS)
-      : null
-  const content = validateContent(rawContent, (noteAttachments?.length ?? 0) > 0)
+  // Same write-side attachment gate as replies: trusted URL + size first,
+  // then empty-content is allowed only when a validated attachment remains.
+  const attachmentsValidated = validateAttachments(attachments)
+  const noteAttachments = attachmentsValidated.length > 0 ? attachmentsValidated : null
+  const content = validateContent(rawContent, attachmentsValidated.length > 0)
 
   // Sanitize on write (Layer 1), like every other TipTap-doc path (comments,
   // posts, changelog). Drops disallowed nodes/attrs + caps depth, so a tampered

--- a/apps/web/src/lib/server/domains/conversation/conversation.service.ts
+++ b/apps/web/src/lib/server/domains/conversation/conversation.service.ts
@@ -665,7 +665,9 @@ export async function startAgentConversation(
     conversationId: txResult.conversation.id,
     visitorPrincipalId: txResult.conversation.visitorPrincipalId,
     // Full text, not the truncated preview — notify derives its own excerpt.
-    content: content || fallbackLabel,
+    // Same fallback as sendAgentMessage: attachment-only opens have no
+    // contentJson image node, so richMessageFallbackLabel is empty.
+    content: content || preview(fallbackLabel, attachments),
     contentJson: safeContentJson,
     agentName: agent.displayName ?? 'Support',
     messageId: txResult.message.id,

--- a/apps/web/src/lib/server/domains/conversation/conversation.service.ts
+++ b/apps/web/src/lib/server/domains/conversation/conversation.service.ts
@@ -537,6 +537,7 @@ export interface StartAgentConversationInput {
   targetPrincipalId: PrincipalId
   content: string
   contentJson?: TiptapContent | null
+  attachments?: ConversationAttachment[]
 }
 
 /**
@@ -559,6 +560,7 @@ export async function startAgentConversation(
   // Rich-composer doc (inline embeds/images): sanitized on write like the
   // agent-reply path, but no origin restriction — this message is always
   // agent-authored, never a visitor upload.
+  const attachments = validateAttachments(input.attachments)
   const safeContentJson = input.contentJson ? sanitizeTiptapContent(input.contentJson) : null
   // A text-less rich message is valid only when it carries an inline image or
   // a shared post; this label also backs the subject/preview/notification body.
@@ -567,7 +569,7 @@ export async function startAgentConversation(
   // caller sent blank content alongside a text-bearing one.
   const content = validateContent(
     resolveMessageContent(input.content, safeContentJson),
-    !!fallbackLabel
+    attachments.length > 0 || !!fallbackLabel
   )
 
   const [target] = await db
@@ -615,7 +617,7 @@ export async function startAgentConversation(
         // The composer owns the thread from the start — it lands in "Mine".
         assignedAgentPrincipalId: agent.principalId,
         status: 'open',
-        subject: preview(content || fallbackLabel, []),
+        subject: preview(content || fallbackLabel, attachments),
       })
       .returning()
 
@@ -627,6 +629,7 @@ export async function startAgentConversation(
         senderType: 'agent',
         content,
         contentJson: safeContentJson,
+        attachments: attachments.length > 0 ? attachments : null,
       })
       .returning()
 
@@ -634,7 +637,7 @@ export async function startAgentConversation(
       .update(conversations)
       .set({
         lastMessageAt: message.createdAt,
-        lastMessagePreview: preview(content || fallbackLabel, []),
+        lastMessagePreview: preview(content || fallbackLabel, attachments),
         // Composing counts as reading on the agent side.
         agentLastReadAt: message.createdAt,
         updatedAt: message.createdAt,

--- a/apps/web/src/lib/server/domains/tickets/__tests__/requester.service.test.ts
+++ b/apps/web/src/lib/server/domains/tickets/__tests__/requester.service.test.ts
@@ -309,10 +309,23 @@ describe.skipIf(!fixture.available)('requester ticket service (real DB, rolled b
       contentJson,
       attachments,
     })
-    expect(message.attachments).toHaveLength(1)
-    const images = (message.contentJson?.content ?? []).filter((n) => n.type === 'resizableImage')
-    // External host neutralized; own-storage src kept (visitor images are
-    // trusted-origin only).
+    // Read-time lift moves the surviving own-storage image onto attachments.
+    expect(message.attachments).toHaveLength(2)
+    expect(message.attachments.map((a) => a.url)).toEqual([
+      '/api/storage/chat-images/screenshot.png',
+      '/api/storage/portal-images/mine.png',
+    ])
+    expect((message.contentJson?.content ?? []).some((n) => n.type === 'resizableImage')).toBe(
+      false
+    )
+
+    const [row] = await testDb
+      .select({ contentJson: conversationMessages.contentJson })
+      .from(conversationMessages)
+      .where(eq(conversationMessages.id, message.id))
+    const images = (row?.contentJson?.content ?? []).filter((n) => n.type === 'resizableImage')
+    // Stored row still has both nodes: external host neutralized, own-storage
+    // src kept (visitor images are trusted-origin only). No DB rewrite.
     expect(images[0]?.attrs?.src).toBe('')
     expect(images[1]?.attrs?.src).toBe('/api/storage/portal-images/mine.png')
   })

--- a/apps/web/src/lib/server/domains/tickets/__tests__/ticket-message.service.test.ts
+++ b/apps/web/src/lib/server/domains/tickets/__tests__/ticket-message.service.test.ts
@@ -193,7 +193,15 @@ describe.skipIf(!fixture.available)('ticket message service (real DB, rolled bac
     // with no text) — it was never a source for the stored `content`, so
     // that stays blank rather than being replaced with derived or label text.
     expect(message.content).toBe('')
-    expect(message.contentJson?.content?.[0]?.type).toBe('chatImage')
+    expect(message.attachments).toEqual([
+      {
+        url: '/api/storage/chat-images/x.png',
+        name: 'x.png',
+        contentType: 'image/png',
+        size: 0,
+      },
+    ])
+    expect(message.contentJson?.content?.some((n) => n.type === 'chatImage')).toBe(false)
   })
 
   it('extends the same image-only allowance to a resizableImage doc (the unified RichTextEditor node)', async () => {
@@ -208,7 +216,15 @@ describe.skipIf(!fixture.available)('ticket message service (real DB, rolled bac
     const { message } = await sendTicketMessage(actor, { ticketId, content: '', contentJson })
 
     expect(message.content).toBe('')
-    expect(message.contentJson?.content?.[0]?.type).toBe('resizableImage')
+    expect(message.attachments).toEqual([
+      {
+        url: '/api/storage/chat-images/x.png',
+        name: 'x.png',
+        contentType: 'image/png',
+        size: 0,
+      },
+    ])
+    expect(message.contentJson?.content?.some((n) => n.type === 'resizableImage')).toBe(false)
   })
 
   it('rejects an image-only message whose image src was cleared (renders blank)', async () => {
@@ -264,8 +280,15 @@ describe.skipIf(!fixture.available)('ticket message service (real DB, rolled bac
       contentJson,
     })
 
-    const img = (message.contentJson?.content ?? []).find((n) => n.type === 'resizableImage')
-    expect(img?.attrs?.src).toBe('https://docs.example.com/diagram.png')
+    expect(message.contentJson?.content?.some((n) => n.type === 'resizableImage')).toBe(false)
+    expect(message.attachments).toEqual([
+      {
+        url: 'https://docs.example.com/diagram.png',
+        name: 'diagram',
+        contentType: 'image/png',
+        size: 0,
+      },
+    ])
   })
 
   it('prefers explicit non-blank content over deriving from contentJson', async () => {

--- a/apps/web/src/lib/server/domains/tickets/__tests__/ticket.service.test.ts
+++ b/apps/web/src/lib/server/domains/tickets/__tests__/ticket.service.test.ts
@@ -328,14 +328,23 @@ describe.skipIf(!fixture.available)('ticket.service (real DB, rolled back)', () 
     )
     const page = await listTicketMessages(dto.id, { includeInternal: true })
     const stored = page.messages[0]
-    const types = stored.contentJson?.content?.map((n) => n.type)
-    expect(types).not.toContain('script')
-    expect(types).toEqual(['paragraph', 'image'])
-    const imageNode = stored.contentJson?.content?.find((n) => n.type === 'image')
-    expect(imageNode?.attrs?.src).toBe('')
     // Derived from the sanitized doc: the surviving paragraph's text, plus the
     // `[image]` placeholder for the (now-neutralized) image node.
     expect(stored.content).toBe('Safe text.\n[image]')
+    // Empty-src image is stripped on read (it would not render) and is not
+    // lifted onto attachments.
+    expect(stored.contentJson?.content?.map((n) => n.type)).toEqual(['paragraph'])
+    expect(stored.attachments).toEqual([])
+
+    const [row] = await testDb
+      .select({ contentJson: conversationMessages.contentJson })
+      .from(conversationMessages)
+      .where(eq(conversationMessages.id, stored.id))
+    const types = row?.contentJson?.content?.map((n) => n.type)
+    expect(types).not.toContain('script')
+    expect(types).toEqual(['paragraph', 'image'])
+    const imageNode = row?.contentJson?.content?.find((n) => n.type === 'image')
+    expect(imageNode?.attrs?.src).toBe('')
   })
 
   it('persists attachments on the opening message', async () => {

--- a/apps/web/src/lib/server/functions/conversation.ts
+++ b/apps/web/src/lib/server/functions/conversation.ts
@@ -234,9 +234,10 @@ const setInboxTranslationEnabledSchema = z.object({
 const startConversationSchema = z.object({
   targetPrincipalId: z.string(),
   content: z.string().max(MAX_CONVERSATION_MESSAGE_LENGTH).default(''),
-  // Rich-composer TipTap doc (inline embeds / images). Sanitized server-side;
+  // Rich-composer TipTap doc (inline embeds). Sanitized server-side;
   // the plain `content` is the doc's text, kept for previews/notifications/search.
   contentJson: z.unknown().nullable().optional(),
+  attachments: z.array(attachmentSchema).max(MAX_CONVERSATION_ATTACHMENTS).optional(),
 })
 
 const agentNoteSchema = z.object({
@@ -1126,6 +1127,7 @@ export const startAgentConversationFn = createServerFn({ method: 'POST' })
         content: data.content,
         contentJson: (data.contentJson ?? null) as
           import('@/lib/shared/db-types').TiptapContent | null,
+        attachments: data.attachments as ConversationAttachment[] | undefined,
       },
       {
         principalId: ctx.principal.id,

--- a/apps/web/src/lib/server/functions/conversation.ts
+++ b/apps/web/src/lib/server/functions/conversation.ts
@@ -242,7 +242,9 @@ const startConversationSchema = z.object({
 
 const agentNoteSchema = z.object({
   conversationId: z.string(),
-  content: z.string().min(1).max(MAX_CONVERSATION_MESSAGE_LENGTH),
+  // Empty is allowed only with attachments — same rule as replies; the
+  // service's validateContent enforces it.
+  content: z.string().max(MAX_CONVERSATION_MESSAGE_LENGTH).default(''),
   // TipTap doc from the note editor (carries @-mention nodes). Validated +
   // mention-extracted server-side; omitted for a plain-text note.
   contentJson: z.unknown().nullable().optional(),

--- a/apps/web/src/lib/server/messages/__tests__/message-core.test.ts
+++ b/apps/web/src/lib/server/messages/__tests__/message-core.test.ts
@@ -51,15 +51,47 @@ describe('toMessageDTO — storage read tokens', () => {
       }),
       null
     )
-    expect(dto.contentJson).toEqual({
-      type: 'doc',
-      content: [
-        {
-          type: 'image',
-          attrs: { src: 'https://old.example.com/api/storage/chat-images/a.png?read=live' },
+    expect(dto.contentJson).toEqual({ type: 'doc', content: [] })
+    expect(dto.attachments).toEqual([
+      {
+        url: 'https://old.example.com/api/storage/chat-images/a.png?read=live',
+        name: 'a.png',
+        contentType: 'image/png',
+        size: 0,
+      },
+    ])
+  })
+
+  it('lifts a stored 500×500 resizableImage onto attachments', () => {
+    const dto = toMessageDTO(
+      message({
+        content: '',
+        contentJson: {
+          type: 'doc',
+          content: [
+            {
+              type: 'resizableImage',
+              attrs: {
+                src: 'https://cdn.example.com/wide.png',
+                width: 500,
+                height: 500,
+                'data-keep-ratio': true,
+              },
+            },
+          ],
         },
-      ],
-    })
+      }),
+      null
+    )
+    expect(dto.attachments).toEqual([
+      {
+        url: 'https://cdn.example.com/wide.png',
+        name: 'wide.png',
+        contentType: 'image/png',
+        size: 0,
+      },
+    ])
+    expect(dto.contentJson).toEqual({ type: 'doc', content: [] })
   })
 })
 

--- a/apps/web/src/lib/server/messages/message-core.ts
+++ b/apps/web/src/lib/server/messages/message-core.ts
@@ -20,6 +20,7 @@ import {
   type ConversationMessageDTO,
   type MessageSenderType,
 } from '@/lib/shared/conversation/types'
+import { liftInlineImagesToAttachments } from '@/lib/shared/conversation/lift-inline-images'
 
 export const PREVIEW_LENGTH = 120
 const MAX_ATTACHMENT_BYTES = 5 * 1024 * 1024
@@ -125,6 +126,10 @@ export function toMessageDTO(
   author: ConversationAuthorDTO | null,
   assistantPrincipalId?: PrincipalId | null
 ): ConversationMessageDTO {
+  const { contentJson, attachments } = liftInlineImagesToAttachments(
+    contentJsonForClient(message.contentJson ?? null),
+    message.attachments ?? []
+  )
   return {
     id: message.id,
     conversationId: message.conversationId,
@@ -133,11 +138,11 @@ export function toMessageDTO(
     content: message.content,
     createdAt: message.createdAt.toISOString(),
     author,
-    attachments: message.attachments ?? [],
+    attachments,
     citations: message.citations ?? [],
     isAssistant: assistantPrincipalId != null && message.principalId === assistantPrincipalId,
     isInternal: message.isInternal,
-    contentJson: contentJsonForClient(message.contentJson ?? null),
+    contentJson,
     viaEmail: message.metadata?.source === 'email',
     systemEvent: message.metadata?.systemEvent ?? null,
     block: message.metadata?.block ?? null,

--- a/apps/web/src/lib/shared/__tests__/content-html.test.ts
+++ b/apps/web/src/lib/shared/__tests__/content-html.test.ts
@@ -99,6 +99,15 @@ describe('generateContentHTML', () => {
     expect(html).toContain('alt="shot"')
   })
 
+  it('does not force a 1:1 aspect-ratio when width and height are absent', () => {
+    const html = generateContentHTML({
+      type: 'doc',
+      content: [{ type: 'resizableImage', attrs: { src: 'https://cdn.example.com/a.png' } }],
+    })
+    expect(html).toContain('<img')
+    expect(html).not.toContain('aspect-ratio')
+  })
+
   it('drops an image with an unsafe (javascript:) src', () => {
     const html = generateContentHTML({
       type: 'doc',

--- a/apps/web/src/lib/shared/content-html.ts
+++ b/apps/web/src/lib/shared/content-html.ts
@@ -187,7 +187,7 @@ export function generateContentHTML(content: JSONContent): string {
         const src = escapeHtmlAttr(sanitizeImageUrl(String(node.attrs?.src ?? '')))
         const alt = escapeHtmlAttr(String(node.attrs?.alt ?? ''))
         if (!src) return ''
-        return `<img src="${src}" alt="${alt}" class="max-w-xs rounded-md" />`
+        return `<img src="${src}" alt="${alt}" class="max-w-xs h-auto object-contain rounded-md" />`
       }
 
       case 'youtube': {

--- a/apps/web/src/lib/shared/conversation/__tests__/lift-inline-images.test.ts
+++ b/apps/web/src/lib/shared/conversation/__tests__/lift-inline-images.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest'
+import { liftInlineImagesToAttachments } from '../lift-inline-images'
+import { MAX_CONVERSATION_ATTACHMENTS } from '../types'
+import type { ConversationAttachment } from '../types'
+
+const png = (url: string, extra?: Partial<ConversationAttachment>): ConversationAttachment => ({
+  url,
+  name: extra?.name ?? 'shot.png',
+  contentType: extra?.contentType ?? 'image/png',
+  size: extra?.size ?? 10,
+})
+
+describe('liftInlineImagesToAttachments', () => {
+  it('returns the same references when the doc has no images', () => {
+    const attachments: ConversationAttachment[] = []
+    const doc = {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hi' }] }],
+    }
+    const result = liftInlineImagesToAttachments(doc, attachments)
+    expect(result.contentJson).toBe(doc)
+    expect(result.attachments).toBe(attachments)
+  })
+
+  it('lifts a square 500×500 resizableImage onto attachments and strips the node', () => {
+    const result = liftInlineImagesToAttachments(
+      {
+        type: 'doc',
+        content: [
+          {
+            type: 'resizableImage',
+            attrs: {
+              src: 'https://cdn.example.com/shot.png',
+              alt: 'Install page',
+              width: 500,
+              height: 500,
+            },
+          },
+        ],
+      },
+      []
+    )
+    expect(result.attachments).toEqual([
+      {
+        url: 'https://cdn.example.com/shot.png',
+        name: 'Install page',
+        contentType: 'image/png',
+        size: 0,
+      },
+    ])
+    expect(result.contentJson).toEqual({ type: 'doc', content: [] })
+  })
+
+  it('lifts chatImage and image nodes, keeps surrounding text, and dedupes by URL', () => {
+    const existing = [png('https://cdn.example.com/a.png')]
+    const result = liftInlineImagesToAttachments(
+      {
+        type: 'doc',
+        content: [
+          { type: 'paragraph', content: [{ type: 'text', text: 'hi' }] },
+          { type: 'chatImage', attrs: { src: 'https://cdn.example.com/a.png', alt: 'dup' } },
+          { type: 'image', attrs: { src: 'https://cdn.example.com/b.jpg' } },
+        ],
+      },
+      existing
+    )
+    expect(result.attachments).toEqual([
+      existing[0],
+      {
+        url: 'https://cdn.example.com/b.jpg',
+        name: 'b.jpg',
+        contentType: 'image/jpeg',
+        size: 0,
+      },
+    ])
+    expect(result.contentJson).toEqual({
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hi' }] }],
+    })
+  })
+
+  it('strips a javascript: image without attaching it', () => {
+    const result = liftInlineImagesToAttachments(
+      {
+        type: 'doc',
+        content: [{ type: 'image', attrs: { src: 'javascript:alert(1)' } }],
+      },
+      []
+    )
+    expect(result.attachments).toEqual([])
+    expect(result.contentJson).toEqual({ type: 'doc', content: [] })
+  })
+
+  it('does not exceed MAX_CONVERSATION_ATTACHMENTS', () => {
+    const existing = Array.from({ length: MAX_CONVERSATION_ATTACHMENTS }, (_, i) =>
+      png(`https://cdn.example.com/${i}.png`)
+    )
+    const result = liftInlineImagesToAttachments(
+      {
+        type: 'doc',
+        content: [{ type: 'image', attrs: { src: 'https://cdn.example.com/overflow.png' } }],
+      },
+      existing
+    )
+    expect(result.attachments).toBe(existing)
+    expect(result.contentJson).toEqual({ type: 'doc', content: [] })
+  })
+})

--- a/apps/web/src/lib/shared/conversation/__tests__/lift-inline-images.test.ts
+++ b/apps/web/src/lib/shared/conversation/__tests__/lift-inline-images.test.ts
@@ -11,6 +11,18 @@ const png = (url: string, extra?: Partial<ConversationAttachment>): Conversation
 })
 
 describe('liftInlineImagesToAttachments', () => {
+  it('returns contentJson null for a missing doc', () => {
+    const attachments: ConversationAttachment[] = []
+    expect(liftInlineImagesToAttachments(null, attachments)).toEqual({
+      contentJson: null,
+      attachments,
+    })
+    expect(liftInlineImagesToAttachments(undefined, attachments)).toEqual({
+      contentJson: null,
+      attachments,
+    })
+  })
+
   it('returns the same references when the doc has no images', () => {
     const attachments: ConversationAttachment[] = []
     const doc = {

--- a/apps/web/src/lib/shared/conversation/lift-inline-images.ts
+++ b/apps/web/src/lib/shared/conversation/lift-inline-images.ts
@@ -1,0 +1,92 @@
+/**
+ * Read-time lift of legacy inline conversation images into `attachments[]`.
+ *
+ * Admin paste used to author `resizableImage` / `image` / `chatImage` nodes
+ * inside `contentJson`. Those now display as tray attachments. Stored rows
+ * are not rewritten — this helper is applied when mapping a row to a DTO so
+ * every surface uses ConversationAttachmentList.
+ */
+import type { JSONContent } from '@tiptap/core'
+import type { ConversationAttachment } from '@/lib/shared/conversation/types'
+import { MAX_CONVERSATION_ATTACHMENTS } from '@/lib/shared/conversation/types'
+import { sanitizeImageUrl } from '@/lib/shared/utils/sanitize'
+
+const INLINE_IMAGE_TYPES = new Set(['image', 'resizableImage', 'chatImage'])
+
+function guessContentType(url: string): string {
+  const path = url.split('?')[0]?.toLowerCase() ?? ''
+  if (path.endsWith('.png')) return 'image/png'
+  if (path.endsWith('.jpg') || path.endsWith('.jpeg')) return 'image/jpeg'
+  if (path.endsWith('.gif')) return 'image/gif'
+  if (path.endsWith('.webp')) return 'image/webp'
+  if (path.endsWith('.avif')) return 'image/avif'
+  return 'image/*'
+}
+
+function attachmentName(src: string, alt?: unknown): string {
+  if (typeof alt === 'string' && alt.trim()) return alt.trim().slice(0, 255)
+  try {
+    const path = new URL(src, 'https://example.invalid').pathname
+    const base = decodeURIComponent(path.split('/').pop() || '')
+    return (base || 'image').slice(0, 255)
+  } catch {
+    return 'image'
+  }
+}
+
+function toAttachment(src: string, alt?: unknown): ConversationAttachment {
+  return {
+    url: src,
+    name: attachmentName(src, alt),
+    contentType: guessContentType(src),
+    size: 0,
+  }
+}
+
+/** Strip image nodes and collect displayable srcs. Returns null to drop the node. */
+function stripImages(
+  node: JSONContent,
+  collected: ConversationAttachment[],
+  seen: Set<string>,
+  slotsLeft: number
+): JSONContent | null {
+  if (INLINE_IMAGE_TYPES.has(node.type ?? '')) {
+    const raw = typeof node.attrs?.src === 'string' ? node.attrs.src : ''
+    const src = sanitizeImageUrl(raw)
+    if (src && !seen.has(src) && collected.length < slotsLeft) {
+      seen.add(src)
+      collected.push(toAttachment(src, node.attrs?.alt))
+    }
+    return null
+  }
+  if (!node.content?.length) return node
+  const next = node.content
+    .map((child) => stripImages(child, collected, seen, slotsLeft))
+    .filter((child): child is JSONContent => child != null)
+  return next.length === node.content.length && next.every((c, i) => c === node.content![i])
+    ? node
+    : { ...node, content: next }
+}
+
+/**
+ * Move inline image nodes onto `attachments` and remove them from the doc.
+ * Dedupes by URL. Caps at {@link MAX_CONVERSATION_ATTACHMENTS}. Returns the
+ * original `attachments` / `contentJson` references when nothing is lifted.
+ */
+export function liftInlineImagesToAttachments(
+  contentJson: JSONContent | null | undefined,
+  attachments: ConversationAttachment[]
+): { contentJson: JSONContent | null; attachments: ConversationAttachment[] } {
+  if (!contentJson) return { contentJson: contentJson ?? null, attachments }
+  const lifted: ConversationAttachment[] = []
+  const seen = new Set(attachments.map((a) => a.url))
+  const slotsLeft = Math.max(0, MAX_CONVERSATION_ATTACHMENTS - attachments.length)
+  const stripped = stripImages(contentJson, lifted, seen, slotsLeft)
+  if (lifted.length === 0 && stripped === contentJson) {
+    return { contentJson, attachments }
+  }
+  return {
+    contentJson: stripped,
+    attachments: lifted.length === 0 ? attachments : [...attachments, ...lifted],
+  }
+}

--- a/apps/web/src/lib/shared/conversation/lift-inline-images.ts
+++ b/apps/web/src/lib/shared/conversation/lift-inline-images.ts
@@ -6,9 +6,9 @@
  * are not rewritten — this helper is applied when mapping a row to a DTO so
  * every surface uses ConversationAttachmentList.
  */
-import type { JSONContent } from '@tiptap/core'
 import type { ConversationAttachment } from '@/lib/shared/conversation/types'
 import { MAX_CONVERSATION_ATTACHMENTS } from '@/lib/shared/conversation/types'
+import type { TiptapContent } from '@/lib/shared/db-types'
 import { sanitizeImageUrl } from '@/lib/shared/utils/sanitize'
 
 const INLINE_IMAGE_TYPES = new Set(['image', 'resizableImage', 'chatImage'])
@@ -45,12 +45,12 @@ function toAttachment(src: string, alt?: unknown): ConversationAttachment {
 
 /** Strip image nodes and collect displayable srcs. Returns null to drop the node. */
 function stripImages(
-  node: JSONContent,
+  node: TiptapContent,
   collected: ConversationAttachment[],
   seen: Set<string>,
   slotsLeft: number
-): JSONContent | null {
-  if (INLINE_IMAGE_TYPES.has(node.type ?? '')) {
+): TiptapContent | null {
+  if (INLINE_IMAGE_TYPES.has(node.type)) {
     const raw = typeof node.attrs?.src === 'string' ? node.attrs.src : ''
     const src = sanitizeImageUrl(raw)
     if (src && !seen.has(src) && collected.length < slotsLeft) {
@@ -62,7 +62,7 @@ function stripImages(
   if (!node.content?.length) return node
   const next = node.content
     .map((child) => stripImages(child, collected, seen, slotsLeft))
-    .filter((child): child is JSONContent => child != null)
+    .filter((child): child is TiptapContent => child != null)
   return next.length === node.content.length && next.every((c, i) => c === node.content![i])
     ? node
     : { ...node, content: next }
@@ -74,10 +74,10 @@ function stripImages(
  * original `attachments` / `contentJson` references when nothing is lifted.
  */
 export function liftInlineImagesToAttachments(
-  contentJson: JSONContent | null | undefined,
+  contentJson: TiptapContent | null | undefined,
   attachments: ConversationAttachment[]
-): { contentJson: JSONContent | null; attachments: ConversationAttachment[] } {
-  if (!contentJson) return { contentJson: contentJson ?? null, attachments }
+): { contentJson: TiptapContent | null; attachments: ConversationAttachment[] } {
+  if (!contentJson) return { contentJson: null, attachments }
   const lifted: ConversationAttachment[] = []
   const seen = new Set(attachments.map((a) => a.url))
   const slotsLeft = Math.max(0, MAX_CONVERSATION_ATTACHMENTS - attachments.length)

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -92,6 +92,38 @@ function keepSsrOnlyDepsOutOfClientOptimizer(): PluginOption {
   }
 }
 
+/**
+ * Nitro's Vite pre-middleware skips any request it classifies as a static
+ * asset (`sec-fetch-dest: image`, or a `.png`/`.jpg`/… extension without
+ * `Accept: text/html`) and marks it `_nitroHandled` so the post-middleware
+ * never sees it either. Browser `<img src="/api/storage/…/file.png">` is
+ * exactly that shape, so the splat route never runs and Vite answers
+ * `Cannot GET`. Clear the asset signals for this prefix only; Nitro's
+ * post-middleware then serves the bytes.
+ */
+function letNitroServeStorageAssets(): PluginOption {
+  return {
+    name: 'quackback:let-nitro-serve-storage-assets',
+    apply: 'serve',
+    configureServer(server) {
+      server.middlewares.use((req, _res, next) => {
+        const pathname = req.url?.split('?')[0] ?? ''
+        if (!pathname.startsWith('/api/storage/')) {
+          next()
+          return
+        }
+        // Drop dest so Nitro does not take the `image`/`style` branch.
+        delete req.headers['sec-fetch-dest']
+        const accept = req.headers.accept
+        if (typeof accept !== 'string' || !/\btext\/html\b/.test(accept)) {
+          req.headers.accept = accept ? `${accept}, text/html` : 'text/html'
+        }
+        next()
+      })
+    },
+  }
+}
+
 function getBuildInfo() {
   const pkg = JSON.parse(readFileSync(path.resolve(__dirname, 'package.json'), 'utf-8'))
   let gitCommit = 'unknown'
@@ -154,6 +186,7 @@ export default defineConfig(({ mode }) => {
       tsconfigPaths: true,
     },
     plugins: [
+      letNitroServeStorageAssets(),
       keepSsrOnlyDepsOutOfClientOptimizer(),
       stubServerLoggerInClient(),
       tailwindcss(),


### PR DESCRIPTION
## Summary
- Route conversation paste/drop/paperclip through the attachment tray (no inline TipTap `resizableImage` in chat), so landscape screenshots stay in aspect as contain-fitted thumbs that open the existing zoom modal.
- Lift stored `image` / `resizableImage` / `chatImage` nodes onto `attachments[]` in `toMessageDTO` (no DB rewrite) so old smashed 500×500 admin shots use the same renderer.
- Stop Vite-dev Nitro from skipping `/api/storage/*.png` so local thumbs actually load; posts/changelog still inline images.

## Test plan
- [x] Paste a wide screenshot in an admin reply: it stages in the tray (not the editor), then shows a contain-fitted thumb; click opens zoom.
- [x] Same paste/attach flow in the widget messenger.
- [x] Open a thread that already has an inline 500×500 screenshot: contain thumb + modal, not a square smash.
- [x] Paste an image in a changelog/post editor: still inlines in the document, no chat tray.
- [x] On local `bun run dev`, refresh after a real paste — the thumb loads (not a filename chip / broken image).

Verified locally against `http://acme.localhost:3009` (`PLAYWRIGHT_REUSE_SERVER=1`, real MinIO upload for the refresh case). Coverage lives in `apps/web/e2e/tests/{admin,widget}/conversation-images.spec.ts`.

Made with [Cursor](https://cursor.com)