### PR TITLE
fix(e2e): bust caches with IN and retarget post-MCP-move specs

### DIFF
--- a/apps/web/e2e/scripts/_lib.ts
+++ b/apps/web/e2e/scripts/_lib.ts
@@ -36,7 +36,11 @@ export async function bustWorkspaceSettings(sql: postgres.Sql): Promise<void> {
  * — a cache that was never busted looks exactly like a cache that was.
  */
 export async function deleteCacheKeys(sql: postgres.Sql, keys: string[]): Promise<number> {
-  const rows = await sql`DELETE FROM kv_store WHERE key = ANY(${sql.array(keys)}) RETURNING key`
+  if (keys.length === 0) return 0
+  // postgres.js `IN ${sql(keys)}` expands to `IN ('a', 'b')`. `= ANY(sql.array())`
+  // serializes as a scalar here and Postgres rejects it with
+  // "op ANY/ALL (array) requires array on right side".
+  const rows = await sql`DELETE FROM kv_store WHERE key IN ${sql(keys)} RETURNING key`
   return rows.length
 }
 

--- a/apps/web/e2e/tests/admin/settings-api-keys.spec.ts
+++ b/apps/web/e2e/tests/admin/settings-api-keys.spec.ts
@@ -13,7 +13,9 @@ test.describe('Admin API Keys Settings', () => {
   })
 
   test('shows page header description', async ({ page }) => {
-    await expect(page.getByText(/manage api keys for programmatic access/i)).toBeVisible({
+    await expect(
+      page.getByText(/api keys, webhooks, and the mcp server for programmatic integrations/i)
+    ).toBeVisible({
       timeout: 10000,
     })
   })
@@ -97,17 +99,11 @@ test.describe('Admin API Keys Settings', () => {
     await createDialog.getByRole('textbox', { name: /^name$/i }).fill(keyName)
     await createDialog.getByRole('button', { name: /create key/i }).click()
 
-    // Create dialog closes and reveal dialog opens
-    await expect(createDialog).toBeHidden({ timeout: 10000 })
-
+    // Reveal replaces create in-place; both are role=dialog, so assert on title.
     const revealDialog = page.getByRole('dialog')
-    await expect(revealDialog).toBeVisible({ timeout: 10000 })
+    await expect(revealDialog.getByText(/api key created/i)).toBeVisible({ timeout: 10000 })
 
-    // Should show "API Key Created" title
-    await expect(revealDialog.getByText(/api key created/i)).toBeVisible()
-
-    // The key value should be visible in a code element
-    await expect(revealDialog.locator('code')).toBeVisible()
+    await expect(revealDialog.locator('code').filter({ hasText: /^qb_/ })).toBeVisible()
 
     // Copy button should be present (aria-label contains "copy")
     const copyButton = revealDialog.getByRole('button', { name: /copy/i })
@@ -154,11 +150,11 @@ test.describe('Admin API Keys Settings', () => {
     await page.waitForTimeout(500)
 
     // Create a key first if none exist
-    const revokeButtons = page.getByRole('button', { name: /revoke .* api key/i })
+    const revokeButtons = page.getByRole('button', { name: /^revoke /i })
 
     if ((await revokeButtons.count()) === 0) {
       // Create one
-      const keyName = `Revoke Test ${Date.now()}`
+      const keyName = `Cleanup Test ${Date.now()}`
       const createButton = page
         .getByRole('button', { name: /create key/i })
         .or(page.getByRole('button', { name: /create your first api key/i }))
@@ -168,17 +164,15 @@ test.describe('Admin API Keys Settings', () => {
       await expect(createDialog).toBeVisible({ timeout: 5000 })
       await createDialog.getByRole('textbox', { name: /^name$/i }).fill(keyName)
       await createDialog.getByRole('button', { name: /create key/i }).click()
-      await expect(createDialog).toBeHidden({ timeout: 10000 })
 
-      // Dismiss reveal dialog
       const revealDialog = page.getByRole('dialog')
-      await expect(revealDialog).toBeVisible({ timeout: 10000 })
+      await expect(revealDialog.getByText(/api key created/i)).toBeVisible({ timeout: 10000 })
       await revealDialog.getByRole('button', { name: /i've saved my key/i }).click()
       await expect(revealDialog).toBeHidden({ timeout: 5000 })
     }
 
     // Click the revoke button (trash icon, aria-label "Revoke X API key")
-    const revokeBtn = page.getByRole('button', { name: /revoke .* api key/i }).first()
+    const revokeBtn = page.getByRole('button', { name: /^revoke /i }).first()
 
     if ((await revokeBtn.count()) > 0) {
       await revokeBtn.click()

--- a/apps/web/e2e/tests/admin/settings-mcp.spec.ts
+++ b/apps/web/e2e/tests/admin/settings-mcp.spec.ts
@@ -2,21 +2,29 @@ import { test, expect } from '@playwright/test'
 
 test.describe('Admin MCP Settings', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/admin/settings/mcp')
+    await page.goto('/admin/settings/developers?tab=mcp')
     await page.waitForLoadState('networkidle')
+  })
+
+  test('legacy /admin/settings/mcp URL lands on the developers MCP tab', async ({ page }) => {
+    await page.goto('/admin/settings/mcp')
+    await page.waitForURL(/\/admin\/settings\/developers\?tab=mcp/)
+    await expect(page.getByText('MCP Server').first()).toBeVisible({ timeout: 10000 })
   })
 
   test('page loads and shows MCP Server heading', async ({ page }) => {
     await expect(page.getByText('MCP Server').first()).toBeVisible({ timeout: 10000 })
     await expect(
-      page.getByText('Allow AI tools to interact with your feedback data via the Model Context Protocol')
+      page.getByText('Enable or disable the MCP endpoint for AI integrations.')
     ).toBeVisible({ timeout: 10000 })
   })
 
   test('shows Enable MCP Server toggle', async ({ page }) => {
     await expect(page.getByText('Enable MCP Server').first()).toBeVisible({ timeout: 10000 })
     await expect(
-      page.getByText('Allow AI tools like Claude Code to interact with your feedback data via the MCP protocol')
+      page.getByText(
+        'Allow AI tools like Claude Code to interact with your feedback data via the MCP protocol'
+      )
     ).toBeVisible()
   })
 
@@ -24,6 +32,15 @@ test.describe('Admin MCP Settings', () => {
     const mcpToggle = page.locator('#mcp-toggle')
     await expect(mcpToggle).toBeVisible({ timeout: 10000 })
     await expect(mcpToggle).toBeEnabled()
+  })
+
+  test('shows Dynamic client registration toggle', async ({ page }) => {
+    const dcrToggle = page.locator('#dynamic-registration-toggle')
+    await expect(page.getByText('Dynamic client registration').first()).toBeVisible({
+      timeout: 10000,
+    })
+    await expect(dcrToggle).toBeVisible()
+    await expect(dcrToggle).toBeEnabled()
   })
 
   test('can toggle MCP server on and off', async ({ page }) => {
@@ -96,7 +113,7 @@ test.describe('Admin MCP Settings', () => {
     await expect(apiKeyLink).toBeVisible({ timeout: 10000 })
 
     const href = await apiKeyLink.getAttribute('href')
-    expect(href).toMatch(/api-keys/)
+    expect(href).toMatch(/developers\?tab=keys/)
   })
 
   test('shows Choose your client step with client selector buttons', async ({ page }) => {

--- a/apps/web/e2e/tests/public/auth.spec.ts
+++ b/apps/web/e2e/tests/public/auth.spec.ts
@@ -5,7 +5,7 @@ import { closeDialog } from '../../utils/helpers'
  * Public portal auth tests — no prior authentication.
  *
  * The portal exposes auth via a Dialog triggered from the header.
- * Login mode: title "Welcome back", description "Sign in to your account..."
+ * Login mode: title "Welcome back", description "Sign in to vote and comment..."
  * Signup mode: title "Create an account", description "Sign up to vote..."
  *
  * The default auth step depends on whether password auth is enabled:
@@ -67,20 +67,18 @@ test.describe('Portal Auth Dialog', () => {
     await page.getByRole('button', { name: /log in/i }).click()
     await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 })
 
-    await expect(
-      page.getByText(/sign in to your account to vote and comment/i)
-    ).toBeVisible()
+    await expect(page.getByText(/sign in to vote and comment on feedback/i)).toBeVisible()
   })
 
-  test('login dialog has a Sign up switch link for users without an account', async ({ page }) => {
+  test('login dialog has a Create an account switch for users without an account', async ({
+    page,
+  }) => {
     await page.getByRole('button', { name: /log in/i }).click()
     await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 })
 
-    // "Don't have an account? Sign up" link
-    const signUpLink = page.getByRole('dialog').getByRole('button', { name: /sign up/i })
-    if ((await signUpLink.count()) > 0) {
-      await expect(signUpLink.first()).toBeVisible()
-    }
+    await expect(
+      page.getByRole('dialog').getByRole('button', { name: /create an account/i })
+    ).toBeVisible()
   })
 
   // ---------------------------------------------------------------------------
@@ -117,10 +115,7 @@ test.describe('Portal Auth Dialog', () => {
     await page.getByRole('button', { name: /sign up/i }).click()
     await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 })
 
-    const signInLink = page.getByRole('dialog').getByRole('button', { name: /sign in/i })
-    if ((await signInLink.count()) > 0) {
-      await expect(signInLink.first()).toBeVisible()
-    }
+    await expect(page.getByRole('dialog').getByRole('button', { name: /sign in/i })).toBeVisible()
   })
 
   // ---------------------------------------------------------------------------
@@ -133,17 +128,19 @@ test.describe('Portal Auth Dialog', () => {
     await page.getByRole('button', { name: /log in/i }).click()
     await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 })
 
-    // Navigate to the email-OTP step if we're on the password step first
-    const useEmailCodeLink = page
+    // Password step offers a magic-link / email-code escape hatch.
+    const useEmailInstead = page
       .getByRole('dialog')
-      .getByRole('button', { name: /use email code instead/i })
-    if ((await useEmailCodeLink.count()) > 0) {
-      await useEmailCodeLink.click()
+      .getByRole('button', { name: /email me a sign-in link instead|use email code instead/i })
+    if ((await useEmailInstead.count()) > 0) {
+      await useEmailInstead.click()
     }
 
     // Skip if the email OTP step is not available (email OTP may be disabled).
     // Wait briefly for the transition after clicking "use email code instead".
-    const continueWithEmailBtn = page.getByRole('dialog').getByRole('button', { name: /continue with email/i })
+    const continueWithEmailBtn = page
+      .getByRole('dialog')
+      .getByRole('button', { name: /continue with email/i })
     try {
       await expect(continueWithEmailBtn).toBeVisible({ timeout: 2000 })
     } catch {
@@ -166,8 +163,7 @@ test.describe('Portal Auth Dialog', () => {
 
     expect(otpResponse.ok()).toBeTruthy()
 
-    // Code verification step is now visible
-    await expect(page.getByText(/we sent a 6-digit code to/i)).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText(/for your 6-digit code/i)).toBeVisible({ timeout: 10000 })
     await expect(page.getByText('test@example.com')).toBeVisible()
   })
 
@@ -175,11 +171,11 @@ test.describe('Portal Auth Dialog', () => {
     await page.getByRole('button', { name: /log in/i }).click()
     await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 })
 
-    const useEmailCodeLink = page
+    const useEmailInstead = page
       .getByRole('dialog')
-      .getByRole('button', { name: /use email code instead/i })
-    if ((await useEmailCodeLink.count()) > 0) {
-      await useEmailCodeLink.click()
+      .getByRole('button', { name: /email me a sign-in link instead|use email code instead/i })
+    if ((await useEmailInstead.count()) > 0) {
+      await useEmailInstead.click()
     }
 
     const continueWithEmailBtn = page.getByRole('button', { name: /continue with email/i })
@@ -198,7 +194,7 @@ test.describe('Portal Auth Dialog', () => {
       continueWithEmailBtn.click(),
     ])
 
-    const codeInput = page.locator('#inline-code')
+    const codeInput = page.getByRole('dialog').getByLabel(/verification code/i)
     await expect(codeInput).toBeVisible({ timeout: 10000 })
     await expect(codeInput).toHaveAttribute('maxlength', '6')
   })
@@ -209,7 +205,7 @@ test.describe('Portal Auth Dialog', () => {
 
     const useEmailCodeLink = page
       .getByRole('dialog')
-      .getByRole('button', { name: /use email code instead/i })
+      .getByRole('button', { name: /email me a sign-in link instead|use email code instead/i })
     if ((await useEmailCodeLink.count()) > 0) {
       await useEmailCodeLink.click()
     }
@@ -230,7 +226,7 @@ test.describe('Portal Auth Dialog', () => {
       continueWithEmailBtn.click(),
     ])
 
-    const codeInput = page.locator('#inline-code')
+    const codeInput = page.getByRole('dialog').getByLabel(/verification code/i)
     await expect(codeInput).toBeVisible({ timeout: 10000 })
 
     const verifyButton = page.getByRole('button', { name: /verify code/i })
@@ -249,7 +245,7 @@ test.describe('Portal Auth Dialog', () => {
 
     const useEmailCodeLink = page
       .getByRole('dialog')
-      .getByRole('button', { name: /use email code instead/i })
+      .getByRole('button', { name: /email me a sign-in link instead|use email code instead/i })
     if ((await useEmailCodeLink.count()) > 0) {
       await useEmailCodeLink.click()
     }
@@ -270,10 +266,13 @@ test.describe('Portal Auth Dialog', () => {
       continueWithEmailBtn.click(),
     ])
 
-    await expect(page.locator('#inline-code')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByRole('dialog').getByLabel(/verification code/i)).toBeVisible({
+      timeout: 10000,
+    })
 
-    // Click the Back button inside the dialog
-    const backButton = page.getByRole('dialog').getByRole('button', { name: /back/i })
+    const backButton = page
+      .getByRole('dialog')
+      .getByRole('button', { name: /use a different email/i })
     await expect(backButton).toBeVisible()
     await backButton.click()
 
@@ -287,7 +286,7 @@ test.describe('Portal Auth Dialog', () => {
 
     const useEmailCodeLink = page
       .getByRole('dialog')
-      .getByRole('button', { name: /use email code instead/i })
+      .getByRole('button', { name: /email me a sign-in link instead|use email code instead/i })
     if ((await useEmailCodeLink.count()) > 0) {
       await useEmailCodeLink.click()
     }
@@ -308,8 +307,10 @@ test.describe('Portal Auth Dialog', () => {
       continueWithEmailBtn.click(),
     ])
 
-    await expect(page.locator('#inline-code')).toBeVisible({ timeout: 10000 })
-    await expect(page.getByText(/resend code in \d+s/i)).toBeVisible()
+    await expect(page.getByRole('dialog').getByLabel(/verification code/i)).toBeVisible({
+      timeout: 10000,
+    })
+    await expect(page.getByText(/resend in \d+s/i)).toBeVisible()
   })
 
   // ---------------------------------------------------------------------------
@@ -323,14 +324,16 @@ test.describe('Portal Auth Dialog', () => {
     // Navigate to OTP email step
     const useEmailCodeLink = page
       .getByRole('dialog')
-      .getByRole('button', { name: /use email code instead/i })
+      .getByRole('button', { name: /email me a sign-in link instead|use email code instead/i })
     if ((await useEmailCodeLink.count()) > 0) {
       await useEmailCodeLink.click()
     }
 
     // Skip if the email OTP step is not available (email OTP may be disabled).
     // Wait briefly for the transition after clicking "use email code instead".
-    const continueWithEmailBtn = page.getByRole('dialog').getByRole('button', { name: /continue with email/i })
+    const continueWithEmailBtn = page
+      .getByRole('dialog')
+      .getByRole('button', { name: /continue with email/i })
     try {
       await expect(continueWithEmailBtn).toBeVisible({ timeout: 2000 })
     } catch {
@@ -389,9 +392,7 @@ test.describe('Portal Auth Dialog', () => {
     await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 })
 
     // shadcn Dialog renders a close button with aria-label "Close"
-    const closeButton = page
-      .getByRole('dialog')
-      .getByRole('button', { name: /close/i })
+    const closeButton = page.getByRole('dialog').getByRole('button', { name: /close/i })
     if ((await closeButton.count()) > 0) {
       await closeButton.click()
       await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 5000 })
@@ -408,15 +409,14 @@ test.describe('Portal Auth Dialog', () => {
       timeout: 5000,
     })
 
-    // Click the "Sign up" mode-switch link inside the dialog
-    const signUpModeLink = page.getByRole('dialog').getByRole('button', { name: /sign up/i })
-    expect(await signUpModeLink.count()).toBeGreaterThan(0)
-    if ((await signUpModeLink.count()) > 0) {
-      await signUpModeLink.first().click()
-      await expect(page.getByRole('heading', { name: /create an account/i })).toBeVisible({
-        timeout: 5000,
-      })
-    }
+    const signUpModeLink = page
+      .getByRole('dialog')
+      .getByRole('button', { name: /create an account/i })
+    await expect(signUpModeLink).toBeVisible()
+    await signUpModeLink.click()
+    await expect(page.getByRole('heading', { name: /create an account/i })).toBeVisible({
+      timeout: 5000,
+    })
   })
 
   test('switching from signup to login changes the dialog title', async ({ page }) => {
@@ -425,13 +425,11 @@ test.describe('Portal Auth Dialog', () => {
       timeout: 5000,
     })
 
-    // Click the "Sign in" mode-switch link inside the dialog
     const signInModeLink = page.getByRole('dialog').getByRole('button', { name: /sign in/i })
-    if ((await signInModeLink.count()) > 0) {
-      await signInModeLink.first().click()
-      await expect(page.getByRole('heading', { name: /welcome back/i })).toBeVisible({
-        timeout: 5000,
-      })
-    }
+    await expect(signInModeLink).toBeVisible()
+    await signInModeLink.click()
+    await expect(page.getByRole('heading', { name: /welcome back/i })).toBeVisible({
+      timeout: 5000,
+    })
   })
 })

--- a/apps/web/src/routes/admin/__tests__/settings.mcp-redirect.test.ts
+++ b/apps/web/src/routes/admin/__tests__/settings.mcp-redirect.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+
+const { Route } = await import('../settings.mcp')
+
+type BeforeLoadFn = (ctx: unknown) => void
+
+describe('settings.mcp route', () => {
+  it('redirects to /admin/settings/developers?tab=mcp', () => {
+    let thrown: unknown
+    try {
+      ;(Route.options.beforeLoad as BeforeLoadFn)({})
+    } catch (e) {
+      thrown = e
+    }
+    expect(thrown).toBeInstanceOf(Response)
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    const opts = (thrown as any).options as Record<string, unknown>
+    expect(opts.to).toBe('/admin/settings/developers')
+    expect(opts.search).toEqual({ tab: 'mcp' })
+  })
+})

--- a/apps/web/src/routes/admin/settings.mcp.tsx
+++ b/apps/web/src/routes/admin/settings.mcp.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute, redirect } from '@tanstack/react-router'
+
+/**
+ * MCP settings moved onto the Developers page. Keep this path so bookmarks
+ * and the old e2e URL land on the MCP tab.
+ */
+export const Route = createFileRoute('/admin/settings/mcp')({
+  beforeLoad: () => {
+    throw redirect({ to: '/admin/settings/developers', search: { tab: 'mcp' } })
+  },
+})


### PR DESCRIPTION
## Summary
- `deleteCacheKeys` now uses `IN ${sql(keys)}` so local e2e cache busts work (postgres.js `ANY(sql.array())` was rejected as a scalar).
- Portal auth, MCP, and API-key Playwright specs match the current dialog copy and the Developers page (`?tab=mcp` / `?tab=keys`).
- `/admin/settings/mcp` redirects to the Developers MCP tab so old bookmarks and the previous e2e URL still land.

## Test plan
- [x] `bust-caches.ts settings:workspace` deletes the kv row (exit 0)
- [x] `settings.mcp-redirect` unit test
- [x] Playwright `auth.spec.ts` (public dialog copy + mode switch)
- [x] Playwright `settings-mcp.spec.ts` including the legacy URL
- [x] Playwright `settings-api-keys.spec.ts` including reveal + revoke


Made with [Cursor](https://cursor.com)