### PR TITLE
fix(auth): pre-insert MCP oauth_resource before Better Auth seed

### DIFF
--- a/apps/web/src/lib/server/auth/__tests__/ensure-mcp-oauth-resource.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/ensure-mcp-oauth-resource.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ensureMcpOauthResource, mcpOauthResourceSeedRow } from '../ensure-mcp-oauth-resource'
+
+const IDENTIFIER = 'https://acme.example.com/api/mcp'
+const SCOPES = ['read:feedback', 'write:feedback'] as const
+
+describe('mcpOauthResourceSeedRow', () => {
+  it('matches the Better Auth insertOnly seed payload for the MCP resource', () => {
+    const row = mcpOauthResourceSeedRow(IDENTIFIER, SCOPES)
+    expect(row.identifier).toBe(IDENTIFIER)
+    expect(row.name).toBe(IDENTIFIER)
+    expect(row.allowedScopes).toEqual([...SCOPES])
+    expect(row.dpopBoundAccessTokensRequired).toBe(false)
+    expect(row.disabled).toBe(false)
+    expect(row.policyVersion).toBe(1)
+    expect(row.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i)
+  })
+})
+
+describe('ensureMcpOauthResource', () => {
+  it('inserts with ON CONFLICT DO NOTHING on identifier', async () => {
+    const onConflictDoNothing = vi.fn(async () => undefined)
+    const values = vi.fn(() => ({ onConflictDoNothing }))
+    const insert = vi.fn(() => ({ values }))
+    const table = { identifier: { name: 'identifier' } }
+
+    await ensureMcpOauthResource({
+      db: { insert } as never,
+      table: table as never,
+      identifier: IDENTIFIER,
+      allowedScopes: SCOPES,
+    })
+
+    expect(insert).toHaveBeenCalledWith(table)
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        identifier: IDENTIFIER,
+        allowedScopes: [...SCOPES],
+      })
+    )
+    expect(onConflictDoNothing).toHaveBeenCalledWith({ target: table.identifier })
+  })
+})

--- a/apps/web/src/lib/server/auth/ensure-mcp-oauth-resource.ts
+++ b/apps/web/src/lib/server/auth/ensure-mcp-oauth-resource.ts
@@ -1,0 +1,60 @@
+/**
+ * Pre-insert the MCP protected-resource row so Better Auth's boot-time seed
+ * does not try to create it.
+ *
+ * Better Auth 1.7 `mcp()` seeds `oauth_resource` from config on every
+ * `createAuth()`. The seed is supposed to treat a UNIQUE collision as a no-op
+ * (another replica already inserted the identifier), but it matches
+ * `/unique|duplicate/` against `err.message`. Drizzle wraps the driver error
+ * as `Failed query: insert into "oauth_resource"…` and puts SQLSTATE 23505 on
+ * `cause`, so the guard misses, plugin init throws, and `getAuth()` fails —
+ * which is how portal sign-in started returning "Failed to send sign-in email".
+ *
+ * Upstream: https://github.com/better-auth/better-auth/issues/11034
+ * (fix in https://github.com/better-auth/better-auth/pull/11087, unreleased).
+ * Their documented workaround until that ships: insert the row with
+ * `ON CONFLICT DO NOTHING` so `findOne` hits and `create` is never attempted.
+ * There is no config flag that disables the seed.
+ *
+ * A static migration cannot do this for us: the identifier is the workspace
+ * origin (`https://<slug>.quackback.io/api/mcp`), not a fleet-wide constant.
+ */
+
+type OauthResourceTable = { identifier: unknown }
+
+export function mcpOauthResourceSeedRow(identifier: string, allowedScopes: readonly string[]) {
+  const now = new Date()
+  return {
+    id: crypto.randomUUID(),
+    identifier,
+    name: identifier,
+    allowedScopes: [...allowedScopes],
+    dpopBoundAccessTokensRequired: false,
+    disabled: false,
+    policyVersion: 1,
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+export async function ensureMcpOauthResource(opts: {
+  /**
+   * Drizzle's insert builder is invariant in the row type, so this is the
+   * insert → values → onConflictDoNothing chain rather than `typeof db`.
+   */
+  db: {
+    insert: (table: OauthResourceTable) => {
+      values: (row: ReturnType<typeof mcpOauthResourceSeedRow>) => {
+        onConflictDoNothing: (args: { target: unknown }) => Promise<unknown>
+      }
+    }
+  }
+  table: OauthResourceTable
+  identifier: string
+  allowedScopes: readonly string[]
+}): Promise<void> {
+  await opts.db
+    .insert(opts.table)
+    .values(mcpOauthResourceSeedRow(opts.identifier, opts.allowedScopes))
+    .onConflictDoNothing({ target: opts.table.identifier })
+}

--- a/apps/web/src/lib/server/auth/index.ts
+++ b/apps/web/src/lib/server/auth/index.ts
@@ -24,6 +24,7 @@ import type { GenericOAuthConfig } from './build-oauth-configs'
 import { guardBetterAuthUserCreation } from './signup-policy'
 import { isSignInMethodEnabled } from '@/lib/shared/signin-methods'
 import { workspaceAuthTrustedOrigins } from './trusted-origins'
+import { ensureMcpOauthResource } from './ensure-mcp-oauth-resource'
 
 const log = logger.child({ component: 'auth-config' })
 
@@ -371,6 +372,19 @@ async function createAuth() {
   // instance is cached per workspace, so the callback origin and the cookie
   // `secure` flag below follow the hostname the request arrived on.
   const baseURL = config.baseUrl
+  const mcpResourceIdentifier = betterAuthMcpResource(`${baseURL}/api/mcp`)
+  // Better Auth 1.7 seeds oauth_resource on plugin init. Pre-insert so a
+  // Drizzle-wrapped unique from a concurrent replica cannot abort that init
+  // (better-auth/better-auth#11034). Both spellings: e2e rewrites *.localhost
+  // on the plugin `resource` only.
+  for (const identifier of new Set([`${baseURL}/api/mcp`, mcpResourceIdentifier])) {
+    await ensureMcpOauthResource({
+      db: db as Parameters<typeof ensureMcpOauthResource>[0]['db'],
+      table: oauthResourceTable,
+      identifier,
+      allowedScopes: API_KEY_SCOPES,
+    })
+  }
 
   // Origin allowlist. Better Auth rejects an auth POST whose Origin is
   // absent. The list is the documented per-request callback
@@ -707,7 +721,7 @@ async function createAuth() {
       mcp({
         loginPage: '/auth/login',
         consentPage: '/oauth/consent',
-        resource: betterAuthMcpResource(`${baseURL}/api/mcp`),
+        resource: mcpResourceIdentifier,
         allowDynamicClientRegistration:
           workspaceSettings?.developerConfig?.oauthDynamicClientRegistrationEnabled ?? true,
         allowUnauthenticatedClientRegistration: true,


### PR DESCRIPTION
## Summary

Cloud portal email sign-in could 500 with **Failed to send sign-in email** without sending mail. `getAuth()` was dying inside Better Auth 1.7 `mcp()` resource seed on a unique constraint:

```
insert into "oauth_resource" … identifier = https://<workspace>/api/mcp
duplicate key value violates unique constraint "oauth_resource_identifier_unique"
```

This is a known Better Auth bug: [better-auth/better-auth#11034](https://github.com/better-auth/better-auth/issues/11034), fix in unreleased [PR #11087](https://github.com/better-auth/better-auth/pull/11087).

`seedResources` treats a UNIQUE collision as a no-op by matching `/unique|duplicate/` against `err.message`. Drizzle wraps the driver error as `Failed query: insert into "oauth_resource"…` and puts SQLSTATE 23505 on `cause`, so the guard misses, plugin init throws, and every `/api/auth/portal-signin` 500s.

## Approach

Not an adapter wrap — that would intercept every `oauthResource` create. Upstream's documented workaround until #11087 ships:

> pre-insert the `oauthResource` row (`insert ... on conflict do nothing`) … so `findOne` finds it and `create` is never attempted.

Identifier is the workspace origin (`https://<slug>.quackback.io/api/mcp`), so this cannot be a fleet-wide migration. `createAuth()` inserts the row for this workspace before `betterAuth()` runs.

Drop this helper when we pick up a Better Auth release that includes #11087.

## Test plan

- [x] Unit: seed row shape matches insertOnly payload; insert uses `onConflictDoNothing` on `identifier`
- [ ] After deploy: Cloud portal email sign-in no longer 500s on the MCP resource seed
- [ ] Workspaces that already have the row still sign in (insert is a no-op)