### PR TITLE
fix(auth): keep OIDC sign-out local to Quackback

### DIFF
--- a/apps/web/src/lib/server/auth/__tests__/provider-registration.test.ts
+++ b/apps/web/src/lib/server/auth/__tests__/provider-registration.test.ts
@@ -96,6 +96,14 @@ describe('buildGenericOAuthConfigs', () => {
     expect(cfgs[0].providerId).toBe('sso') // preserved registration id, NOT oidc_idp_abc
     expect(cfgs[0].pkce).toBe(true)
     expect(cfgs[0].disableSignUp).toBe(false)
+    expect(cfgs[0].disableProviderLogout).toBe(true)
+  })
+
+  it('keeps sign-out local so a GitHub session does not federate Microsoft logout', async () => {
+    // Better Auth 1.7 RP-initiated logout redirects to any linked OIDC
+    // provider with end_session_endpoint, not the provider used this session.
+    const cfg = await buildOne()
+    expect(cfg.disableProviderLogout).toBe(true)
   })
 
   it('requests the broadly-supported prompt=login, not the OIDC-optional select_account', async () => {

--- a/apps/web/src/lib/server/auth/build-oauth-configs.ts
+++ b/apps/web/src/lib/server/auth/build-oauth-configs.ts
@@ -58,6 +58,17 @@ export interface GenericOAuthConfig {
   clientId: string
   clientSecret: string
   disableSignUp?: boolean
+  /**
+   * Keep sign-out local to Quackback.
+   *
+   * Better Auth 1.7 RP-initiated logout ([docs](https://better-auth.com/docs/plugins/generic-oauth#rp-initiated-logout),
+   * #9368) redirects `signOut()` to whichever linked OIDC provider exposes
+   * `end_session_endpoint`, picking the most recently updated account. GitHub
+   * has no logout URL, so a GitHub session still federates out of Microsoft
+   * when that account is linked. Discovery fills `end_session_endpoint` for
+   * Entra automatically. We always disable it.
+   */
+  disableProviderLogout: true
   discoveryUrl?: string
   pkce?: boolean
   authorizationUrl?: string
@@ -324,6 +335,7 @@ export async function buildGenericOAuthConfigs({
       // reject without it; RFC 7636 §5 makes the params backwards-compatible
       // (IdPs without PKCE support simply ignore them).
       pkce: true,
+      disableProviderLogout: true,
       ...(prompt ? { prompt } : {}),
       authentication: request.tokenAuth,
       // Better-Auth's JIT block. When false, the OAuth callback aborts in


### PR DESCRIPTION
## Summary

Signing out after a GitHub login could federate into a Microsoft (or other OIDC) logout. Same Better Auth 1.7 upgrade as the portal sign-in 500, different feature.

1.7 added [RP-initiated logout](https://better-auth.com/docs/plugins/generic-oauth#rp-initiated-logout) (#9368). `signOut()`:

1. Deletes the Quackback session
2. Loads **every** linked account
3. Keeps providers that implement `createEndSessionURL`
4. Redirects to the most recently updated of those

GitHub has no OIDC `end_session_endpoint`, so it is skipped. Microsoft Entra (and any custom OIDC we register from `identity_provider`) gets that URL from discovery automatically. We never set `disableProviderLogout`, so a GitHub session still logs the user out of Microsoft if that account is linked.

## Approach

Set `disableProviderLogout: true` on every generic OAuth config `buildGenericOAuthConfigs` emits. Built-in social providers (GitHub/Google/…) do not implement `createEndSessionURL` in 1.7.4, so they were already local.

This is the documented escape hatch: *To keep sign-out local to Better Auth, disable provider logout for that config.*

## Test plan

- [x] `buildGenericOAuthConfigs` always sets `disableProviderLogout: true`
- [ ] After deploy: GitHub sign-out stays on Quackback (no IdP logout page)
- [ ] OIDC/SSO sign-in still works; only federated *logout* is skipped