### PR TITLE
feat(widget): pair the agent install so the signing secret never hits chat

### DIFF
--- a/apps/web/e2e/tests/admin/settings-widget.spec.ts
+++ b/apps/web/e2e/tests/admin/settings-widget.spec.ts
@@ -48,7 +48,7 @@ test.describe('Admin Widget Settings', () => {
 
   test('shows install status inside Add to your site', async ({ page }) => {
     await expect(page.getByText('Add to your site')).toBeVisible({ timeout: 10000 })
-    await expect(page.getByRole('link', { name: /Install widget|View installation/ })).toBeVisible()
+    await expect(page.getByRole('link', { name: /Set it up|View installation/ })).toBeVisible()
     await expect(page.getByRole('heading', { name: 'Installation' })).toHaveCount(0)
   })
 

--- a/apps/web/src/components/admin/settings/widget/__tests__/copy-agent-prompt-button.test.tsx
+++ b/apps/web/src/components/admin/settings/widget/__tests__/copy-agent-prompt-button.test.tsx
@@ -29,4 +29,18 @@ describe('CopyAgentPromptButton', () => {
       expect(screen.getByRole('button', { name: 'Install prompt copied' })).toBeTruthy()
     })
   })
+
+  it('resolves getPrompt on click so a pairing code can be minted then', async () => {
+    const getPrompt = vi.fn().mockResolvedValue('prompt with qbi_code')
+    render(<CopyAgentPromptButton getPrompt={getPrompt} />)
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Copy install prompt for your coding agent' })
+    )
+
+    await waitFor(() => {
+      expect(getPrompt).toHaveBeenCalled()
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('prompt with qbi_code')
+    })
+  })
 })

--- a/apps/web/src/components/admin/settings/widget/__tests__/copy-agent-prompt-button.test.tsx
+++ b/apps/web/src/components/admin/settings/widget/__tests__/copy-agent-prompt-button.test.tsx
@@ -1,18 +1,26 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+const { copyWithFallback } = vi.hoisted(() => ({
+  copyWithFallback: vi.fn(),
+}))
+
+vi.mock('@/components/admin/activation-action-button', () => ({
+  copyWithFallback: (...args: unknown[]) => copyWithFallback(...args),
+}))
+
 import { CopyAgentPromptButton } from '../copy-agent-prompt-button'
 
 describe('CopyAgentPromptButton', () => {
   beforeEach(() => {
-    Object.defineProperty(navigator, 'clipboard', {
-      configurable: true,
-      value: { writeText: vi.fn().mockResolvedValue(undefined) },
-    })
+    copyWithFallback.mockReset()
+    copyWithFallback.mockResolvedValue(undefined)
   })
 
-  it('copies the prompt and shows a success label', async () => {
-    render(<CopyAgentPromptButton prompt="Install the Quackback widget" />)
+  it('resolves getPrompt on click, copies it, and shows a success label', async () => {
+    const getPrompt = vi.fn().mockResolvedValue('prompt with qbi_code')
+    render(<CopyAgentPromptButton getPrompt={getPrompt} />)
 
     const button = screen.getByRole('button', {
       name: 'Copy install prompt for your coding agent',
@@ -25,22 +33,9 @@ describe('CopyAgentPromptButton', () => {
     fireEvent.click(button)
 
     await waitFor(() => {
-      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('Install the Quackback widget')
-      expect(screen.getByRole('button', { name: 'Install prompt copied' })).toBeTruthy()
-    })
-  })
-
-  it('resolves getPrompt on click so a pairing code can be minted then', async () => {
-    const getPrompt = vi.fn().mockResolvedValue('prompt with qbi_code')
-    render(<CopyAgentPromptButton getPrompt={getPrompt} />)
-
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Copy install prompt for your coding agent' })
-    )
-
-    await waitFor(() => {
       expect(getPrompt).toHaveBeenCalled()
-      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('prompt with qbi_code')
+      expect(copyWithFallback).toHaveBeenCalledWith('prompt with qbi_code')
+      expect(screen.getByRole('button', { name: 'Install prompt copied' })).toBeTruthy()
     })
   })
 })

--- a/apps/web/src/components/admin/settings/widget/__tests__/widget-preview.test.tsx
+++ b/apps/web/src/components/admin/settings/widget/__tests__/widget-preview.test.tsx
@@ -3,8 +3,8 @@
 /**
  * <WidgetPreview> — admin widget settings live preview.
  *
- * The preview embeds the real `/widget` app in an iframe and simulates only
- * the host chrome the SDK provides on a customer page:
+ * The preview embeds the real `/widget` app in an iframe and the real SDK
+ * launcher (createLauncher) in the fake page:
  *   - The iframe targets /widget with the selected theme forced via ?theme=.
  *   - The launcher button toggles the panel open/closed.
  *   - Panel and launcher share a bottom corner (panel above, button below).
@@ -12,7 +12,7 @@
  *   - The widget's own close button messages its host (quackback:close);
  *     the preview honours it like the SDK would, but only from its own origin.
  */
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { WidgetPreview } from '../widget-preview'
 
@@ -20,7 +20,19 @@ function sendClose(origin: string) {
   fireEvent(window, new MessageEvent('message', { data: { type: 'quackback:close' }, origin }))
 }
 
+function launcher() {
+  return screen.getByRole('button', { name: /feedback widget/i })
+}
+
 describe('WidgetPreview', () => {
+  beforeEach(() => {
+    try {
+      sessionStorage.clear()
+    } catch {
+      /* ignore */
+    }
+  })
+
   it('embeds the real widget with the selected theme forced', () => {
     render(<WidgetPreview position="bottom-right" theme="dark" />)
 
@@ -28,14 +40,31 @@ describe('WidgetPreview', () => {
     expect(iframe.getAttribute('src')).toBe('/widget?theme=dark')
   })
 
+  it('uses the real SDK launcher button', () => {
+    render(<WidgetPreview position="bottom-right" />)
+
+    const btn = launcher()
+    expect(btn.querySelector('svg')).toBeTruthy()
+    expect(btn.style.position).toBe('absolute')
+    expect(btn.getAttribute('aria-expanded')).toBe('true')
+    expect(btn.className).not.toContain('bg-primary')
+    expect(btn.style.backgroundColor).toBeTruthy()
+  })
+
+  it('turns the real launcher into a pill when a label is set', () => {
+    render(<WidgetPreview position="bottom-right" label="Feedback" />)
+
+    expect(launcher().textContent).toContain('Feedback')
+    expect(launcher().style.borderRadius).toBe('24px')
+  })
+
   it('toggles the panel via the launcher button', () => {
     render(<WidgetPreview position="bottom-right" />)
 
-    const launcher = screen.getByRole('button', { name: /feedback widget/i })
-    fireEvent.click(launcher)
+    fireEvent.click(launcher())
     expect(screen.queryByTitle('Widget preview')).toBeNull()
 
-    fireEvent.click(launcher)
+    fireEvent.click(launcher())
     expect(screen.getByTitle('Widget preview')).toBeTruthy()
   })
 
@@ -56,17 +85,18 @@ describe('WidgetPreview', () => {
   it('places the launcher on the configured side', () => {
     render(<WidgetPreview position="bottom-left" />)
 
-    expect(screen.getByRole('button', { name: /feedback widget/i }).className).toContain('left-0')
+    expect(launcher().style.left).toBe('0px')
+    expect(launcher().style.right).toBe('')
   })
 
   it('stacks the open panel above the launcher in the same corner', () => {
     render(<WidgetPreview position="bottom-right" />)
 
     const panel = screen.getByTitle('Widget preview').parentElement
-    const launcher = screen.getByRole('button', { name: /feedback widget/i })
+    const btn = launcher()
     expect(panel?.className).toContain('bottom-[88px]')
-    expect(launcher.className).toContain('bottom-0')
-    expect(launcher.className).toContain('right-0')
+    expect(btn.style.bottom).toBe('0px')
+    expect(btn.style.right).toBe('0px')
     expect(panel?.parentElement?.className).toContain('w-[400px]')
     expect(panel?.parentElement?.parentElement?.className).toContain('items-center')
     expect(panel?.parentElement?.parentElement?.className).toContain('justify-center')
@@ -75,28 +105,36 @@ describe('WidgetPreview', () => {
   it('shows the launcher greeting bubble while the panel is closed', () => {
     render(<WidgetPreview position="bottom-right" greeting="Need a hand?" />)
 
-    expect(screen.queryByText('Need a hand?')).toBeNull()
-    fireEvent.click(screen.getByRole('button', { name: /feedback widget/i }))
-    expect(screen.getByText('Need a hand?')).toBeTruthy()
-    fireEvent.click(screen.getByRole('button', { name: 'Dismiss greeting' }))
-    expect(screen.queryByText('Need a hand?')).toBeNull()
+    const bubble = () => screen.getByText('Need a hand?').parentElement
+    expect(bubble()?.style.display).toBe('none')
+    fireEvent.click(launcher())
+    expect(bubble()?.style.display).toBe('flex')
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }))
+    expect(bubble()?.style.display).toBe('none')
   })
 
   it('opens the panel when the greeting bubble is clicked', () => {
     render(<WidgetPreview position="bottom-right" greeting="Hi there" />)
 
-    fireEvent.click(screen.getByRole('button', { name: /feedback widget/i }))
+    fireEvent.click(launcher())
     expect(screen.queryByTitle('Widget preview')).toBeNull()
 
     fireEvent.click(screen.getByText('Hi there'))
     expect(screen.getByTitle('Widget preview')).toBeTruthy()
-    expect(screen.queryByText('Hi there')).toBeNull()
+    expect(screen.getByText('Hi there').parentElement?.style.display).toBe('none')
   })
 
   it('places the greeting bubble on the same side as the launcher', () => {
     render(<WidgetPreview position="bottom-left" greeting="Hello" />)
 
-    fireEvent.click(screen.getByRole('button', { name: /feedback widget/i }))
-    expect(screen.getByText('Hello').parentElement?.className).toContain('left-0')
+    fireEvent.click(launcher())
+    expect(screen.getByText('Hello').parentElement?.style.left).toBe('0px')
+  })
+
+  it('does not persist greeting dismiss to the host-page session key', () => {
+    render(<WidgetPreview position="bottom-right" greeting="Need a hand?" />)
+    fireEvent.click(launcher())
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }))
+    expect(sessionStorage.getItem('quackback:launcher-greeting-dismissed')).toBeNull()
   })
 })

--- a/apps/web/src/components/admin/settings/widget/__tests__/widget-signing-secret.test.tsx
+++ b/apps/web/src/components/admin/settings/widget/__tests__/widget-signing-secret.test.tsx
@@ -66,7 +66,7 @@ describe('WidgetSigningSecret', () => {
     const { WidgetSigningSecret } = await import('../widget-signing-secret')
     render(<WidgetSigningSecret secret="wgt_abc123secret" />)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Regenerate…' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Regenerate signing secret' }))
     expect(screen.getByText('Regenerate signing secret?')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Regenerate secret' }))
 
@@ -81,7 +81,7 @@ describe('WidgetSigningSecret', () => {
     const { WidgetSigningSecret } = await import('../widget-signing-secret')
     render(<WidgetSigningSecret secret="wgt_abc123secret" />)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Regenerate…' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Regenerate signing secret' }))
     fireEvent.click(screen.getByRole('button', { name: 'Regenerate secret' }))
 
     await waitFor(() => {

--- a/apps/web/src/components/admin/settings/widget/copy-agent-prompt-button.tsx
+++ b/apps/web/src/components/admin/settings/widget/copy-agent-prompt-button.tsx
@@ -1,33 +1,46 @@
+import { useEffect, useRef, useState } from 'react'
 import { CheckIcon } from '@heroicons/react/24/solid'
 import { AGENT_BRANDS } from '@/components/admin/settings/widget/agent-brand-icons'
-import { useCopyToClipboard } from '@/lib/client/hooks/use-copy-to-clipboard'
+import { copyWithFallback } from '@/components/admin/activation-action-button'
 import { cn } from '@/lib/shared/utils'
-
-interface CopyAgentPromptButtonProps {
-  /** Static prompt. Ignored when getPrompt is set. */
-  prompt?: string
-  /** Mint a pairing code (or otherwise build the prompt) at click time. */
-  getPrompt?: () => string | Promise<string>
-  className?: string
-  disabled?: boolean
-}
 
 /**
  * Cloudflare-style agent onboard pill: one click copies the install prompt,
  * with brand marks for the agents people actually paste into.
  */
 export function CopyAgentPromptButton({
-  prompt,
   getPrompt,
   className,
   disabled,
-}: CopyAgentPromptButtonProps) {
-  const { copied, copy } = useCopyToClipboard()
+}: {
+  getPrompt: () => string | Promise<string>
+  className?: string
+  disabled?: boolean
+}) {
+  const [copied, setCopied] = useState(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(
+    () => () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    },
+    []
+  )
 
   async function handleClick() {
-    const text = getPrompt ? await getPrompt() : (prompt ?? '')
+    const text = await getPrompt()
     if (!text) return
-    await copy(text)
+    try {
+      await copyWithFallback(text)
+    } catch {
+      return
+    }
+    setCopied(true)
+    if (timerRef.current) clearTimeout(timerRef.current)
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null
+      setCopied(false)
+    }, 2000)
   }
 
   return (

--- a/apps/web/src/components/admin/settings/widget/copy-agent-prompt-button.tsx
+++ b/apps/web/src/components/admin/settings/widget/copy-agent-prompt-button.tsx
@@ -4,27 +4,44 @@ import { useCopyToClipboard } from '@/lib/client/hooks/use-copy-to-clipboard'
 import { cn } from '@/lib/shared/utils'
 
 interface CopyAgentPromptButtonProps {
-  prompt: string
+  /** Static prompt. Ignored when getPrompt is set. */
+  prompt?: string
+  /** Mint a pairing code (or otherwise build the prompt) at click time. */
+  getPrompt?: () => string | Promise<string>
   className?: string
+  disabled?: boolean
 }
 
 /**
  * Cloudflare-style agent onboard pill: one click copies the install prompt,
  * with brand marks for the agents people actually paste into.
  */
-export function CopyAgentPromptButton({ prompt, className }: CopyAgentPromptButtonProps) {
+export function CopyAgentPromptButton({
+  prompt,
+  getPrompt,
+  className,
+  disabled,
+}: CopyAgentPromptButtonProps) {
   const { copied, copy } = useCopyToClipboard()
+
+  async function handleClick() {
+    const text = getPrompt ? await getPrompt() : (prompt ?? '')
+    if (!text) return
+    await copy(text)
+  }
 
   return (
     <button
       type="button"
-      onClick={() => copy(prompt)}
+      onClick={() => void handleClick()}
+      disabled={disabled}
       aria-label={copied ? 'Install prompt copied' : 'Copy install prompt for your coding agent'}
       className={cn(
         'group inline-flex items-center gap-3 rounded-full bg-zinc-950 pl-4 pr-2 py-1.5',
         'text-[13px] font-medium text-white shadow-sm',
         'ring-1 ring-white/10 hover:ring-white/20',
         'transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40',
+        'disabled:cursor-not-allowed disabled:opacity-60',
         className
       )}
     >

--- a/apps/web/src/components/admin/settings/widget/widget-preview.tsx
+++ b/apps/web/src/components/admin/settings/widget/widget-preview.tsx
@@ -1,6 +1,18 @@
-import { useEffect, useState } from 'react'
-import { ChatBubbleOvalLeftEllipsisIcon } from '@heroicons/react/24/solid'
+import { useEffect, useRef, useState } from 'react'
+import {
+  createLauncher,
+  type LauncherHandle,
+} from '../../../../../../../packages/widget/src/core/launcher'
 import { cn } from '@/lib/shared/utils'
+
+type PreviewServerTheme = {
+  theme?: {
+    lightPrimary?: string
+    lightPrimaryForeground?: string
+    darkPrimary?: string
+    darkPrimaryForeground?: string
+  }
+}
 
 interface WidgetPreviewProps {
   position: 'bottom-right' | 'bottom-left'
@@ -17,12 +29,26 @@ interface WidgetPreviewProps {
   refreshKey?: string
 }
 
+function applyLauncherTheme(
+  handle: LauncherHandle,
+  theme: 'light' | 'dark',
+  config: PreviewServerTheme
+) {
+  const t = config.theme
+  if (!t) return
+  const dark = theme === 'dark'
+  handle.setColors({
+    backgroundColor: dark ? (t.darkPrimary ?? t.lightPrimary) : t.lightPrimary,
+    foregroundColor: dark
+      ? (t.darkPrimaryForeground ?? t.lightPrimaryForeground)
+      : t.lightPrimaryForeground,
+  })
+}
+
 /**
  * Live preview of the embedded widget: the real `/widget` app in an iframe
- * (the same document the customer-facing SDK frames), surrounded by the same
- * chrome the SDK provides on a host page — a launcher button and the page
- * behind it. Only the chrome is simulated; everything inside the panel is the
- * production widget with real settings and content.
+ * (the same document the customer-facing SDK frames) and the real SDK
+ * launcher button, on a fake page. Only the page behind it is simulated.
  */
 export function WidgetPreview({
   position,
@@ -31,26 +57,75 @@ export function WidgetPreview({
   theme = 'light',
   refreshKey,
 }: WidgetPreviewProps) {
+  const hostRef = useRef<HTMLDivElement>(null)
+  const launcherRef = useRef<LauncherHandle | null>(null)
+  const themeConfigRef = useRef<PreviewServerTheme | null>(null)
   const [isOpen, setIsOpen] = useState(true)
-  const [greetingDismissed, setGreetingDismissed] = useState(false)
-  const greetingText = greeting?.trim() || ''
   const onRight = position !== 'bottom-left'
-  // Same corner stack as the SDK: greeting sits above the launcher, and the
-  // open panel covers that corner so the bubble hides.
-  const showGreeting = greetingText.length > 0 && !greetingDismissed && !isOpen
-  const corner = onRight ? 'right-0' : 'left-0'
 
   useEffect(() => {
-    setGreetingDismissed(false)
-  }, [greetingText])
+    const host = hostRef.current
+    if (!host) return
+    const handle = createLauncher({
+      placement: onRight ? 'right' : 'left',
+      root: host,
+      onClick: () => setIsOpen((open) => !open),
+    })
+    launcherRef.current = handle
+    handle.setOpen(isOpen)
+    handle.setLabel(label ?? '')
+    handle.setGreeting(greeting ?? '')
+    if (themeConfigRef.current) applyLauncherTheme(handle, theme, themeConfigRef.current)
+    handle.reveal()
+    return () => {
+      handle.remove()
+      if (launcherRef.current === handle) launcherRef.current = null
+    }
+    // Remount only when the corner changes. Label / greeting / open sync below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- see above
+  }, [onRight])
 
-  // The widget's in-panel close button messages its host (the SDK on a real
-  // page); here the preview is the host, so honour it the same way.
+  useEffect(() => {
+    launcherRef.current?.setOpen(isOpen)
+  }, [isOpen])
+
+  useEffect(() => {
+    launcherRef.current?.setLabel(label ?? '')
+  }, [label])
+
+  useEffect(() => {
+    launcherRef.current?.setGreeting(greeting ?? '')
+  }, [greeting])
+
+  useEffect(() => {
+    if (themeConfigRef.current && launcherRef.current) {
+      applyLauncherTheme(launcherRef.current, theme, themeConfigRef.current)
+    }
+    let cancelled = false
+    void fetch('/api/widget/config.json')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((config: PreviewServerTheme | null) => {
+        if (cancelled || !config) return
+        themeConfigRef.current = config
+        if (!launcherRef.current) return
+        applyLauncherTheme(launcherRef.current, theme, config)
+      })
+      .catch(() => {
+        /* keep the SDK defaults */
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [theme, refreshKey])
+
   useEffect(() => {
     function onMessage(event: MessageEvent) {
       if (event.origin !== window.location.origin) return
-      const msg = event.data as { type?: string } | null
+      const msg = event.data as { type?: string; count?: number } | null
       if (msg?.type === 'quackback:close') setIsOpen(false)
+      if (msg?.type === 'quackback:unread') {
+        launcherRef.current?.setUnread(typeof msg.count === 'number' ? msg.count : 0)
+      }
     }
     window.addEventListener('message', onMessage)
     return () => window.removeEventListener('message', onMessage)
@@ -59,14 +134,10 @@ export function WidgetPreview({
   return (
     <div className={cn('h-full', theme === 'dark' && 'dark')}>
       <div className="relative h-full min-h-[560px] rounded-xl border border-border bg-muted/30 overflow-hidden text-foreground">
-        {/* Simulated page background */}
         <PageBackdrop />
 
-        {/* Widget + launcher as one centered unit so a wide pane doesn't pin
-            them to a far corner. The button still sits below the panel on the
-            configured side (SDK: bottom 88px, 400×600). */}
         <div className="absolute inset-0 flex items-center justify-center p-6">
-          <div className="relative h-[688px] w-[400px] max-h-full max-w-full">
+          <div ref={hostRef} className="relative h-[688px] w-[400px] max-h-full max-w-full">
             {isOpen && (
               <div
                 className={cn(
@@ -83,52 +154,6 @@ export function WidgetPreview({
                 />
               </div>
             )}
-
-            {/* Greeting bubble — same side as the launcher, just above it.
-                Hidden while the panel is open, matching the host-page SDK. */}
-            {showGreeting && (
-              <div
-                className={cn(
-                  'absolute bottom-[84px] z-10 flex max-w-[220px] items-center gap-2 rounded-[14px] px-3 py-2.5',
-                  'bg-white text-[13px] leading-snug text-zinc-900 shadow-lg',
-                  corner
-                )}
-              >
-                <button
-                  type="button"
-                  className="min-w-0 flex-1 cursor-pointer text-start"
-                  onClick={() => setIsOpen(true)}
-                >
-                  {greetingText}
-                </button>
-                <button
-                  type="button"
-                  aria-label="Dismiss greeting"
-                  onClick={() => setGreetingDismissed(true)}
-                  className="flex size-[18px] shrink-0 items-center justify-center rounded-full text-base leading-none text-zinc-400 hover:text-zinc-600"
-                >
-                  ×
-                </button>
-              </div>
-            )}
-
-            {/* Trigger button — bottom of the same side, below the open panel. */}
-            <button
-              type="button"
-              aria-label={isOpen ? 'Close feedback widget' : 'Open feedback widget'}
-              aria-expanded={isOpen}
-              onClick={() => setIsOpen(!isOpen)}
-              className={cn(
-                'absolute bottom-0 z-20 flex items-center justify-center h-12 rounded-full',
-                'bg-primary text-primary-foreground shadow-md',
-                'transition-all hover:shadow-lg hover:-translate-y-0.5',
-                label ? 'gap-1.5 ps-3 pe-4 text-xs font-semibold' : 'w-12',
-                corner
-              )}
-            >
-              <ChatBubbleOvalLeftEllipsisIcon className="w-5 h-5 shrink-0" />
-              {label && <span className="max-w-40 truncate">{label}</span>}
-            </button>
           </div>
         </div>
       </div>
@@ -139,7 +164,6 @@ export function WidgetPreview({
 function PageBackdrop() {
   return (
     <div className="absolute inset-0 p-4 pointer-events-none select-none opacity-40">
-      {/* Nav bar */}
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
           <div className="w-5 h-5 rounded bg-muted-foreground/20" />
@@ -151,14 +175,12 @@ function PageBackdrop() {
           <div className="w-12 h-2 rounded-full bg-muted-foreground/10" />
         </div>
       </div>
-      {/* Hero */}
       <div className="mt-8 mb-6 space-y-2 max-w-[60%]">
         <div className="w-48 h-3 rounded-full bg-muted-foreground/15" />
         <div className="w-36 h-3 rounded-full bg-muted-foreground/10" />
         <div className="w-full h-2 rounded-full bg-muted-foreground/8 mt-3" />
         <div className="w-4/5 h-2 rounded-full bg-muted-foreground/8" />
       </div>
-      {/* Content blocks */}
       <div className="grid grid-cols-3 gap-3 mt-6">
         {[1, 2, 3].map((i) => (
           <div key={i} className="rounded-lg border border-muted-foreground/10 p-3 space-y-2">

--- a/apps/web/src/components/admin/settings/widget/widget-signing-secret.tsx
+++ b/apps/web/src/components/admin/settings/widget/widget-signing-secret.tsx
@@ -1,5 +1,10 @@
 import { useState } from 'react'
-import { ClipboardDocumentIcon, EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline'
+import {
+  ArrowPathIcon,
+  ClipboardDocumentIcon,
+  EyeIcon,
+  EyeSlashIcon,
+} from '@heroicons/react/24/outline'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { ConfirmDialog } from '@/components/shared/confirm-dialog'
@@ -30,13 +35,9 @@ export function WidgetSigningSecret({ secret }: { secret: string }) {
 
   return (
     <div className="space-y-3">
-      <div>
-        <p className="text-sm font-medium">Signing secret</p>
-        <p className="mt-0.5 text-xs text-muted-foreground">
-          Paste this into your app&apos;s server env (any name). Do not add it to Quackback Cloud or
-          your Quackback host. Some older notes called it QUACKBACK_WIDGET_SECRET — same value.
-        </p>
-      </div>
+      <p className="text-xs text-muted-foreground">
+        Verifies the identity of signed-in users. Keep it private and server-side only.
+      </p>
       <div className="flex flex-wrap items-center gap-2 rounded-lg border border-border/50 bg-muted/30 px-3 py-2">
         <code className="min-w-0 flex-1 truncate font-mono text-xs" data-testid="signing-secret">
           {revealed ? secret : maskSigningSecret(secret)}
@@ -62,26 +63,28 @@ export function WidgetSigningSecret({ secret }: { secret: string }) {
             <ClipboardDocumentIcon className="h-4 w-4" />
             {copying ? 'Copying…' : 'Copy'}
           </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={regenerate.isPending}
+            onClick={() => setConfirmOpen(true)}
+            aria-label="Regenerate signing secret"
+          >
+            <ArrowPathIcon className="h-4 w-4" />
+            {regenerate.isPending ? 'Regenerating…' : 'Regenerate'}
+          </Button>
         </div>
       </div>
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        disabled={regenerate.isPending}
-        onClick={() => setConfirmOpen(true)}
-      >
-        Regenerate…
-      </Button>
       <ConfirmDialog
         open={confirmOpen}
         onOpenChange={setConfirmOpen}
         title="Regenerate signing secret?"
-        description="Existing identify tokens stop working until you update the secret in your product and redeploy. The launcher keeps working."
+        description="Signed-in users won't be recognized until you put the new secret in your app and redeploy. The launcher keeps working."
         warning={{
-          title: 'Identify breaks until you deploy the new secret',
+          title: 'Update the secret in your app before you regenerate',
           description:
-            'The old secret is invalidated immediately. Anonymous visitors are unaffected.',
+            'The old secret stops working immediately. Anonymous visitors are unaffected.',
         }}
         confirmLabel="Regenerate secret"
         variant="destructive"

--- a/apps/web/src/lib/client/mutations/settings.ts
+++ b/apps/web/src/lib/client/mutations/settings.ts
@@ -20,6 +20,7 @@ import {
   updateModerationDefaultFn,
   updateWidgetConfigFn,
   regenerateWidgetSecretFn,
+  mintWidgetInstallCodeFn,
   updateThemeFn,
   updateCustomCssFn,
   updateWorkflowAbandonedAutoCloseFn,
@@ -306,6 +307,12 @@ export function useRegenerateWidgetSecret() {
       queryClient.setQueryData(settingsQueries.widgetSecret().queryKey, secret)
       return queryClient.invalidateQueries({ queryKey: settingsQueries.widgetSecret().queryKey })
     },
+  })
+}
+
+export function useMintWidgetInstallCode() {
+  return useMutation({
+    mutationFn: () => mintWidgetInstallCodeFn(),
   })
 }
 

--- a/apps/web/src/lib/server/auth/__tests__/widget-rate-limit.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/widget-rate-limit.test.ts
@@ -11,7 +11,11 @@ const { incrementBuckets, bucketRetryAfter } = vi.hoisted(() => ({
 }))
 vi.mock('@/lib/server/utils/rate-bucket', () => ({ incrementBuckets, bucketRetryAfter }))
 
-import { checkAnonMintRateLimit, checkWidgetIdentifyRateLimit } from '../widget-rate-limit'
+import {
+  checkAnonMintRateLimit,
+  checkWidgetIdentifyRateLimit,
+  checkWidgetInstallContextRateLimit,
+} from '../widget-rate-limit'
 
 beforeEach(() => vi.clearAllMocks())
 
@@ -36,6 +40,16 @@ describe('widget rate limits', () => {
     expect(await checkWidgetIdentifyRateLimit('1.2.3.4')).toEqual({ allowed: true }) // at cap
     incrementBuckets.mockResolvedValue([61])
     expect(await checkWidgetIdentifyRateLimit('1.2.3.4')).toEqual({
+      allowed: false,
+      retryAfter: 42,
+    })
+  })
+
+  it('bounds install-context redeem per IP', async () => {
+    incrementBuckets.mockResolvedValue([20])
+    expect(await checkWidgetInstallContextRateLimit('1.2.3.4')).toEqual({ allowed: true })
+    incrementBuckets.mockResolvedValue([21])
+    expect(await checkWidgetInstallContextRateLimit('1.2.3.4')).toEqual({
       allowed: false,
       retryAfter: 42,
     })

--- a/apps/web/src/lib/server/auth/__tests__/widget-rate-limit.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/widget-rate-limit.test.ts
@@ -11,11 +11,7 @@ const { incrementBuckets, bucketRetryAfter } = vi.hoisted(() => ({
 }))
 vi.mock('@/lib/server/utils/rate-bucket', () => ({ incrementBuckets, bucketRetryAfter }))
 
-import {
-  checkAnonMintRateLimit,
-  checkWidgetIdentifyRateLimit,
-  checkWidgetInstallContextRateLimit,
-} from '../widget-rate-limit'
+import { checkAnonMintRateLimit, checkWidgetIdentifyRateLimit } from '../widget-rate-limit'
 
 beforeEach(() => vi.clearAllMocks())
 
@@ -40,16 +36,6 @@ describe('widget rate limits', () => {
     expect(await checkWidgetIdentifyRateLimit('1.2.3.4')).toEqual({ allowed: true }) // at cap
     incrementBuckets.mockResolvedValue([61])
     expect(await checkWidgetIdentifyRateLimit('1.2.3.4')).toEqual({
-      allowed: false,
-      retryAfter: 42,
-    })
-  })
-
-  it('bounds install-context redeem per IP', async () => {
-    incrementBuckets.mockResolvedValue([20])
-    expect(await checkWidgetInstallContextRateLimit('1.2.3.4')).toEqual({ allowed: true })
-    incrementBuckets.mockResolvedValue([21])
-    expect(await checkWidgetInstallContextRateLimit('1.2.3.4')).toEqual({
       allowed: false,
       retryAfter: 42,
     })

--- a/apps/web/src/lib/server/auth/widget-rate-limit.ts
+++ b/apps/web/src/lib/server/auth/widget-rate-limit.ts
@@ -25,6 +25,8 @@ const ANON_MINT_LIMIT = 100
 const ANON_MINT_WINDOW_S = 10 * 60
 const IDENTIFY_LIMIT = 60
 const IDENTIFY_WINDOW_S = 15 * 60
+const INSTALL_CONTEXT_LIMIT = 20
+const INSTALL_CONTEXT_WINDOW_S = 15 * 60
 
 /** Increment every bucket, then block on the first over its cap. A null count
  *  (the store errored) fails open. */
@@ -54,5 +56,13 @@ export function checkWidgetIdentifyRateLimit(ip: string): Promise<WidgetRateLimi
   return limit(
     [{ key: `widget:identify:ip:${ip}`, windowSeconds: IDENTIFY_WINDOW_S }],
     [IDENTIFY_LIMIT]
+  )
+}
+
+/** Bound pairing-code redeem attempts — this endpoint returns the signing secret. */
+export function checkWidgetInstallContextRateLimit(ip: string): Promise<WidgetRateLimitResult> {
+  return limit(
+    [{ key: `widget:install-context:ip:${ip}`, windowSeconds: INSTALL_CONTEXT_WINDOW_S }],
+    [INSTALL_CONTEXT_LIMIT]
   )
 }

--- a/apps/web/src/lib/server/auth/widget-rate-limit.ts
+++ b/apps/web/src/lib/server/auth/widget-rate-limit.ts
@@ -25,8 +25,6 @@ const ANON_MINT_LIMIT = 100
 const ANON_MINT_WINDOW_S = 10 * 60
 const IDENTIFY_LIMIT = 60
 const IDENTIFY_WINDOW_S = 15 * 60
-const INSTALL_CONTEXT_LIMIT = 20
-const INSTALL_CONTEXT_WINDOW_S = 15 * 60
 
 /** Increment every bucket, then block on the first over its cap. A null count
  *  (the store errored) fails open. */
@@ -56,13 +54,5 @@ export function checkWidgetIdentifyRateLimit(ip: string): Promise<WidgetRateLimi
   return limit(
     [{ key: `widget:identify:ip:${ip}`, windowSeconds: IDENTIFY_WINDOW_S }],
     [IDENTIFY_LIMIT]
-  )
-}
-
-/** Bound pairing-code redeem attempts — this endpoint returns the signing secret. */
-export function checkWidgetInstallContextRateLimit(ip: string): Promise<WidgetRateLimitResult> {
-  return limit(
-    [{ key: `widget:install-context:ip:${ip}`, windowSeconds: INSTALL_CONTEXT_WINDOW_S }],
-    [INSTALL_CONTEXT_LIMIT]
   )
 }

--- a/apps/web/src/lib/server/domains/settings/__tests__/widget-config.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/widget-config.test.ts
@@ -24,6 +24,7 @@ import {
   publicMessengerConfig,
   getPublicWidgetConfig,
 } from '../settings.widget'
+import { getWidgetInstallStatus } from '../widget-install-pairing'
 import { deepMerge } from '../settings.helpers'
 
 function fixtureRow(widget: WidgetConfig, featureFlags?: Record<string, boolean>) {
@@ -369,5 +370,25 @@ describe('ensureWidgetSecret', () => {
   it('returns the existing secret without writing', async () => {
     settingsRow.current = { id: 'settings_1', widgetSecret: 'wgt_existing' }
     await expect(ensureWidgetSecret()).resolves.toBe('wgt_existing')
+  })
+})
+
+describe('getWidgetInstallStatus', () => {
+  it('reports connection evidence without a signing secret', async () => {
+    settingsRow.current = {
+      id: 'settings_1',
+      widgetSecret: 'wgt_must_not_leak',
+      widgetConfig: JSON.stringify({ enabled: true }),
+      widgetInstalledFirstSeenAt: new Date('2026-09-11T10:00:00.000Z'),
+      widgetInstalledLastSeenAt: new Date('2026-09-11T10:05:00.000Z'),
+      widgetInstalledOriginHost: 'app.example.com',
+      widgetInstalledSdkVersion: '0.1.6',
+    }
+    const status = await getWidgetInstallStatus()
+    expect(status.connected).toBe(true)
+    expect(status.enabled).toBe(true)
+    expect(status.originHost).toBe('app.example.com')
+    expect(status.lastDetectedAt).toBe('2026-09-11T10:05:00.000Z')
+    expect(JSON.stringify(status)).not.toContain('wgt_')
   })
 })

--- a/apps/web/src/lib/server/domains/settings/__tests__/widget-install-pairing.db.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/widget-install-pairing.db.test.ts
@@ -1,0 +1,57 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  cleanupWorkspaces,
+  closeHarness,
+  ensureKvSchema,
+  testSql,
+  uniqueKey,
+  withRealWorkspace,
+  workspacePair,
+} from '@/lib/server/kv/__tests__/harness'
+import { kvGet, kvSet } from '@/lib/server/kv/pg-kv'
+import {
+  consumeWidgetInstallCode,
+  hashWidgetInstallCode,
+  widgetInstallPairingKey,
+} from '../widget-install-pairing'
+
+const [T] = workspacePair()
+
+beforeAll(async () => {
+  await ensureKvSchema()
+})
+
+afterAll(async () => {
+  await cleanupWorkspaces(T)
+  await closeHarness()
+})
+
+async function expire(key: string): Promise<void> {
+  await testSql()`
+    UPDATE kv_store SET expires_at = now() - interval '1 second'
+    WHERE workspace_key = ${T} AND key = ${key}
+  `
+}
+
+describe('consumeWidgetInstallCode against kv_store', () => {
+  it('allows two uses then refuses a third', async () => {
+    const code = `qbi_${uniqueKey('code').replace(/-/g, '').slice(0, 16)}`
+    const key = widgetInstallPairingKey(hashWidgetInstallCode(code))
+    await withRealWorkspace(T, () => kvSet(key, { remaining: 2 }, 60))
+
+    await expect(withRealWorkspace(T, () => consumeWidgetInstallCode(code))).resolves.toBe(true)
+    await expect(withRealWorkspace(T, () => kvGet<{ remaining: number }>(key))).resolves.toEqual({
+      remaining: 1,
+    })
+    await expect(withRealWorkspace(T, () => consumeWidgetInstallCode(code))).resolves.toBe(true)
+    await expect(withRealWorkspace(T, () => consumeWidgetInstallCode(code))).resolves.toBe(false)
+  })
+
+  it('refuses an expired code even if the row is still present', async () => {
+    const code = `qbi_${uniqueKey('exp').replace(/-/g, '').slice(0, 16)}`
+    const key = widgetInstallPairingKey(hashWidgetInstallCode(code))
+    await withRealWorkspace(T, () => kvSet(key, { remaining: 2 }, 60))
+    await expire(key)
+    await expect(withRealWorkspace(T, () => consumeWidgetInstallCode(code))).resolves.toBe(false)
+  })
+})

--- a/apps/web/src/lib/server/domains/settings/__tests__/widget-install-pairing.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/widget-install-pairing.test.ts
@@ -4,7 +4,6 @@ const kvSet = vi.fn()
 const dbExecute = vi.fn()
 const ensureWidgetSecret = vi.fn()
 const updateWidgetConfig = vi.fn()
-const requireSettings = vi.fn()
 const getBaseUrl = vi.fn(() => 'https://feedback.example.com/')
 
 vi.mock('@/lib/server/kv/pg-kv', () => ({ kvSet: (...a: unknown[]) => kvSet(...a) }))
@@ -14,10 +13,6 @@ vi.mock('../settings.widget', () => ({
   ensureWidgetSecret: (...a: unknown[]) => ensureWidgetSecret(...a),
   updateWidgetConfig: (...a: unknown[]) => updateWidgetConfig(...a),
 }))
-vi.mock('../settings.helpers', () => ({
-  requireSettings: () => requireSettings(),
-  parseWidgetConfig: (raw: string) => JSON.parse(raw),
-}))
 
 import {
   WIDGET_INSTALL_CODE_MAX_USES,
@@ -26,7 +21,6 @@ import {
   consumeWidgetInstallCode,
   generateWidgetInstallCode,
   hashWidgetInstallCode,
-  isHttpsRequest,
   mintWidgetInstallCode,
   redeemWidgetInstallCode,
   widgetInstallPairingKey,
@@ -36,7 +30,6 @@ beforeEach(() => {
   vi.clearAllMocks()
   ensureWidgetSecret.mockResolvedValue('wgt_mintedsecret')
   updateWidgetConfig.mockResolvedValue({ enabled: true })
-  requireSettings.mockResolvedValue({ widgetConfig: JSON.stringify({ enabled: false }) })
   dbExecute.mockResolvedValue([{ remaining: 1 }])
 })
 
@@ -63,9 +56,7 @@ describe('mintWidgetInstallCode', () => {
   it('ensures a secret exists and stores a hashed TTL record with two uses', async () => {
     const minted = await mintWidgetInstallCode()
     expect(ensureWidgetSecret).toHaveBeenCalledTimes(1)
-    expect(minted.code.startsWith(WIDGET_INSTALL_CODE_PREFIX)).toBe(true)
-    expect(minted.expiresInSeconds).toBe(WIDGET_INSTALL_CODE_TTL_SECONDS)
-    expect(minted.redeemUrl).toBe('https://feedback.example.com/api/widget/install-context')
+    expect(minted).toEqual({ code: expect.stringMatching(/^qbi_/) })
     expect(kvSet).toHaveBeenCalledWith(
       widgetInstallPairingKey(hashWidgetInstallCode(minted.code)),
       { remaining: WIDGET_INSTALL_CODE_MAX_USES },
@@ -97,46 +88,10 @@ describe('redeemWidgetInstallCode', () => {
     expect(updateWidgetConfig).toHaveBeenCalledWith({ enabled: true })
   })
 
-  it('does not re-enable when the widget is already on', async () => {
-    requireSettings.mockResolvedValue({ widgetConfig: JSON.stringify({ enabled: true }) })
-    await expect(redeemWidgetInstallCode('qbi_ok')).resolves.toMatchObject({
-      signingSecret: 'wgt_mintedsecret',
-    })
-    expect(updateWidgetConfig).not.toHaveBeenCalled()
-  })
-
   it('returns null without enabling when the code is spent or expired', async () => {
     dbExecute.mockResolvedValue([])
     await expect(redeemWidgetInstallCode('qbi_spent')).resolves.toBeNull()
     expect(ensureWidgetSecret).not.toHaveBeenCalled()
     expect(updateWidgetConfig).not.toHaveBeenCalled()
-  })
-})
-
-describe('isHttpsRequest', () => {
-  it('trusts the first forwarded proto', () => {
-    expect(
-      isHttpsRequest(
-        new Request('http://internal/api/widget/install-context', {
-          headers: { 'x-forwarded-proto': 'https, http' },
-        })
-      )
-    ).toBe(true)
-    expect(
-      isHttpsRequest(
-        new Request('http://internal/api/widget/install-context', {
-          headers: { 'x-forwarded-proto': 'http' },
-        })
-      )
-    ).toBe(false)
-  })
-
-  it('falls back to the request URL', () => {
-    expect(
-      isHttpsRequest(new Request('https://feedback.example.com/api/widget/install-context'))
-    ).toBe(true)
-    expect(isHttpsRequest(new Request('http://127.0.0.1:3020/api/widget/install-context'))).toBe(
-      false
-    )
   })
 })

--- a/apps/web/src/lib/server/domains/settings/__tests__/widget-install-pairing.test.ts
+++ b/apps/web/src/lib/server/domains/settings/__tests__/widget-install-pairing.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const kvSet = vi.fn()
+const dbExecute = vi.fn()
+const ensureWidgetSecret = vi.fn()
+const updateWidgetConfig = vi.fn()
+const requireSettings = vi.fn()
+const getBaseUrl = vi.fn(() => 'https://feedback.example.com/')
+
+vi.mock('@/lib/server/kv/pg-kv', () => ({ kvSet: (...a: unknown[]) => kvSet(...a) }))
+vi.mock('@/lib/server/db', () => ({ db: { execute: (...a: unknown[]) => dbExecute(...a) } }))
+vi.mock('@/lib/server/config', () => ({ getBaseUrl: () => getBaseUrl() }))
+vi.mock('../settings.widget', () => ({
+  ensureWidgetSecret: (...a: unknown[]) => ensureWidgetSecret(...a),
+  updateWidgetConfig: (...a: unknown[]) => updateWidgetConfig(...a),
+}))
+vi.mock('../settings.helpers', () => ({
+  requireSettings: () => requireSettings(),
+  parseWidgetConfig: (raw: string) => JSON.parse(raw),
+}))
+
+import {
+  WIDGET_INSTALL_CODE_MAX_USES,
+  WIDGET_INSTALL_CODE_PREFIX,
+  WIDGET_INSTALL_CODE_TTL_SECONDS,
+  consumeWidgetInstallCode,
+  generateWidgetInstallCode,
+  hashWidgetInstallCode,
+  isHttpsRequest,
+  mintWidgetInstallCode,
+  redeemWidgetInstallCode,
+  widgetInstallPairingKey,
+} from '../widget-install-pairing'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  ensureWidgetSecret.mockResolvedValue('wgt_mintedsecret')
+  updateWidgetConfig.mockResolvedValue({ enabled: true })
+  requireSettings.mockResolvedValue({ widgetConfig: JSON.stringify({ enabled: false }) })
+  dbExecute.mockResolvedValue([{ remaining: 1 }])
+})
+
+describe('generateWidgetInstallCode', () => {
+  it('is a short opaque qbi_ code', () => {
+    const code = generateWidgetInstallCode()
+    expect(code.startsWith(WIDGET_INSTALL_CODE_PREFIX)).toBe(true)
+    expect(code.length).toBeGreaterThan(12)
+    expect(code).not.toContain('wgt_')
+    expect(generateWidgetInstallCode()).not.toBe(code)
+  })
+})
+
+describe('hashWidgetInstallCode', () => {
+  it('is a stable sha256 hex of the trimmed code', () => {
+    const hash = hashWidgetInstallCode(' qbi_abc ')
+    expect(hash).toMatch(/^[a-f0-9]{64}$/)
+    expect(hashWidgetInstallCode('qbi_abc')).toBe(hash)
+    expect(hashWidgetInstallCode('qbi_other')).not.toBe(hash)
+  })
+})
+
+describe('mintWidgetInstallCode', () => {
+  it('ensures a secret exists and stores a hashed TTL record with two uses', async () => {
+    const minted = await mintWidgetInstallCode()
+    expect(ensureWidgetSecret).toHaveBeenCalledTimes(1)
+    expect(minted.code.startsWith(WIDGET_INSTALL_CODE_PREFIX)).toBe(true)
+    expect(minted.expiresInSeconds).toBe(WIDGET_INSTALL_CODE_TTL_SECONDS)
+    expect(minted.redeemUrl).toBe('https://feedback.example.com/api/widget/install-context')
+    expect(kvSet).toHaveBeenCalledWith(
+      widgetInstallPairingKey(hashWidgetInstallCode(minted.code)),
+      { remaining: WIDGET_INSTALL_CODE_MAX_USES },
+      WIDGET_INSTALL_CODE_TTL_SECONDS
+    )
+  })
+})
+
+describe('consumeWidgetInstallCode', () => {
+  it('returns true when the statement consumes a live use', async () => {
+    dbExecute.mockResolvedValue([{ remaining: 1 }])
+    await expect(consumeWidgetInstallCode('qbi_live')).resolves.toBe(true)
+  })
+
+  it('returns false for expiry or reuse (no row)', async () => {
+    dbExecute.mockResolvedValue([])
+    await expect(consumeWidgetInstallCode('qbi_dead')).resolves.toBe(false)
+  })
+})
+
+describe('redeemWidgetInstallCode', () => {
+  it('returns instance URL, sdk URL, and signing secret and enables the widget', async () => {
+    const result = await redeemWidgetInstallCode('qbi_ok')
+    expect(result).toEqual({
+      instanceUrl: 'https://feedback.example.com',
+      sdkUrl: 'https://feedback.example.com/api/widget/sdk.js',
+      signingSecret: 'wgt_mintedsecret',
+    })
+    expect(updateWidgetConfig).toHaveBeenCalledWith({ enabled: true })
+  })
+
+  it('does not re-enable when the widget is already on', async () => {
+    requireSettings.mockResolvedValue({ widgetConfig: JSON.stringify({ enabled: true }) })
+    await expect(redeemWidgetInstallCode('qbi_ok')).resolves.toMatchObject({
+      signingSecret: 'wgt_mintedsecret',
+    })
+    expect(updateWidgetConfig).not.toHaveBeenCalled()
+  })
+
+  it('returns null without enabling when the code is spent or expired', async () => {
+    dbExecute.mockResolvedValue([])
+    await expect(redeemWidgetInstallCode('qbi_spent')).resolves.toBeNull()
+    expect(ensureWidgetSecret).not.toHaveBeenCalled()
+    expect(updateWidgetConfig).not.toHaveBeenCalled()
+  })
+})
+
+describe('isHttpsRequest', () => {
+  it('trusts the first forwarded proto', () => {
+    expect(
+      isHttpsRequest(
+        new Request('http://internal/api/widget/install-context', {
+          headers: { 'x-forwarded-proto': 'https, http' },
+        })
+      )
+    ).toBe(true)
+    expect(
+      isHttpsRequest(
+        new Request('http://internal/api/widget/install-context', {
+          headers: { 'x-forwarded-proto': 'http' },
+        })
+      )
+    ).toBe(false)
+  })
+
+  it('falls back to the request URL', () => {
+    expect(
+      isHttpsRequest(new Request('https://feedback.example.com/api/widget/install-context'))
+    ).toBe(true)
+    expect(isHttpsRequest(new Request('http://127.0.0.1:3020/api/widget/install-context'))).toBe(
+      false
+    )
+  })
+})

--- a/apps/web/src/lib/server/domains/settings/widget-install-pairing.ts
+++ b/apps/web/src/lib/server/domains/settings/widget-install-pairing.ts
@@ -14,14 +14,11 @@ import { getExecuteRows } from '@/lib/server/utils/execute-rows'
 import { currentWorkspaceNamespace } from '@/lib/server/workspaces/workspace-keyed'
 import { getBaseUrl } from '@/lib/server/config'
 import { CURRENT_WIDGET_SDK_VERSION, widgetSdkNeedsUpdate } from '@/lib/shared/widget/sdk-version'
+import { trimTrailingSlash } from '@/lib/shared/widget/install-prompt'
+import { toIsoStringOrNull } from '@/lib/shared/utils/date'
 import { logger } from '@/lib/server/logger'
 import { ensureWidgetSecret, updateWidgetConfig } from './settings.widget'
-import {
-  parseWidgetConfig,
-  requireSettings,
-  requireSettingsCached,
-  wrapDbError,
-} from './settings.helpers'
+import { parseWidgetConfig, requireSettingsCached, wrapDbError } from './settings.helpers'
 
 const log = logger.child({ component: 'widget-install-pairing' })
 
@@ -41,29 +38,7 @@ export function widgetInstallPairingKey(hash: string): string {
   return `widget:install-pairing:${hash}`
 }
 
-export function trimInstanceUrl(url: string): string {
-  return url.replace(/\/+$/, '')
-}
-
-export function widgetInstallContextUrl(instanceUrl: string): string {
-  return `${trimInstanceUrl(instanceUrl)}/api/widget/install-context`
-}
-
-export function isHttpsRequest(request: Request): boolean {
-  const forwarded = request.headers.get('x-forwarded-proto')
-  if (forwarded) return forwarded.split(',')[0]?.trim() === 'https'
-  try {
-    return new URL(request.url).protocol === 'https:'
-  } catch {
-    return false
-  }
-}
-
-export async function mintWidgetInstallCode(): Promise<{
-  code: string
-  expiresInSeconds: number
-  redeemUrl: string
-}> {
+export async function mintWidgetInstallCode(): Promise<{ code: string }> {
   await ensureWidgetSecret()
   const code = generateWidgetInstallCode()
   await kvSet(
@@ -71,12 +46,7 @@ export async function mintWidgetInstallCode(): Promise<{
     { remaining: WIDGET_INSTALL_CODE_MAX_USES },
     WIDGET_INSTALL_CODE_TTL_SECONDS
   )
-  const instanceUrl = trimInstanceUrl(getBaseUrl())
-  return {
-    code,
-    expiresInSeconds: WIDGET_INSTALL_CODE_TTL_SECONDS,
-    redeemUrl: widgetInstallContextUrl(instanceUrl),
-  }
+  return { code }
 }
 
 /** Decrement remaining uses. True iff this caller consumed a live use. */
@@ -109,13 +79,9 @@ export async function redeemWidgetInstallCode(code: string): Promise<WidgetInsta
   if (!consumed) return null
 
   const signingSecret = await ensureWidgetSecret()
-  const org = await requireSettings()
-  const previous = parseWidgetConfig(org.widgetConfig)
-  if (!previous.enabled) {
-    await updateWidgetConfig({ enabled: true })
-  }
+  await updateWidgetConfig({ enabled: true })
 
-  const instanceUrl = trimInstanceUrl(getBaseUrl())
+  const instanceUrl = trimTrailingSlash(getBaseUrl())
   return {
     instanceUrl,
     sdkUrl: `${instanceUrl}/api/widget/sdk.js`,
@@ -133,12 +99,6 @@ export interface WidgetInstallStatus {
   sdkNeedsUpdate: boolean
 }
 
-function toIso(value: Date | string | null | undefined): string | null {
-  if (!value) return null
-  if (value instanceof Date) return value.toISOString()
-  return String(value)
-}
-
 /** Read-only install evidence for MCP / admin — never includes the HMAC. */
 export async function getWidgetInstallStatus(): Promise<WidgetInstallStatus> {
   try {
@@ -148,7 +108,7 @@ export async function getWidgetInstallStatus(): Promise<WidgetInstallStatus> {
     return {
       connected,
       enabled: config.enabled === true,
-      lastDetectedAt: toIso(org.widgetInstalledLastSeenAt),
+      lastDetectedAt: toIsoStringOrNull(org.widgetInstalledLastSeenAt),
       originHost: org.widgetInstalledOriginHost ?? null,
       sdkVersion: org.widgetInstalledSdkVersion ?? null,
       currentSdkVersion: CURRENT_WIDGET_SDK_VERSION,

--- a/apps/web/src/lib/server/domains/settings/widget-install-pairing.ts
+++ b/apps/web/src/lib/server/domains/settings/widget-install-pairing.ts
@@ -1,0 +1,163 @@
+/**
+ * Short-lived pairing codes for agent-first widget install.
+ *
+ * The copied install prompt carries a code, not the HMAC signing secret.
+ * The host-app coding agent redeems it over HTTP and writes the secret to
+ * a server-only host env var. Codes are hashed in kv_store, TTL ~15 minutes,
+ * two uses so a single retry works.
+ */
+import { createHash, randomBytes } from 'crypto'
+import { sql } from 'drizzle-orm'
+import { db } from '@/lib/server/db'
+import { kvSet } from '@/lib/server/kv/pg-kv'
+import { getExecuteRows } from '@/lib/server/utils/execute-rows'
+import { currentWorkspaceNamespace } from '@/lib/server/workspaces/workspace-keyed'
+import { getBaseUrl } from '@/lib/server/config'
+import { CURRENT_WIDGET_SDK_VERSION, widgetSdkNeedsUpdate } from '@/lib/shared/widget/sdk-version'
+import { logger } from '@/lib/server/logger'
+import { ensureWidgetSecret, updateWidgetConfig } from './settings.widget'
+import {
+  parseWidgetConfig,
+  requireSettings,
+  requireSettingsCached,
+  wrapDbError,
+} from './settings.helpers'
+
+const log = logger.child({ component: 'widget-install-pairing' })
+
+export const WIDGET_INSTALL_CODE_TTL_SECONDS = 15 * 60
+export const WIDGET_INSTALL_CODE_MAX_USES = 2
+export const WIDGET_INSTALL_CODE_PREFIX = 'qbi_'
+
+export function generateWidgetInstallCode(): string {
+  return `${WIDGET_INSTALL_CODE_PREFIX}${randomBytes(12).toString('base64url')}`
+}
+
+export function hashWidgetInstallCode(code: string): string {
+  return createHash('sha256').update(code.trim(), 'utf8').digest('hex')
+}
+
+export function widgetInstallPairingKey(hash: string): string {
+  return `widget:install-pairing:${hash}`
+}
+
+export function trimInstanceUrl(url: string): string {
+  return url.replace(/\/+$/, '')
+}
+
+export function widgetInstallContextUrl(instanceUrl: string): string {
+  return `${trimInstanceUrl(instanceUrl)}/api/widget/install-context`
+}
+
+export function isHttpsRequest(request: Request): boolean {
+  const forwarded = request.headers.get('x-forwarded-proto')
+  if (forwarded) return forwarded.split(',')[0]?.trim() === 'https'
+  try {
+    return new URL(request.url).protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+export async function mintWidgetInstallCode(): Promise<{
+  code: string
+  expiresInSeconds: number
+  redeemUrl: string
+}> {
+  await ensureWidgetSecret()
+  const code = generateWidgetInstallCode()
+  await kvSet(
+    widgetInstallPairingKey(hashWidgetInstallCode(code)),
+    { remaining: WIDGET_INSTALL_CODE_MAX_USES },
+    WIDGET_INSTALL_CODE_TTL_SECONDS
+  )
+  const instanceUrl = trimInstanceUrl(getBaseUrl())
+  return {
+    code,
+    expiresInSeconds: WIDGET_INSTALL_CODE_TTL_SECONDS,
+    redeemUrl: widgetInstallContextUrl(instanceUrl),
+  }
+}
+
+/** Decrement remaining uses. True iff this caller consumed a live use. */
+export async function consumeWidgetInstallCode(code: string): Promise<boolean> {
+  const key = widgetInstallPairingKey(hashWidgetInstallCode(code))
+  const result = await db.execute(sql`
+    UPDATE kv_store
+    SET value = jsonb_set(value, '{remaining}', to_jsonb((value->>'remaining')::int - 1))
+    WHERE workspace_key = ${currentWorkspaceNamespace()}
+      AND key = ${key}
+      AND expires_at > now()
+      AND COALESCE((value->>'remaining')::int, 0) > 0
+    RETURNING (value->>'remaining')::int AS remaining
+  `)
+  return getExecuteRows(result).length > 0
+}
+
+export interface WidgetInstallContext {
+  instanceUrl: string
+  sdkUrl: string
+  signingSecret: string
+}
+
+/**
+ * Redeem a pairing code: consume it, return the signing secret once, and turn
+ * on Show on your website so the agent path does not need a second admin click.
+ */
+export async function redeemWidgetInstallCode(code: string): Promise<WidgetInstallContext | null> {
+  const consumed = await consumeWidgetInstallCode(code)
+  if (!consumed) return null
+
+  const signingSecret = await ensureWidgetSecret()
+  const org = await requireSettings()
+  const previous = parseWidgetConfig(org.widgetConfig)
+  if (!previous.enabled) {
+    await updateWidgetConfig({ enabled: true })
+  }
+
+  const instanceUrl = trimInstanceUrl(getBaseUrl())
+  return {
+    instanceUrl,
+    sdkUrl: `${instanceUrl}/api/widget/sdk.js`,
+    signingSecret,
+  }
+}
+
+export interface WidgetInstallStatus {
+  connected: boolean
+  enabled: boolean
+  lastDetectedAt: string | null
+  originHost: string | null
+  sdkVersion: string | null
+  currentSdkVersion: string
+  sdkNeedsUpdate: boolean
+}
+
+function toIso(value: Date | string | null | undefined): string | null {
+  if (!value) return null
+  if (value instanceof Date) return value.toISOString()
+  return String(value)
+}
+
+/** Read-only install evidence for MCP / admin — never includes the HMAC. */
+export async function getWidgetInstallStatus(): Promise<WidgetInstallStatus> {
+  try {
+    const org = await requireSettingsCached()
+    const config = parseWidgetConfig(org.widgetConfig)
+    const connected = Boolean(org.widgetInstalledFirstSeenAt)
+    return {
+      connected,
+      enabled: config.enabled === true,
+      lastDetectedAt: toIso(org.widgetInstalledLastSeenAt),
+      originHost: org.widgetInstalledOriginHost ?? null,
+      sdkVersion: org.widgetInstalledSdkVersion ?? null,
+      currentSdkVersion: CURRENT_WIDGET_SDK_VERSION,
+      sdkNeedsUpdate:
+        connected &&
+        widgetSdkNeedsUpdate(org.widgetInstalledSdkVersion, CURRENT_WIDGET_SDK_VERSION),
+    }
+  } catch (error) {
+    log.error({ err: error }, 'get widget install status failed')
+    wrapDbError('fetch widget install status', error)
+  }
+}

--- a/apps/web/src/lib/server/functions/settings.ts
+++ b/apps/web/src/lib/server/functions/settings.ts
@@ -900,6 +900,14 @@ export const regenerateWidgetSecretFn = createServerFn({ method: 'POST' }).handl
   return await regenerateWidgetSecret()
 })
 
+export const mintWidgetInstallCodeFn = createServerFn({ method: 'POST' }).handler(async () => {
+  log.info('mint widget install pairing code')
+  await requireAuth({ permission: PERMISSIONS.SETTINGS_MANAGE })
+  const { mintWidgetInstallCode } =
+    await import('@/lib/server/domains/settings/widget-install-pairing')
+  return await mintWidgetInstallCode()
+})
+
 // ============================================
 // Office Hours Operations
 // ============================================

--- a/apps/web/src/lib/server/mcp/__tests__/handler.test.ts
+++ b/apps/web/src/lib/server/mcp/__tests__/handler.test.ts
@@ -680,7 +680,8 @@ describe('MCP HTTP Handler', () => {
       expect(toolNames).toContain('add_ticket_note')
       expect(toolNames).toContain('link_ticket')
       expect(toolNames).toContain('unlink_ticket')
-      expect(toolNames).toHaveLength(38)
+      expect(toolNames).toContain('widget_install_status')
+      expect(toolNames).toHaveLength(39)
     })
 
     it('should handle resources/list request', async () => {

--- a/apps/web/src/lib/server/mcp/required-scope.ts
+++ b/apps/web/src/lib/server/mcp/required-scope.ts
@@ -43,6 +43,7 @@ export const TOOL_SCOPES: Readonly<Record<string, McpScope>> = {
   add_ticket_note: 'write:chat',
   link_ticket: 'write:chat',
   unlink_ticket: 'write:chat',
+  widget_install_status: 'read:feedback',
 }
 
 export const RESOURCE_SCOPES: Readonly<Record<string, McpScope>> = {

--- a/apps/web/src/lib/server/mcp/tools/__tests__/widget.test.ts
+++ b/apps/web/src/lib/server/mcp/tools/__tests__/widget.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+
+const mockStatus = vi.fn()
+vi.mock('@/lib/server/domains/settings/widget-install-pairing', () => ({
+  getWidgetInstallStatus: (...a: unknown[]) => mockStatus(...a),
+}))
+
+import { registerWidgetTools } from '../widget'
+import type { McpAuthContext } from '../../types'
+
+type Handler = (args: Record<string, unknown>) => Promise<CallToolResult>
+
+function collect(auth: McpAuthContext): Map<string, Handler> {
+  const handlers = new Map<string, Handler>()
+  const fakeServer = {
+    tool: (name: string, _d: string, _s: unknown, _a: unknown, handler: Handler) => {
+      handlers.set(name, handler)
+    },
+  }
+  registerWidgetTools(fakeServer as never, auth)
+  return handlers
+}
+
+const teamAuth = {
+  principalId: 'principal_key',
+  userId: 'user_1',
+  name: 'Agent',
+  email: 'agent@acme.com',
+  role: 'admin' as const,
+  authMethod: 'api-key' as const,
+  scopes: ['read:feedback'],
+} as unknown as McpAuthContext
+
+const parse = (r: CallToolResult) => JSON.parse((r.content[0] as { text: string }).text)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockStatus.mockResolvedValue({
+    connected: true,
+    enabled: true,
+    lastDetectedAt: '2026-09-11T10:00:00.000Z',
+    originHost: 'app.example.com',
+    sdkVersion: '0.1.6',
+    currentSdkVersion: '0.1.6',
+    sdkNeedsUpdate: false,
+  })
+})
+
+describe('widget MCP tools', () => {
+  it('registers widget_install_status', () => {
+    expect([...collect(teamAuth).keys()]).toEqual(['widget_install_status'])
+  })
+
+  it('returns connection evidence and never a signing secret', async () => {
+    const out = await collect(teamAuth).get('widget_install_status')!({})
+    const body = parse(out)
+    expect(body.connected).toBe(true)
+    expect(body.enabled).toBe(true)
+    expect(body.originHost).toBe('app.example.com')
+    expect(JSON.stringify(body)).not.toContain('wgt_')
+    expect(JSON.stringify(body)).not.toMatch(/secret/i)
+  })
+
+  it('is team-only', async () => {
+    const portal = { ...teamAuth, role: 'user' } as unknown as McpAuthContext
+    const out = await collect(portal).get('widget_install_status')!({})
+    expect(out.isError).toBe(true)
+    expect(mockStatus).not.toHaveBeenCalled()
+  })
+
+  it('requires read:feedback', async () => {
+    const noScope = { ...teamAuth, scopes: [] } as unknown as McpAuthContext
+    const out = await collect(noScope).get('widget_install_status')!({})
+    expect(out.isError).toBe(true)
+    expect(mockStatus).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/lib/server/mcp/tools/index.ts
+++ b/apps/web/src/lib/server/mcp/tools/index.ts
@@ -22,6 +22,7 @@
  * - tickets.ts       list_tickets, get_ticket, create_ticket,
  *                    reply_to_ticket, add_ticket_note, link_ticket,
  *                    unlink_ticket
+ * - widget.ts        widget_install_status
  */
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
@@ -34,6 +35,7 @@ import { registerSuggestionTools } from './suggestions'
 import { registerHelpCenterTools } from './help-center'
 import { registerConversationTools } from './conversations'
 import { registerTicketTools } from './tickets'
+import { registerWidgetTools } from './widget'
 
 export function registerTools(server: McpServer, auth: McpAuthContext) {
   registerSearchTools(server, auth)
@@ -44,4 +46,5 @@ export function registerTools(server: McpServer, auth: McpAuthContext) {
   registerHelpCenterTools(server, auth)
   registerConversationTools(server, auth)
   registerTicketTools(server, auth)
+  registerWidgetTools(server, auth)
 }

--- a/apps/web/src/lib/server/mcp/tools/widget.ts
+++ b/apps/web/src/lib/server/mcp/tools/widget.ts
@@ -1,0 +1,28 @@
+/**
+ * Team-only widget install status. Read-only evidence that the snippet is
+ * connected — not first-connect, not the HMAC signing secret.
+ */
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { McpAuthContext } from '../types'
+import { registerTool, jsonResult, READ_ONLY } from './helpers'
+
+export function registerWidgetTools(server: McpServer, auth: McpAuthContext) {
+  registerTool<Record<string, never>>(server, auth, {
+    name: 'widget_install_status',
+    description: `Read whether the Quackback widget is connected on the customer site.
+
+Returns connected (snippet seen), enabled (Show on your website), last detected time, origin host, and SDK version. Does not return the signing secret. Use after install to prove the launcher loaded — same idea as verifying identity via search, not by fetching credentials.
+
+Examples:
+- widget_install_status()`,
+    schema: {},
+    annotations: READ_ONLY,
+    scope: 'read:feedback',
+    teamOnly: true,
+    handler: async () => {
+      const { getWidgetInstallStatus } =
+        await import('@/lib/server/domains/settings/widget-install-pairing')
+      return jsonResult(await getWidgetInstallStatus())
+    },
+  })
+}

--- a/apps/web/src/lib/server/policy/authz-matrix/MATRIX.md
+++ b/apps/web/src/lib/server/policy/authz-matrix/MATRIX.md
@@ -100,7 +100,7 @@ Profiles: **Owner** = admin class + an admin-owned full API key (scoped keys hol
 
 ## 2. Surfaces and their enforced authorization
 
-### Server functions (`requireAuth`) — 682 surfaces
+### Server functions (`requireAuth`) — 683 surfaces
 
 | Surface | Enforces |
 | --- | --- |
@@ -588,6 +588,7 @@ Profiles: **Owner** = admin class + an admin-owned full API key (scoped keys hol
 | `lib/server/functions/settings.ts`::saveWidgetHeroImageKeyFn | settings.manage |
 | `lib/server/functions/settings.ts`::deleteWidgetHeroImageFn | settings.manage |
 | `lib/server/functions/settings.ts`::regenerateWidgetSecretFn | settings.manage |
+| `lib/server/functions/settings.ts`::mintWidgetInstallCodeFn | settings.manage |
 | `lib/server/functions/settings.ts`::fetchOfficeHoursFn | office_hours.manage |
 | `lib/server/functions/settings.ts`::fetchConversationRoutingFn | settings.manage |
 | `lib/server/functions/settings.ts`::updateConversationRoutingFn | settings.manage |
@@ -938,7 +939,7 @@ Profiles: **Owner** = admin class + an admin-owned full API key (scoped keys hol
 
 ## 3. MCP tools
 
-38 tools. "Team" = requires an admin/member role in addition to the scope.
+39 tools. "Team" = requires an admin/member role in addition to the scope.
 
 | Tool | Scope(s) | Team |
 | --- | --- | :---: |
@@ -980,6 +981,7 @@ Profiles: **Owner** = admin class + an admin-owned full API key (scoped keys hol
 | update_changelog | write:changelog | ✓ |
 | update_comment | write:feedback | · |
 | vote_post | write:feedback | · |
+| widget_install_status | read:feedback | ✓ |
 
 ### MCP scope holdings by class
 
@@ -993,7 +995,7 @@ Key scopes are enforced: an API key holds exactly its stored scopes (owner permi
 
 ## 4. Entry points without a requireAuth/key gate
 
-195 of 989 entry points hold no `requireAuth` / `withApiKeyAuth` / `requireTeamAuth` gate.
+196 of 991 entry points hold no `requireAuth` / `withApiKeyAuth` / `requireTeamAuth` gate.
 Each is expected to be intentionally public, a pre-auth flow, a signature-verified webhook, or a handler that delegates auth (e.g. the MCP route).
 **Adding a row here is an access-control change** — confirm the new entry point is meant to be reachable without a gate.
 
@@ -1174,6 +1176,7 @@ Each is expected to be intentionally public, a pre-auth flow, a signature-verifi
 | `routes/api/widget/config[.]json.ts`::GET | route |
 | `routes/api/widget/device.ts`::POST | route |
 | `routes/api/widget/identify.ts`::POST | route |
+| `routes/api/widget/install-context.ts`::POST | route |
 | `routes/api/widget/kb-ask.ts`::GET | route |
 | `routes/api/widget/kb-ask.ts`::POST | route |
 | `routes/api/widget/kb-search.ts`::GET | route |

--- a/apps/web/src/lib/server/policy/authz-matrix/__tests__/scan.test.ts
+++ b/apps/web/src/lib/server/policy/authz-matrix/__tests__/scan.test.ts
@@ -265,9 +265,9 @@ describe('scanMcpTools — tool authorization extraction', () => {
 })
 
 describe('scanAllMcpTools — live tool modules', () => {
-  it('finds all 38 tools across the tool modules, each with at least one scope', () => {
+  it('finds all 39 tools across the tool modules, each with at least one scope', () => {
     const tools = scanAllMcpTools(SRC_ROOT)
-    expect(tools).toHaveLength(38)
+    expect(tools).toHaveLength(39)
     expect(tools.filter((t) => t.scopes.length === 0)).toEqual([])
   })
 })

--- a/apps/web/src/lib/shared/launch-checklist.ts
+++ b/apps/web/src/lib/shared/launch-checklist.ts
@@ -234,7 +234,7 @@ export function buildLaunchTasks(
     title: 'Connect Messenger',
     description: status.hasWidgetInstalled
       ? `Messenger was found on ${status.widgetOriginHost ?? 'your site'}.`
-      : 'Add the SDK to your website to connect it.',
+      : 'Copy a prompt for your agent to add it to your site.',
     completed:
       status.hasWidgetInstalled === true &&
       status.hasWidgetEnabled === true &&

--- a/apps/web/src/lib/shared/widget/__tests__/install-prompt.test.ts
+++ b/apps/web/src/lib/shared/widget/__tests__/install-prompt.test.ts
@@ -7,69 +7,51 @@ import {
 } from '../install-prompt'
 
 describe('buildWidgetInstallPrompt', () => {
-  it('installs the launcher only by default', () => {
+  it('always includes redeem instructions and never a wgt_ secret', () => {
     const prompt = buildWidgetInstallPrompt({
       instanceUrl: 'https://feedback.example.com/',
-      widgetSecret: 'wgt_abc123secret',
+      pairingCode: 'qbi_testpairingcode',
     })
 
     expect(prompt).toContain('Instance URL: https://feedback.example.com')
     expect(prompt).toContain('https://feedback.example.com/api/widget/sdk.js')
+    expect(prompt).toContain('POST https://feedback.example.com/api/widget/install-context')
+    expect(prompt).toContain('qbi_testpairingcode')
     expect(prompt).toContain(WIDGET_SKILL_RAW)
-    expect(prompt).toContain('Do not ask the user for QUACKBACK_WIDGET_SECRET')
-    expect(prompt).toContain('Do not implement identify')
-    expect(prompt).toContain('Show on your website')
-    expect(prompt).not.toContain('wgt_abc123secret')
-    expect(prompt).not.toContain('Do not skip identify')
-    expect(prompt).not.toContain('No widget secret has been generated yet')
-  })
-
-  it('includes the signing secret and identify steps when identify is on', () => {
-    const prompt = buildWidgetInstallPrompt({
-      instanceUrl: 'https://feedback.example.com/',
-      widgetSecret: 'wgt_abc123secret',
-      identify: true,
-    })
-
-    expect(prompt).toContain('wgt_abc123secret')
-    expect(prompt).toContain('host app server-side secret store')
+    expect(prompt).toContain('do not ask the user for the HMAC signing secret')
+    expect(prompt).toContain('If this app has login')
+    expect(prompt).toContain('signingSecret')
     expect(prompt).toContain('ssoToken')
     expect(prompt).toContain('Once per session')
-    expect(prompt).toContain('Never pass raw id/email from the client')
+    expect(prompt).toContain('Show on your website')
+    expect(prompt).not.toContain('Do not implement identify')
+    expect(prompt).not.toContain('with identify on')
+    expect(prompt).not.toMatch(/wgt_[A-Za-z0-9]/)
     expect(prompt).not.toContain('QUACKBACK_WIDGET_SECRET')
   })
 
-  it('does not invent a placeholder secret when identify is on but the secret is missing', () => {
+  it('does not invent a pairing code when the code is missing', () => {
     const prompt = buildWidgetInstallPrompt({
       instanceUrl: 'https://feedback.example.com',
-      widgetSecret: null,
-      identify: true,
+      pairingCode: null,
     })
 
-    expect(prompt).toContain('Do not invent one')
+    expect(prompt).toContain('Do not invent a code or secret')
+    expect(prompt).toContain('copy the install prompt again')
+    expect(prompt).not.toContain('with identify on')
     expect(prompt).not.toContain('wgt_YOUR_WIDGET_SECRET')
-    expect(prompt).not.toContain('after they regenerate it')
+    expect(prompt).not.toMatch(/wgt_[A-Za-z0-9]/)
   })
 })
 
 describe('buildWidgetInstallSnippet', () => {
-  it('omits identify by default', () => {
+  it('always documents identify primitives without a live secret', () => {
     const snippet = buildWidgetInstallSnippet({
       instanceUrl: 'https://feedback.example.com/',
     })
 
     expect(snippet).toContain('https://feedback.example.com/api/widget/sdk.js')
     expect(snippet).toContain('Quackback("init")')
-    expect(snippet).not.toContain('ssoToken')
-    expect(snippet).not.toContain('QUACKBACK_WIDGET_SECRET')
-  })
-
-  it('documents identify primitives without assuming a host session API', () => {
-    const snippet = buildWidgetInstallSnippet({
-      instanceUrl: 'https://feedback.example.com/',
-      identify: true,
-    })
-
     expect(snippet).toContain('ssoToken')
     expect(snippet).toContain('Quackback("identify", { ssoToken })')
     expect(snippet).toContain('Quackback("logout")')
@@ -80,27 +62,22 @@ describe('buildWidgetInstallSnippet', () => {
     expect(snippet).not.toContain('fetch(')
     expect(snippet).not.toContain('/api/quackback')
     expect(snippet).not.toContain('user.id')
+    expect(snippet).not.toMatch(/wgt_[A-Za-z0-9]/)
   })
 })
 
 describe('maskWidgetSecretInPrompt', () => {
-  it('masks the live secret for the on-screen preview', () => {
+  it('masks a secret if one is still present in the text', () => {
     const secret = 'wgt_abc123secret'
-    const prompt = buildWidgetInstallPrompt({
-      instanceUrl: 'https://feedback.example.com',
-      widgetSecret: secret,
-      identify: true,
-    })
-
-    const masked = maskWidgetSecretInPrompt(prompt, secret)
+    const masked = maskWidgetSecretInPrompt(`secret ${secret} here`, secret)
     expect(masked).not.toContain(secret)
     expect(masked).toContain('wgt_abc1••••••••')
   })
 
-  it('leaves launcher-only prompts unchanged', () => {
+  it('leaves prompts unchanged when no secret is passed', () => {
     const prompt = buildWidgetInstallPrompt({
       instanceUrl: 'https://feedback.example.com',
-      widgetSecret: null,
+      pairingCode: 'qbi_x',
     })
     expect(maskWidgetSecretInPrompt(prompt, null)).toBe(prompt)
   })

--- a/apps/web/src/lib/shared/widget/__tests__/install-prompt.test.ts
+++ b/apps/web/src/lib/shared/widget/__tests__/install-prompt.test.ts
@@ -3,15 +3,11 @@ import {
   WIDGET_SKILL_RAW,
   buildWidgetInstallPrompt,
   buildWidgetInstallSnippet,
-  maskWidgetSecretInPrompt,
 } from '../install-prompt'
 
 describe('buildWidgetInstallPrompt', () => {
   it('always includes redeem instructions and never a wgt_ secret', () => {
-    const prompt = buildWidgetInstallPrompt({
-      instanceUrl: 'https://feedback.example.com/',
-      pairingCode: 'qbi_testpairingcode',
-    })
+    const prompt = buildWidgetInstallPrompt('https://feedback.example.com/', 'qbi_testpairingcode')
 
     expect(prompt).toContain('Instance URL: https://feedback.example.com')
     expect(prompt).toContain('https://feedback.example.com/api/widget/sdk.js')
@@ -22,33 +18,19 @@ describe('buildWidgetInstallPrompt', () => {
     expect(prompt).toContain('If this app has login')
     expect(prompt).toContain('signingSecret')
     expect(prompt).toContain('ssoToken')
-    expect(prompt).toContain('Once per session')
+    expect(prompt).toContain('once per session')
     expect(prompt).toContain('Show on your website')
     expect(prompt).not.toContain('Do not implement identify')
     expect(prompt).not.toContain('with identify on')
     expect(prompt).not.toMatch(/wgt_[A-Za-z0-9]/)
     expect(prompt).not.toContain('QUACKBACK_WIDGET_SECRET')
-  })
-
-  it('does not invent a pairing code when the code is missing', () => {
-    const prompt = buildWidgetInstallPrompt({
-      instanceUrl: 'https://feedback.example.com',
-      pairingCode: null,
-    })
-
-    expect(prompt).toContain('Do not invent a code or secret')
-    expect(prompt).toContain('copy the install prompt again')
-    expect(prompt).not.toContain('with identify on')
-    expect(prompt).not.toContain('wgt_YOUR_WIDGET_SECRET')
-    expect(prompt).not.toMatch(/wgt_[A-Za-z0-9]/)
+    expect(prompt).not.toContain('identify-users.md')
   })
 })
 
 describe('buildWidgetInstallSnippet', () => {
   it('always documents identify primitives without a live secret', () => {
-    const snippet = buildWidgetInstallSnippet({
-      instanceUrl: 'https://feedback.example.com/',
-    })
+    const snippet = buildWidgetInstallSnippet('https://feedback.example.com/')
 
     expect(snippet).toContain('https://feedback.example.com/api/widget/sdk.js')
     expect(snippet).toContain('Quackback("init")')
@@ -63,22 +45,5 @@ describe('buildWidgetInstallSnippet', () => {
     expect(snippet).not.toContain('/api/quackback')
     expect(snippet).not.toContain('user.id')
     expect(snippet).not.toMatch(/wgt_[A-Za-z0-9]/)
-  })
-})
-
-describe('maskWidgetSecretInPrompt', () => {
-  it('masks a secret if one is still present in the text', () => {
-    const secret = 'wgt_abc123secret'
-    const masked = maskWidgetSecretInPrompt(`secret ${secret} here`, secret)
-    expect(masked).not.toContain(secret)
-    expect(masked).toContain('wgt_abc1••••••••')
-  })
-
-  it('leaves prompts unchanged when no secret is passed', () => {
-    const prompt = buildWidgetInstallPrompt({
-      instanceUrl: 'https://feedback.example.com',
-      pairingCode: 'qbi_x',
-    })
-    expect(maskWidgetSecretInPrompt(prompt, null)).toBe(prompt)
   })
 })

--- a/apps/web/src/lib/shared/widget/__tests__/sdk-version.test.ts
+++ b/apps/web/src/lib/shared/widget/__tests__/sdk-version.test.ts
@@ -57,7 +57,7 @@ describe('widgetSdkNeedsUpdate', () => {
 
 describe('copy', () => {
   it('names the connected and update states', () => {
-    expect(widgetConnectedStatusLabel({})).toBe('Not detected yet')
+    expect(widgetConnectedStatusLabel({})).toBe('Not on your site yet')
     expect(widgetConnectedStatusLabel({ hasWidgetInstalled: true })).toBe('Widget connected')
     expect(
       widgetConnectedStatusLabel({ hasWidgetInstalled: true, widgetSdkNeedsUpdate: true })

--- a/apps/web/src/lib/shared/widget/__tests__/widget-origin.test.ts
+++ b/apps/web/src/lib/shared/widget/__tests__/widget-origin.test.ts
@@ -19,7 +19,7 @@ describe('widget origin evidence copy', () => {
 describe('widgetInstallPresence', () => {
   it('stays idle until a request is observed', () => {
     expect(widgetInstallPresence({ connected: false, enabled: true })).toMatchObject({
-      title: 'Not detected yet',
+      title: 'Not on your site yet',
       tone: 'idle',
     })
   })
@@ -32,7 +32,7 @@ describe('widgetInstallPresence', () => {
         originHost: 'docs.example.com',
       })
     ).toEqual({
-      title: 'SDK detected',
+      title: 'On your site, but hidden',
       description:
         'First request came from docs.example.com. Turn on Show on your website so visitors can see it.',
       tone: 'detected',

--- a/apps/web/src/lib/shared/widget/install-prompt.ts
+++ b/apps/web/src/lib/shared/widget/install-prompt.ts
@@ -1,27 +1,15 @@
-export interface WidgetInstallPromptInput {
-  instanceUrl: string
-  /** Pairing code minted on copy. Never embed the raw wgt_ HMAC. */
-  pairingCode?: string | null
-}
-
 export const WIDGET_SKILL_REPO = 'https://github.com/QuackbackIO/skills'
 export const WIDGET_SKILL_RAW =
   'https://raw.githubusercontent.com/QuackbackIO/skills/main/skills/quackback/install-widget/SKILL.md'
-export const WIDGET_IDENTIFY_RAW =
-  'https://raw.githubusercontent.com/QuackbackIO/skills/main/skills/quackback/install-widget/references/identify-users.md'
 
-function trimTrailingSlash(url: string): string {
+export function trimTrailingSlash(url: string): string {
   return url.replace(/\/+$/, '')
 }
 
 /** Short prompt an agent pastes: install the public skill, then use these credentials. */
-export function buildWidgetInstallPrompt(input: WidgetInstallPromptInput): string {
-  const instanceUrl = trimTrailingSlash(input.instanceUrl)
-  const redeemUrl = `${instanceUrl}/api/widget/install-context`
-  const code = input.pairingCode?.trim() || ''
-  const codeLine = code
-    ? `- Pairing code: ${code}`
-    : '- Pairing code: missing. Ask the user to copy the install prompt again from Admin → Settings → Widget → Install. Do not invent a code or secret.'
+export function buildWidgetInstallPrompt(instanceUrl: string, pairingCode: string): string {
+  const base = trimTrailingSlash(instanceUrl)
+  const redeemUrl = `${base}/api/widget/install-context`
 
   return `# Install the Quackback widget
 
@@ -30,30 +18,22 @@ Redeem the pairing code over HTTP — do not ask the user for the HMAC signing s
 The launcher must appear for anonymous visitors after init. If this app already has signed-in users, also identify them with a backend-signed ssoToken. If it does not, leave the signing secret in server-only env and stop after init. Do not invent auth or a placeholder user id.
 
 ## Workspace
-- Instance URL: ${instanceUrl}
-- SDK script: ${instanceUrl}/api/widget/sdk.js
+- Instance URL: ${base}
+- SDK script: ${base}/api/widget/sdk.js
 - Redeem URL: POST ${redeemUrl}
-${codeLine}
+- Pairing code: ${pairingCode.trim()}
 
 ## What to do
 1. Fetch and follow the \`install-widget\` skill:
    - ${WIDGET_SKILL_RAW}
-   - ${WIDGET_IDENTIFY_RAW}
 2. POST JSON \`{ "code": "<pairing code>" }\` to the redeem URL. Write \`signingSecret\` to a **server-only** host env var (any name). Do not commit it, log it, or put it in public env. Redeeming turns on Show on your website.
 3. Add the snippet or npm package and call init so anonymous visitors see the launcher.
-4. If this app has login / a session / a current user: identify signed-in users with a backend-signed ssoToken. If it does not, stop. Leave the secret in env for later.
+4. If this app has login / a session / a current user: identify signed-in users with a backend-signed ssoToken, once per session. If it does not, stop. Leave the secret in env for later.
 5. Open a page with the widget so Admin → Settings → Widget → Install can flip to connected. If the launcher stays hidden, ask the user to turn on Show on your website.
 6. Do not invent APIs.
 
 Repo: ${WIDGET_SKILL_REPO}
-
-## Identify (only if the host already has signed-in users)
-Call identify as soon as you know who the user is: when the app first loads if they are already signed in, and immediately after login or signup. Once per session — not on every navigation. Mint a fresh HS256 JWT at that moment with the host-app signing secret and call \`Quackback("identify", { ssoToken })\`. \`sub\` is a unique stable host user id, not email. Call \`Quackback("logout")\` on logout. Never pass raw id/email from the client.
 `
-}
-
-export interface WidgetInstallSnippetInput {
-  instanceUrl: string
 }
 
 function widgetLoader(instanceUrl: string): string {
@@ -66,8 +46,8 @@ function widgetLoader(instanceUrl: string): string {
 }
 
 /** Script-tag snippet for hand install. Always documents identify. */
-export function buildWidgetInstallSnippet(input: WidgetInstallSnippetInput): string {
-  const loader = widgetLoader(input.instanceUrl)
+export function buildWidgetInstallSnippet(instanceUrl: string): string {
+  const loader = widgetLoader(instanceUrl)
   return `<script>
   // Quackback widget. Init first so anonymous visitors still get the launcher.
   ${loader}
@@ -88,10 +68,4 @@ export function buildWidgetInstallSnippet(input: WidgetInstallSnippetInput): str
   // Quackback("identify", { ssoToken });
   // Quackback("logout");
 </script>`
-}
-
-/** Mask the live secret in the on-screen preview so screenshots do not leak it. */
-export function maskWidgetSecretInPrompt(prompt: string, secret: string | null): string {
-  if (!secret) return prompt
-  return prompt.replaceAll(secret, `${secret.slice(0, 8)}${'•'.repeat(8)}`)
 }

--- a/apps/web/src/lib/shared/widget/install-prompt.ts
+++ b/apps/web/src/lib/shared/widget/install-prompt.ts
@@ -1,8 +1,7 @@
 export interface WidgetInstallPromptInput {
   instanceUrl: string
-  widgetSecret: string | null
-  /** When true, the prompt includes identify steps and the signing secret. */
-  identify?: boolean
+  /** Pairing code minted on copy. Never embed the raw wgt_ HMAC. */
+  pairingCode?: string | null
 }
 
 export const WIDGET_SKILL_REPO = 'https://github.com/QuackbackIO/skills'
@@ -18,66 +17,43 @@ function trimTrailingSlash(url: string): string {
 /** Short prompt an agent pastes: install the public skill, then use these credentials. */
 export function buildWidgetInstallPrompt(input: WidgetInstallPromptInput): string {
   const instanceUrl = trimTrailingSlash(input.instanceUrl)
-  const identify = input.identify === true
-  const secret = identify ? input.widgetSecret : null
-
-  if (!identify) {
-    return `# Install the Quackback widget
-
-Launcher only. Anonymous visitors should see the widget after init.
-
-Do not ask the user for QUACKBACK_WIDGET_SECRET. Do not invent a signing secret. Do not implement identify. Quackback Cloud and self-host do not define a widget secret env var.
-
-## Workspace
-- Instance URL: ${instanceUrl}
-- SDK script: ${instanceUrl}/api/widget/sdk.js
-
-## What to do
-1. Add the snippet or npm package and call init. Use the URL above.
-2. Remind the user to turn on Show on your website in Admin → Settings → Widget → Install.
-3. Stop. If they later want identify, they will copy the signing secret from Admin → Settings → Widget → Install.
-
-Optional skill (launcher steps only): ${WIDGET_SKILL_RAW}
-
-Repo: ${WIDGET_SKILL_REPO}
-`
-  }
-
-  const secretLine = secret
-    ? `- Widget signing secret (host app server only): ${secret}`
-    : '- Widget signing secret: ask the user to copy it from Admin → Settings → Widget → Install. Do not invent one.'
+  const redeemUrl = `${instanceUrl}/api/widget/install-context`
+  const code = input.pairingCode?.trim() || ''
+  const codeLine = code
+    ? `- Pairing code: ${code}`
+    : '- Pairing code: missing. Ask the user to copy the install prompt again from Admin → Settings → Widget → Install. Do not invent a code or secret.'
 
   return `# Install the Quackback widget
 
-${
-  secret
-    ? 'A signing secret is included below. Store it in the host app server-side secret store — not in Quackback Cloud or self-host env. Never ship it to the browser, commit it, or log it.'
-    : 'The user wants identify. Copy the signing secret from Admin → Settings → Widget → Install. Do not invent one.'
-}
+Redeem the pairing code over HTTP — do not ask the user for the HMAC signing secret. Never invent a secret. Never print the signing secret after redeem.
+
+The launcher must appear for anonymous visitors after init. If this app already has signed-in users, also identify them with a backend-signed ssoToken. If it does not, leave the signing secret in server-only env and stop after init. Do not invent auth or a placeholder user id.
 
 ## Workspace
 - Instance URL: ${instanceUrl}
 - SDK script: ${instanceUrl}/api/widget/sdk.js
-${secretLine}
+- Redeem URL: POST ${redeemUrl}
+${codeLine}
 
 ## What to do
 1. Fetch and follow the \`install-widget\` skill:
    - ${WIDGET_SKILL_RAW}
    - ${WIDGET_IDENTIFY_RAW}
-2. Install the launcher, then identify signed-in users with a backend-signed ssoToken.
-3. Use the credentials above. Do not invent APIs.
+2. POST JSON \`{ "code": "<pairing code>" }\` to the redeem URL. Write \`signingSecret\` to a **server-only** host env var (any name). Do not commit it, log it, or put it in public env. Redeeming turns on Show on your website.
+3. Add the snippet or npm package and call init so anonymous visitors see the launcher.
+4. If this app has login / a session / a current user: identify signed-in users with a backend-signed ssoToken. If it does not, stop. Leave the secret in env for later.
+5. Open a page with the widget so Admin → Settings → Widget → Install can flip to connected. If the launcher stays hidden, ask the user to turn on Show on your website.
+6. Do not invent APIs.
 
 Repo: ${WIDGET_SKILL_REPO}
 
-## Identify (signed-in users)
-The widget appears after init for anonymous visitors. Call identify as soon as you know who the user is: when the app first loads if they are already signed in, and immediately after login or signup. Once per session — not on every navigation. Mint a fresh HS256 JWT at that moment with the signing secret from Admin → Settings → Widget → Install and call \`Quackback("identify", { ssoToken })\`. \`sub\` is a unique stable host user id, not email. Call \`Quackback("logout")\` on logout. Never pass raw id/email from the client.
+## Identify (only if the host already has signed-in users)
+Call identify as soon as you know who the user is: when the app first loads if they are already signed in, and immediately after login or signup. Once per session — not on every navigation. Mint a fresh HS256 JWT at that moment with the host-app signing secret and call \`Quackback("identify", { ssoToken })\`. \`sub\` is a unique stable host user id, not email. Call \`Quackback("logout")\` on logout. Never pass raw id/email from the client.
 `
 }
 
 export interface WidgetInstallSnippetInput {
   instanceUrl: string
-  /** When true, the snippet documents identify. Default false. */
-  identify?: boolean
 }
 
 function widgetLoader(instanceUrl: string): string {
@@ -89,17 +65,9 @@ function widgetLoader(instanceUrl: string): string {
     d.head.appendChild(s)})(window,document);`
 }
 
-/** Script-tag snippet for hand install. Launcher-only is the default. */
+/** Script-tag snippet for hand install. Always documents identify. */
 export function buildWidgetInstallSnippet(input: WidgetInstallSnippetInput): string {
   const loader = widgetLoader(input.instanceUrl)
-  if (input.identify !== true) {
-    return `<script>
-  // Quackback: anonymous visitors see the launcher after init.
-  ${loader}
-  Quackback("init");
-</script>`
-  }
-
   return `<script>
   // Quackback widget. Init first so anonymous visitors still get the launcher.
   ${loader}

--- a/apps/web/src/lib/shared/widget/sdk-version.ts
+++ b/apps/web/src/lib/shared/widget/sdk-version.ts
@@ -57,7 +57,7 @@ export function widgetConnectedStatusLabel(opts: {
   hasWidgetInstalled?: boolean
   widgetSdkNeedsUpdate?: boolean
 }): string {
-  if (!opts.hasWidgetInstalled) return 'Not detected yet'
+  if (!opts.hasWidgetInstalled) return 'Not on your site yet'
   if (opts.widgetSdkNeedsUpdate) return 'Widget connected · SDK update available'
   return 'Widget connected'
 }

--- a/apps/web/src/lib/shared/widget/widget-origin.ts
+++ b/apps/web/src/lib/shared/widget/widget-origin.ts
@@ -53,15 +53,15 @@ export function widgetInstallPresence(input: {
 }): WidgetInstallPresence {
   if (!input.connected) {
     return {
-      title: 'Not detected yet',
-      description: 'Paste the SDK to connect it',
+      title: 'Not on your site yet',
+      description: 'Copy a prompt for your agent, then open a page to confirm it loaded.',
       tone: 'idle',
     }
   }
   const origin = widgetOriginVerifiedLabel(input.originHost)
   if (!input.enabled) {
     return {
-      title: 'SDK detected',
+      title: 'On your site, but hidden',
       description: `${origin} Turn on Show on your website so visitors can see it.`,
       tone: 'detected',
     }

--- a/apps/web/src/routes/admin/__tests__/settings.widget-install-page.test.tsx
+++ b/apps/web/src/routes/admin/__tests__/settings.widget-install-page.test.tsx
@@ -2,25 +2,28 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 
-const { onboarding, updateWidgetConfig, mintInstallCode, toast } = vi.hoisted(() => ({
-  onboarding: {
-    useCase: 'product_feedback',
-    hasWidgetInstalled: false,
-    hasWidgetEnabled: false,
-    widgetOriginHost: null as string | null,
-    widgetLastDetectedAt: null as string | null,
-    widgetSdkNeedsUpdate: false,
-  },
-  updateWidgetConfig: {
-    mutateAsync: vi.fn(),
-    isPending: false,
-  },
-  mintInstallCode: {
-    mutateAsync: vi.fn(),
-    isPending: false,
-  },
-  toast: { success: vi.fn(), error: vi.fn() },
-}))
+const { onboarding, updateWidgetConfig, mintInstallCode, toast, copyWithFallback } = vi.hoisted(
+  () => ({
+    onboarding: {
+      useCase: 'product_feedback',
+      hasWidgetInstalled: false,
+      hasWidgetEnabled: false,
+      widgetOriginHost: null as string | null,
+      widgetLastDetectedAt: null as string | null,
+      widgetSdkNeedsUpdate: false,
+    },
+    updateWidgetConfig: {
+      mutateAsync: vi.fn(),
+      isPending: false,
+    },
+    mintInstallCode: {
+      mutateAsync: vi.fn(),
+      isPending: false,
+    },
+    toast: { success: vi.fn(), error: vi.fn() },
+    copyWithFallback: vi.fn(),
+  })
+)
 
 vi.mock('@tanstack/react-router', async () => {
   const actual =
@@ -65,7 +68,7 @@ vi.mock('@/lib/client/mutations/settings', () => ({
 }))
 
 vi.mock('@/components/admin/activation-action-button', () => ({
-  copyWithFallback: vi.fn(),
+  copyWithFallback: (...args: unknown[]) => copyWithFallback(...args),
 }))
 
 vi.mock('sonner', () => ({
@@ -82,9 +85,9 @@ describe('WidgetInstallPage', () => {
     mintInstallCode.mutateAsync.mockReset()
     mintInstallCode.mutateAsync.mockResolvedValue({
       code: 'qbi_pagepairingcode',
-      expiresInSeconds: 900,
-      redeemUrl: 'https://feedback.example.com/api/widget/install-context',
     })
+    copyWithFallback.mockReset()
+    copyWithFallback.mockResolvedValue(undefined)
     toast.success.mockReset()
     toast.error.mockReset()
   })
@@ -134,11 +137,6 @@ describe('WidgetInstallPage', () => {
   })
 
   it('mints a pairing code into the agent prompt and never copies a wgt_ secret', async () => {
-    const writeText = vi.fn().mockResolvedValue(undefined)
-    Object.defineProperty(navigator, 'clipboard', {
-      configurable: true,
-      value: { writeText },
-    })
     const { WidgetInstallPage } = await import('../settings.widget.install')
     render(<WidgetInstallPage />)
 
@@ -148,9 +146,9 @@ describe('WidgetInstallPage', () => {
 
     await waitFor(() => {
       expect(mintInstallCode.mutateAsync).toHaveBeenCalled()
-      expect(writeText).toHaveBeenCalled()
+      expect(copyWithFallback).toHaveBeenCalled()
     })
-    const copied = writeText.mock.calls[0][0] as string
+    const copied = copyWithFallback.mock.calls[0][0] as string
     expect(copied).toContain('qbi_pagepairingcode')
     expect(copied).toContain('/api/widget/install-context')
     expect(copied).toContain('If this app has login')

--- a/apps/web/src/routes/admin/__tests__/settings.widget-install-page.test.tsx
+++ b/apps/web/src/routes/admin/__tests__/settings.widget-install-page.test.tsx
@@ -2,7 +2,7 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 
-const { onboarding, updateWidgetConfig, toast } = vi.hoisted(() => ({
+const { onboarding, updateWidgetConfig, mintInstallCode, toast } = vi.hoisted(() => ({
   onboarding: {
     useCase: 'product_feedback',
     hasWidgetInstalled: false,
@@ -12,6 +12,10 @@ const { onboarding, updateWidgetConfig, toast } = vi.hoisted(() => ({
     widgetSdkNeedsUpdate: false,
   },
   updateWidgetConfig: {
+    mutateAsync: vi.fn(),
+    isPending: false,
+  },
+  mintInstallCode: {
     mutateAsync: vi.fn(),
     isPending: false,
   },
@@ -57,6 +61,7 @@ vi.mock('@/lib/client/mutations/settings', () => ({
     isPending: false,
   }),
   useUpdateWidgetConfig: () => updateWidgetConfig,
+  useMintWidgetInstallCode: () => mintInstallCode,
 }))
 
 vi.mock('@/components/admin/activation-action-button', () => ({
@@ -71,40 +76,48 @@ describe('WidgetInstallPage', () => {
   beforeEach(() => {
     onboarding.hasWidgetInstalled = false
     onboarding.hasWidgetEnabled = false
+    onboarding.widgetOriginHost = null
     updateWidgetConfig.mutateAsync.mockReset()
     updateWidgetConfig.mutateAsync.mockResolvedValue({ enabled: true })
+    mintInstallCode.mutateAsync.mockReset()
+    mintInstallCode.mutateAsync.mockResolvedValue({
+      code: 'qbi_pagepairingcode',
+      expiresInSeconds: 900,
+      redeemUrl: 'https://feedback.example.com/api/widget/install-context',
+    })
     toast.success.mockReset()
     toast.error.mockReset()
   })
 
-  it('defaults to a launcher-only snippet and keeps identify off', async () => {
+  it('shows setup steps and keeps the signing secret out of the numbered flow', async () => {
     const { WidgetInstallPage } = await import('../settings.widget.install')
     render(<WidgetInstallPage />)
 
+    expect(screen.queryByRole('switch', { name: /identify/i })).toBeNull()
+    expect(screen.getByText(/Copy the prompt for your agent/)).toBeInTheDocument()
+    expect(screen.getByText(/Open a page on your site/)).toBeInTheDocument()
+    expect(screen.getByText(/Install without an agent/)).toBeInTheDocument()
+    expect(screen.getByText(/Skip this unless you are installing by hand/)).toBeInTheDocument()
+    expect(screen.queryByText('3. Signing secret')).toBeNull()
     expect(
-      screen.getByRole('switch', { name: 'Add identify steps to the snippet and prompt' })
-    ).not.toBeChecked()
-    expect(screen.getByText(/Add the launcher/)).toBeInTheDocument()
-    expect(screen.getByText(/Identify signed-in users/)).toBeInTheDocument()
-    expect(screen.getByTestId('signing-secret')).toBeInTheDocument()
+      screen.getByRole('button', { name: 'Copy install prompt for your coding agent' })
+    ).toBeInTheDocument()
 
-    const snippet = screen.getByText(/anonymous visitors see the launcher/i).closest('code')
-    expect(snippet?.textContent).toContain('Quackback("init")')
-    expect(snippet?.textContent).not.toContain('ssoToken')
-    expect(snippet?.textContent).not.toContain('QUACKBACK_WIDGET_SECRET')
+    fireEvent.click(screen.getByRole('button', { name: /Signing secret/ }))
+    expect(screen.getByTestId('signing-secret')).toBeInTheDocument()
   })
 
-  it('adds identify comments to the snippet when the switch is on', async () => {
+  it('shows identify comments in the hand-install snippet after opening it', async () => {
     const { WidgetInstallPage } = await import('../settings.widget.install')
     render(<WidgetInstallPage />)
 
-    fireEvent.click(
-      screen.getByRole('switch', { name: 'Add identify steps to the snippet and prompt' })
-    )
+    fireEvent.click(screen.getByRole('button', { name: /Install without an agent/ }))
 
     const snippet = screen.getByText(/Init first so anonymous visitors/i).closest('code')
     expect(snippet?.textContent).toContain('ssoToken')
+    expect(snippet?.textContent).toContain('Quackback("init")')
     expect(snippet?.textContent).not.toContain('QUACKBACK_WIDGET_SECRET')
+    expect(snippet?.textContent).not.toContain('wgt_testsecret')
   })
 
   it('toasts when Show on your website fails to save', async () => {
@@ -120,12 +133,53 @@ describe('WidgetInstallPage', () => {
     expect(screen.getByRole('switch', { name: 'Show on your website' })).not.toBeChecked()
   })
 
-  it('points a detected install at the toggle on this page', async () => {
+  it('mints a pairing code into the agent prompt and never copies a wgt_ secret', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+    const { WidgetInstallPage } = await import('../settings.widget.install')
+    render(<WidgetInstallPage />)
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Copy install prompt for your coding agent' })
+    )
+
+    await waitFor(() => {
+      expect(mintInstallCode.mutateAsync).toHaveBeenCalled()
+      expect(writeText).toHaveBeenCalled()
+    })
+    const copied = writeText.mock.calls[0][0] as string
+    expect(copied).toContain('qbi_pagepairingcode')
+    expect(copied).toContain('/api/widget/install-context')
+    expect(copied).toContain('If this app has login')
+    expect(copied).not.toContain('wgt_testsecret')
+    expect(copied).not.toMatch(/wgt_[A-Za-z0-9]/)
+    expect(copied).not.toContain('Do not implement identify')
+  })
+
+  it('switches to a manage layout once the SDK has been seen', async () => {
+    onboarding.hasWidgetInstalled = true
+    onboarding.hasWidgetEnabled = true
+    onboarding.widgetOriginHost = 'app.example.com'
+    const { WidgetInstallPage } = await import('../settings.widget.install')
+    render(<WidgetInstallPage />)
+
+    expect(screen.getByText('Widget on your site')).toBeInTheDocument()
+    expect(screen.getByText('Status')).toBeInTheDocument()
+    expect(screen.getByText('Add to another site')).toBeInTheDocument()
+    expect(screen.getByText(/Widget connection verified/)).toBeInTheDocument()
+    expect(screen.queryByText('1. Copy the prompt for your agent')).toBeNull()
+    expect(screen.getByTestId('signing-secret')).toBeInTheDocument()
+  })
+
+  it('points a detected install at the visibility toggle', async () => {
     onboarding.hasWidgetInstalled = true
     const { WidgetInstallPage } = await import('../settings.widget.install')
     render(<WidgetInstallPage />)
 
-    expect(screen.getByText(/Turn on Show on your website above/)).toBeInTheDocument()
+    expect(screen.getByText(/Turn on Show on your website so visitors/)).toBeInTheDocument()
     expect(screen.queryByRole('link', { name: 'Widget settings' })).toBeNull()
   })
 })

--- a/apps/web/src/routes/admin/settings.widget.install.tsx
+++ b/apps/web/src/routes/admin/settings.widget.install.tsx
@@ -73,19 +73,12 @@ export function WidgetInstallPage() {
   })
   const installed = presence.tone !== 'idle'
   const [copyingSnippet, setCopyingSnippet] = useState(false)
-  const snippet = useMemo(
-    () => buildWidgetInstallSnippet({ instanceUrl: baseUrl ?? '' }),
-    [baseUrl]
-  )
+  const snippet = useMemo(() => buildWidgetInstallSnippet(baseUrl ?? ''), [baseUrl])
 
   async function agentPrompt(): Promise<string> {
-    const instanceUrl = baseUrl ?? ''
     try {
       const minted = await mintInstallCode.mutateAsync()
-      return buildWidgetInstallPrompt({
-        instanceUrl,
-        pairingCode: minted.code,
-      })
+      return buildWidgetInstallPrompt(baseUrl ?? '', minted.code)
     } catch {
       toast.error('Could not copy the install prompt. Try again.')
       return ''

--- a/apps/web/src/routes/admin/settings.widget.install.tsx
+++ b/apps/web/src/routes/admin/settings.widget.install.tsx
@@ -12,6 +12,7 @@ import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
+import { CollapsibleSection } from '@/components/ui/collapsible'
 import { PageHeader } from '@/components/shared/page-header'
 import { WarningBox } from '@/components/shared/warning-box'
 import { SettingsCard } from '@/components/admin/settings/settings-card'
@@ -31,7 +32,7 @@ import {
 } from '@/lib/shared/widget/sdk-version'
 import { settingsQueries } from '@/lib/client/queries/settings'
 import { adminQueries } from '@/lib/client/queries/admin'
-import { useUpdateWidgetConfig } from '@/lib/client/mutations/settings'
+import { useMintWidgetInstallCode, useUpdateWidgetConfig } from '@/lib/client/mutations/settings'
 import { PERMISSIONS } from '@/lib/shared/permissions'
 import { assertRoutePermission } from '@/lib/shared/route-permission'
 
@@ -52,6 +53,7 @@ export function WidgetInstallPage() {
   const secretQuery = useSuspenseQuery(settingsQueries.widgetSecret())
   const widgetConfigQuery = useSuspenseQuery(settingsQueries.widgetConfig())
   const updateWidgetConfig = useUpdateWidgetConfig()
+  const mintInstallCode = useMintWidgetInstallCode()
   const [enabled, setEnabled] = useState(Boolean(widgetConfigQuery.data.enabled))
   const statusQuery = useQuery({
     ...adminQueries.onboardingStatus(),
@@ -69,25 +71,26 @@ export function WidgetInstallPage() {
     enabled: Boolean(status.hasWidgetEnabled),
     originHost: status.widgetOriginHost,
   })
+  const installed = presence.tone !== 'idle'
   const [copyingSnippet, setCopyingSnippet] = useState(false)
-  const [identifyUsers, setIdentifyUsers] = useState(false)
   const snippet = useMemo(
-    () =>
-      buildWidgetInstallSnippet({
-        instanceUrl: baseUrl ?? '',
-        identify: identifyUsers,
-      }),
-    [baseUrl, identifyUsers]
+    () => buildWidgetInstallSnippet({ instanceUrl: baseUrl ?? '' }),
+    [baseUrl]
   )
-  const agentPrompt = useMemo(
-    () =>
-      buildWidgetInstallPrompt({
-        instanceUrl: baseUrl ?? '',
-        widgetSecret: secretQuery.data,
-        identify: identifyUsers,
-      }),
-    [baseUrl, secretQuery.data, identifyUsers]
-  )
+
+  async function agentPrompt(): Promise<string> {
+    const instanceUrl = baseUrl ?? ''
+    try {
+      const minted = await mintInstallCode.mutateAsync()
+      return buildWidgetInstallPrompt({
+        instanceUrl,
+        pairingCode: minted.code,
+      })
+    } catch {
+      toast.error('Could not copy the install prompt. Try again.')
+      return ''
+    }
+  }
 
   async function copySnippet() {
     setCopyingSnippet(true)
@@ -101,6 +104,119 @@ export function WidgetInstallPage() {
     }
   }
 
+  const visibilityToggle = (
+    <div className="flex items-center justify-between gap-4 rounded-lg border border-border/50 p-4">
+      <div className="min-w-0">
+        <Label htmlFor="show-on-website" className="cursor-pointer text-sm font-medium">
+          Show on your website
+        </Label>
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          When this is off, visitors won&apos;t see the launcher.
+        </p>
+      </div>
+      <Switch
+        id="show-on-website"
+        checked={enabled}
+        disabled={updateWidgetConfig.isPending}
+        onCheckedChange={(checked) => {
+          const previous = enabled
+          setEnabled(checked)
+          void updateWidgetConfig
+            .mutateAsync({ enabled: checked })
+            .then(() => {
+              toast.success(
+                checked ? 'Widget is visible on your site' : 'Widget hidden from visitors'
+              )
+            })
+            .catch(() => {
+              setEnabled(previous)
+              toast.error('Could not update widget visibility')
+            })
+        }}
+        aria-label="Show on your website"
+      />
+    </div>
+  )
+
+  const agentCta = (
+    <>
+      <CopyAgentPromptButton getPrompt={agentPrompt} disabled={mintInstallCode.isPending} />
+      <p className="mt-3 text-xs text-muted-foreground">
+        The agent installs the widget and turns it on. You never paste the signing secret.{' '}
+        <a
+          href={WIDGET_SKILL_REPO}
+          target="_blank"
+          rel="noreferrer"
+          className="underline underline-offset-2"
+        >
+          What the agent does
+        </a>
+      </p>
+    </>
+  )
+
+  const handInstall = (
+    <CollapsibleSection
+      title="Install without an agent"
+      description="Copy the snippet, or add the npm package."
+    >
+      <pre className="max-h-72 overflow-auto rounded-lg bg-zinc-950 p-4 text-xs text-zinc-100">
+        <code>{snippet}</code>
+      </pre>
+      <div className="mt-4 flex flex-wrap items-center gap-2">
+        <Button onClick={() => void copySnippet()} disabled={copyingSnippet}>
+          <ClipboardDocumentIcon className="h-4 w-4" />
+          {copyingSnippet ? 'Copying…' : 'Copy snippet'}
+        </Button>
+      </div>
+      <p className="mt-3 text-xs text-muted-foreground">
+        Or add <code className="rounded bg-muted px-1 py-0.5">@quackback/widget</code> and call{' '}
+        <code className="rounded bg-muted px-1 py-0.5">Quackback.init</code> with this instance URL.
+      </p>
+    </CollapsibleSection>
+  )
+
+  const secretBlock = secretQuery.data ? (
+    <WidgetSigningSecret secret={secretQuery.data} />
+  ) : (
+    <p className="text-sm text-muted-foreground">
+      Couldn&apos;t load the signing secret. Refresh this page.
+    </p>
+  )
+
+  const connectionBody =
+    presence.tone === 'live' && status.widgetSdkNeedsUpdate ? (
+      <div className="space-y-2">
+        <WarningBox
+          variant="warning"
+          title={widgetConnectedStatusLabel({
+            hasWidgetInstalled: true,
+            widgetSdkNeedsUpdate: true,
+          })}
+          description="Copy a fresh prompt so your site picks up the latest widget."
+        />
+        <WidgetLastDetected at={status.widgetLastDetectedAt} />
+      </div>
+    ) : presence.tone === 'live' ? (
+      <div className="space-y-0.5">
+        <p className="flex items-center gap-2 text-sm text-emerald-600 dark:text-emerald-400">
+          <CheckCircleIcon className="h-5 w-5" /> Widget connection verified
+        </p>
+        <WidgetLastDetected at={status.widgetLastDetectedAt} />
+      </div>
+    ) : presence.tone === 'detected' ? (
+      <div className="space-y-2">
+        <p className="text-sm text-muted-foreground">
+          The widget is installed but hidden. Turn on Show on your website so visitors can see it.
+        </p>
+        <WidgetLastDetected at={status.widgetLastDetectedAt} />
+      </div>
+    ) : (
+      <p className="flex items-center gap-2 text-sm text-muted-foreground">
+        <ArrowPathIcon className="h-4 w-4 animate-spin" /> Waiting for the widget to load…
+      </p>
+    )
+
   return (
     <div className="mx-auto max-w-3xl space-y-6 pb-12">
       <Button asChild variant="ghost" size="sm">
@@ -111,144 +227,89 @@ export function WidgetInstallPage() {
       </Button>
       <PageHeader
         icon={CodeBracketIcon}
-        title={mode === 'messenger' ? 'Add Messenger to your site' : 'Install feedback widget'}
-        description="Get the launcher on your site. Identifying signed-in users is optional."
+        title={
+          installed
+            ? mode === 'messenger'
+              ? 'Messenger on your site'
+              : 'Widget on your site'
+            : mode === 'messenger'
+              ? 'Add Messenger to your site'
+              : 'Add the widget to your site'
+        }
+        description={
+          installed
+            ? 'Change who can see it, or copy a new prompt for another site.'
+            : 'Paste a prompt into the coding agent in your app. Then open a page to confirm it loaded.'
+        }
       />
 
-      <SettingsCard
-        title="1. Add the launcher"
-        description="Paste this before the closing body tag. Visitors see the launcher only when Show on your website is on. No secret needed."
-      >
-        <div className="mb-4 flex items-center justify-between gap-4 rounded-lg border border-border/50 p-4">
-          <div className="min-w-0">
-            <Label htmlFor="show-on-website" className="cursor-pointer text-sm font-medium">
-              Show on your website
-            </Label>
-            <p className="mt-0.5 text-xs text-muted-foreground">
-              Visitors cannot see the launcher until this is on, even after you paste the snippet.
-            </p>
-          </div>
-          <Switch
-            id="show-on-website"
-            checked={enabled}
-            disabled={updateWidgetConfig.isPending}
-            onCheckedChange={(checked) => {
-              const previous = enabled
-              setEnabled(checked)
-              void updateWidgetConfig
-                .mutateAsync({ enabled: checked })
-                .then(() => {
-                  toast.success(
-                    checked ? 'Widget is visible on your site' : 'Widget hidden from visitors'
+      {installed ? (
+        <>
+          <SettingsCard
+            title="Status"
+            description={
+              status.widgetSdkNeedsUpdate
+                ? widgetSdkUpdateDescription(
+                    status.widgetSdkVersion,
+                    status.currentWidgetSdkVersion
                   )
-                })
-                .catch(() => {
-                  setEnabled(previous)
-                  toast.error('Could not update widget visibility')
-                })
-            }}
-            aria-label="Show on your website"
-          />
-        </div>
-        <pre className="max-h-72 overflow-auto rounded-lg bg-zinc-950 p-4 text-xs text-zinc-100">
-          <code>{snippet}</code>
-        </pre>
-        <div className="mt-4 flex flex-wrap items-center gap-2">
-          <Button onClick={() => void copySnippet()} disabled={copyingSnippet}>
-            <ClipboardDocumentIcon className="h-4 w-4" />
-            {copyingSnippet ? 'Copying…' : 'Copy snippet'}
-          </Button>
-          <CopyAgentPromptButton prompt={agentPrompt} />
-        </div>
-        <p className="mt-3 text-xs text-muted-foreground">
-          If an agent asks for QUACKBACK_WIDGET_SECRET, that is the signing secret in step 2 — and
-          you do not need it for the launcher.
-          {identifyUsers
-            ? ' The prompt includes your signing secret; paste it into a local agent only.'
-            : ' The agent prompt is launcher-only until you turn identify on below.'}{' '}
-          <a
-            href={WIDGET_SKILL_REPO}
-            target="_blank"
-            rel="noreferrer"
-            className="underline underline-offset-2"
+                : widgetOriginVerifiedLabel(status.widgetOriginHost)
+            }
           >
-            install-widget skill
-          </a>
-        </p>
-      </SettingsCard>
+            <div className="space-y-4">
+              {connectionBody}
+              {visibilityToggle}
+            </div>
+          </SettingsCard>
 
-      <SettingsCard
-        title="2. Identify signed-in users (optional)"
-        description="Skip this to get the launcher up. Use it later so votes, chats, and posts attach to a person. Your server signs a short-lived token; the browser never sees this secret."
-      >
-        {secretQuery.data ? (
-          <WidgetSigningSecret secret={secretQuery.data} />
-        ) : (
-          <p className="text-sm text-muted-foreground">
-            Couldn&apos;t load the signing secret. Refresh this page.
-          </p>
-        )}
-        <div className="mt-4 flex items-center justify-between gap-4 rounded-lg border border-border/50 p-4">
-          <div className="min-w-0">
-            <Label htmlFor="identify-users" className="cursor-pointer text-sm font-medium">
-              Add identify steps to the snippet and prompt
-            </Label>
-            <p className="mt-0.5 text-xs text-muted-foreground">
-              Adds the identify comments and, for the agent prompt, the signing secret.
-            </p>
-          </div>
-          <Switch
-            id="identify-users"
-            checked={identifyUsers}
-            onCheckedChange={setIdentifyUsers}
-            aria-label="Add identify steps to the snippet and prompt"
-          />
-        </div>
-      </SettingsCard>
+          <SettingsCard
+            title="Add to another site"
+            description="Or copy a fresh prompt to update the widget."
+          >
+            {agentCta}
+          </SettingsCard>
 
-      <SettingsCard
-        title="Connection"
-        description={
-          presence.tone === 'idle'
-            ? 'Open a page that includes the snippet. Localhost counts. This updates when we see a request.'
-            : status.widgetSdkNeedsUpdate
-              ? widgetSdkUpdateDescription(status.widgetSdkVersion, status.currentWidgetSdkVersion)
-              : widgetOriginVerifiedLabel(status.widgetOriginHost)
-        }
-      >
-        {presence.tone === 'live' && status.widgetSdkNeedsUpdate ? (
-          <div className="space-y-2">
-            <WarningBox
-              variant="warning"
-              title={widgetConnectedStatusLabel({
-                hasWidgetInstalled: true,
-                widgetSdkNeedsUpdate: true,
-              })}
-              description="Reinstall with the snippet above so the launcher picks up current features."
-            />
-            <WidgetLastDetected at={status.widgetLastDetectedAt} />
-          </div>
-        ) : presence.tone === 'live' ? (
-          <div className="space-y-0.5">
-            <p className="flex items-center gap-2 text-sm text-emerald-600 dark:text-emerald-400">
-              <CheckCircleIcon className="h-5 w-5" /> Widget connection verified
-            </p>
-            <WidgetLastDetected at={status.widgetLastDetectedAt} />
-          </div>
-        ) : presence.tone === 'detected' ? (
-          <div className="space-y-2">
-            <p className="text-sm text-muted-foreground">
-              The SDK is installed. Turn on Show on your website above so visitors can see it.
-            </p>
-            <WidgetLastDetected at={status.widgetLastDetectedAt} />
-          </div>
-        ) : (
-          <p className="flex items-center gap-2 text-sm text-muted-foreground">
-            <ArrowPathIcon className="h-4 w-4 animate-spin" /> Waiting for a page load with the
-            snippet…
-          </p>
-        )}
-      </SettingsCard>
+          <SettingsCard
+            title="Signing secret"
+            description="Only if you install by hand or need to rotate it."
+          >
+            {secretBlock}
+          </SettingsCard>
+
+          <SettingsCard contentClassName="p-0 sm:p-0">{handInstall}</SettingsCard>
+        </>
+      ) : (
+        <>
+          <SettingsCard
+            title="1. Copy the prompt for your agent"
+            description="Paste it into the coding agent in your app."
+          >
+            {agentCta}
+          </SettingsCard>
+
+          <SettingsCard
+            title="2. Open a page on your site"
+            description="After the agent finishes. Localhost is fine."
+          >
+            <div className="space-y-4">
+              {connectionBody}
+              {visibilityToggle}
+            </div>
+          </SettingsCard>
+
+          <SettingsCard contentClassName="p-0 sm:p-0">
+            {handInstall}
+            <div className="border-t border-border/50">
+              <CollapsibleSection
+                title="Signing secret"
+                description="Skip this unless you are installing by hand."
+              >
+                {secretBlock}
+              </CollapsibleSection>
+            </div>
+          </SettingsCard>
+        </>
+      )}
     </div>
   )
 }

--- a/apps/web/src/routes/admin/settings.widget.tsx
+++ b/apps/web/src/routes/admin/settings.widget.tsx
@@ -292,7 +292,9 @@ function WidgetSiteCard({
             <Label htmlFor="widget-toggle" className="text-xs font-medium cursor-pointer">
               Show on your website
             </Label>
-            <p className="text-xs text-muted-foreground">Visible on pages that include the SDK</p>
+            <p className="text-xs text-muted-foreground">
+              Visitors see the launcher on pages you added it to
+            </p>
           </div>
           <div className="flex items-center gap-2">
             <InlineSpinner visible={saving || isPending} />
@@ -328,7 +330,7 @@ function WidgetSiteCard({
               className="shrink-0"
             >
               <Link to="/admin/settings/widget/install">
-                {presence.tone === 'idle' ? 'Install widget' : 'View installation'}
+                {presence.tone === 'idle' ? 'Set it up' : 'View installation'}
                 <ArrowRightIcon className="h-3.5 w-3.5" />
               </Link>
             </Button>
@@ -336,8 +338,8 @@ function WidgetSiteCard({
           <p className="text-xs text-muted-foreground mt-0.5">{statusDescription}</p>
           {presence.tone === 'idle' && (
             <p className="text-xs text-muted-foreground mt-1">
-              The preview on this page is admin-only. Customers see the widget after you paste the
-              snippet.
+              The launcher on this page is only a preview. Visitors see it after you add it to your
+              site.
             </p>
           )}
           {status.hasWidgetInstalled && <WidgetLastDetected at={status.widgetLastDetectedAt} />}

--- a/apps/web/src/routes/api/widget/__tests__/install-context.test.ts
+++ b/apps/web/src/routes/api/widget/__tests__/install-context.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const redeemWidgetInstallCode = vi.fn()
+const checkRateLimit = vi.fn()
+const pooled = { current: false }
+
+vi.mock('@/lib/server/domains/settings/widget-install-pairing', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/lib/server/domains/settings/widget-install-pairing')>()
+  return {
+    ...actual,
+    redeemWidgetInstallCode: (...a: unknown[]) => redeemWidgetInstallCode(...a),
+  }
+})
+vi.mock('@/lib/server/auth/widget-rate-limit', () => ({
+  checkWidgetInstallContextRateLimit: (...a: unknown[]) => checkRateLimit(...a),
+}))
+vi.mock('@/lib/server/workspaces/mode', () => ({
+  isPooledTenancy: () => pooled.current,
+}))
+vi.mock('@/lib/server/logger', () => ({
+  logger: { child: () => ({ info: vi.fn(), error: vi.fn(), debug: vi.fn() }) },
+}))
+
+import { handleWidgetInstallContext } from '../install-context'
+
+function post(body: unknown, url = 'http://127.0.0.1:3020/api/widget/install-context') {
+  return new Request(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-forwarded-for': '203.0.113.9' },
+    body: JSON.stringify(body),
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  pooled.current = false
+  checkRateLimit.mockResolvedValue({ allowed: true })
+  redeemWidgetInstallCode.mockResolvedValue({
+    instanceUrl: 'https://feedback.example.com',
+    sdkUrl: 'https://feedback.example.com/api/widget/sdk.js',
+    signingSecret: 'wgt_fromredeem',
+  })
+})
+
+describe('POST /api/widget/install-context', () => {
+  it('returns instance URL, sdk URL, and signing secret on a valid code', async () => {
+    const res = await handleWidgetInstallContext(post({ code: 'qbi_validcode12' }))
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({
+      instanceUrl: 'https://feedback.example.com',
+      sdkUrl: 'https://feedback.example.com/api/widget/sdk.js',
+      signingSecret: 'wgt_fromredeem',
+    })
+    expect(redeemWidgetInstallCode).toHaveBeenCalledWith('qbi_validcode12')
+  })
+
+  it('rejects an unknown or spent code', async () => {
+    redeemWidgetInstallCode.mockResolvedValue(null)
+    const res = await handleWidgetInstallContext(post({ code: 'qbi_unknowncode' }))
+    expect(res.status).toBe(404)
+    await expect(res.json()).resolves.toMatchObject({ error: { code: 'CODE_INVALID' } })
+  })
+
+  it('rate-limits by IP', async () => {
+    checkRateLimit.mockResolvedValue({ allowed: false, retryAfter: 42 })
+    const res = await handleWidgetInstallContext(post({ code: 'qbi_validcode12' }))
+    expect(res.status).toBe(429)
+    expect(redeemWidgetInstallCode).not.toHaveBeenCalled()
+  })
+
+  it('requires HTTPS on Cloud (pooled tenancy)', async () => {
+    pooled.current = true
+    const res = await handleWidgetInstallContext(post({ code: 'qbi_validcode12' }))
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toMatchObject({ error: { code: 'HTTPS_REQUIRED' } })
+    expect(redeemWidgetInstallCode).not.toHaveBeenCalled()
+  })
+
+  it('allows HTTPS Cloud redeem', async () => {
+    pooled.current = true
+    const res = await handleWidgetInstallContext(
+      new Request('https://acme.quackback.app/api/widget/install-context', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-forwarded-proto': 'https',
+          'x-forwarded-for': '203.0.113.9',
+        },
+        body: JSON.stringify({ code: 'qbi_validcode12' }),
+      })
+    )
+    expect(res.status).toBe(200)
+  })
+})

--- a/apps/web/src/routes/api/widget/__tests__/install-context.test.ts
+++ b/apps/web/src/routes/api/widget/__tests__/install-context.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const redeemWidgetInstallCode = vi.fn()
-const checkRateLimit = vi.fn()
+const enforcePerIpLimit = vi.fn()
 const pooled = { current: false }
 
 vi.mock('@/lib/server/domains/settings/widget-install-pairing', async (importOriginal) => {
@@ -12,9 +12,13 @@ vi.mock('@/lib/server/domains/settings/widget-install-pairing', async (importOri
     redeemWidgetInstallCode: (...a: unknown[]) => redeemWidgetInstallCode(...a),
   }
 })
-vi.mock('@/lib/server/auth/widget-rate-limit', () => ({
-  checkWidgetInstallContextRateLimit: (...a: unknown[]) => checkRateLimit(...a),
-}))
+vi.mock('@/lib/server/widget/public-endpoint', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/server/widget/public-endpoint')>()
+  return {
+    ...actual,
+    enforcePerIpLimit: (...a: unknown[]) => enforcePerIpLimit(...a),
+  }
+})
 vi.mock('@/lib/server/workspaces/mode', () => ({
   isPooledTenancy: () => pooled.current,
 }))
@@ -23,11 +27,20 @@ vi.mock('@/lib/server/logger', () => ({
 }))
 
 import { handleWidgetInstallContext } from '../install-context'
+import { widgetJsonError } from '@/lib/server/widget/public-endpoint'
 
-function post(body: unknown, url = 'http://127.0.0.1:3020/api/widget/install-context') {
+function post(
+  body: unknown,
+  url = 'http://127.0.0.1:3020/api/widget/install-context',
+  extraHeaders: Record<string, string> = {}
+) {
   return new Request(url, {
     method: 'POST',
-    headers: { 'content-type': 'application/json', 'x-forwarded-for': '203.0.113.9' },
+    headers: {
+      'content-type': 'application/json',
+      'x-forwarded-for': '203.0.113.9',
+      ...extraHeaders,
+    },
     body: JSON.stringify(body),
   })
 }
@@ -35,7 +48,7 @@ function post(body: unknown, url = 'http://127.0.0.1:3020/api/widget/install-con
 beforeEach(() => {
   vi.clearAllMocks()
   pooled.current = false
-  checkRateLimit.mockResolvedValue({ allowed: true })
+  enforcePerIpLimit.mockResolvedValue(null)
   redeemWidgetInstallCode.mockResolvedValue({
     instanceUrl: 'https://feedback.example.com',
     sdkUrl: 'https://feedback.example.com/api/widget/sdk.js',
@@ -53,6 +66,14 @@ describe('POST /api/widget/install-context', () => {
       signingSecret: 'wgt_fromredeem',
     })
     expect(redeemWidgetInstallCode).toHaveBeenCalledWith('qbi_validcode12')
+    expect(enforcePerIpLimit).toHaveBeenCalledWith(
+      expect.any(Request),
+      expect.objectContaining({
+        keyPrefix: 'widget:install-context',
+        limit: 20,
+        windowSeconds: 15 * 60,
+      })
+    )
   })
 
   it('rejects an unknown or spent code', async () => {
@@ -63,7 +84,9 @@ describe('POST /api/widget/install-context', () => {
   })
 
   it('rate-limits by IP', async () => {
-    checkRateLimit.mockResolvedValue({ allowed: false, retryAfter: 42 })
+    enforcePerIpLimit.mockResolvedValue(
+      widgetJsonError(429, 'RATE_LIMITED', 'Too many install attempts, try again later')
+    )
     const res = await handleWidgetInstallContext(post({ code: 'qbi_validcode12' }))
     expect(res.status).toBe(429)
     expect(redeemWidgetInstallCode).not.toHaveBeenCalled()
@@ -80,14 +103,18 @@ describe('POST /api/widget/install-context', () => {
   it('allows HTTPS Cloud redeem', async () => {
     pooled.current = true
     const res = await handleWidgetInstallContext(
-      new Request('https://acme.quackback.app/api/widget/install-context', {
-        method: 'POST',
-        headers: {
-          'content-type': 'application/json',
-          'x-forwarded-proto': 'https',
-          'x-forwarded-for': '203.0.113.9',
-        },
-        body: JSON.stringify({ code: 'qbi_validcode12' }),
+      post({ code: 'qbi_validcode12' }, 'https://acme.quackback.app/api/widget/install-context', {
+        'x-forwarded-proto': 'https',
+      })
+    )
+    expect(res.status).toBe(200)
+  })
+
+  it('trusts the first forwarded proto on Cloud', async () => {
+    pooled.current = true
+    const res = await handleWidgetInstallContext(
+      post({ code: 'qbi_validcode12' }, 'http://internal/api/widget/install-context', {
+        'x-forwarded-proto': 'https, http',
       })
     )
     expect(res.status).toBe(200)

--- a/apps/web/src/routes/api/widget/install-context.ts
+++ b/apps/web/src/routes/api/widget/install-context.ts
@@ -1,0 +1,56 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { z } from 'zod'
+import { getClientIp } from '@/lib/server/domains/api/rate-limit'
+import { checkWidgetInstallContextRateLimit } from '@/lib/server/auth/widget-rate-limit'
+import { isPooledTenancy } from '@/lib/server/workspaces/mode'
+import {
+  isHttpsRequest,
+  redeemWidgetInstallCode,
+} from '@/lib/server/domains/settings/widget-install-pairing'
+import { widgetCorsHeaders, widgetJsonError } from '@/lib/server/widget/public-endpoint'
+import { logger } from '@/lib/server/logger'
+
+const log = logger.child({ component: 'widget-install-context' })
+
+const bodySchema = z.object({
+  code: z.string().trim().min(8).max(80),
+})
+
+export async function handleWidgetInstallContext(request: Request): Promise<Response> {
+  if (isPooledTenancy() && !isHttpsRequest(request)) {
+    return widgetJsonError(400, 'HTTPS_REQUIRED', 'Redeem pairing codes over HTTPS')
+  }
+
+  const rl = await checkWidgetInstallContextRateLimit(getClientIp(request)).catch(() => ({
+    allowed: true as const,
+  }))
+  if (!rl.allowed) {
+    return widgetJsonError(429, 'RATE_LIMITED', 'Too many install attempts, try again later', {
+      'Retry-After': String(rl.retryAfter ?? 60),
+    })
+  }
+
+  let code: string
+  try {
+    const raw = await request.json()
+    code = bodySchema.parse(raw).code
+  } catch {
+    return widgetJsonError(400, 'VALIDATION_ERROR', 'Invalid request body')
+  }
+
+  const context = await redeemWidgetInstallCode(code)
+  if (!context) {
+    return widgetJsonError(404, 'CODE_INVALID', 'Invalid or expired install code')
+  }
+
+  log.info('widget install pairing redeemed')
+  return Response.json(context, { headers: widgetCorsHeaders() })
+}
+
+export const Route = createFileRoute('/api/widget/install-context')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => handleWidgetInstallContext(request),
+    },
+  },
+})

--- a/apps/web/src/routes/api/widget/install-context.ts
+++ b/apps/web/src/routes/api/widget/install-context.ts
@@ -1,13 +1,12 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { z } from 'zod'
-import { getClientIp } from '@/lib/server/domains/api/rate-limit'
-import { checkWidgetInstallContextRateLimit } from '@/lib/server/auth/widget-rate-limit'
 import { isPooledTenancy } from '@/lib/server/workspaces/mode'
+import { redeemWidgetInstallCode } from '@/lib/server/domains/settings/widget-install-pairing'
 import {
-  isHttpsRequest,
-  redeemWidgetInstallCode,
-} from '@/lib/server/domains/settings/widget-install-pairing'
-import { widgetCorsHeaders, widgetJsonError } from '@/lib/server/widget/public-endpoint'
+  enforcePerIpLimit,
+  widgetCorsHeaders,
+  widgetJsonError,
+} from '@/lib/server/widget/public-endpoint'
 import { logger } from '@/lib/server/logger'
 
 const log = logger.child({ component: 'widget-install-context' })
@@ -16,19 +15,24 @@ const bodySchema = z.object({
   code: z.string().trim().min(8).max(80),
 })
 
+function isHttpsRequest(request: Request): boolean {
+  const forwarded = request.headers.get('x-forwarded-proto')
+  if (forwarded) return forwarded.split(',')[0]?.trim() === 'https'
+  return new URL(request.url).protocol === 'https:'
+}
+
 export async function handleWidgetInstallContext(request: Request): Promise<Response> {
   if (isPooledTenancy() && !isHttpsRequest(request)) {
     return widgetJsonError(400, 'HTTPS_REQUIRED', 'Redeem pairing codes over HTTPS')
   }
 
-  const rl = await checkWidgetInstallContextRateLimit(getClientIp(request)).catch(() => ({
-    allowed: true as const,
-  }))
-  if (!rl.allowed) {
-    return widgetJsonError(429, 'RATE_LIMITED', 'Too many install attempts, try again later', {
-      'Retry-After': String(rl.retryAfter ?? 60),
-    })
-  }
+  const limited = await enforcePerIpLimit(request, {
+    keyPrefix: 'widget:install-context',
+    limit: 20,
+    windowSeconds: 15 * 60,
+    message: 'Too many install attempts, try again later',
+  })
+  if (limited) return limited
 
   let code: string
   try {

--- a/packages/widget/__tests__/launcher.test.ts
+++ b/packages/widget/__tests__/launcher.test.ts
@@ -190,3 +190,35 @@ describe('launcher setPlacement', () => {
     expect(bubble.style.right).toBe('')
   })
 })
+
+describe('launcher contained in a root', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    try {
+      sessionStorage.clear()
+    } catch {
+      /* ignore */
+    }
+  })
+
+  it('positions absolutely inside the root instead of the viewport', () => {
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    const l = createLauncher({ placement: 'right', root, onClick: () => {} })
+    expect(l.el.parentElement).toBe(root)
+    expect(l.el.style.position).toBe('absolute')
+    expect(l.el.style.right).toBe('0px')
+    expect(l.el.style.bottom).toBe('0px')
+  })
+
+  it('does not write the host-page greeting dismiss key', () => {
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    const l = createLauncher({ placement: 'right', root, onClick: () => {} })
+    l.setGreeting('Hi')
+    const bubble = root.querySelector('div') as HTMLElement
+    ;(bubble.lastElementChild as HTMLElement).click()
+    expect(bubble.style.display).toBe('none')
+    expect(sessionStorage.getItem('quackback:launcher-greeting-dismissed')).toBeNull()
+  })
+})

--- a/packages/widget/src/core/launcher.ts
+++ b/packages/widget/src/core/launcher.ts
@@ -1,6 +1,12 @@
 export interface LauncherOptions {
   placement: 'left' | 'right'
   onClick: () => void
+  /**
+   * Mount the button (and greeting) inside this element with absolute
+   * positioning. Used by the admin live preview so the real launcher sits in
+   * the fake page instead of `position: fixed` on the viewport.
+   */
+  root?: HTMLElement
 }
 
 export interface LauncherHandle {
@@ -46,10 +52,15 @@ export function createLauncher(opts: LauncherOptions): LauncherHandle {
   // Visible button label — when set, it doubles as the accessible name.
   let labelText = ''
   // Proactive greeting bubble state. Dismissal persists per browser session so
-  // the bubble invites once without nagging on every page.
+  // the bubble invites once without nagging on every page. A contained preview
+  // must not write that key — it would hide the bubble for a later host visit.
   let greetingText: string | null = null
+  let localDismissed = false
+  const contained = Boolean(opts.root)
+  const edge = contained ? '0px' : '24px'
   const GREETING_DISMISS_KEY = 'quackback:launcher-greeting-dismissed'
   const greetingDismissed = (): boolean => {
+    if (contained) return localDismissed
     try {
       return sessionStorage.getItem(GREETING_DISMISS_KEY) === '1'
     } catch {
@@ -59,9 +70,9 @@ export function createLauncher(opts: LauncherOptions): LauncherHandle {
 
   const btn = document.createElement('button')
   Object.assign(btn.style, {
-    position: 'fixed',
-    bottom: '24px',
-    [opts.placement === 'left' ? 'left' : 'right']: '24px',
+    position: contained ? 'absolute' : 'fixed',
+    bottom: contained ? '0px' : '24px',
+    [opts.placement === 'left' ? 'left' : 'right']: edge,
     zIndex: '2147483647',
     display: 'flex',
     alignItems: 'center',
@@ -171,9 +182,9 @@ export function createLauncher(opts: LauncherOptions): LauncherHandle {
   const side = opts.placement === 'left' ? 'left' : 'right'
   const bubble = document.createElement('div')
   Object.assign(bubble.style, {
-    position: 'fixed',
+    position: contained ? 'absolute' : 'fixed',
     bottom: '84px',
-    [side]: '24px',
+    [side]: edge,
     zIndex: '2147483646',
     display: 'none',
     alignItems: 'center',
@@ -213,17 +224,22 @@ export function createLauncher(opts: LauncherOptions): LauncherHandle {
     bubble.style.display = show ? 'flex' : 'none'
   }
   bubbleClose.addEventListener('click', () => {
-    try {
-      sessionStorage.setItem(GREETING_DISMISS_KEY, '1')
-    } catch {
-      /* private mode — dismiss for this page load only */
-      greetingText = null
+    if (contained) {
+      localDismissed = true
+    } else {
+      try {
+        sessionStorage.setItem(GREETING_DISMISS_KEY, '1')
+      } catch {
+        /* private mode — dismiss for this page load only */
+        greetingText = null
+      }
     }
     renderGreeting()
   })
   bubble.appendChild(bubbleText)
   bubble.appendChild(bubbleClose)
-  document.body.appendChild(bubble)
+  const mount = opts.root ?? document.body
+  mount.appendChild(bubble)
 
   btn.addEventListener('mouseenter', () => {
     btn.style.transform = 'translateY(-2px)'
@@ -235,7 +251,7 @@ export function createLauncher(opts: LauncherOptions): LauncherHandle {
   })
   btn.addEventListener('click', opts.onClick)
 
-  document.body.appendChild(btn)
+  mount.appendChild(btn)
 
   return {
     el: btn,
@@ -268,7 +284,9 @@ export function createLauncher(opts: LauncherOptions): LauncherHandle {
       renderBadge()
     },
     setGreeting(text) {
-      greetingText = text?.trim() || null
+      const next = text?.trim() || null
+      if (contained && next !== greetingText) localDismissed = false
+      greetingText = next
       bubbleText.textContent = greetingText ?? ''
       renderGreeting()
     },
@@ -285,10 +303,10 @@ export function createLauncher(opts: LauncherOptions): LauncherHandle {
       if (!isOpen) btn.setAttribute('aria-label', labelText || 'Open feedback widget')
     },
     setPlacement(side) {
-      btn.style.left = side === 'left' ? '24px' : ''
-      btn.style.right = side === 'right' ? '24px' : ''
-      bubble.style.left = side === 'left' ? '24px' : ''
-      bubble.style.right = side === 'right' ? '24px' : ''
+      btn.style.left = side === 'left' ? edge : ''
+      btn.style.right = side === 'right' ? edge : ''
+      bubble.style.left = side === 'left' ? edge : ''
+      bubble.style.right = side === 'right' ? edge : ''
     },
     reveal() {
       btn.style.opacity = '1'


### PR DESCRIPTION
## Summary
- The copied install prompt now carries a short-lived pairing code. The host-app agent redeems it over HTTP and writes the signing secret to server-only env — the HMAC never goes in chat or MCP.
- Install page is agent-first: two setup steps, then a manage layout once the widget is seen. The signing secret is a credential (reveal / copy / regenerate), not a numbered step. Identify is wired only when the host already has login.
- Adds `POST /api/widget/install-context` (hashed codes, 15-minute TTL, two uses, per-IP rate limit, HTTPS on Cloud) and a team-only `widget_install_status` MCP tool that returns connection evidence, not the secret.

## Test plan
- [x] Copy the agent prompt on Admin → Settings → Widget → Install and confirm the clipboard has a `qbi_` code, not a `wgt_` secret
- [x] Redeem once from a host app: secret lands in server-only env, Show on your website turns on, launcher appears logged out
- [x] Host with login: after sign-in the widget greets the person; host without login: init only, no invented identify route
- [x] Second redeem of the same code works; third returns `CODE_INVALID`
- [x] Reveal / Copy / Regenerate still work; regenerate asks before invalidating the old secret
- [x] `widget_install_status` reports connected/enabled and never includes `wgt_`

Verified locally on 2026-09-11 against `91fe3be85` (admin on `:3020`, Lumen `:4180`, Atlas `:4181`). Regenerating was confirmed via the confirm dialog only — the live secret was not rotated.


Made with [Cursor](https://cursor.com)