### PR TITLE
fix(auth): label social callback failures as oauth, not SSO

### DIFF
--- a/apps/web/src/lib/server/audit/log.ts
+++ b/apps/web/src/lib/server/audit/log.ts
@@ -160,7 +160,8 @@ export type AuditEventType =
 export type AuditEventOutcome = 'success' | 'failure'
 
 export type AuditActorType = 'user' | 'service' | 'anonymous' | 'system' | 'api_key' | 'support'
-export type AuditAuthMethod = 'password' | 'sso' | 'magic_link' | 'ott' | 'api_key' | 'session'
+export type AuditAuthMethod =
+  'password' | 'sso' | 'oauth' | 'magic_link' | 'ott' | 'api_key' | 'session'
 
 export interface AuditActor {
   userId?: UserId | null

--- a/apps/web/src/lib/server/auth/__tests__/hooks-signin-failure-audit.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/hooks-signin-failure-audit.test.ts
@@ -1,7 +1,7 @@
 /**
  * `handleSignInFailureAudit` — emits `auth.signin.failed` when a sign-in
  * path is hit but no session is created (wrong password, invalid/expired
- * magic-link token).
+ * magic-link token, failed OIDC / social callback).
  *
  * Key behaviors covered:
  *  - Emits with INVALID_CREDENTIALS on a failed credential (password) path.
@@ -10,6 +10,8 @@
  *  - Does NOT log the attempted password or token — only email + reason code.
  *  - Does NOT emit for non-sign-in paths.
  *  - Survives an audit-store failure (best-effort emit).
+ *  - Shared `/callback/:id` is `sso` only for a registered customer IdP;
+ *    GitHub / Google / Microsoft stay `oauth`.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
@@ -197,6 +199,23 @@ function oidcCtx(opts: { error?: string; withSession?: boolean; providerId?: str
   }
 }
 
+function sharedCallbackCtx(opts: { id: string; error?: string; withSession?: boolean }) {
+  const location = opts.error
+    ? `https://acme.test/api/auth/error?error=${opts.error}`
+    : 'https://acme.test/api/auth/error'
+  return {
+    path: '/callback/:id',
+    params: { id: opts.id },
+    body: {},
+    context: {
+      newSession: opts.withSession
+        ? { user: { id: 'user_1' }, session: { token: 'session_tok' } }
+        : null,
+      returned: new Response(null, { status: 302, headers: { location } }),
+    },
+  }
+}
+
 describe('handleSignInFailureAudit — OIDC callback', () => {
   it('emits with the IdP-reported reason code', async () => {
     await handleSignInFailureAudit(oidcCtx({ error: 'email_is_missing' }) as never)
@@ -236,5 +255,52 @@ describe('handleSignInFailureAudit — OIDC callback', () => {
     // there is one) belongs to the IdP response rather than a typed attempt.
     await handleSignInFailureAudit(oidcCtx({ error: 'email_is_missing' }) as never)
     expect(mockRecordAuditEvent.mock.calls[0][0].actor.email).toBeNull()
+  })
+})
+
+describe('handleSignInFailureAudit — shared /callback/:id', () => {
+  const registered = new Set(['oidc_abc', 'sso'])
+
+  it('labels a registered customer IdP as SSO', async () => {
+    await handleSignInFailureAudit(
+      sharedCallbackCtx({ id: 'oidc_abc', error: 'email_is_missing' }) as never,
+      registered
+    )
+    const call = mockRecordAuditEvent.mock.calls[0][0]
+    expect(call.actor.authMethod).toBe('sso')
+    expect(call.metadata).toMatchObject({
+      reason: 'EMAIL_IS_MISSING',
+      providerId: 'oidc_abc',
+    })
+  })
+
+  it('labels GitHub / Google / Microsoft as oauth, not SSO', async () => {
+    for (const id of ['github', 'google', 'microsoft'] as const) {
+      mockRecordAuditEvent.mockClear()
+      await handleSignInFailureAudit(
+        sharedCallbackCtx({ id, error: 'access_denied' }) as never,
+        registered
+      )
+      const call = mockRecordAuditEvent.mock.calls[0][0]
+      expect(call.actor.authMethod).toBe('oauth')
+      expect(call.metadata).toMatchObject({
+        reason: 'ACCESS_DENIED',
+        providerId: id,
+      })
+    }
+  })
+
+  it('falls back to OAUTH_SIGNIN_FAILED when a social redirect has no error', async () => {
+    await handleSignInFailureAudit(sharedCallbackCtx({ id: 'github' }) as never, registered)
+    expect(mockRecordAuditEvent.mock.calls[0][0].metadata.reason).toBe('OAUTH_SIGNIN_FAILED')
+    expect(mockRecordAuditEvent.mock.calls[0][0].actor.authMethod).toBe('oauth')
+  })
+
+  it('does not emit when the social callback created a session', async () => {
+    await handleSignInFailureAudit(
+      sharedCallbackCtx({ id: 'github', withSession: true }) as never,
+      registered
+    )
+    expect(mockRecordAuditEvent).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/lib/server/auth/hooks.ts
+++ b/apps/web/src/lib/server/auth/hooks.ts
@@ -38,7 +38,11 @@ import {
   type SignInRateLimiter,
 } from './signin-rate-limit'
 import { checkAnonMintRateLimit } from './widget-rate-limit'
-import { isOidcCallbackPath, oidcCallbackProviderId } from './oidc-callback-path'
+import {
+  isOidcCallbackPath,
+  LEGACY_OIDC_CALLBACK_PATH,
+  oidcCallbackProviderId,
+} from './oidc-callback-path'
 import { formatSignInDevice, forgetDevice, isDeviceUnseen } from './signin-device-tracker'
 import {
   deviceCookieAttributes,
@@ -1089,10 +1093,13 @@ export async function handleTwoFactorLifecycleAudit(ctx: {
  * are logged. Passwords, tokens, and credential material are never
  * recorded.
  *
- * Covers two paths:
+ * Covers:
  *  - `/sign-in/email` (password) — newSession absent on wrong password.
  *  - `/magic-link/verify` / `/sign-in/email-otp` — newSession absent
  *    on invalid or expired token.
+ *  - OIDC / social callbacks — labeled `sso` only for a registered
+ *    customer IdP (or the legacy OIDC-only template). GitHub / Google
+ *    / Microsoft on the shared `/callback/:id` path are `oauth`.
  */
 const CREDENTIAL_FAILURE_PATHS = new Set<string>(['/sign-in/email'])
 const MAGIC_LINK_FAILURE_PATHS = new Set<string>(['/magic-link/verify', '/sign-in/email-otp'])
@@ -1114,25 +1121,29 @@ function oidcFailureReason(returned: unknown): string | null {
   }
 }
 
-export async function handleSignInFailureAudit(ctx: {
-  path?: string
-  params?: Record<string, unknown>
-  body?: Record<string, unknown>
-  context?: {
-    newSession?: {
-      user?: { id?: string; email?: string }
-      session?: { token?: string }
-    } | null
-    /** The Response the route produced, when the hook chain exposes it. */
-    returned?: unknown
-  }
-}): Promise<void> {
+export async function handleSignInFailureAudit(
+  ctx: {
+    path?: string
+    params?: Record<string, unknown>
+    body?: Record<string, unknown>
+    context?: {
+      newSession?: {
+        user?: { id?: string; email?: string }
+        session?: { token?: string }
+      } | null
+      /** The Response the route produced, when the hook chain exposes it. */
+      returned?: unknown
+    }
+  },
+  /** OIDC provider ids registered right now (from getRegisteredOidcProviderIds). */
+  registeredOidcIds: Set<string> = new Set()
+): Promise<void> {
   // Only fire on sign-in paths where a failure produces no newSession.
   const path = ctx.path ?? ''
   const isCredentialPath = CREDENTIAL_FAILURE_PATHS.has(path)
   const isMagicLinkPath = MAGIC_LINK_FAILURE_PATHS.has(path)
-  const isOidcCallback = isOidcCallbackPath(path)
-  if (!isCredentialPath && !isMagicLinkPath && !isOidcCallback) return
+  const isCallback = isOidcCallbackPath(path)
+  if (!isCredentialPath && !isMagicLinkPath && !isCallback) return
 
   // If a session was actually created, the success audit handles it.
   const sessionCreated =
@@ -1141,16 +1152,26 @@ export async function handleSignInFailureAudit(ctx: {
 
   // Each path shape contributes only its actor + reason; the emit tail below is
   // shared so a change to it (a retry, a new field, the log level) lands once.
-  let actor: { email: string | null; type: 'user'; authMethod: 'sso' | 'magic_link' | 'password' }
+  let actor: {
+    email: string | null
+    type: 'user'
+    authMethod: 'sso' | 'oauth' | 'magic_link' | 'password'
+  }
   let metadata: Record<string, unknown>
 
-  if (isOidcCallback) {
+  if (isCallback) {
     // No email is recorded. The callback body carries no typed credential, and
     // any address in play came from the IdP response rather than a user attempt.
-    actor = { email: null, type: 'user', authMethod: 'sso' }
+    const providerId = oidcCallbackProviderId(ctx)
+    const isSso =
+      path === LEGACY_OIDC_CALLBACK_PATH ||
+      (providerId !== null && isRegisteredOidcProvider(providerId, registeredOidcIds))
+    actor = { email: null, type: 'user', authMethod: isSso ? 'sso' : 'oauth' }
     metadata = {
-      reason: oidcFailureReason(ctx.context?.returned) ?? 'OIDC_SIGNIN_FAILED',
-      providerId: oidcCallbackProviderId(ctx),
+      reason:
+        oidcFailureReason(ctx.context?.returned) ??
+        (isSso ? 'OIDC_SIGNIN_FAILED' : 'OAUTH_SIGNIN_FAILED'),
+      providerId,
     }
   } else {
     // Never log passwords, tokens, or other credential material — only the
@@ -1558,7 +1579,10 @@ export const hooksAfter = createAuthMiddleware(async (ctx) => {
   // both can fire on the same request only for the verify-totp
   // enrollment path (which itself does not constitute a sign-in).
   await handleTwoFactorLifecycleAudit(ctx as Parameters<typeof handleTwoFactorLifecycleAudit>[0])
-  await handleSignInFailureAudit(ctx as Parameters<typeof handleSignInFailureAudit>[0])
+  await handleSignInFailureAudit(
+    ctx as Parameters<typeof handleSignInFailureAudit>[0],
+    registeredOidcIds
+  )
   await handleSignInSuccessAudit(ctx as Parameters<typeof handleSignInSuccessAudit>[0])
   // Geo-IP country from CDN headers; written best-effort, never blocks.
   await handleCountryCapture(ctx as Parameters<typeof handleCountryCapture>[0])

--- a/packages/db/src/schema/audit-log.ts
+++ b/packages/db/src/schema/audit-log.ts
@@ -31,7 +31,7 @@ export const auditLog = pgTable(
     requestId: text('request_id'),
     /** Denormalised principal type at write time ('user' | 'service' | 'anonymous' | 'system' | 'api_key' | 'support'). */
     actorType: text('actor_type'),
-    /** Auth method used for sign-in events ('password' | 'sso' | 'magic_link' | 'ott' | 'api_key' | 'session'). */
+    /** Auth method used for sign-in events ('password' | 'sso' | 'oauth' | 'magic_link' | 'ott' | 'api_key' | 'session'). */
     authMethod: text('auth_method'),
     /** Dotted taxonomy — see `AuditEventType`. */
     eventType: text('event_type').notNull(),


### PR DESCRIPTION
## Summary
- After Better Auth 1.7, customer OIDC and GitHub/Google/Microsoft share `/callback/:id`. The failure auditor treated that whole path as SSO.
- JIT and claim mapping already use `isRegisteredOidcProvider`. Failure audit now does the same: registered IdPs stay `sso` / `OIDC_*`; social stays `oauth` / `OAUTH_SIGNIN_FAILED`.
- Adds `oauth` to `AuditAuthMethod`. The legacy `/oauth2/callback/:providerId` template remains SSO.

## Test plan
- [x] `hooks-signin-failure-audit` — password, magic-link, legacy OIDC, shared-path SSO vs GitHub/Google/Microsoft
- [x] Live `demo@example.com` password success/failure on localhost and `acme.localhost:3010`
- [x] Live GitHub / unregistered OIDC callbacks wrote `authMethod=oauth` (not `sso`)
- [x] MCP PRM advertises the three first-connect reads; AS metadata still has the full write catalogue
- [x] Authorize rewrite expands `scope=` and overwrites a stuffed `qb_requested_scope` on the first hop
- [ ] CI auth + MCP suites


Made with [Cursor](https://cursor.com)