### PR TITLE
fix(inbox): skip non-list cache entries when patching posts

### DIFF
--- a/apps/web/src/lib/client/mutations/__tests__/inbox-list-cache.test.ts
+++ b/apps/web/src/lib/client/mutations/__tests__/inbox-list-cache.test.ts
@@ -1,0 +1,83 @@
+import { QueryClient } from '@tanstack/react-query'
+import { describe, expect, it } from 'vitest'
+import type { PostId } from '@quackback/ids'
+import { inboxKeys } from '@/lib/client/hooks/use-inbox-query'
+import {
+  isInboxInfiniteList,
+  removePostFromInboxLists,
+  updatePostInInboxLists,
+} from '../inbox-list-cache'
+import type { InboxPostListResult, PostListItem } from '@/lib/shared/db-types'
+
+const POST_A = 'post_aaaaaaaaaaaaaaaaaaaaaaaaaa' as PostId
+const POST_B = 'post_bbbbbbbbbbbbbbbbbbbbbbbbbb' as PostId
+
+function listItem(id: PostId, title: string): PostListItem {
+  return { id, title } as PostListItem
+}
+
+function infiniteList(items: PostListItem[]) {
+  return {
+    pages: [{ items, nextCursor: null, hasMore: false } satisfies InboxPostListResult],
+    pageParams: [undefined],
+  }
+}
+
+describe('isInboxInfiniteList', () => {
+  it('accepts infinite list pages', () => {
+    expect(isInboxInfiniteList(infiniteList([listItem(POST_A, 'One')]))).toBe(true)
+  })
+
+  it('rejects facet-count payloads and other non-page entries', () => {
+    expect(isInboxInfiniteList(undefined)).toBe(false)
+    expect(isInboxInfiniteList({ statuses: { open: 2 }, boards: {} })).toBe(false)
+    expect(isInboxInfiniteList({ pages: [{ items: undefined }] })).toBe(false)
+    expect(isInboxInfiniteList({ pages: [null] })).toBe(false)
+  })
+})
+
+describe('updatePostInInboxLists', () => {
+  it('patches the matching list row and leaves sibling prefix entries untouched', () => {
+    const queryClient = new QueryClient()
+    const listKey = inboxKeys.list({})
+    const facetKey = inboxKeys.facetCounts({})
+    const facets = { statuses: { open: 1 }, boards: {}, tags: {} }
+
+    queryClient.setQueryData(
+      listKey,
+      infiniteList([listItem(POST_A, 'Before'), listItem(POST_B, 'Other')])
+    )
+    queryClient.setQueryData(facetKey, facets)
+
+    expect(() => {
+      updatePostInInboxLists(queryClient, POST_A, (post) => ({ ...post, title: 'After' }))
+    }).not.toThrow()
+
+    const list = queryClient.getQueryData<ReturnType<typeof infiniteList>>(listKey)
+    expect(list?.pages[0]?.items.map((p) => p.title)).toEqual(['After', 'Other'])
+    expect(queryClient.getQueryData(facetKey)).toEqual(facets)
+  })
+})
+
+describe('removePostFromInboxLists', () => {
+  it('drops the post from list pages without touching sibling prefix entries', () => {
+    const queryClient = new QueryClient()
+    const listKey = inboxKeys.list({})
+    const facetKey = inboxKeys.facetCounts({})
+    const facets = { statuses: { open: 1 } }
+
+    queryClient.setQueryData(
+      listKey,
+      infiniteList([listItem(POST_A, 'Keep-me-not'), listItem(POST_B, 'Stay')])
+    )
+    queryClient.setQueryData(facetKey, facets)
+
+    expect(() => {
+      removePostFromInboxLists(queryClient, POST_A)
+    }).not.toThrow()
+
+    const list = queryClient.getQueryData<ReturnType<typeof infiniteList>>(listKey)
+    expect(list?.pages[0]?.items.map((p) => p.id)).toEqual([POST_B])
+    expect(queryClient.getQueryData(facetKey)).toEqual(facets)
+  })
+})

--- a/apps/web/src/lib/client/mutations/comments.ts
+++ b/apps/web/src/lib/client/mutations/comments.ts
@@ -7,6 +7,7 @@
 import { useMutation, useQueryClient, type InfiniteData } from '@tanstack/react-query'
 import { createCommentFn, addReactionFn, removeReactionFn } from '@/lib/server/functions/comments'
 import { inboxKeys } from '@/lib/client/hooks/use-inbox-query'
+import { updatePostInInboxLists } from '@/lib/client/mutations/inbox-list-cache'
 import type { PostDetails, PostCommentReaction, CommentWithReplies } from '@/lib/shared/types'
 import type { InboxPostListResult } from '@/lib/shared/db-types'
 import type { PostCommentId, PrincipalId, PostId } from '@quackback/ids'
@@ -42,27 +43,13 @@ interface AddCommentInput {
 // Helper Functions
 // ============================================================================
 
-/** Update a post in all list caches */
+/** Update a post in all infinite inbox list caches (skips non-list siblings). */
 function updatePostInLists(
   queryClient: ReturnType<typeof useQueryClient>,
   postId: PostId,
   updater: (post: { commentCount: number }) => { commentCount: number }
 ): void {
-  queryClient.setQueriesData<InfiniteData<InboxPostListResult>>(
-    { queryKey: inboxKeys.lists() },
-    (old) => {
-      if (!old) return old
-      return {
-        ...old,
-        pages: old.pages.map((page) => ({
-          ...page,
-          items: page.items.map((post) =>
-            post.id === postId ? { ...post, ...updater(post) } : post
-          ),
-        })),
-      }
-    }
-  )
+  updatePostInInboxLists(queryClient, postId, (post) => ({ ...post, ...updater(post) }))
 }
 
 /** Optimistically update reactions in nested comment structure */

--- a/apps/web/src/lib/client/mutations/inbox-list-cache.ts
+++ b/apps/web/src/lib/client/mutations/inbox-list-cache.ts
@@ -1,0 +1,52 @@
+/**
+ * Inbox infinite-list cache patches.
+ *
+ * Facet-count queries sit under the same `inboxKeys.lists()` prefix so list
+ * invalidation also refreshes counts. Those entries are not `{ pages }`
+ * infinite-query data. Any updater that assumes that shape must skip them.
+ */
+
+import type { InfiniteData, QueryClient } from '@tanstack/react-query'
+import { inboxKeys } from '@/lib/client/hooks/use-inbox-query'
+import type { InboxPostListResult, PostListItem } from '@/lib/shared/db-types'
+import type { PostId } from '@quackback/ids'
+
+export function isInboxInfiniteList(old: unknown): old is InfiniteData<InboxPostListResult> {
+  if (!old || typeof old !== 'object') return false
+  const pages = (old as { pages?: unknown }).pages
+  if (!Array.isArray(pages)) return false
+  return pages.every((page) => {
+    if (page === null || typeof page !== 'object') return false
+    return Array.isArray((page as { items?: unknown }).items)
+  })
+}
+
+export function updatePostInInboxLists(
+  queryClient: QueryClient,
+  postId: PostId,
+  updater: (post: PostListItem) => PostListItem
+): void {
+  queryClient.setQueriesData({ queryKey: inboxKeys.lists() }, (old) => {
+    if (!isInboxInfiniteList(old)) return old
+    return {
+      ...old,
+      pages: old.pages.map((page) => ({
+        ...page,
+        items: page.items.map((post) => (post.id === postId ? updater(post) : post)),
+      })),
+    }
+  })
+}
+
+export function removePostFromInboxLists(queryClient: QueryClient, postId: PostId): void {
+  queryClient.setQueriesData({ queryKey: inboxKeys.lists() }, (old) => {
+    if (!isInboxInfiniteList(old)) return old
+    return {
+      ...old,
+      pages: old.pages.map((page) => ({
+        ...page,
+        items: page.items.filter((post) => post.id !== postId),
+      })),
+    }
+  })
+}

--- a/apps/web/src/lib/client/mutations/posts.ts
+++ b/apps/web/src/lib/client/mutations/posts.ts
@@ -21,6 +21,10 @@ import {
 } from '@/lib/server/functions/posts'
 import { toggleVoteFn } from '@/lib/server/functions/public-posts'
 import { inboxKeys } from '@/lib/client/hooks/use-inbox-query'
+import {
+  updatePostInInboxLists,
+  removePostFromInboxLists,
+} from '@/lib/client/mutations/inbox-list-cache'
 import { roadmapPostsKeys } from '@/lib/client/hooks/use-roadmap-posts-query'
 import { votedPostsKeys } from '@/lib/client/hooks/use-portal-posts-query'
 import { adminQueries } from '@/lib/client/queries/admin'
@@ -114,25 +118,13 @@ function invalidateRoadmapForStatus(
   })
 }
 
-/** Update a post in all list caches */
+/** Update a post in all infinite inbox list caches (skips non-list siblings). */
 function updatePostInLists(
   queryClient: ReturnType<typeof useQueryClient>,
   postId: PostId,
   updater: (post: PostListItem) => PostListItem
 ): void {
-  queryClient.setQueriesData<InfiniteData<InboxPostListResult>>(
-    { queryKey: inboxKeys.lists() },
-    (old) => {
-      if (!old) return old
-      return {
-        ...old,
-        pages: old.pages.map((page) => ({
-          ...page,
-          items: page.items.map((post) => (post.id === postId ? updater(post) : post)),
-        })),
-      }
-    }
-  )
+  updatePostInInboxLists(queryClient, postId, updater)
 }
 
 // ============================================================================
@@ -630,20 +622,7 @@ export function useDeletePost() {
     mutationFn: async ({ postId, cascadeChoices }: DeletePostInput): Promise<DeletePostResult> =>
       deletePostFn({ data: { id: postId, cascadeChoices } }),
     onSuccess: (_data, { postId }) => {
-      // Remove from all list caches
-      queryClient.setQueriesData<InfiniteData<InboxPostListResult>>(
-        { queryKey: inboxKeys.lists() },
-        (old) => {
-          if (!old) return old
-          return {
-            ...old,
-            pages: old.pages.map((page) => ({
-              ...page,
-              items: page.items.filter((post) => post.id !== postId),
-            })),
-          }
-        }
-      )
+      removePostFromInboxLists(queryClient, postId)
       // Remove detail cache
       queryClient.removeQueries({ queryKey: inboxKeys.detail(postId) })
       // Invalidate lists and roadmap
@@ -664,20 +643,7 @@ export function useRestorePost() {
   return useMutation({
     mutationFn: (postId: PostId) => restorePostFn({ data: { id: postId } }),
     onSuccess: (_data, postId) => {
-      // Remove from current (deleted) list cache
-      queryClient.setQueriesData<InfiniteData<InboxPostListResult>>(
-        { queryKey: inboxKeys.lists() },
-        (old) => {
-          if (!old) return old
-          return {
-            ...old,
-            pages: old.pages.map((page) => ({
-              ...page,
-              items: page.items.filter((post) => post.id !== postId),
-            })),
-          }
-        }
-      )
+      removePostFromInboxLists(queryClient, postId)
       // Remove detail cache
       queryClient.removeQueries({ queryKey: inboxKeys.detail(postId) })
       // Invalidate all lists and roadmap (restored posts may reappear in roadmaps)


### PR DESCRIPTION
## Summary
- Optimistic inbox mutations used `setQueriesData` on `inboxKeys.lists()`, which also matches facet-count queries nested under that prefix.
- Those entries are not infinite-query `{ pages, items }` data, so `old.pages.map` threw in `onMutate` and TanStack Query aborted before the server write. Creating a post worked; changing status, title, description, tags, owner, or vote from `/admin/feedback` failed with `Cannot read properties of undefined (reading 'map')`.
- List patches now skip non-list siblings. Post and comment mutations share that helper, with coverage that a list row updates while a facet-count sibling is left alone.

## Test plan
- [ ] On an unfixed build, open `/admin/feedback`, create a post, then change its status or edit the title — confirm the `.map` error.
- [ ] On this branch, repeat the same path: status, title/description, tags, owner, and vote all persist; console stays clean.
- [ ] `cd apps/web && bunx vitest run src/lib/client/mutations/__tests__/inbox-list-cache.test.ts`


Made with [Cursor](https://cursor.com)