### PR TITLE
feat(widget): scope sessions by audience

### DIFF
--- a/apps/web/src/lib/server/audit/__tests__/log.test.ts
+++ b/apps/web/src/lib/server/audit/__tests__/log.test.ts
@@ -214,6 +214,7 @@ describe('actorFromAuth', () => {
       principal: { id: 'principal_admin1' as never, role: 'admin', type: 'user' },
       settings: { id: 'workspace_1' as never, slug: 's', name: 'n', logoKey: null },
       permissions: [],
+      scope: 'dashboard',
     })
 
     expect(actor).toEqual({

--- a/apps/web/src/lib/server/auth/index.ts
+++ b/apps/web/src/lib/server/auth/index.ts
@@ -531,6 +531,9 @@ async function createAuth() {
       storeSessionInDatabase: true,
       expiresIn: 60 * 60 * 24 * 7, // 7 days
       updateAge: 60 * 60 * 24, // Update session every 24 hours
+      additionalFields: {
+        scope: { type: 'string', required: false, input: false, defaultValue: 'dashboard' },
+      },
     },
 
     advanced: {
@@ -607,6 +610,16 @@ async function createAuth() {
                   log.error({ err }, 'failed to auto-subscribe to changelog on signup')
                 )
               }
+            }
+          },
+        },
+      },
+      session: {
+        create: {
+          // Only the widget's lazy anonymous mint; everything else is a dashboard sign-in.
+          before: async (sessionData, context) => {
+            if (context?.path === '/sign-in/anonymous') {
+              return { data: { ...sessionData, scope: 'widget' } }
             }
           },
         },

--- a/apps/web/src/lib/server/auth/session.ts
+++ b/apps/web/src/lib/server/auth/session.ts
@@ -3,7 +3,8 @@ import type { UserId, SessionId } from '@quackback/ids'
 import { auth } from '@/lib/server/auth/index'
 import { db, principal as principalTable, eq } from '@/lib/server/db'
 import { logger } from '@/lib/server/logger'
-import type { PrincipalType } from '@/lib/shared/roles'
+import type { PrincipalType, SessionScope } from '@/lib/shared/roles'
+import { toSessionScope } from '@/lib/shared/roles'
 
 const log = logger.child({ component: 'auth-session' })
 
@@ -31,6 +32,7 @@ export interface Session {
     createdAt: string
     updatedAt: string
     userId: UserId
+    scope: SessionScope
   }
   user: SessionUser
 }
@@ -60,6 +62,7 @@ export async function getSession(): Promise<Session | null> {
         createdAt: session.session.createdAt.toISOString(),
         updatedAt: session.session.updatedAt.toISOString(),
         userId,
+        scope: toSessionScope(session.session.scope),
       },
       user: {
         id: userId,

--- a/apps/web/src/lib/server/fleet/__tests__/migrator-gate.test.ts
+++ b/apps/web/src/lib/server/fleet/__tests__/migrator-gate.test.ts
@@ -354,6 +354,7 @@ describe('replayGateVerdict', () => {
       '0277_widget_chat_to_messenger',
       '0278_two_factor_lockout',
       '0279_better_auth_17',
+      '0280_widget_session_scope',
     ])
     const verdict = replayGateVerdict(before, verdictsFor(replaySetFor(before)), false)
     expect(verdict.ok).toBe(false)

--- a/apps/web/src/lib/server/functions/__tests__/auth-scope.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/auth-scope.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { PERMISSIONS } from '@/lib/shared/permissions'
+
+const mockGetSession = vi.fn()
+vi.mock('@/lib/server/auth', () => ({
+  auth: { api: { getSession: (...args: unknown[]) => mockGetSession(...args) } },
+}))
+
+vi.mock('@tanstack/react-start/server', () => ({
+  getRequestHeaders: () => new Headers(),
+}))
+
+const mockPrincipalFindFirst = vi.fn()
+vi.mock('@/lib/server/db', () => ({
+  db: {
+    query: {
+      principal: { findFirst: (...args: unknown[]) => mockPrincipalFindFirst(...args) },
+    },
+  },
+  principal: {},
+  eq: vi.fn(),
+}))
+
+vi.mock('../auth-request-cache', () => ({
+  memoizePerRequest: (_key: string, fn: () => unknown) => fn(),
+}))
+
+vi.mock('@/lib/server/domains/settings/settings.helpers', () => ({
+  requireSettingsCached: vi.fn(async () => ({
+    id: 'workspace_1',
+    slug: 'main',
+    name: 'Main',
+    logoKey: null,
+  })),
+}))
+
+vi.mock('@/lib/server/domains/principals/principal.factory', () => ({
+  ensurePrincipalForUser: vi.fn(),
+}))
+
+vi.mock('@/lib/server/policy/permissions', () => ({
+  permissionsForPrincipal: vi.fn(async () => new Set([PERMISSIONS.SETTINGS_MANAGE])),
+}))
+
+vi.mock('@/lib/server/domains/segments/segment-membership.service', () => ({
+  segmentIdsForPrincipal: vi.fn(async () => new Set()),
+}))
+
+import { assertPermission, requireAuth } from '../auth-helpers'
+import { toSessionScope } from '@/lib/shared/roles'
+
+function sessionWithScope(scope: string) {
+  return {
+    session: { id: 'sess_1', scope },
+    user: { id: 'user_1', email: 'ada@example.com', name: 'Ada', image: null },
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockPrincipalFindFirst.mockResolvedValue({ id: 'principal_1', role: 'admin', type: 'user' })
+})
+
+describe('requireAuth permission gates are dashboard-only', () => {
+  it('denies a widget session even after the principal was promoted to admin', async () => {
+    mockGetSession.mockResolvedValue(sessionWithScope('widget'))
+
+    await expect(requireAuth({ permission: PERMISSIONS.SETTINGS_MANAGE })).rejects.toThrow(
+      /dashboard session/
+    )
+  })
+
+  it('denies a portal session at a permission gate', async () => {
+    mockGetSession.mockResolvedValue(sessionWithScope('portal'))
+
+    await expect(requireAuth({ permission: PERMISSIONS.SETTINGS_MANAGE })).rejects.toThrow(
+      /dashboard session/
+    )
+  })
+
+  it('allows the same principal on a dashboard session', async () => {
+    mockGetSession.mockResolvedValue(sessionWithScope('dashboard'))
+
+    const auth = await requireAuth({ permission: PERMISSIONS.SETTINGS_MANAGE })
+    expect(auth.scope).toBe('dashboard')
+    expect(auth.permissions).toContain(PERMISSIONS.SETTINGS_MANAGE)
+  })
+
+  it('bare requireAuth stays cross-plane', async () => {
+    mockGetSession.mockResolvedValue(sessionWithScope('widget'))
+
+    const auth = await requireAuth()
+    expect(auth.scope).toBe('widget')
+  })
+})
+
+describe('assertPermission scope gate', () => {
+  it('denies a widget session holding the permission', () => {
+    expect(() =>
+      assertPermission(
+        {
+          permissions: [PERMISSIONS.SETTINGS_MANAGE],
+          principal: { id: 'principal_1', role: 'admin', type: 'user' },
+          scope: 'widget',
+        },
+        PERMISSIONS.SETTINGS_MANAGE
+      )
+    ).toThrow(/dashboard session/)
+  })
+
+  it('allows a dashboard session holding the permission', () => {
+    expect(() =>
+      assertPermission(
+        {
+          permissions: [PERMISSIONS.SETTINGS_MANAGE],
+          principal: { id: 'principal_1', role: 'admin', type: 'user' },
+          scope: 'dashboard',
+        },
+        PERMISSIONS.SETTINGS_MANAGE
+      )
+    ).not.toThrow()
+  })
+})
+
+describe('toSessionScope', () => {
+  it('maps known scopes', () => {
+    expect(toSessionScope('widget')).toBe('widget')
+    expect(toSessionScope('portal')).toBe('portal')
+    expect(toSessionScope('dashboard')).toBe('dashboard')
+  })
+
+  it('treats unknown values as dashboard', () => {
+    expect(toSessionScope(undefined)).toBe('dashboard')
+    expect(toSessionScope(null)).toBe('dashboard')
+    expect(toSessionScope('future')).toBe('dashboard')
+  })
+})

--- a/apps/web/src/lib/server/functions/__tests__/auth-scope.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/auth-scope.test.ts
@@ -48,7 +48,7 @@ vi.mock('@/lib/server/domains/segments/segment-membership.service', () => ({
 
 import { assertPermission, getOptionalAuth, requireAuth } from '../auth-helpers'
 import { ensurePrincipalForUser } from '@/lib/server/domains/principals/principal.factory'
-import { toSessionScope } from '@/lib/shared/roles'
+import { sessionRole, toSessionScope } from '@/lib/shared/roles'
 
 function sessionWithScope(scope: string) {
   return {
@@ -167,5 +167,14 @@ describe('toSessionScope', () => {
     expect(toSessionScope(undefined)).toBe('dashboard')
     expect(toSessionScope(null)).toBe('dashboard')
     expect(toSessionScope('future')).toBe('dashboard')
+  })
+})
+
+describe('sessionRole', () => {
+  it('keeps the role only for dashboard sessions', () => {
+    expect(sessionRole('admin', 'dashboard')).toBe('admin')
+    expect(sessionRole('member', 'dashboard')).toBe('member')
+    expect(sessionRole('admin', 'widget')).toBe('user')
+    expect(sessionRole('member', 'portal')).toBe('user')
   })
 })

--- a/apps/web/src/lib/server/functions/__tests__/auth-scope.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/auth-scope.test.ts
@@ -46,7 +46,8 @@ vi.mock('@/lib/server/domains/segments/segment-membership.service', () => ({
   segmentIdsForPrincipal: vi.fn(async () => new Set()),
 }))
 
-import { assertPermission, requireAuth } from '../auth-helpers'
+import { assertPermission, getOptionalAuth, requireAuth } from '../auth-helpers'
+import { ensurePrincipalForUser } from '@/lib/server/domains/principals/principal.factory'
 import { toSessionScope } from '@/lib/shared/roles'
 
 function sessionWithScope(scope: string) {
@@ -59,6 +60,10 @@ function sessionWithScope(scope: string) {
 beforeEach(() => {
   vi.clearAllMocks()
   mockPrincipalFindFirst.mockResolvedValue({ id: 'principal_1', role: 'admin', type: 'user' })
+  vi.mocked(ensurePrincipalForUser).mockResolvedValue({
+    principal: { id: 'principal_1', role: 'admin', type: 'user' } as never,
+    created: false,
+  })
 })
 
 describe('requireAuth permission gates are dashboard-only', () => {
@@ -86,11 +91,40 @@ describe('requireAuth permission gates are dashboard-only', () => {
     expect(auth.permissions).toContain(PERMISSIONS.SETTINGS_MANAGE)
   })
 
-  it('bare requireAuth stays cross-plane', async () => {
+  it('bare requireAuth stays cross-plane but strips team authority from widget scope', async () => {
     mockGetSession.mockResolvedValue(sessionWithScope('widget'))
 
     const auth = await requireAuth()
     expect(auth.scope).toBe('widget')
+    expect(auth.principal.role).toBe('user')
+    expect(auth.permissions).toEqual([])
+  })
+
+  it('keeps the team role and permissions on a dashboard session', async () => {
+    mockGetSession.mockResolvedValue(sessionWithScope('dashboard'))
+
+    const auth = await requireAuth()
+    expect(auth.principal.role).toBe('admin')
+    expect(auth.permissions).toContain(PERMISSIONS.SETTINGS_MANAGE)
+  })
+})
+
+describe('getOptionalAuth strips team authority from non-dashboard scopes', () => {
+  it('downgrades a promoted widget principal to the portal tier', async () => {
+    mockGetSession.mockResolvedValue(sessionWithScope('widget'))
+
+    const auth = await getOptionalAuth()
+    expect(auth?.scope).toBe('widget')
+    expect(auth?.principal.role).toBe('user')
+    expect(auth?.permissions).toEqual([])
+  })
+
+  it('keeps the team role on a dashboard session', async () => {
+    mockGetSession.mockResolvedValue(sessionWithScope('dashboard'))
+
+    const auth = await getOptionalAuth()
+    expect(auth?.principal.role).toBe('admin')
+    expect(auth?.permissions).toContain(PERMISSIONS.SETTINGS_MANAGE)
   })
 })
 

--- a/apps/web/src/lib/server/functions/__tests__/onboarding-admin-promotion.fn.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/onboarding-admin-promotion.fn.test.ts
@@ -136,7 +136,10 @@ const { bootstrapAdminLock } = await import('@/lib/server/domains/principals/boo
 beforeEach(() => {
   vi.clearAllMocks()
   hoisted.flagWrites = []
-  hoisted.getSession.mockResolvedValue({ user: { id: 'user_caller' } })
+  hoisted.getSession.mockResolvedValue({
+    session: { scope: 'dashboard' },
+    user: { id: 'user_caller' },
+  })
   hoisted.postStatusesFindFirst.mockResolvedValue({ id: 'status_existing' })
   hoisted.stamp.value = null
   // The transaction's `execute` answers by statement, as the real one does: the

--- a/apps/web/src/lib/server/functions/__tests__/onboarding-bootstrap-claim.db.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/onboarding-bootstrap-claim.db.test.ts
@@ -167,7 +167,10 @@ describe.skipIf(!fixture.available)('bootstrap promotion guard', () => {
     const ownerId = await seedUser('owner@acme.example')
     await seedPrincipal({ userId: ownerId, role: 'admin' })
     const intruderId = await seedUser('someone.else@acme.example')
-    hoisted.getSession.mockResolvedValue({ user: { id: intruderId } })
+    hoisted.getSession.mockResolvedValue({
+      session: { scope: 'dashboard' },
+      user: { id: intruderId },
+    })
 
     await expect(saveWorkspaceAndGoalFn({ data: WORKSPACE_INPUT })).rejects.toThrow(/only admin/i)
     expect(hoisted.ensurePrincipalForUser).not.toHaveBeenCalled()
@@ -179,7 +182,10 @@ describe.skipIf(!fixture.available)('bootstrap promotion guard', () => {
     await seedPrincipal({ userId: ownerId, role: 'admin' })
     const memberId = await seedUser('member@acme.example')
     await seedPrincipal({ userId: memberId, role: 'member' })
-    hoisted.getSession.mockResolvedValue({ user: { id: memberId } })
+    hoisted.getSession.mockResolvedValue({
+      session: { scope: 'dashboard' },
+      user: { id: memberId },
+    })
 
     await expect(saveWorkspaceAndGoalFn({ data: WORKSPACE_INPUT })).rejects.toThrow(/only admin/i)
     expect(hoisted.ensurePrincipalForUser).not.toHaveBeenCalled()
@@ -196,7 +202,7 @@ describe.skipIf(!fixture.available)('bootstrap promotion guard', () => {
       createdAt: new Date(),
     })
     const firstId = await seedUser('first@acme.example')
-    hoisted.getSession.mockResolvedValue({ user: { id: firstId } })
+    hoisted.getSession.mockResolvedValue({ session: { scope: 'dashboard' }, user: { id: firstId } })
 
     await saveWorkspaceAndGoalFn({ data: WORKSPACE_INPUT })
 
@@ -209,7 +215,7 @@ describe.skipIf(!fixture.available)('bootstrap promotion guard', () => {
   it('lets the seeded owner through without a second promotion', async () => {
     const ownerId = await seedUser('owner@acme.example')
     await seedPrincipal({ userId: ownerId, role: 'admin' })
-    hoisted.getSession.mockResolvedValue({ user: { id: ownerId } })
+    hoisted.getSession.mockResolvedValue({ session: { scope: 'dashboard' }, user: { id: ownerId } })
 
     await saveWorkspaceAndGoalFn({ data: WORKSPACE_INPUT })
 
@@ -220,7 +226,7 @@ describe.skipIf(!fixture.available)('bootstrap promotion guard', () => {
 
   it('promotes the first user on a workspace nobody has claimed', async () => {
     const firstId = await seedUser('first@acme.example')
-    hoisted.getSession.mockResolvedValue({ user: { id: firstId } })
+    hoisted.getSession.mockResolvedValue({ session: { scope: 'dashboard' }, user: { id: firstId } })
 
     await saveWorkspaceAndGoalFn({ data: WORKSPACE_INPUT })
 
@@ -239,7 +245,7 @@ describe.skipIf(!fixture.available)('bootstrap promotion guard', () => {
   it('upgrades a first user whose principal was already created at the default role', async () => {
     const firstId = await seedUser('first@acme.example')
     await seedPrincipal({ userId: firstId, role: 'user' })
-    hoisted.getSession.mockResolvedValue({ user: { id: firstId } })
+    hoisted.getSession.mockResolvedValue({ session: { scope: 'dashboard' }, user: { id: firstId } })
     hoisted.ensurePrincipalForUser.mockImplementation(async ({ userId }: { userId: UserId }) => {
       const existing = await testDb.query.principal.findFirst({
         where: eq(principal.userId, userId),
@@ -266,7 +272,7 @@ describe.skipIf(!fixture.available)('bootstrap promotion guard', () => {
     const ownerId = await seedUser('owner@acme.example')
     await seedPrincipal({ userId: ownerId, role: 'admin' })
     const loserId = await seedUser('loser@acme.example')
-    hoisted.getSession.mockResolvedValue({ user: { id: loserId } })
+    hoisted.getSession.mockResolvedValue({ session: { scope: 'dashboard' }, user: { id: loserId } })
     hoisted.findHumanAdmin
       .mockImplementationOnce(async () => undefined)
       .mockImplementation(realBootstrap.findHumanAdmin)
@@ -285,7 +291,10 @@ describe.skipIf(!fixture.available)('bootstrap promotion guard', () => {
   it('refuses to hand a provisioned workspace to whoever arrives first', async () => {
     await seedProvisionedWorkspace()
     const arrivalId = await seedUser('whoever@evil.example')
-    hoisted.getSession.mockResolvedValue({ user: { id: arrivalId } })
+    hoisted.getSession.mockResolvedValue({
+      session: { scope: 'dashboard' },
+      user: { id: arrivalId },
+    })
 
     await expect(saveWorkspaceAndGoalFn({ data: WORKSPACE_INPUT })).rejects.toThrow(
       /not open to be set up/i
@@ -301,7 +310,10 @@ describe.skipIf(!fixture.available)('bootstrap promotion guard', () => {
     await seedProvisionedWorkspace()
     const arrivalId = await seedUser('whoever@evil.example')
     await seedPrincipal({ userId: arrivalId, role: 'user' })
-    hoisted.getSession.mockResolvedValue({ user: { id: arrivalId } })
+    hoisted.getSession.mockResolvedValue({
+      session: { scope: 'dashboard' },
+      user: { id: arrivalId },
+    })
 
     await expect(saveWorkspaceAndGoalFn({ data: WORKSPACE_INPUT })).rejects.toThrow(
       /not open to be set up/i
@@ -317,7 +329,7 @@ describe.skipIf(!fixture.available)('bootstrap promotion guard', () => {
     await testDb.execute(sql`UPDATE settings SET cloud_workspace_key = NULL`)
     hoisted.getSettings.mockResolvedValue({ id: 'workspace_1' })
     const firstId = await seedUser('first@acme.example')
-    hoisted.getSession.mockResolvedValue({ user: { id: firstId } })
+    hoisted.getSession.mockResolvedValue({ session: { scope: 'dashboard' }, user: { id: firstId } })
 
     await saveWorkspaceAndGoalFn({ data: WORKSPACE_INPUT })
 
@@ -339,7 +351,10 @@ describe.skipIf(!fixture.available)('bootstrap promotion guard', () => {
       metadata: JSON.stringify({ cloudTenant: { v: 1, workspaceKey: 'ws_acme', stampedAt: '' } }),
     })
     const arrivalId = await seedUser('whoever@evil.example')
-    hoisted.getSession.mockResolvedValue({ user: { id: arrivalId } })
+    hoisted.getSession.mockResolvedValue({
+      session: { scope: 'dashboard' },
+      user: { id: arrivalId },
+    })
 
     await expect(saveWorkspaceAndGoalFn({ data: WORKSPACE_INPUT })).rejects.toThrow(
       /not open to be set up/i
@@ -354,7 +369,7 @@ describe.skipIf(!fixture.available)('bootstrap promotion guard', () => {
     hoisted.getSettings.mockResolvedValue({ id: 'workspace_1' })
     const ownerId = await seedUser('owner@acme.example')
     await seedPrincipal({ userId: ownerId, role: 'admin' })
-    hoisted.getSession.mockResolvedValue({ user: { id: ownerId } })
+    hoisted.getSession.mockResolvedValue({ session: { scope: 'dashboard' }, user: { id: ownerId } })
 
     await saveWorkspaceAndGoalFn({ data: WORKSPACE_INPUT })
 
@@ -369,7 +384,10 @@ describe.skipIf(!fixture.available)('bootstrap promotion guard', () => {
     await seedPrincipal({ userId: ownerId, role: 'admin' })
     const visitorId = await seedUser('visitor@acme.example')
     await seedPrincipal({ userId: visitorId, role: 'user' })
-    hoisted.getSession.mockResolvedValue({ user: { id: visitorId } })
+    hoisted.getSession.mockResolvedValue({
+      session: { scope: 'dashboard' },
+      user: { id: visitorId },
+    })
 
     await expect(saveWorkspaceAndGoalFn({ data: WORKSPACE_INPUT })).rejects.toThrow(/only admin/i)
     expect(hoisted.setPrincipalRole).not.toHaveBeenCalled()

--- a/apps/web/src/lib/server/functions/__tests__/policy-actor-from-auth.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/policy-actor-from-auth.test.ts
@@ -51,6 +51,7 @@ function buildAuth(overrides: {
       type: overrides.principalType ?? 'user',
     },
     permissions: overrides.permissions ?? [],
+    scope: 'dashboard',
   }
 }
 

--- a/apps/web/src/lib/server/functions/__tests__/portal-permissions.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/portal-permissions.test.ts
@@ -74,6 +74,7 @@ function buildAuth(overrides: {
           ? SYSTEM_ROLE_PERMISSIONS.manager
           : []),
     ],
+    scope: 'dashboard',
   }
 }
 

--- a/apps/web/src/lib/server/functions/__tests__/resolve-portal-access.test.ts
+++ b/apps/web/src/lib/server/functions/__tests__/resolve-portal-access.test.ts
@@ -143,6 +143,7 @@ describe('resolvePortalAccessForRequest — config-throw contract', () => {
     // Same regression for an authenticated user — must NOT default to
     // granted/public. Authenticated callers get the unauthorized screen.
     mockGetSession.mockResolvedValue({
+      session: { id: 'sess_1', scope: 'dashboard' },
       user: { id: 'user_1', email: 'user@acme.com', emailVerified: true },
     })
     mockPrincipalFindFirst.mockResolvedValue({ type: 'user', role: 'user' })
@@ -200,6 +201,7 @@ describe('resolvePortalAccessForRequest — private portal', () => {
 
   it('denies an authenticated non-team caller whose domain is not allowed', async () => {
     mockGetSession.mockResolvedValue({
+      session: { id: 'sess_1', scope: 'dashboard' },
       user: { id: 'user_1', email: 'outsider@evil.com', emailVerified: true },
     })
     mockPrincipalFindFirst.mockResolvedValue({ type: 'user', role: 'user' })
@@ -217,6 +219,7 @@ describe('resolvePortalAccessForRequest — private portal', () => {
 
   it('grants a team member (admin) on a private portal', async () => {
     mockGetSession.mockResolvedValue({
+      session: { id: 'sess_1', scope: 'dashboard' },
       user: { id: 'user_admin', email: 'admin@acme.com', emailVerified: true },
     })
     mockPrincipalFindFirst.mockResolvedValue({ type: 'user', role: 'admin' })
@@ -231,6 +234,7 @@ describe('resolvePortalAccessForRequest — private portal', () => {
 
   it('grants a verified caller whose email domain is on the allowlist', async () => {
     mockGetSession.mockResolvedValue({
+      session: { id: 'sess_1', scope: 'dashboard' },
       user: { id: 'user_2', email: 'person@acme.com', emailVerified: true },
     })
     mockPrincipalFindFirst.mockResolvedValue({ type: 'user', role: 'user' })
@@ -246,6 +250,7 @@ describe('resolvePortalAccessForRequest — private portal', () => {
   it('denies an anonymous-principal session on a private portal', async () => {
     // An anonymous Better Auth session must not count as authenticated.
     mockGetSession.mockResolvedValue({
+      session: { id: 'sess_1', scope: 'dashboard' },
       user: { id: 'user_anon', email: 'anon@anon.quackback.io', emailVerified: false },
     })
     mockPrincipalFindFirst.mockResolvedValue({ type: 'anonymous', role: 'user' })
@@ -265,6 +270,7 @@ describe('resolvePortalAccessForRequest — private portal', () => {
     // A DB error during principal resolution must never grant access and must
     // not throw out of the function — the never-throw contract must hold.
     mockGetSession.mockResolvedValue({
+      session: { id: 'sess_1', scope: 'dashboard' },
       user: { id: 'user_1', email: 'user@acme.com', emailVerified: true },
     })
     mockPrincipalFindFirst.mockRejectedValue(new Error('DB_CONN_TIMEOUT'))
@@ -286,6 +292,7 @@ describe('resolvePortalAccessForRequest — private portal', () => {
     // closed for team-member detection — but a public portal still grants.
     // The function must not throw.
     mockGetSession.mockResolvedValue({
+      session: { id: 'sess_1', scope: 'dashboard' },
       user: { id: 'user_1', email: 'user@acme.com', emailVerified: true },
     })
     mockPrincipalFindFirst.mockRejectedValue(new Error('DB_CONN_TIMEOUT'))
@@ -300,6 +307,7 @@ describe('resolvePortalAccessForRequest — private portal', () => {
 describe('resolvePortalAccessForRequest — portal invite grant', () => {
   it('grants reason=invite for a verified caller with an accepted portal invite', async () => {
     mockGetSession.mockResolvedValue({
+      session: { id: 'sess_1', scope: 'dashboard' },
       user: { id: 'user_inv', email: 'invitee@example.com', emailVerified: true },
     })
     mockPrincipalFindFirst.mockResolvedValue({ type: 'user', role: 'user' })
@@ -315,6 +323,7 @@ describe('resolvePortalAccessForRequest — portal invite grant', () => {
 
   it('denies when no accepted invite exists (invite lookup returns null)', async () => {
     mockGetSession.mockResolvedValue({
+      session: { id: 'sess_1', scope: 'dashboard' },
       user: { id: 'user_inv', email: 'uninvited@example.com', emailVerified: true },
     })
     mockPrincipalFindFirst.mockResolvedValue({ type: 'user', role: 'user' })
@@ -334,6 +343,7 @@ describe('resolvePortalAccessForRequest — portal invite grant', () => {
   it('fails CLOSED on invite lookup DB error (deny, not throw)', async () => {
     // A DB error during the invite lookup must never grant access.
     mockGetSession.mockResolvedValue({
+      session: { id: 'sess_1', scope: 'dashboard' },
       user: { id: 'user_inv', email: 'invitee@example.com', emailVerified: true },
     })
     mockPrincipalFindFirst.mockResolvedValue({ type: 'user', role: 'user' })
@@ -352,6 +362,7 @@ describe('resolvePortalAccessForRequest — portal invite grant', () => {
 
   it('skips invite lookup when emailVerified=false (unverified email cannot claim invite)', async () => {
     mockGetSession.mockResolvedValue({
+      session: { id: 'sess_1', scope: 'dashboard' },
       user: { id: 'user_inv', email: 'invitee@example.com', emailVerified: false },
     })
     mockPrincipalFindFirst.mockResolvedValue({ type: 'user', role: 'user' })
@@ -387,6 +398,7 @@ describe('resolvePortalAccessForRequest — case-insensitive invite lookup', () 
     // return a mixed-case address stored on the session as-is. The resolver
     // must lowercase before the SQL lookup.
     mockGetSession.mockResolvedValue({
+      session: { id: 'sess_1', scope: 'dashboard' },
       user: { id: 'user_inv', email: 'Alice@Example.com', emailVerified: true },
     })
     mockPrincipalFindFirst.mockResolvedValue({ type: 'user', role: 'user' })
@@ -411,6 +423,7 @@ describe('resolvePortalAccessForRequest — case-insensitive invite lookup', () 
     // We check the eq mock directly — it records the value passed for the
     // email column (invitation.email). The email field stub is 'email' (string).
     mockGetSession.mockResolvedValue({
+      session: { id: 'sess_1', scope: 'dashboard' },
       user: { id: 'user_inv', email: 'MixedCase@EXAMPLE.COM', emailVerified: true },
     })
     mockPrincipalFindFirst.mockResolvedValue({ type: 'user', role: 'user' })
@@ -446,6 +459,7 @@ describe('resolvePortalAccessForRequest — accepted invites are permanent', () 
     // Invite was sent 20 days ago, accepted on day 2. Without the fix, the
     // expires_at filter (< now) would exclude this row and deny access.
     mockGetSession.mockResolvedValue({
+      session: { id: 'sess_1', scope: 'dashboard' },
       user: { id: 'user_inv', email: 'alice@example.com', emailVerified: true },
     })
     mockPrincipalFindFirst.mockResolvedValue({ type: 'user', role: 'user' })
@@ -469,6 +483,7 @@ describe('resolvePortalAccessForRequest — accepted invites are permanent', () 
     const sqlCalls = (sqlMock as unknown as ReturnType<typeof vi.fn>).mock.calls
 
     mockGetSession.mockResolvedValue({
+      session: { id: 'sess_1', scope: 'dashboard' },
       user: { id: 'user_inv', email: 'bob@example.com', emailVerified: true },
     })
     mockPrincipalFindFirst.mockResolvedValue({ type: 'user', role: 'user' })

--- a/apps/web/src/lib/server/functions/auth-helpers.ts
+++ b/apps/web/src/lib/server/functions/auth-helpers.ts
@@ -153,7 +153,9 @@ export async function requireAuth(options?: { permission?: PermissionKey }): Pro
     }
   )
 
-  const role = principalRecord.role as Role
+  const role: Role = scope === 'dashboard' ? (principalRecord.role as Role) : 'user'
+  // Non-dashboard audiences never carry team authority downstream.
+  const permissions: PermissionKey[] = scope === 'dashboard' ? [...resolvedPermissions] : []
 
   if (options?.permission && scope !== 'dashboard') {
     throw new Error(
@@ -161,7 +163,7 @@ export async function requireAuth(options?: { permission?: PermissionKey }): Pro
     )
   }
 
-  if (options?.permission && !resolvedPermissions.has(options.permission)) {
+  if (options?.permission && !permissions.includes(options.permission)) {
     throw new Error(
       `Access denied: Requires permission '${options.permission}', role ${role} lacks it`
     )
@@ -182,10 +184,10 @@ export async function requireAuth(options?: { permission?: PermissionKey }): Pro
     },
     principal: {
       id: principalRecord.id as PrincipalId,
-      role: principalRecord.role as Role,
+      role,
       type: principalRecord.type,
     },
-    permissions: [...resolvedPermissions],
+    permissions,
     scope,
   }
 }
@@ -266,6 +268,11 @@ export async function getOptionalAuth(): Promise<AuthContext | null> {
     }
   )
 
+  const scope = toSessionScope(session.session.scope)
+  const role: Role = scope === 'dashboard' ? (principalRecord.role as Role) : 'user'
+  // Non-dashboard audiences never carry team authority downstream.
+  const permissions: PermissionKey[] = scope === 'dashboard' ? [...resolvedPermissions] : []
+
   return {
     settings: {
       id: appSettings.id as WorkspaceId,
@@ -281,11 +288,11 @@ export async function getOptionalAuth(): Promise<AuthContext | null> {
     },
     principal: {
       id: principalRecord.id as PrincipalId,
-      role: principalRecord.role as Role,
+      role,
       type: principalRecord.type,
     },
-    permissions: [...resolvedPermissions],
-    scope: toSessionScope(session.session.scope),
+    permissions,
+    scope,
   }
 }
 

--- a/apps/web/src/lib/server/functions/auth-helpers.ts
+++ b/apps/web/src/lib/server/functions/auth-helpers.ts
@@ -7,6 +7,7 @@
 import type { UserId, PrincipalId, WorkspaceId } from '@quackback/ids'
 import type { Role } from '@/lib/server/auth'
 import { auth } from '@/lib/server/auth'
+import { toSessionScope, type SessionScope } from '@/lib/shared/roles'
 import { getRequestHeaders } from '@tanstack/react-start/server'
 import { db, principal, eq, type PermissionKey } from '@/lib/server/db'
 import { ensurePrincipalForUser } from '@/lib/server/domains/principals/principal.factory'
@@ -107,6 +108,8 @@ export interface AuthContext {
    * be narrower than the preset, and a fallback would silently widen.
    */
   permissions: PermissionKey[]
+  /** Session audience; only 'dashboard' may carry permissions. */
+  scope: SessionScope
 }
 
 /**
@@ -127,6 +130,7 @@ export async function requireAuth(options?: { permission?: PermissionKey }): Pro
     throw new Error('Authentication required')
   }
   const userId = session.user.id as UserId
+  const scope = toSessionScope(session.session.scope)
 
   const appSettings = await getAuthSettings()
   if (!appSettings) {
@@ -150,6 +154,12 @@ export async function requireAuth(options?: { permission?: PermissionKey }): Pro
   )
 
   const role = principalRecord.role as Role
+
+  if (options?.permission && scope !== 'dashboard') {
+    throw new Error(
+      `Access denied: Requires permission '${options.permission}' on a dashboard session`
+    )
+  }
 
   if (options?.permission && !resolvedPermissions.has(options.permission)) {
     throw new Error(
@@ -176,6 +186,7 @@ export async function requireAuth(options?: { permission?: PermissionKey }): Pro
       type: principalRecord.type,
     },
     permissions: [...resolvedPermissions],
+    scope,
   }
 }
 
@@ -195,9 +206,12 @@ export { isAuthDenialError } from './auth-errors'
  * fallback, which could be wider than a custom role's actual grant.
  */
 export function assertPermission(
-  auth: Pick<AuthContext, 'permissions' | 'principal'>,
+  auth: Pick<AuthContext, 'permissions' | 'principal' | 'scope'>,
   permission: PermissionKey
 ): void {
+  if (auth.scope !== 'dashboard') {
+    throw new Error(`Access denied: Requires permission '${permission}' on a dashboard session`)
+  }
   if (!auth.permissions.includes(permission)) {
     throw new Error(
       `Access denied: Requires permission '${permission}', role ${auth.principal.role} lacks it`
@@ -271,6 +285,7 @@ export async function getOptionalAuth(): Promise<AuthContext | null> {
       type: principalRecord.type,
     },
     permissions: [...resolvedPermissions],
+    scope: toSessionScope(session.session.scope),
   }
 }
 

--- a/apps/web/src/lib/server/functions/auth-helpers.ts
+++ b/apps/web/src/lib/server/functions/auth-helpers.ts
@@ -7,7 +7,7 @@
 import type { UserId, PrincipalId, WorkspaceId } from '@quackback/ids'
 import type { Role } from '@/lib/server/auth'
 import { auth } from '@/lib/server/auth'
-import { toSessionScope, type SessionScope } from '@/lib/shared/roles'
+import { toSessionScope, sessionRole, type SessionScope } from '@/lib/shared/roles'
 import { getRequestHeaders } from '@tanstack/react-start/server'
 import { db, principal, eq, type PermissionKey } from '@/lib/server/db'
 import { ensurePrincipalForUser } from '@/lib/server/domains/principals/principal.factory'
@@ -153,7 +153,7 @@ export async function requireAuth(options?: { permission?: PermissionKey }): Pro
     }
   )
 
-  const role: Role = scope === 'dashboard' ? (principalRecord.role as Role) : 'user'
+  const role: Role = sessionRole(principalRecord.role as Role, scope)
   // Non-dashboard audiences never carry team authority downstream.
   const permissions: PermissionKey[] = scope === 'dashboard' ? [...resolvedPermissions] : []
 
@@ -269,7 +269,7 @@ export async function getOptionalAuth(): Promise<AuthContext | null> {
   )
 
   const scope = toSessionScope(session.session.scope)
-  const role: Role = scope === 'dashboard' ? (principalRecord.role as Role) : 'user'
+  const role: Role = sessionRole(principalRecord.role as Role, scope)
   // Non-dashboard audiences never carry team authority downstream.
   const permissions: PermissionKey[] = scope === 'dashboard' ? [...resolvedPermissions] : []
 

--- a/apps/web/src/lib/server/functions/bootstrap.ts
+++ b/apps/web/src/lib/server/functions/bootstrap.ts
@@ -1,6 +1,6 @@
 import { createServerFn, createServerOnlyFn } from '@tanstack/react-start'
 import type { Role } from '@/lib/shared/roles'
-import { toSessionScope } from '@/lib/shared/roles'
+import { sessionRole, toSessionScope } from '@/lib/shared/roles'
 import { getThemeCookie, parsePrefersColorScheme, type Theme } from '@/lib/shared/theme'
 import { getUpdateBannerDismissedVersionCookie } from '@/lib/shared/update-banner-cookie'
 import { resolveLocale, type SupportedLocale } from '@/lib/shared/i18n'
@@ -115,6 +115,8 @@ async function getSessionAndRole(): Promise<{
       if (principalRecord) await cacheSet(cacheKey, principalRecord, 300)
     }
 
+    const scope = toSessionScope(session.session.scope)
+
     return {
       session: {
         session: {
@@ -123,7 +125,7 @@ async function getSessionAndRole(): Promise<{
           createdAt: session.session.createdAt.toISOString(),
           updatedAt: session.session.updatedAt.toISOString(),
           userId,
-          scope: toSessionScope(session.session.scope),
+          scope,
         },
         user: {
           id: userId,
@@ -136,7 +138,7 @@ async function getSessionAndRole(): Promise<{
           updatedAt: session.user.updatedAt.toISOString(),
         },
       },
-      role: (principalRecord?.role as Role | null) ?? null,
+      role: principalRecord ? sessionRole(principalRecord.role as Role, scope) : null,
     }
   } catch (error) {
     // During SSR, auth might fail due to env var issues

--- a/apps/web/src/lib/server/functions/bootstrap.ts
+++ b/apps/web/src/lib/server/functions/bootstrap.ts
@@ -1,5 +1,6 @@
 import { createServerFn, createServerOnlyFn } from '@tanstack/react-start'
 import type { Role } from '@/lib/shared/roles'
+import { toSessionScope } from '@/lib/shared/roles'
 import { getThemeCookie, parsePrefersColorScheme, type Theme } from '@/lib/shared/theme'
 import { getUpdateBannerDismissedVersionCookie } from '@/lib/shared/update-banner-cookie'
 import { resolveLocale, type SupportedLocale } from '@/lib/shared/i18n'
@@ -122,6 +123,7 @@ async function getSessionAndRole(): Promise<{
           createdAt: session.session.createdAt.toISOString(),
           updatedAt: session.session.updatedAt.toISOString(),
           userId,
+          scope: toSessionScope(session.session.scope),
         },
         user: {
           id: userId,

--- a/apps/web/src/lib/server/functions/conversation.ts
+++ b/apps/web/src/lib/server/functions/conversation.ts
@@ -844,7 +844,7 @@ export const mintConversationStreamTokenFn = createServerFn({ method: 'GET' }).h
   const ctx = await requireAuth()
   await assertVisitorConversationAccess(ctx.principal.role)
   const { mintStreamToken } = await import('@/lib/server/realtime/stream-token')
-  return { token: mintStreamToken(ctx.principal.id) }
+  return { token: mintStreamToken(ctx.principal.id, ctx.scope) }
 })
 
 /** Soft-delete a message (team members; or a visitor deleting their own). */

--- a/apps/web/src/lib/server/functions/onboarding.ts
+++ b/apps/web/src/lib/server/functions/onboarding.ts
@@ -212,6 +212,7 @@ export const saveWorkspaceAndGoalFn = createServerFn({ method: 'POST' })
       )
       const session = await getSession()
       if (!session?.user) throw new Error('Authentication required')
+      if (session.session.scope !== 'dashboard') throw new Error('Only admin can change setup')
 
       const workspaceName = data.workspaceName.trim()
       const slug = slugify(workspaceName)
@@ -354,6 +355,7 @@ export const saveCloudOnboardingGoalFn = createServerFn({ method: 'POST' })
   .handler(async ({ data }) => {
     const session = await getSession()
     if (!session?.user) throw new Error('Authentication required')
+    if (session.session.scope !== 'dashboard') throw new Error('Only admin can change setup')
     const caller = await db.query.principal.findFirst({
       where: eq(principal.userId, session.user.id as UserId),
     })

--- a/apps/web/src/lib/server/functions/portal-access.ts
+++ b/apps/web/src/lib/server/functions/portal-access.ts
@@ -3,7 +3,7 @@
  * and update portal access settings (admin only).
  */
 import { z } from 'zod'
-import type { Role } from '@/lib/shared/roles'
+import { sessionRole, toSessionScope, type Role } from '@/lib/shared/roles'
 import { createServerFn, createServerOnlyFn } from '@tanstack/react-start'
 import type { UserId, PrincipalId, SegmentId } from '@quackback/ids'
 import { PERMISSIONS } from '@/lib/shared/permissions'
@@ -103,7 +103,10 @@ export const resolvePortalAccessForRequest = createServerOnlyFn(
         if (principalRecord?.type === 'anonymous') {
           isAnonymousPrincipal = true
         }
-        role = (principalRecord?.role as Role | null) ?? null
+        const rawRole = (principalRecord?.role as Role | null) ?? null
+        // Non-dashboard audiences are portal-tier: a promoted principal on a
+        // widget/portal session must not take the evaluator's team branch.
+        role = rawRole ? sessionRole(rawRole, toSessionScope(session.session.scope)) : null
         resolvedPrincipalId = principalRecord?.id ?? null
       }
     }

--- a/apps/web/src/lib/server/functions/widget-auth.ts
+++ b/apps/web/src/lib/server/functions/widget-auth.ts
@@ -2,6 +2,7 @@ import type { PrincipalId, UserId, WorkspaceId } from '@quackback/ids'
 import { getRequestHeaders } from '@tanstack/react-start/server'
 import type { Role } from '@/lib/server/auth'
 import { auth } from '@/lib/server/auth'
+import { toSessionScope } from '@/lib/shared/roles'
 import { db, session, principal, eq, and, gt } from '@/lib/server/db'
 import { ensurePrincipalForUser } from '@/lib/server/domains/principals/principal.factory'
 import { resolveUserAvatarUrl } from '@/lib/server/domains/principals/principal-display'
@@ -101,7 +102,10 @@ export async function getWidgetSession(opts?: {
     },
     principal: {
       id: principalRecord.id as PrincipalId,
-      role: principalRecord.role as Role,
+      // Widget/portal audiences are portal-tier; only dashboard sessions keep a team role.
+      role: (toSessionScope(sessionRecord.scope) === 'dashboard'
+        ? principalRecord.role
+        : 'user') as Role,
       type: principalRecord.type ?? 'user',
     },
   }

--- a/apps/web/src/lib/server/functions/widget-auth.ts
+++ b/apps/web/src/lib/server/functions/widget-auth.ts
@@ -2,7 +2,7 @@ import type { PrincipalId, UserId, WorkspaceId } from '@quackback/ids'
 import { getRequestHeaders } from '@tanstack/react-start/server'
 import type { Role } from '@/lib/server/auth'
 import { auth } from '@/lib/server/auth'
-import { toSessionScope } from '@/lib/shared/roles'
+import { sessionRole, toSessionScope } from '@/lib/shared/roles'
 import { db, session, principal, eq, and, gt } from '@/lib/server/db'
 import { ensurePrincipalForUser } from '@/lib/server/domains/principals/principal.factory'
 import { resolveUserAvatarUrl } from '@/lib/server/domains/principals/principal-display'
@@ -103,9 +103,7 @@ export async function getWidgetSession(opts?: {
     principal: {
       id: principalRecord.id as PrincipalId,
       // Widget/portal audiences are portal-tier; only dashboard sessions keep a team role.
-      role: (toSessionScope(sessionRecord.scope) === 'dashboard'
-        ? principalRecord.role
-        : 'user') as Role,
+      role: sessionRole(principalRecord.role as Role, toSessionScope(sessionRecord.scope)),
       type: principalRecord.type ?? 'user',
     },
   }

--- a/apps/web/src/lib/server/functions/workspace-utils.ts
+++ b/apps/web/src/lib/server/functions/workspace-utils.ts
@@ -83,6 +83,11 @@ export const requireWorkspaceRole = createServerFn({ method: 'GET' })
       throw redirect(buildSigninRedirect('/admin', { error: 'not_team_member' }))
     }
 
+    // Team routes and permission-gated routes only accept dashboard sessions.
+    if ((teamOnly || data.permission) && session.session.scope !== 'dashboard') {
+      throw redirect(buildSigninRedirect('/admin', { error: 'not_team_member' }))
+    }
+
     const resolvedPermissions = await permissionsForPrincipal(
       principalRecord.id,
       principalRecord.role as Role

--- a/apps/web/src/lib/server/functions/workspace.ts
+++ b/apps/web/src/lib/server/functions/workspace.ts
@@ -12,7 +12,7 @@
  * `bun run check:server-fn-manifest` guards the general case.
  */
 
-import type { Role } from '@/lib/shared/roles'
+import { sessionRole, type Role } from '@/lib/shared/roles'
 import { db, principal, eq } from '@/lib/server/db'
 import { getSession } from '@/lib/server/auth/session'
 import { logger } from '@/lib/server/logger'
@@ -52,7 +52,7 @@ export async function getCurrentUserRole(): Promise<Role | null> {
     return null
   }
   log.debug({ role: principalRecord.role }, 'current user role')
-  return principalRecord.role as Role
+  return sessionRole(principalRecord.role as Role, session.session.scope)
 }
 
 /**
@@ -62,6 +62,11 @@ export async function validateApiWorkspaceAccess() {
   const session = await getSession()
   if (!session?.user) {
     return { success: false as const, error: 'Unauthorized', status: 401 as const }
+  }
+
+  // Import/export are team surfaces; a widget/portal audience never qualifies.
+  if (session.session.scope !== 'dashboard') {
+    return { success: false as const, error: 'Forbidden', status: 403 as const }
   }
 
   const [principalRecord, appSettings] = await Promise.all([

--- a/apps/web/src/lib/server/integrations/oauth-handlers.ts
+++ b/apps/web/src/lib/server/integrations/oauth-handlers.ts
@@ -10,6 +10,7 @@ import type { PrincipalId, UserId } from '@quackback/ids'
 import { getIntegration } from '.'
 import { verifyOAuthState } from '@/lib/server/auth/oauth-state'
 import { auth } from '@/lib/server/auth'
+import { toSessionScope } from '@/lib/shared/roles'
 import { db, principal, eq } from '@/lib/server/db'
 import {
   STATE_EXPIRY_MS,
@@ -170,6 +171,10 @@ export async function handleOAuthCallback(
   try {
     const session = await auth.api.getSession({ headers: request.headers })
     if (!session?.user) {
+      return redirectResponse(fail('auth_required'))
+    }
+    // Credential-linking is dashboard-only.
+    if (toSessionScope(session.session.scope) !== 'dashboard') {
       return redirectResponse(fail('auth_required'))
     }
     const principalRecord = await db.query.principal.findFirst({

--- a/apps/web/src/lib/server/policy/migration-contract/CONTRACT.md
+++ b/apps/web/src/lib/server/policy/migration-contract/CONTRACT.md
@@ -6,7 +6,7 @@ Regenerate with `bunx vitest run apps/web/src/lib/server/policy/migration-contra
 
 ## Summary
 
-Migrations scanned: 257. Migrations with destructive DDL: 35.
+Migrations scanned: 258. Migrations with destructive DDL: 35.
 
 | Kind | Occurrences |
 | --- | --- |

--- a/apps/web/src/lib/server/policy/migration-contract/__tests__/replay-safety.test.ts
+++ b/apps/web/src/lib/server/policy/migration-contract/__tests__/replay-safety.test.ts
@@ -282,6 +282,7 @@ describe('the real corpus', () => {
     // that are not already present, so a second run writes zero rows.
     // 0279 wraps oauth_client backfills, the oauth_client_resource FK rewrite,
     // and the Microsoft oid rewrite so each second run writes zero rows.
+    // 0280 marks session scope behind scope predicates, so a second run writes zero rows.
     const vouching = files.filter(
       (f) => assessReplaySafety(f, readFileSync(join(MIGRATIONS_DIR, f), 'utf8')).vouched.length > 0
     )
@@ -295,6 +296,7 @@ describe('the real corpus', () => {
       '0274_slack_agent_gateway.sql',
       '0277_widget_chat_to_messenger.sql',
       '0279_better_auth_17.sql',
+      '0280_widget_session_scope.sql',
     ])
   })
 

--- a/apps/web/src/lib/server/realtime/__tests__/stream-token.test.ts
+++ b/apps/web/src/lib/server/realtime/__tests__/stream-token.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mintStreamToken, verifyStreamToken } from '../stream-token'
+
+vi.mock('../../secret-key', () => ({
+  activeSecretKey: () => 'test-secret-key-at-least-32-characters-long',
+}))
+
+describe('stream token audience', () => {
+  it('round-trips the bound scope', () => {
+    const token = mintStreamToken('principal_1' as never, 'widget')
+    expect(verifyStreamToken(token)).toEqual({ principalId: 'principal_1', scope: 'widget' })
+  })
+
+  it('defaults to dashboard', () => {
+    const token = mintStreamToken('principal_1' as never)
+    expect(verifyStreamToken(token)).toEqual({ principalId: 'principal_1', scope: 'dashboard' })
+  })
+
+  it('rejects a tampered signature', () => {
+    const token = mintStreamToken('principal_1' as never, 'dashboard')
+    expect(verifyStreamToken(`${token.slice(0, -2)}xx`)).toBeNull()
+  })
+
+  it('returns null for missing or malformed tokens', () => {
+    expect(verifyStreamToken(null)).toBeNull()
+    expect(verifyStreamToken('garbage')).toBeNull()
+  })
+})

--- a/apps/web/src/lib/server/realtime/__tests__/stream-token.test.ts
+++ b/apps/web/src/lib/server/realtime/__tests__/stream-token.test.ts
@@ -1,9 +1,21 @@
+import { createHmac } from 'node:crypto'
 import { describe, expect, it, vi } from 'vitest'
 import { mintStreamToken, verifyStreamToken } from '../stream-token'
 
+const TEST_KEY = 'test-secret-key-at-least-32-characters-long'
+
 vi.mock('../../secret-key', () => ({
-  activeSecretKey: () => 'test-secret-key-at-least-32-characters-long',
+  activeSecretKey: () => TEST_KEY,
 }))
+
+/** Pre-scope token shape: `${principalId}.${expiry}`. */
+function legacyStreamToken(principalId: string, ttlMs = 60_000): string {
+  const payload = `${principalId}.${Date.now() + ttlMs}`
+  const signature = createHmac('sha256', TEST_KEY)
+    .update(`chat-stream:v1\n${payload}`)
+    .digest('base64url')
+  return `${Buffer.from(payload).toString('base64url')}.${signature}`
+}
 
 describe('stream token audience', () => {
   it('round-trips the bound scope', () => {
@@ -24,5 +36,9 @@ describe('stream token audience', () => {
   it('returns null for missing or malformed tokens', () => {
     expect(verifyStreamToken(null)).toBeNull()
     expect(verifyStreamToken('garbage')).toBeNull()
+  })
+
+  it('rejects audience-less legacy tokens', () => {
+    expect(verifyStreamToken(legacyStreamToken('principal_1'))).toBeNull()
   })
 })

--- a/apps/web/src/lib/server/realtime/stream-token.ts
+++ b/apps/web/src/lib/server/realtime/stream-token.ts
@@ -13,6 +13,7 @@
 import { createHmac, timingSafeEqual } from 'crypto'
 import { activeSecretKey } from '../secret-key'
 import type { PrincipalId } from '@quackback/ids'
+import { toSessionScope, type SessionScope } from '@/lib/shared/roles'
 
 // Short TTL: the token only authorizes the initial SSE handshake, and the
 // client re-mints via the authenticated mint fn on every reconnect — so a
@@ -35,14 +36,23 @@ function sign(payload: string): string {
     .digest('base64url')
 }
 
+export interface VerifiedStreamToken {
+  principalId: PrincipalId
+  scope: SessionScope
+}
+
 /** Mint a stream token for a principal, valid for `ttlMs` (default 2 min). */
-export function mintStreamToken(principalId: PrincipalId, ttlMs: number = DEFAULT_TTL_MS): string {
-  const payload = `${principalId}.${Date.now() + ttlMs}`
+export function mintStreamToken(
+  principalId: PrincipalId,
+  scope: SessionScope = 'dashboard',
+  ttlMs: number = DEFAULT_TTL_MS
+): string {
+  const payload = `${principalId}.${scope}.${Date.now() + ttlMs}`
   return `${b64url(payload)}.${sign(payload)}`
 }
 
-/** Verify a stream token, returning the principal id or null if invalid/expired. */
-export function verifyStreamToken(token: string | null | undefined): PrincipalId | null {
+/** Verify a stream token, returning its principal and audience or null if invalid/expired. */
+export function verifyStreamToken(token: string | null | undefined): VerifiedStreamToken | null {
   if (!token) return null
   const dot = token.lastIndexOf('.')
   if (dot <= 0) return null
@@ -63,9 +73,17 @@ export function verifyStreamToken(token: string | null | undefined): PrincipalId
 
   const sep = payload.lastIndexOf('.')
   if (sep <= 0) return null
-  const principalId = payload.slice(0, sep)
   const exp = Number(payload.slice(sep + 1))
   if (!Number.isFinite(exp) || Date.now() > exp) return null
 
-  return principalId as PrincipalId
+  // `${principalId}.${scope}.${exp}`; legacy `${principalId}.${exp}` is dashboard.
+  const withoutExpiry = payload.slice(0, sep)
+  const scopeSep = withoutExpiry.lastIndexOf('.')
+  if (scopeSep <= 0) {
+    return { principalId: withoutExpiry as PrincipalId, scope: 'dashboard' }
+  }
+  return {
+    principalId: withoutExpiry.slice(0, scopeSep) as PrincipalId,
+    scope: toSessionScope(withoutExpiry.slice(scopeSep + 1)),
+  }
 }

--- a/apps/web/src/lib/server/realtime/stream-token.ts
+++ b/apps/web/src/lib/server/realtime/stream-token.ts
@@ -76,12 +76,12 @@ export function verifyStreamToken(token: string | null | undefined): VerifiedStr
   const exp = Number(payload.slice(sep + 1))
   if (!Number.isFinite(exp) || Date.now() > exp) return null
 
-  // `${principalId}.${scope}.${exp}`; legacy `${principalId}.${exp}` is dashboard.
+  // `${principalId}.${scope}.${exp}`. Audience-less legacy tokens are refused:
+  // they are short-lived and the client re-mints on reconnect, so failing
+  // closed costs a handshake rather than leaking an unbound audience.
   const withoutExpiry = payload.slice(0, sep)
   const scopeSep = withoutExpiry.lastIndexOf('.')
-  if (scopeSep <= 0) {
-    return { principalId: withoutExpiry as PrincipalId, scope: 'dashboard' }
-  }
+  if (scopeSep <= 0) return null
   return {
     principalId: withoutExpiry.slice(0, scopeSep) as PrincipalId,
     scope: toSessionScope(withoutExpiry.slice(scopeSep + 1)),

--- a/apps/web/src/lib/shared/roles.ts
+++ b/apps/web/src/lib/shared/roles.ts
@@ -21,6 +21,14 @@ export type Role = 'admin' | 'member' | 'user'
 /** What kind of actor a principal is. */
 export type PrincipalType = 'user' | 'anonymous' | 'service' | 'support'
 
+/** Session audience. Only 'dashboard' may satisfy team/permission gates. */
+export type SessionScope = 'dashboard' | 'widget' | 'portal'
+
+/** Normalize a stored scope; unmarked values are dashboard. */
+export function toSessionScope(value: unknown): SessionScope {
+  return value === 'widget' || value === 'portal' ? value : 'dashboard'
+}
+
 /** Role privilege order, low to high. Used to compare/escalate roles. */
 export const ROLE_RANK: Record<Role, number> = { user: 0, member: 1, admin: 2 }
 

--- a/apps/web/src/lib/shared/roles.ts
+++ b/apps/web/src/lib/shared/roles.ts
@@ -29,6 +29,11 @@ export function toSessionScope(value: unknown): SessionScope {
   return value === 'widget' || value === 'portal' ? value : 'dashboard'
 }
 
+/** Team roles only apply to dashboard sessions; every other audience is portal-tier. */
+export function sessionRole(role: Role, scope: SessionScope): Role {
+  return scope === 'dashboard' ? role : 'user'
+}
+
 /** Role privilege order, low to high. Used to compare/escalate roles. */
 export const ROLE_RANK: Record<Role, number> = { user: 0, member: 1, admin: 2 }
 

--- a/apps/web/src/routes/__tests__/auth.widget-handoff.test.ts
+++ b/apps/web/src/routes/__tests__/auth.widget-handoff.test.ts
@@ -37,6 +37,12 @@ const mockOnConflictDoNothing: any = vi.fn()
 const mockInsertValues: any = vi.fn(() => ({ onConflictDoNothing: mockOnConflictDoNothing }))
 // oxlint-disable-next-line @typescript-eslint/no-explicit-any
 const mockDbInsert: any = vi.fn(() => ({ values: mockInsertValues }))
+// oxlint-disable-next-line @typescript-eslint/no-explicit-any
+const mockUpdateWhere: any = vi.fn(async () => undefined)
+// oxlint-disable-next-line @typescript-eslint/no-explicit-any
+const mockUpdateSet: any = vi.fn(() => ({ where: mockUpdateWhere }))
+// oxlint-disable-next-line @typescript-eslint/no-explicit-any
+const mockDbUpdate: any = vi.fn(() => ({ set: mockUpdateSet }))
 // Provenance lookup: tests default to hmacVerified=true so the
 // existing redirect/audit assertions still exercise the success
 // path. The provenance gate itself is covered in detail by
@@ -46,6 +52,7 @@ vi.mock('@/lib/server/db', () => ({
   db: {
     // oxlint-disable-next-line @typescript-eslint/no-explicit-any
     insert: (arg: any) => mockDbInsert(arg),
+    update: (arg: unknown) => mockDbUpdate(arg),
     query: {
       widgetIdentifiedSession: {
         findFirst: (...args: unknown[]) => mockWidgetIdentifiedFindFirst(...(args as [])),
@@ -54,6 +61,7 @@ vi.mock('@/lib/server/db', () => ({
   },
   widgetOriginSession: {},
   widgetIdentifiedSession: { sessionId: 'widget_identified_session.session_id' },
+  session: { id: 'session.id' },
   eq: vi.fn((col, val) => ({ kind: 'eq', col, val })),
 }))
 
@@ -70,7 +78,7 @@ vi.stubGlobal('fetch', mockFetch)
 async function runHandoffLoader(search: string) {
   const { setResponseHeader, getRequestHeaders } = await import('@tanstack/react-start/server')
   const { config } = await import('@/lib/server/config')
-  const { db, widgetOriginSession } = await import('@/lib/server/db')
+  const { db, widgetOriginSession, session } = await import('@/lib/server/db')
   const { recordAuditEvent } = await import('@/lib/server/audit/log')
   const { isSafeCallbackUrl } = await import('@/lib/shared/routing')
 
@@ -172,7 +180,14 @@ async function runHandoffLoader(search: string) {
     return { status: 'invalid' as const }
   }
 
-  // Provenance passed — safe to install the session cookie now.
+  // Provenance passed — promote to portal audience, then install the cookie.
+  try {
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    await (db.update(session) as any).set({ scope: 'portal' }).where(eq(session.id, sessionId))
+  } catch {
+    /* non-fatal */
+  }
+
   for (const cookie of setCookieValues) {
     setResponseHeader('Set-Cookie', cookie)
   }
@@ -265,6 +280,13 @@ describe('widget handoff loader — valid OTT', () => {
     expect(mockDbInsert).toHaveBeenCalled()
   })
 
+  it('promotes the verified session to portal scope', async () => {
+    mockFetch.mockResolvedValue(makeOkResponse({ id: 'sess_1', userId: 'user_abc' }))
+
+    await runHandoffLoader('?ott=valid-token')
+    expect(mockUpdateSet).toHaveBeenCalledWith({ scope: 'portal' })
+  })
+
   it('records the consumed audit event', async () => {
     mockFetch.mockResolvedValue(makeOkResponse({ id: 'sess_1', userId: 'user_abc' }))
 
@@ -305,6 +327,7 @@ describe('widget handoff loader — valid OTT', () => {
       const result = await runHandoffLoader('?ott=valid-token')
       expect(result.status).toBe('invalid')
       expect(mockDbInsert).not.toHaveBeenCalled()
+      expect(mockUpdateSet).not.toHaveBeenCalled()
     })
 
     it('rejects when hmac_verified is false (email-capture identify)', async () => {

--- a/apps/web/src/routes/__tests__/auth.widget-handoff.test.ts
+++ b/apps/web/src/routes/__tests__/auth.widget-handoff.test.ts
@@ -78,7 +78,7 @@ vi.stubGlobal('fetch', mockFetch)
 async function runHandoffLoader(search: string) {
   const { setResponseHeader, getRequestHeaders } = await import('@tanstack/react-start/server')
   const { config } = await import('@/lib/server/config')
-  const { db, widgetOriginSession, session } = await import('@/lib/server/db')
+  const { db, widgetOriginSession, session, eq } = await import('@/lib/server/db')
   const { recordAuditEvent } = await import('@/lib/server/audit/log')
   const { isSafeCallbackUrl } = await import('@/lib/shared/routing')
 

--- a/apps/web/src/routes/api/chat/__tests__/stream.test.ts
+++ b/apps/web/src/routes/api/chat/__tests__/stream.test.ts
@@ -167,8 +167,8 @@ function tokenPrincipal(role: string, type = 'user') {
   mockPrincipalFindFirst.mockResolvedValue({ id: 'principal_tok', role, type })
 }
 
-function sessionPrincipal(role: string, type = 'user') {
-  mockGetSession.mockResolvedValue({ user: { id: 'user_1' } })
+function sessionPrincipal(role: string, type = 'user', scope = 'dashboard') {
+  mockGetSession.mockResolvedValue({ session: { id: 'sess_1', scope }, user: { id: 'user_1' } })
   mockPrincipalFindFirst.mockResolvedValue({ id: 'principal_sess', role, type })
 }
 
@@ -217,6 +217,13 @@ describe('GET /api/chat/stream - inbox scope', () => {
     expect(res.headers.get('Content-Type')).toContain('text/event-stream')
     await settleAndClose(res)
     expect(mockSubscribe).toHaveBeenCalledWith(['conversation:inbox'], expect.any(Function))
+  })
+
+  it('403s a promoted team role carried on a non-dashboard session', async () => {
+    sessionPrincipal('admin', 'user', 'widget')
+    const res = await GET({ request: req('?scope=inbox') })
+    expect(res.status).toBe(403)
+    expect(mockSubscribe).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/web/src/routes/api/chat/__tests__/stream.test.ts
+++ b/apps/web/src/routes/api/chat/__tests__/stream.test.ts
@@ -162,8 +162,8 @@ beforeEach(() => {
   mockReadActivitySnapshot.mockResolvedValue(null)
 })
 
-function tokenPrincipal(role: string, type = 'user') {
-  mockVerifyStreamToken.mockReturnValue('principal_tok')
+function tokenPrincipal(role: string, type = 'user', scope = 'dashboard') {
+  mockVerifyStreamToken.mockReturnValue({ principalId: 'principal_tok', scope })
   mockPrincipalFindFirst.mockResolvedValue({ id: 'principal_tok', role, type })
 }
 
@@ -186,7 +186,7 @@ describe('GET /api/chat/stream - principal resolution', () => {
   })
 
   it('401s for a valid-signature token whose principal no longer exists', async () => {
-    mockVerifyStreamToken.mockReturnValue('principal_gone')
+    mockVerifyStreamToken.mockReturnValue({ principalId: 'principal_gone', scope: 'dashboard' })
     mockPrincipalFindFirst.mockResolvedValue(undefined)
     const res = await GET({ request: req('?scope=inbox&token=t') })
     expect(res.status).toBe(401)
@@ -217,6 +217,13 @@ describe('GET /api/chat/stream - inbox scope', () => {
     expect(res.headers.get('Content-Type')).toContain('text/event-stream')
     await settleAndClose(res)
     expect(mockSubscribe).toHaveBeenCalledWith(['conversation:inbox'], expect.any(Function))
+  })
+
+  it('403s a promoted team role carried on a non-dashboard token', async () => {
+    tokenPrincipal('admin', 'user', 'widget')
+    const res = await GET({ request: req('?scope=inbox&token=t') })
+    expect(res.status).toBe(403)
+    expect(mockSubscribe).not.toHaveBeenCalled()
   })
 
   it('403s a promoted team role carried on a non-dashboard session', async () => {

--- a/apps/web/src/routes/api/chat/stream.ts
+++ b/apps/web/src/routes/api/chat/stream.ts
@@ -27,7 +27,7 @@ import { readActivitySnapshot } from '@/lib/server/domains/assistant/assistant-a
 import { canViewConversation } from '@/lib/server/policy/conversation'
 import { assertTicketVisible } from '@/lib/server/domains/tickets/ticket.service'
 import { NotFoundError } from '@/lib/shared/errors'
-import { isTeamMember } from '@/lib/shared/roles'
+import { isTeamMember, toSessionScope, type SessionScope } from '@/lib/shared/roles'
 import {
   loadAuthors,
   toMessageDTO,
@@ -52,6 +52,8 @@ interface StreamPrincipal {
   /** How the principal was authenticated: a minted token (portal access already
    *  enforced at mint) vs a raw session cookie (must be re-gated here). */
   via: 'token' | 'session'
+  /** Session audience; null for minted tokens. Non-dashboard sessions are portal-tier here. */
+  scope: SessionScope | null
 }
 
 /** Resolve the principal for a stream from a signed token (widget) or the
@@ -61,7 +63,8 @@ async function resolveStreamPrincipal(request: Request): Promise<StreamPrincipal
   const tokenPrincipalId = verifyStreamToken(url.searchParams.get('token'))
   if (tokenPrincipalId) {
     const row = await db.query.principal.findFirst({ where: eq(principal.id, tokenPrincipalId) })
-    if (row) return { principalId: row.id, role: row.role, type: row.type, via: 'token' }
+    if (row)
+      return { principalId: row.id, role: row.role, type: row.type, via: 'token', scope: null }
     return null
   }
 
@@ -71,7 +74,13 @@ async function resolveStreamPrincipal(request: Request): Promise<StreamPrincipal
     where: eq(principal.userId, session.user.id as never),
   })
   if (!row) return null
-  return { principalId: row.id, role: row.role, type: row.type, via: 'session' }
+  return {
+    principalId: row.id,
+    role: row.role,
+    type: row.type,
+    via: 'session',
+    scope: toSessionScope(session.session.scope),
+  }
 }
 
 /** Frame a raw pub/sub payload as a named SSE event (id carried for message
@@ -105,6 +114,9 @@ export const Route = createFileRoute('/api/chat/stream')({
           return new Response('Unauthorized', { status: 401 })
         }
 
+        // A non-dashboard session is portal-tier regardless of principal role.
+        const effectiveRole = me.via === 'session' && me.scope !== 'dashboard' ? 'user' : me.role
+
         // Feature-flag gate: stop streams when the relevant surface is off (a
         // token may have been minted before the flag flipped). Portal access
         // for visitors was enforced when the stream token was minted. A ticket
@@ -124,7 +136,7 @@ export const Route = createFileRoute('/api/chat/stream')({
 
         const actor: Actor = {
           principalId: me.principalId,
-          role: (me.role as Actor['role']) ?? null,
+          role: (effectiveRole as Actor['role']) ?? null,
           principalType: normalizePrincipalType(me.type),
           segmentIds: new Set(),
         }
@@ -134,14 +146,14 @@ export const Route = createFileRoute('/api/chat/stream')({
         let backfillConversationId: ConversationId | null = null
 
         if (scope === 'inbox') {
-          if (!isTeamMember(me.role)) {
+          if (!isTeamMember(effectiveRole)) {
             return new Response('Forbidden', { status: 403 })
           }
           channels.push(CONVERSATION_INBOX_CHANNEL)
         } else if (scope === 'presence') {
           // App-wide agent presence: any admin page keeps a team member marked
           // online for routing. Heartbeat only — no channel subscription.
-          if (!isTeamMember(me.role)) {
+          if (!isTeamMember(effectiveRole)) {
             return new Response('Forbidden', { status: 403 })
           }
         } else if (conversationIdParam) {
@@ -149,7 +161,7 @@ export const Route = createFileRoute('/api/chat/stream')({
           // A cookie-authed (non-token) visitor bypassed the mint-time portal
           // gate, so re-check portal access here. Token streams were already
           // gated at mint; team members reach chat from the admin inbox.
-          if (me.via === 'session' && !isTeamMember(me.role)) {
+          if (me.via === 'session' && !isTeamMember(effectiveRole)) {
             const { resolvePortalAccessForRequest } =
               await import('@/lib/server/functions/portal-access')
             const access = await resolvePortalAccessForRequest()
@@ -170,7 +182,7 @@ export const Route = createFileRoute('/api/chat/stream')({
           // Team-member-only in this phase (unified inbox §3.2, M3) — there is
           // no requester-facing ticket stream yet, so unlike conversationId
           // above there's no visitor/portal branch to re-gate.
-          if (!isTeamMember(me.role)) {
+          if (!isTeamMember(effectiveRole)) {
             return new Response('Forbidden', { status: 403 })
           }
           const ticketId = ticketIdParam as TicketId
@@ -339,7 +351,7 @@ export const Route = createFileRoute('/api/chat/stream')({
                         // Visitor (non-team) reconnect backfill must exclude
                         // them — publish-time channel separation doesn't cover
                         // this DB read path.
-                        isTeamMember(me.role)
+                        isTeamMember(effectiveRole)
                           ? undefined
                           : eq(conversationMessages.isInternal, false),
                         or(

--- a/apps/web/src/routes/api/chat/stream.ts
+++ b/apps/web/src/routes/api/chat/stream.ts
@@ -52,19 +52,27 @@ interface StreamPrincipal {
   /** How the principal was authenticated: a minted token (portal access already
    *  enforced at mint) vs a raw session cookie (must be re-gated here). */
   via: 'token' | 'session'
-  /** Session audience; null for minted tokens. Non-dashboard sessions are portal-tier here. */
-  scope: SessionScope | null
+  /** Bound audience; non-dashboard tokens and sessions are portal-tier here. */
+  scope: SessionScope
 }
 
 /** Resolve the principal for a stream from a signed token (widget) or the
  * session cookie / Bearer header (admin + identified portal). */
 async function resolveStreamPrincipal(request: Request): Promise<StreamPrincipal | null> {
   const url = new URL(request.url)
-  const tokenPrincipalId = verifyStreamToken(url.searchParams.get('token'))
-  if (tokenPrincipalId) {
-    const row = await db.query.principal.findFirst({ where: eq(principal.id, tokenPrincipalId) })
+  const tokenPrincipal = verifyStreamToken(url.searchParams.get('token'))
+  if (tokenPrincipal) {
+    const row = await db.query.principal.findFirst({
+      where: eq(principal.id, tokenPrincipal.principalId),
+    })
     if (row)
-      return { principalId: row.id, role: row.role, type: row.type, via: 'token', scope: null }
+      return {
+        principalId: row.id,
+        role: row.role,
+        type: row.type,
+        via: 'token',
+        scope: tokenPrincipal.scope,
+      }
     return null
   }
 
@@ -113,9 +121,8 @@ export const Route = createFileRoute('/api/chat/stream')({
         if (!me) {
           return new Response('Unauthorized', { status: 401 })
         }
-
-        // A non-dashboard session is portal-tier regardless of principal role.
-        const effectiveRole = me.via === 'session' && me.scope !== 'dashboard' ? 'user' : me.role
+        // A non-dashboard audience is portal-tier regardless of principal role.
+        const effectiveRole = me.scope !== 'dashboard' ? 'user' : me.role
 
         // Feature-flag gate: stop streams when the relevant surface is off (a
         // token may have been minted before the flag flipped). Portal access

--- a/apps/web/src/routes/api/upload/image.ts
+++ b/apps/web/src/routes/api/upload/image.ts
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import type { UserId } from '@quackback/ids'
 import { auth } from '@/lib/server/auth'
+import { toSessionScope } from '@/lib/shared/roles'
 import { db, eq, principal } from '@/lib/server/db'
 import { isS3Usable, uploadImageFromFormData } from '@/lib/server/storage/s3'
 
@@ -17,6 +18,9 @@ export async function handleAdminUpload({ request }: { request: Request }): Prom
   const session = await auth.api.getSession({ headers: request.headers })
   if (!session?.user) {
     return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if (toSessionScope(session.session.scope) !== 'dashboard') {
+    return Response.json({ error: 'Forbidden' }, { status: 403 })
   }
   const principalRecord = await db.query.principal.findFirst({
     where: eq(principal.userId, session.user.id as UserId),

--- a/apps/web/src/routes/api/widget/identify.ts
+++ b/apps/web/src/routes/api/widget/identify.ts
@@ -112,6 +112,7 @@ async function findOrCreateSession(
     where: and(
       eq(session.userId, userId),
       gt(session.expiresAt, new Date()),
+      sql`${session.scope} in ('widget', 'portal')`,
       sql`exists (select 1 from widget_identified_session wis where wis.session_id = ${session.id} and wis.hmac_verified = true)`
     ),
   })
@@ -129,6 +130,7 @@ async function findOrCreateSession(
     id,
     token,
     userId,
+    scope: 'widget',
     expiresAt: new Date(now.getTime() + SESSION_TTL_MS),
     createdAt: now,
     updatedAt: now,

--- a/apps/web/src/routes/auth.widget-handoff.tsx
+++ b/apps/web/src/routes/auth.widget-handoff.tsx
@@ -247,6 +247,14 @@ const consumeWidgetHandoffFn = createServerFn({ method: 'POST' })
       return { kind: 'error', status: 'invalid' }
     }
 
+    // Promote to portal audience so the cookie can never satisfy team gates.
+    try {
+      const { db, session: sessionTable, eq } = await import('@/lib/server/db')
+      await db.update(sessionTable).set({ scope: 'portal' }).where(eq(sessionTable.id, sessionId))
+    } catch (err) {
+      log.error({ err }, 'failed to promote handoff session to portal scope')
+    }
+
     // Provenance passed — safe to install the BA session cookie now.
     // Pass the array so h3/Node emits a separate Set-Cookie line per
     // cookie. Calling setResponseHeader in a loop would overwrite (set,

--- a/packages/db/drizzle/0280_widget_session_scope.sql
+++ b/packages/db/drizzle/0280_widget_session_scope.sql
@@ -14,6 +14,17 @@ BEGIN
   WHERE "scope" = 'dashboard'
     AND "user_id" IN (SELECT "id" FROM "user" WHERE "is_anonymous" = true);
 
+  -- Sessions that predate the user's first account were minted before any
+  -- credential existed — the preserved session of an anonymous→signup absorb,
+  -- whose user.is_anonymous is already false by upgrade time. Conservative by
+  -- design: a false positive costs a re-login, a false negative keeps a
+  -- widget token dashboard-capable.
+  UPDATE "session" AS s SET "scope" = 'widget'
+  WHERE s."scope" = 'dashboard'
+    AND s."created_at" < (
+      SELECT min(a."created_at") FROM account a WHERE a."user_id" = s."user_id"
+    );
+
   UPDATE "session" SET "scope" = 'portal'
   WHERE "scope" <> 'portal'
     AND "id" IN (SELECT "session_id" FROM "widget_origin_session");

--- a/packages/db/drizzle/0280_widget_session_scope.sql
+++ b/packages/db/drizzle/0280_widget_session_scope.sql
@@ -9,6 +9,11 @@ BEGIN
   WHERE "scope" = 'dashboard'
     AND "id" IN (SELECT "session_id" FROM "widget_identified_session");
 
+  -- Anonymous users are only ever minted by the widget's lazy anonymous sign-in.
+  UPDATE "session" SET "scope" = 'widget'
+  WHERE "scope" = 'dashboard'
+    AND "user_id" IN (SELECT "id" FROM "user" WHERE "is_anonymous" = true);
+
   UPDATE "session" SET "scope" = 'portal'
   WHERE "scope" <> 'portal'
     AND "id" IN (SELECT "session_id" FROM "widget_origin_session");

--- a/packages/db/drizzle/0280_widget_session_scope.sql
+++ b/packages/db/drizzle/0280_widget_session_scope.sql
@@ -1,0 +1,15 @@
+-- Session audience scoping: dashboard | widget | portal. Only dashboard sessions
+-- may satisfy team/permission gates. Backfill precedence: portal > widget > dashboard.
+ALTER TABLE "session" ADD COLUMN IF NOT EXISTS "scope" text DEFAULT 'dashboard' NOT NULL;
+--> statement-breakpoint
+-- @replay: guarded-by scope predicates; already-marked rows are skipped, so a second run changes nothing
+DO $$
+BEGIN
+  UPDATE "session" SET "scope" = 'widget'
+  WHERE "scope" = 'dashboard'
+    AND "id" IN (SELECT "session_id" FROM "widget_identified_session");
+
+  UPDATE "session" SET "scope" = 'portal'
+  WHERE "scope" <> 'portal'
+    AND "id" IN (SELECT "session_id" FROM "widget_origin_session");
+END $$;

--- a/packages/db/drizzle/0280_widget_session_scope.sql
+++ b/packages/db/drizzle/0280_widget_session_scope.sql
@@ -29,3 +29,22 @@ BEGIN
   WHERE "scope" <> 'portal'
     AND "id" IN (SELECT "session_id" FROM "widget_origin_session");
 END $$;
+--> statement-breakpoint
+-- Rolling deploys: an old replica's identify insert omits scope, so a session
+-- minted after the backfill would keep the dashboard default. Provenance is
+-- written for every identified session, so re-scope on its insert.
+CREATE OR REPLACE FUNCTION quackback_widget_session_scope()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  UPDATE "session" SET "scope" = 'widget'
+  WHERE "id" = NEW.session_id AND "scope" = 'dashboard';
+  RETURN NEW;
+END $$;
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS widget_identified_session_scope ON widget_identified_session;
+--> statement-breakpoint
+CREATE TRIGGER widget_identified_session_scope
+  AFTER INSERT OR UPDATE ON widget_identified_session
+  FOR EACH ROW EXECUTE FUNCTION quackback_widget_session_scope();

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1800,6 +1800,13 @@
       "when": 1789117200000,
       "tag": "0279_better_auth_17",
       "breakpoints": true
+    },
+    {
+      "idx": 257,
+      "version": "7",
+      "when": 1789166954246,
+      "tag": "0280_widget_session_scope",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -266,6 +266,8 @@ export const session = pgTable(
       .notNull(),
     ipAddress: text('ip_address'),
     userAgent: text('user_agent'),
+    // Session audience: dashboard | widget | portal. Only dashboard may satisfy team/permission gates.
+    scope: text('scope').notNull().default('dashboard'),
     userId: typeIdColumn('user')('user_id')
       .notNull()
       .references(() => user.id, { onDelete: 'cascade' }),


### PR DESCRIPTION
## Problem

Widget-minted sessions and dashboard sessions shared one credential universe. The only guard against a widget token satisfying team/permission gates was the identify-time staff check (`IDENTITY_NOT_ALLOWED`). That check is not structural: a principal identified as `user` and later promoted (invite, role change) keeps its 7-day widget session, and the promoted role then passes `requireWorkspaceRole` / `requireAuth({ permission })`. The OTT handoff also installed a normal dashboard-capable cookie for the same session.

## Change

Sessions now carry an explicit audience: `session.scope` = `dashboard | widget | portal`. Only `dashboard` may satisfy team/permission gates.

- **Schema/migration** (`0280_widget_session_scope`): `session.scope` with default `dashboard`; replay-safe backfill with precedence portal > widget > dashboard.
- **Minting**: `/api/widget/identify` inserts `scope='widget'` and only reuses widget/portal sessions (never a dashboard one); the anonymous widget mint (`/sign-in/anonymous`) is tagged `widget` via a Better Auth `session.create.before` hook.
- **Handoff**: after the existing OTT + `hmac_verified` provenance gate, the session is promoted to `portal` before the cookie is forwarded.
- **Enforcement**: `requireAuth({ permission })` and `assertPermission` require `dashboard`; `requireWorkspaceRole` requires `dashboard` on team/permission routes; `getWidgetSession` presents portal-tier roles for non-dashboard audiences; direct role checks hardened in the chat stream, admin upload, and integration OAuth linking.
- `IDENTITY_NOT_ALLOWED` stays as the identity-level guard; scope is the structural backstop.

## Tests

- New `auth-scope.test.ts`: identify as `user` → promote to `admin` → widget token still fails permission gates; bare `requireAuth()` stays cross-plane; dashboard session allowed.
- Handoff: asserts `portal` promotion, and that it does not run when provenance fails.
- Migration contract: replay-safety list + `CONTRACT.md` updated; double-apply replay passes.
- Targeted suites pass. Remaining full-suite failures are pre-existing environment issues (missing `@base-ui` deps in this checkout; `open-handoff`/`oauth-gateway` failures reproduce on clean `main`).

## Manual verification (local install)

Ran the widget install against a local Quackback production build (`127.0.0.1:3041`) with brie-force as the host: anonymous launcher, sign-up → `/api/widget-sso` 200 → local `POST /api/widget/identify` 200, session `scope=widget`. Promoted the principal to admin: `POST /api/upload/image` → 403, `GET /api/export/users` → 403, dashboard admin cookie → 200. OTT handoff → 307 + cookie, session `scope=portal` with the `widget_origin_session` marker; portal token 403 on the team gate, 200 on `/api/widget/session`.
